### PR TITLE
charter save refuses from a workspace clone that is itself a plane, instead of committing the outer one (#809)

### DIFF
--- a/charter/commands.py
+++ b/charter/commands.py
@@ -487,12 +487,14 @@ def cmd_save(args) -> int:
     HTTPS token — no SSH keys, no 1Password signing hang. (For a *clone's* changes, work
     in a repo-rooted session; this is only the control plane's orchestration files.)
 
-    **Refused from a linked worktree of the plane** (#806). ``config.ROOT`` from a worktree
-    is the clone it was cut from (`root._plane_of`, and for identity that is right), so this
-    ran ``git -C <the plane's clone> add -A`` and committed a tree the caller was not
-    standing in: the operator's mid-edit files under the agent's message, and none of the
-    agent's own work. The guard is in `planegit.commit_push` rather than here, keyed on the
-    add staging files it never named — the danger is the unbounded stage, not this name.
+    **Refused from either kind of tree that is not the plane's own** — a linked worktree of
+    it (#806) and a workspace clone that is itself a plane (#809). Both made this run ``git
+    -C <somewhere else> add -A`` and commit a tree the caller was not standing in: the
+    operator's mid-edit files under the agent's message, and none of the agent's own work.
+    They are detected separately (`root.tree_of`, `root.nested_plane_in`) because the
+    evidence differs — a worktree's ``.git`` is a file, a clone's is a directory — but both
+    guards are in `planegit.commit_push` rather than here, keyed on the add staging files it
+    never named: the danger is the unbounded stage, not this command's name.
     """
     return commit_push(config.ROOT, ["add", "-A"], args.message,
                        sign=getattr(args, "sign", False), no_push=getattr(args, "no_push", False))

--- a/charter/planegit.py
+++ b/charter/planegit.py
@@ -661,6 +661,42 @@ def commit_push(root, add_cmd: list, message: str | None,
                       f"{_root.ENV_VAR}={tree} charter save")
             return 1
 
+        # #809: the same two harms, reached the other way. `charter clone` puts clones at
+        # `workspaces/<ws>/<repo>`, `charter.toml` is tracked, and charter dogfoods on a
+        # clone of itself — so `workspaces/dev/charter` is a plane inside a plane, and
+        # `root._outermost` resolves outward to the enclosing one by #140's deliberate
+        # choice. That choice is right and is not touched here: the outer plane holds the
+        # vault, the personas and the memory, and #200 measured what happens when identity
+        # lands in the inner one. It just means `charter save` typed in the clone ran `git
+        # -C <the outer plane> add -A`. Measured on a throwaway plane with a real clone and
+        # the `.gitignore` `charter init` writes: it committed the operator's untracked
+        # NOTES.txt and their half-edited `charter.toml` under the agent's message and
+        # exited 0, and the agent's own work in the clone was not committed at all.
+        #
+        # A SECOND ROUTE, not a widening of the first. `tree_of` reads the `.git` FILE in a
+        # linked worktree; a clone has a real `.git` directory, so it answers `None` here
+        # and must keep doing so — widening it to "am I inside any other plane" would
+        # collapse the plane/tree distinction its docstring exists to draw.
+        #
+        # REFUSE rather than commit the inner plane instead. Committing the inner one would
+        # make `save` disagree with every other command about which plane it acts on —
+        # `persona remember`, the vault, the dispatch tally and the workspace manifest all
+        # follow `config.ROOT` outward — and split the plane in two. Committing the outer
+        # one is the defect. So charter names both trees and lets the caller say which they
+        # meant (ADR 0013's second rule), which is the shape #808 took.
+        nested = _root.nested_plane_in(root)
+        if nested is not None:
+            util.err(f"Refusing to stage all of {root} — you are standing in {nested}, a "
+                     f"control plane of its own under that plane's workspaces/. charter "
+                     f"resolves outward to the plane holding the vault, so committing every "
+                     f"change there would take that tree's uncommitted work under your "
+                     f"message, and leave your own work here unsaved.")
+            util.info(f"  your own work:   git -C {nested} add -A && git -C {nested} commit")
+            util.info(f"  the plane's own: run `charter save` from {root}")
+            util.info(f"  you really do mean this plane: "
+                      f"{_root.ENV_VAR}={nested} charter save")
+            return 1
+
     # A plane is not always a git repo: `charter init` in a fresh directory does not run
     # `git init`, and that is exactly the README's 60-second path. Every git call below
     # runs with check=False (this is reached from hooks and background paths that must

--- a/charter/root.py
+++ b/charter/root.py
@@ -259,41 +259,51 @@ def nested_plane_in(plane: Path, start: Path | None = None) -> Path | None:
     plane`` looks equivalent and is not: in a plane inside a plane inside a plane, under
     ``$CHARTER_ROOT=<the middle one>``, the outermost is not the tree being committed, yet
     standing in the leaf still commits a tree the caller is not in. Membership of the chain
-    is the honest test. ``seen`` guards a symlink arrangement that could otherwise cycle,
-    on the same grounds as `_outermost`'s.
+    is the honest test.
 
     The answer is the INNERMOST plane the caller stands in, never an intermediate one: it is
     printed as "run git here", and that has to be the tree actually holding their work.
 
+    **No ``seen`` set, and no ``inner == target`` short-circuit, unlike `_outermost`.** Both
+    were written here first and the deletion sweep charged them as unreachable, which they
+    are: :func:`enclosing_plane` answers an element of ``here.resolve().parents``, so every
+    hop is a strictly SHORTER resolved path. The chain therefore cannot revisit anything —
+    ``outer in seen`` is never true and the loop always terminates at ``None`` — and it can
+    never arrive back at ``inner``, so a caller standing in the very plane being committed
+    (the ``$CHARTER_ROOT`` hatch) falls out of the loop returning ``None`` without needing to
+    be checked for. `_outermost`'s copy of the guard is older, is charged to nobody, and is
+    left alone; this note is here so the next reader does not "restore" a set that provably
+    never holds a second element.
+
     Never raises: it sits on a command path, beside `tree_of`, which makes the same promise.
+    Each of the three catches below is pinned by a test that makes the call under it throw —
+    `TestTheDetectorNeverRaises` — because "never raises" asserted only by paths that never
+    fail is a promise nothing measured.
     """
     try:
         cur = (Path(start) if start is not None else Path.cwd()).resolve()
         target = Path(plane).resolve()
-    except (OSError, RuntimeError):
+    except (OSError, RuntimeError):       # cwd deleted (OSError); symlink loop (RuntimeError)
         return None
-    inner = None
     try:
         for d in (cur, *cur.parents):
             if (d / MARKER).is_file():
                 inner = _plane_of(d)
                 break
+        else:
+            return None                   # no marker above `start` at all
     except OSError:                       # PermissionError on an ancestor mid-walk
         return None
-    if inner is None or inner == target:
-        return None
-    seen = {inner}
     cur_plane = inner
     while True:
         try:
             outer = enclosing_plane(cur_plane)
         except OSError:
             return None
-        if outer is None or outer in seen:
+        if outer is None:
             return None
         if outer == target:
             return inner
-        seen.add(outer)
         cur_plane = outer
 
 

--- a/charter/root.py
+++ b/charter/root.py
@@ -230,6 +230,73 @@ def tree_of(plane: Path, start: Path | None = None) -> Path | None:
     return None
 
 
+def nested_plane_in(plane: Path, start: Path | None = None) -> Path | None:
+    """The plane nested inside *plane*'s ``workspaces/`` that *start* stands in — else
+    ``None``.
+
+    :func:`tree_of`'s sibling, and deliberately a **second route rather than a widening of
+    it** (#809). Both answer one question — *is the caller standing somewhere other than the
+    tree this command is about to commit?* — but the two arrangements are told apart by
+    different evidence, and neither detector can see the other's:
+
+    * a linked WORKTREE is a view of the plane's own repo, marked by the ``.git`` **file**
+      git writes into it. That is `tree_of`, pure path arithmetic.
+    * a nested PLANE is a *different repository* that happens to carry a tracked
+      ``charter.toml``, sitting where `charter clone` puts clones. Its ``.git`` is a real
+      directory, so `tree_of` correctly answers ``None`` for it — and must keep doing so.
+      Teaching `tree_of` this case would mean teaching it "am I inside any other plane",
+      which is :func:`enclosing_plane`'s question, answered on purpose in a different way.
+
+    **Root-relative, exactly like `tree_of`, and that is what makes ``$CHARTER_ROOT`` work.**
+    The question is not "is this plane nested" — it is "is the caller standing in a plane
+    nested inside *the one being committed*". With ``$CHARTER_ROOT=<the clone>`` the plane
+    being committed IS the one they are standing in, the first branch below returns ``None``,
+    and the operator gets what they explicitly asked for. A detector keyed on
+    :func:`standing_in_nested_plane` instead would refuse there too — and the refusal that
+    uses this prints that very override as its remedy, so the advice would be a lie.
+
+    **The chain is walked, not shortcut through :func:`_outermost`.** ``_outermost(inner) ==
+    plane`` looks equivalent and is not: in a plane inside a plane inside a plane, under
+    ``$CHARTER_ROOT=<the middle one>``, the outermost is not the tree being committed, yet
+    standing in the leaf still commits a tree the caller is not in. Membership of the chain
+    is the honest test. ``seen`` guards a symlink arrangement that could otherwise cycle,
+    on the same grounds as `_outermost`'s.
+
+    The answer is the INNERMOST plane the caller stands in, never an intermediate one: it is
+    printed as "run git here", and that has to be the tree actually holding their work.
+
+    Never raises: it sits on a command path, beside `tree_of`, which makes the same promise.
+    """
+    try:
+        cur = (Path(start) if start is not None else Path.cwd()).resolve()
+        target = Path(plane).resolve()
+    except (OSError, RuntimeError):
+        return None
+    inner = None
+    try:
+        for d in (cur, *cur.parents):
+            if (d / MARKER).is_file():
+                inner = _plane_of(d)
+                break
+    except OSError:                       # PermissionError on an ancestor mid-walk
+        return None
+    if inner is None or inner == target:
+        return None
+    seen = {inner}
+    cur_plane = inner
+    while True:
+        try:
+            outer = enclosing_plane(cur_plane)
+        except OSError:
+            return None
+        if outer is None or outer in seen:
+            return None
+        if outer == target:
+            return inner
+        seen.add(outer)
+        cur_plane = outer
+
+
 def _plane_of(marked: Path) -> Path:
     """The plane a found marker really belongs to.
 

--- a/docs/control-plane.md
+++ b/docs/control-plane.md
@@ -257,17 +257,35 @@ message, while other workers held their own worktrees over the same clone.
 
 ### Nested planes
 
-`charter` takes the **innermost** `charter.toml` above your working directory. That is the
-right rule — it is the one git, cargo and npm use — but a plane clones product repos into
-its workspaces, and a product repo may itself carry a `charter.toml`, since `charter init`
-is run inside existing repos. So `cd`-ing into `workspaces/<ws>/<repo>` can land you in a
-*different* control
-plane: different personas, a different vault, and memories written somewhere you did not
-choose.
+`charter` takes the **innermost** `charter.toml` above your working directory — the rule
+git, cargo and npm use — with **one exception, and charter builds the shape it covers.** A
+plane clones repos into its workspaces, and a cloned repo may itself carry a `charter.toml`,
+since `charter init` is run inside existing repos. Taking the innermost marker there landed
+you in a *different* control plane: different personas, a different vault, and memories
+written somewhere you did not choose.
 
-The rule does not change; charter just stops being quiet about it. When the active plane
-sits inside another plane's `workspaces/`, the status line carries a warning naming both
-planes and the `$CHARTER_ROOT` export that pins you to the outer one.
+So when a plane sits inside another plane's `workspaces/`, resolution hops **outward** to
+the enclosing one, and keeps hopping until nothing encloses it — the plane that actually
+holds the vault wins. The hop is allowed only through an enclosing plane's own
+`workspaces/`: a stray `charter.toml` in `~` does not swallow every plane beneath it.
+`$CHARTER_ROOT` still wins outright, and is the escape hatch when you genuinely mean the
+inner one.
+
+Charter is not quiet about the hop. The status line names both planes and the
+`$CHARTER_ROOT` export that pins you to the inner one, and **`charter save` refuses**
+outright rather than committing a tree you are not standing in — that being the one command
+whose whole job is to stage everything under the plane it resolved:
+
+```
+✗ Refusing to stage all of /…/plane — you are standing in /…/plane/workspaces/dev/charter,
+  a control plane of its own under that plane's workspaces/. …
+•   your own work:   git -C /…/workspaces/dev/charter add -A && git -C /…/workspaces/dev/charter commit
+•   the plane's own: run `charter save` from /…/plane
+•   you really do mean this plane: CHARTER_ROOT=/…/workspaces/dev/charter charter save
+```
+
+Only the unbounded stage refuses: memory, the dispatch tally, the workspace manifest and the
+version pin name plane-state files, and those keep reaching the plane from inside a clone.
 
 ## A self-hosted example
 

--- a/docs/news/unreleased-charter-save-refuses-from-a-workspace-clone-that-is-a-plane.md
+++ b/docs/news/unreleased-charter-save-refuses-from-a-workspace-clone-that-is-a-plane.md
@@ -1,0 +1,75 @@
+---
+version: unreleased
+headline: '`charter save` from a workspace clone that is itself a plane refuses, instead of committing the outer plane'
+---
+
+*"I ran `charter save` in `workspaces/dev/charter`. It committed the operator's `NOTES.txt`
+from the plane above me — and none of my own work in the clone."*
+
+## What was measured
+
+A throwaway plane, a real `git clone` of it at `workspaces/dev/charter` (where `charter
+clone` puts clones), and the `.gitignore` `charter init` writes. The operator is mid-edit in
+the outer plane; the agent's own change sits in the clone. `charter save "agent: unrelated
+security fix"`, typed in the clone, on the tree before this change:
+
+```
+✓ Committed a581f80 in /…/plane: agent: unrelated security fix  (1 file(s))
+ NOTES.txt | 1 +
+--- the agent's own work, in the clone ---
+?? agent-work.txt
+```
+
+Exit 0. Two harms, both silent:
+
+1. the operator's untracked `NOTES.txt` in the **outer** plane, committed under the agent's
+   message, on the plane's own branch;
+2. the agent's own work — the only thing it asked to save — **not committed at all**, and
+   the clone's `HEAD` not moved.
+
+## Why this was not already fixed
+
+`charter clone` puts clones at `workspaces/<ws>/<repo>`, `charter.toml` is a tracked file,
+and charter dogfoods on a clone of itself — so `workspaces/dev/charter` is a control plane
+nested inside a control plane. `root._outermost` resolves outward there, so `config.ROOT` is
+the plane above, and `charter save` is `commit_push(config.ROOT, ["add", "-A"], …)`.
+
+**That resolution is right and has not changed.** The outer plane is the one holding the
+vault, the personas and the memory; #200 measured what happens when identity lands in the
+inner one instead. What was wrong was `save` inheriting an answer meant for identity and
+using it to pick a *working tree*.
+
+The worktree fix that shipped alongside this (`charter save` refuses from a linked worktree)
+could not cover it. Its detector reads the `.git` **file** git writes into a linked worktree;
+a clone has a real `.git` **directory**, so it correctly answers "not a worktree" and must
+keep doing so. This is a second detector, `root.nested_plane_in`, asking the `workspaces/`
+question — not a widening of the first.
+
+## What happens now
+
+```
+✗ Refusing to stage all of /…/plane — you are standing in /…/plane/workspaces/dev/charter,
+  a control plane of its own under that plane's workspaces/. charter resolves outward to the
+  plane holding the vault, so committing every change there would take that tree's
+  uncommitted work under your message, and leave your own work here unsaved.
+•   your own work:   git -C /…/workspaces/dev/charter add -A && git -C /…/workspaces/dev/charter commit
+•   the plane's own: run `charter save` from /…/plane
+•   you really do mean this plane: CHARTER_ROOT=/…/workspaces/dev/charter charter save
+```
+
+Charter refuses and names **both** trees, rather than silently picking one. Committing the
+inner plane instead would have made `save` disagree with every other command about which
+plane it acts on — `persona remember`, the vault, the dispatch tally and the workspace
+manifest all follow `config.ROOT` outward — and split the plane in two.
+
+## What still works from inside a clone
+
+Only the **unbounded** stage refuses. `charter save` is the sole caller that stages the whole
+tree; reactive memory, the dispatch tally, the workspace manifest and `version pin --push`
+all name plane-state files, and those keep committing to the plane from anywhere. Working
+inside a clone is the ordinary way work happens on a charter plane, and every agent doing it
+writes memory — refusing that would have been a larger harm than the one being fixed.
+
+`CHARTER_ROOT=<the clone> charter save` commits the clone, as the refusal says. The guard
+asks whether you are standing in a plane nested inside *the plane being committed*; under
+that override, the plane being committed is the one you are standing in.

--- a/tests/test_save_from_a_nested_plane.py
+++ b/tests/test_save_from_a_nested_plane.py
@@ -1,0 +1,439 @@
+"""`charter save` typed in a workspace clone that is itself a plane committed the OUTER
+plane's whole working tree.
+
+`charter clone` puts clones at ``workspaces/<ws>/<repo>``, ``charter.toml`` is a tracked
+file, and charter dogfoods on a clone of itself — so ``workspaces/dev/charter`` is a control
+plane nested inside a control plane. `root._outermost` resolves outward to the enclosing
+plane there, by **#140's deliberate choice**, and that choice is not in question here: the
+outer plane is the one holding the vault, the personas and the memory, and #200 measured what
+happens when identity lands in the inner one instead.
+
+`charter save` is ``commit_push(config.ROOT, ["add", "-A"], …)``, so from inside the clone it
+ran ``git -C <the outer plane> add -A``. Measured on a throwaway plane (a real ``git clone``
+into ``workspaces/dev/charter``, and the ``.gitignore`` `charter init` writes):
+
+1. the operator's untracked ``NOTES.txt`` in the outer plane, committed under the agent's
+   message, exit 0;
+2. the agent's own work in the clone — the only thing it asked to save — not committed at
+   all, and the clone's HEAD not moved.
+
+**This is a second route, not a widening of #808's.** `root.tree_of` is path arithmetic on
+the ``.git`` *file* git writes into a linked worktree; a clone has a real ``.git``
+**directory**, so `tree_of` correctly answers ``None`` here (asserted below, because the
+whole shape of this fix rests on it). Widening it to "am I inside any other plane" would
+collapse the plane/tree distinction its own docstring exists to draw. So the detector is
+`root.nested_plane_in`, which asks the ``workspaces/`` question `enclosing_plane` already
+answers, and the guard sits beside #808's in the same `stages_the_whole_tree` block.
+
+**Refuse — not "commit the inner one instead".** The issue offered three answers. Committing
+the inner plane would make `charter save` disagree with every other charter command about
+which plane it is acting on: `persona remember`, `vault`, the dispatch tally and the
+workspace manifest all follow `config.ROOT` outward, and a `save` that went the other way
+would split the plane in two. Committing the outer one is the defect. So the refusal names
+both trees and lets the caller say which they meant — ADR 0013's second rule, and the shape
+#808 took.
+
+**Keyed on the ADD, so plane state still reaches the plane.** `charter save` is the only
+caller of `commit_push` that stages the whole tree; reactive memory, the dispatch tally, the
+workspace manifest and the version pin all name plane-state files. Those must keep working
+from inside a clone, because working inside a clone is the ordinary way work happens on this
+plane and every agent doing it writes memory.
+
+**`$CHARTER_ROOT=<clone>` is honoured, for free** — the same property #808 relied on.
+`nested_plane_in` asks whether the caller stands in a plane nested inside *the plane being
+committed*; under the override the plane being committed IS the one they are standing in, so
+the answer is ``None`` and the save proceeds. The refusal prints that hatch, so it has to
+work or the advice is a lie.
+"""
+
+from __future__ import annotations
+
+import io
+import os
+import subprocess
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from pathlib import Path
+from types import SimpleNamespace
+
+from charter import commands, config, root
+from tests._isolation import PersonaIso
+
+#: The arrangement the operator hand-maintains in the outer plane's `charter.toml`.
+ARRANGEMENT = '[[frame.component]]\nuse = "workspaces"\n'
+
+PLANE_TOML = ('schema = 1\n\n[[forge]]\nkind = "github"\n\n'
+              '[frame]\nslots = ["top"]\n\n' + ARRANGEMENT)
+
+#: What `charter init` writes (`commands.py`'s `_GITIGNORE`). Not decoration: without
+#: ``/workspaces/*/*`` the outer plane's ``git add -A`` records the clone as a **gitlink**,
+#: and a fixture missing this line reports a harm no real plane can reach.
+PLANE_GITIGNORE = "/.charter/\n/workspaces/*/*\n!/workspaces/.gitkeep\n"
+
+
+def _run(fn, *a, **kw):
+    """``(rc, everything it said)``. `util` writes to stderr, some commands print to
+    stdout; a refusal has to be findable in either."""
+    out, err = io.StringIO(), io.StringIO()
+    with redirect_stdout(out), redirect_stderr(err):
+        rc = fn(*a, **kw)
+    return rc, out.getvalue() + err.getvalue()
+
+
+def _save_args(message="agent: unrelated security fix"):
+    return SimpleNamespace(message=message, sign=False, no_push=True)
+
+
+class PlaneInsideAPlane(PersonaIso):
+    """An outer plane with a REAL ``git clone`` of itself at ``workspaces/dev/charter``.
+
+    A real clone, for the reason #808's fixture gives about worktrees: what separates this
+    case from that one is that a clone has a ``.git`` **directory**, and a fixture that faked
+    one would be asserting against this module's idea of git's layout rather than git's.
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+        # `find_root` consults $CHARTER_ROOT before walking, and the developer running the
+        # suite may well have one exported — it would win outright and every case here
+        # would resolve their plane instead of the fixture.
+        self._env = os.environ.pop(root.ENV_VAR, None)
+        if self._env is not None:
+            self.addCleanup(os.environ.__setitem__, root.ENV_VAR, self._env)
+
+        self.plane = self.tmp / "plane"
+        self.plane.mkdir(parents=True, exist_ok=True)
+        (self.plane / "charter.toml").write_text(PLANE_TOML)
+        (self.plane / ".gitignore").write_text(PLANE_GITIGNORE)
+        (self.plane / "personas").mkdir()
+        (self.plane / "personas" / "steward.md").write_text("# steward\n")
+        self.git("init", "-q", "-b", "main", ".")
+        self.git("config", "user.email", "r@e.invalid")
+        self.git("config", "user.name", "r")
+        self.git("config", "commit.gpgsign", "false")
+        self.git("add", "-A")
+        self.git("commit", "-qm", "plane")
+        self.base = self.head()
+
+        # Where `charter clone` puts it, and what charter's own dogfooding looks like.
+        self.clone = self.plane / "workspaces" / "dev" / "charter"
+        self.clone.parent.mkdir(parents=True)
+        subprocess.run(["git", "clone", "-q", str(self.plane), str(self.clone)],
+                       check=True, capture_output=True, text=True)
+        self._git_in(self.clone, "config", "user.email", "a@e.invalid")
+        self._git_in(self.clone, "config", "user.name", "a")
+        self._git_in(self.clone, "config", "commit.gpgsign", "false")
+        self.clone_base = self._git_in(self.clone, "rev-parse", "HEAD")
+
+        # The operator is mid-edit IN THE OUTER PLANE: the arrangement half-deleted in a
+        # tracked file, plus an untracked scratch file. The agent's own work is in the clone.
+        (self.plane / "charter.toml").write_text(PLANE_TOML.replace(ARRANGEMENT, ""))
+        (self.plane / "NOTES.txt").write_text("operator scratch\n")
+        (self.clone / "agent-work.txt").write_text("the agent's own work\n")
+
+        self.addCleanup(config.restore, config.use(self.plane))
+        # `config.use` derives `NESTED_ORIGIN` from the ROOT, never the cwd (its own comment
+        # says why), so it is `None` throughout this module. Stated, not assumed: a guard
+        # written against `config.NESTED_ORIGIN` would pass every test here by never firing.
+        self.assertIsNone(config.NESTED_ORIGIN)
+        self.assertIn("edm-test-", str(config.STATE_DIR))
+
+    def _git_in(self, where: Path, *argv: str) -> str:
+        p = subprocess.run(["git", "-C", str(where), *argv],
+                           check=True, capture_output=True, text=True)
+        return p.stdout.strip()
+
+    def git(self, *argv: str) -> str:
+        return self._git_in(self.plane, *argv)
+
+    def head(self) -> str:
+        return self.git("rev-parse", "HEAD")
+
+    def clone_head(self) -> str:
+        return self._git_in(self.clone, "rev-parse", "HEAD")
+
+    def staged(self) -> list[str]:
+        return [ln for ln in self.git("diff", "--cached", "--name-only").splitlines() if ln]
+
+    def standing_in(self, where: Path):
+        """chdir for the rest of the test. Registered rather than a ``finally``, and before
+        `PersonaIso`'s rmtree: a cwd left inside a deleted temp directory makes `Path.cwd()`
+        raise for every test that runs after this one."""
+        here = Path.cwd()
+        self.addCleanup(os.chdir, here)
+        os.chdir(where)
+
+    def save_from(self, where: Path, **kw):
+        self.standing_in(where)
+        return _run(commands.cmd_save, _save_args(**kw))
+
+
+class TestTheFixtureIsTheShapeTheIssueDescribes(PlaneInsideAPlane):
+    """Preconditions. Every one of these is a claim the fix rests on, and each would make
+    the cases below vacuous if it stopped holding."""
+
+    def test_the_clone_is_itself_a_plane(self):
+        self.assertTrue((self.clone / root.MARKER).is_file())
+
+    def test_the_clone_has_a_real_git_directory(self):
+        """The single fact that separates this from #808. A linked worktree's ``.git`` is a
+        FILE; a clone's is a directory, which is why `tree_of` cannot see this case."""
+        self.assertTrue((self.clone / ".git").is_dir())
+
+    def test_the_worktree_detector_correctly_answers_none(self):
+        """#808's route, measured rather than assumed. If this ever answered the clone, the
+        fix below would be a duplicate and `tree_of` would have swallowed the plane/tree
+        distinction it exists to draw."""
+        self.assertIsNone(root.main_worktree_of(self.clone))
+        self.assertIsNone(root.tree_of(self.plane, self.clone))
+
+    def test_resolution_still_goes_outward(self):
+        """#140's settled choice, which this fix does not touch."""
+        self.assertEqual(root.find_root(self.clone), self.plane.resolve())
+
+    def test_the_clone_is_ignored_by_the_outer_plane(self):
+        """`charter init`'s ``/workspaces/*/*``. Without it the outer ``add -A`` records a
+        gitlink and the harm under test is not the one real planes have."""
+        proc = subprocess.run(["git", "-C", str(self.plane), "check-ignore",
+                               "workspaces/dev/charter"], capture_output=True, text=True)
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+
+
+class TestSaveFromTheCloneIsRefused(PlaneInsideAPlane):
+    """The defect. Each case is one of the two harms the issue measured."""
+
+    def test_it_refuses(self):
+        rc, said = self.save_from(self.clone)
+        self.assertEqual(rc, 1, said)
+
+    def test_it_refuses_from_a_directory_inside_the_clone(self):
+        """The agent is rarely standing exactly on the clone's marker — it is in
+        ``charter/`` or ``tests/`` inside it, which is where `charter save` gets typed."""
+        deep = self.clone / "charter" / "frame"
+        deep.mkdir(parents=True)
+        rc, said = self.save_from(deep)
+        self.assertEqual(rc, 1, said)
+
+    def test_it_commits_nothing_in_the_outer_plane(self):
+        """Harm 1. Without the guard the outer plane's HEAD moves, carrying `NOTES.txt`."""
+        self.save_from(self.clone)
+        self.assertEqual(self.head(), self.base,
+                         "charter save moved the outer plane's HEAD from a nested clone")
+
+    def test_it_stages_nothing_in_the_outer_plane(self):
+        """Pins the guard's PLACEMENT, the half the HEAD check cannot see: a refusal that
+        has already run ``git add -A`` has done the damage and merely declined to name it —
+        the operator's next commit, by any hand, carries it."""
+        self.save_from(self.clone)
+        self.assertEqual(self.staged(), [],
+                         "the outer plane's index was left holding the operator's work")
+
+    def test_the_operators_mid_edit_file_is_left_uncommitted(self):
+        """Harm 1 stated as the thing actually lost: an arrangement the operator was in the
+        middle of editing, committed as deleted under someone else's message."""
+        self.save_from(self.clone)
+        self.assertIn("frame.component", self.git("show", "HEAD:charter.toml"))
+
+    def test_the_remedy_points_at_the_tree_that_holds_the_unsaved_work(self):
+        """Harm 2, pinned as the pairing it is. A refusal does not *save* the agent's work —
+        that file is uncommitted either way, so asserting "agent-work.txt is still untracked"
+        would be equally true of the defect and would measure nothing. What the guard owes is
+        that the tree it names in the remedy is the tree that really holds the work."""
+        _rc, said = self.save_from(self.clone)
+        st = self._git_in(self.clone, "status", "--porcelain")
+        self.assertIn("agent-work.txt", st)
+        self.assertIn(f"git -C {self.clone.resolve()}", said)
+
+    def test_it_leaves_the_clones_own_history_alone(self):
+        """The guard refuses; it does not quietly commit the other side instead."""
+        self.save_from(self.clone)
+        self.assertEqual(self.clone_head(), self.clone_base)
+
+
+class TestTheRefusalNamesBothTrees(PlaneInsideAPlane):
+    """The issue's third option: the only answer that does not silently pick a side.
+    Literals are hand-spelled — a test comparing a message against the constant that spells
+    it dies to nothing."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        rc, self.said = self.save_from(self.clone)
+        # A precondition, so that if the refusal stops happening these report that rather
+        # than quietly matching the success line, which names the plane's path too.
+        self.assertEqual(rc, 1, self.said)
+
+    def test_it_names_the_plane_the_caller_is_standing_in(self):
+        self.assertIn(str(self.clone.resolve()), self.said)
+
+    def test_it_names_the_plane_it_would_have_committed(self):
+        self.assertIn(str(self.plane), self.said)
+
+    def test_it_says_why_the_two_are_different(self):
+        """Not decoration. The caller is standing in a directory with a `charter.toml` in
+        it; without the word, the refusal reads as a bug in charter rather than as the
+        outward resolution doing exactly what it was built to do."""
+        self.assertIn("workspaces/", self.said)
+
+    def test_it_offers_git_for_the_callers_own_work(self):
+        self.assertIn(f"git -C {self.clone.resolve()}", self.said)
+
+    def test_it_offers_the_plane_for_the_planes_own_work(self):
+        self.assertIn("charter save", self.said)
+
+    def test_it_names_the_override(self):
+        """A guard with no documented override is a guard people uninstall (#370). This one
+        is honoured — `TestAnExplicitRootIsHonoured` below runs it."""
+        self.assertIn(root.ENV_VAR, self.said)
+
+    def test_it_does_not_call_the_clone_a_worktree(self):
+        """The two refusals must not be interchangeable. Telling an agent standing in a
+        clone that it is in a linked worktree sends it to `git worktree list`, where it
+        finds nothing and concludes charter is confused."""
+        self.assertNotIn("linked worktree", self.said)
+
+
+class TestThePlaneItselfIsUnchanged(PlaneInsideAPlane):
+    """The regression half. `nested_plane_in` answers ``None`` for a caller standing in the
+    plane being committed, so the ordinary path — which is nearly every caller — is
+    untouched."""
+
+    def test_it_commits(self):
+        rc, said = self.save_from(self.plane)
+        self.assertEqual(rc, 0, said)
+        self.assertNotEqual(self.head(), self.base)
+
+    def test_it_committed_the_operators_work(self):
+        self.save_from(self.plane)
+        self.assertIn("NOTES.txt", self.git("show", "--name-only", "--format=", "HEAD"))
+
+    def test_it_says_nothing_about_a_nested_plane(self):
+        _rc, said = self.save_from(self.plane)
+        self.assertNotIn("Refusing to stage", said)
+
+
+class TestAnOrdinaryRepoCloneIsNotRefused(PlaneInsideAPlane):
+    """The narrowness that keeps this from becoming "refuse from anywhere under
+    ``workspaces/``".
+
+    Most clones in a workspace are not planes. Standing in one, `charter save` commits the
+    plane — which is what it says it does, and there is no second plane for it to have meant.
+    Refusing there would break the documented command for the ordinary case, on a plane whose
+    workspaces are full of ordinary repos.
+    """
+
+    def test_a_clone_without_a_marker_still_saves_the_plane(self):
+        repo = self.plane / "workspaces" / "dev" / "widget"
+        repo.mkdir(parents=True)
+        (repo / "README.md").write_text("not a plane\n")
+        rc, said = self.save_from(repo)
+        self.assertEqual(rc, 0, said)
+        self.assertIn("NOTES.txt", self.git("show", "--name-only", "--format=", "HEAD"))
+
+
+class TestAnExplicitRootIsHonoured(PlaneInsideAPlane):
+    """``$CHARTER_ROOT=<clone>`` — the hatch the refusal itself prints.
+
+    An explicit override is a person saying "I mean this plane", and the plane they mean is
+    the one they are standing in, so `save` commits it. The harm this module refuses —
+    committing a tree the caller is not in — is not reachable this way, which is why the
+    guard is keyed on the relationship between the root and the cwd rather than on "is this
+    plane nested".
+    """
+
+    def test_it_commits_the_clones_own_tree(self):
+        self.addCleanup(config.restore, config.use(self.clone))
+        self.standing_in(self.clone)
+        rc, said = _run(commands.cmd_save, _save_args())
+        self.assertEqual(rc, 0, said)
+        self.assertIn("agent-work.txt",
+                      self._git_in(self.clone, "show", "--name-only", "--format=", "HEAD"))
+
+    def test_it_leaves_the_outer_plane_alone(self):
+        self.addCleanup(config.restore, config.use(self.clone))
+        self.standing_in(self.clone)
+        _run(commands.cmd_save, _save_args())
+        self.assertEqual(self.head(), self.base)
+        self.assertEqual(self.staged(), [])
+
+
+class TestPlaneStateStillReachesThePlane(PlaneInsideAPlane):
+    """The half that must NOT change, and the reason the guard is keyed on the add.
+
+    Reactive memory, the dispatch tally, the workspace manifest and the version pin all
+    reach `commit_push` with an add scoped to named plane-state files. Working inside a
+    clone is the ordinary way work happens on this plane, and every agent doing it writes
+    memory; refusing those would be a far larger harm than the one being fixed.
+    """
+
+    def test_a_scoped_add_still_commits_from_the_clone(self):
+        from charter import planegit
+        (self.plane / "memo.md").write_text("a memory\n")
+        self.standing_in(self.clone)
+        rc, said = _run(planegit.commit_push, self.plane, ["add", "--", "memo.md"],
+                        "persona: remember", no_push=True)
+        self.assertEqual(rc, 0, said)
+        self.assertIn("memo.md", self.git("show", "--name-only", "--format=", "HEAD"))
+
+
+class TestTheDetector(PlaneInsideAPlane):
+    """`root.nested_plane_in` on its own, including the shapes no `cmd_save` case reaches."""
+
+    def _plane_at(self, *parts: str) -> Path:
+        d = self.tmp.joinpath(*parts)
+        d.mkdir(parents=True, exist_ok=True)
+        (d / root.MARKER).write_text("schema = 1\n")
+        return d
+
+    def test_it_answers_the_clone(self):
+        self.assertEqual(root.nested_plane_in(self.plane, self.clone), self.clone.resolve())
+
+    def test_it_answers_none_standing_in_the_plane_itself(self):
+        self.assertIsNone(root.nested_plane_in(self.plane, self.plane))
+
+    def test_it_answers_none_for_a_directory_that_is_in_no_plane(self):
+        bare = self.tmp / "bare"
+        bare.mkdir()
+        self.assertIsNone(root.nested_plane_in(self.plane, bare))
+
+    def test_it_answers_none_for_an_unrelated_plane(self):
+        """The narrowness `enclosing_plane` already has: a plane somewhere else on disk is
+        not nested inside this one, and committing this one from there is not this defect."""
+        other = self._plane_at("elsewhere")
+        self.assertIsNone(root.nested_plane_in(self.plane, other))
+
+    def test_it_answers_none_when_the_nesting_is_not_through_workspaces(self):
+        """A ``charter.toml`` below the plane but not under its ``workspaces/`` is not a
+        clone charter made; `enclosing_plane` has never claimed it and neither does this."""
+        stray = self.plane / "docs" / "example"
+        stray.mkdir(parents=True)
+        (stray / root.MARKER).write_text("schema = 1\n")
+        self.assertIsNone(root.nested_plane_in(self.plane, stray))
+
+    def test_it_reaches_through_a_chain(self):
+        """A plane inside a plane inside a plane — the shape `_outermost` loops for. Asked
+        of the MIDDLE plane, so the answer cannot come from "outermost wins": under
+        ``$CHARTER_ROOT=<mid>`` the tree being committed is `mid`, and standing in `leaf`
+        commits a tree the caller is not in exactly as before."""
+        top = self._plane_at("top")
+        mid = self._plane_at("top", "workspaces", "a", "mid")
+        leaf = self._plane_at("top", "workspaces", "a", "mid", "workspaces", "b", "leaf")
+        self.assertEqual(root.nested_plane_in(top, leaf), leaf.resolve())
+        self.assertEqual(root.nested_plane_in(mid, leaf), leaf.resolve())
+        self.assertIsNone(root.nested_plane_in(leaf, leaf))
+
+    def test_it_answers_the_innermost_plane_not_an_intermediate_one(self):
+        """The caller is standing in `leaf`; naming `mid` in the remedy would send them to
+        run git in a tree that is not theirs either."""
+        top = self._plane_at("top2")
+        self._plane_at("top2", "workspaces", "a", "mid")
+        leaf = self._plane_at("top2", "workspaces", "a", "mid", "workspaces", "b", "leaf")
+        self.assertEqual(root.nested_plane_in(top, leaf), leaf.resolve())
+
+    def test_it_never_raises_on_a_path_that_is_gone(self):
+        """It sits on a command path, beside `tree_of`, which makes the same promise."""
+        self.assertIsNone(root.nested_plane_in(self.plane, self.tmp / "nope" / "gone"))
+        self.assertIsNone(root.nested_plane_in(self.tmp / "nope" / "gone", self.clone))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_save_from_a_nested_plane.py
+++ b/tests/test_save_from_a_nested_plane.py
@@ -435,6 +435,40 @@ class TestTheDetector(PlaneInsideAPlane):
         leaf = self._plane_at("top2", "workspaces", "a", "mid", "workspaces", "b", "leaf")
         self.assertEqual(root.nested_plane_in(top, leaf), leaf.resolve())
 
+    def test_a_start_reached_through_a_symlink_answers_the_real_directory(self):
+        """`start.resolve()`, pinned — and pinned WITHOUT relying on the platform's tmpdir.
+
+        This was a deletion-sweep survivor on CI and a pin on the developer's macOS, which is
+        the "your machine is not the runner" trap exactly: macOS `/tmp` is a symlink to
+        `/private/tmp`, so every fixture path there needs normalising and `resolve()` looks
+        pinned for free. On Linux `tempfile.mkdtemp()` already hands back a canonical path,
+        nothing needed normalising, and dropping the call changed nothing anywhere.
+
+        A symlink this test makes itself needs normalising on both. It is also the real case:
+        the answer is printed as `git -C <path>` in the refusal, and a path with a symlink
+        still in it names a directory the reader then cannot find in `git worktree list` or
+        match against anything else charter printed.
+        """
+        link = self.tmp / "via-a-link"
+        os.symlink(self.plane, link)
+        through = link / "workspaces" / "dev" / "charter"
+        self.assertEqual(root.nested_plane_in(self.plane, through), self.clone.resolve())
+
+    def test_a_plane_named_through_a_symlink_still_matches_the_chain(self):
+        """`plane.resolve()`, pinned — the other half of the pair, and reached with the first
+        one satisfied so the two cannot mask each other.
+
+        `enclosing_plane` resolves internally, so it answers the REAL enclosing plane. Leave
+        *plane* unresolved and the comparison is symlinked-path vs real-path: it never
+        matches, `nested_plane_in` answers `None`, and `charter save` commits the outer
+        plane exactly as #809 reports — for any operator whose plane is reached through a
+        symlink, which on macOS is every plane under `/tmp` and anywhere a home directory is
+        linked.
+        """
+        link = self.tmp / "plane-by-another-name"
+        os.symlink(self.plane, link)
+        self.assertEqual(root.nested_plane_in(link, self.clone), self.clone.resolve())
+
     def test_it_never_raises_on_a_path_that_is_gone(self):
         """It sits on a command path, beside `tree_of`, which makes the same promise.
 

--- a/tests/test_save_from_a_nested_plane.py
+++ b/tests/test_save_from_a_nested_plane.py
@@ -55,6 +55,7 @@ import unittest
 from contextlib import redirect_stderr, redirect_stdout
 from pathlib import Path
 from types import SimpleNamespace
+from unittest import mock
 
 from charter import commands, config, root
 from tests._isolation import PersonaIso
@@ -435,9 +436,74 @@ class TestTheDetector(PlaneInsideAPlane):
         self.assertEqual(root.nested_plane_in(top, leaf), leaf.resolve())
 
     def test_it_never_raises_on_a_path_that_is_gone(self):
-        """It sits on a command path, beside `tree_of`, which makes the same promise."""
+        """It sits on a command path, beside `tree_of`, which makes the same promise.
+
+        A missing path does not actually THROW — `Path.resolve` tolerates it and `is_file`
+        answers False — so this pins the ANSWER and nothing else.
+        `TestTheDetectorNeverRaises` is where the catches are pinned."""
         self.assertIsNone(root.nested_plane_in(self.plane, self.tmp / "nope" / "gone"))
         self.assertIsNone(root.nested_plane_in(self.tmp / "nope" / "gone", self.clone))
+
+
+class TestTheDetectorNeverRaises(PlaneInsideAPlane):
+    """The "never raises" promise, made observable.
+
+    Every one of these was a deletion-sweep SURVIVOR before it existed: the catches sat over
+    calls that no fixture could make fail, so `narrow-except` changed nothing anywhere and
+    the promise was asserted only by paths that never throw. A hostile filesystem is not
+    exotic on the path this sits on — an unreadable ancestor directory, a cwd deleted out
+    from under the process, a symlink loop — and this runs inside `charter save`, where an
+    escaping `OSError` is a traceback instead of a refusal.
+
+    Each case makes exactly ONE of the three calls throw, so the three catches are pinned
+    separately rather than by one blanket failure.
+    """
+
+    def _raising(self, module, attr, exc=OSError("unreadable")):
+        """The shape `tests/test_doctor_absent_is_not_health.py` uses: swap a module
+        attribute for one that throws, and put it back afterwards."""
+        def boom(*a, **kw):
+            raise exc
+        real = getattr(module, attr)
+        setattr(module, attr, boom)
+        self.addCleanup(setattr, module, attr, real)
+
+    def test_a_cwd_that_no_longer_exists(self):
+        """`Path.cwd()` raises `FileNotFoundError` when the process's working directory has
+        been deleted — the OSError half of the first catch. Reached with ``start=None``,
+        which is how `commit_push` calls it."""
+        with mock.patch.object(Path, "cwd", side_effect=FileNotFoundError("gone")):
+            self.assertIsNone(root.nested_plane_in(self.plane))
+
+    def test_a_symlink_loop_under_the_starting_directory(self):
+        """`Path.resolve()` raises `RuntimeError`, not `OSError`, on a symlink loop — the
+        other half of the first catch, and the reason it names two exception types. Narrow
+        it to `OSError` alone and this is a traceback out of `charter save`."""
+        with mock.patch.object(Path, "resolve", side_effect=RuntimeError("symlink loop")):
+            self.assertIsNone(root.nested_plane_in(self.plane, self.clone))
+
+    def test_an_ancestor_directory_that_cannot_be_read(self):
+        """`Path.is_file()` propagates `PermissionError` (it swallows only
+        ENOENT/ENOTDIR/EBADF/ELOOP, never EACCES) — the second catch, over the marker walk.
+        One unreadable directory between the caller and the plane is enough."""
+        with mock.patch.object(Path, "is_file", side_effect=PermissionError("denied")):
+            self.assertIsNone(root.nested_plane_in(self.plane, self.clone))
+
+    def test_the_walk_outward_hitting_an_unreadable_directory(self):
+        """The third catch, over `enclosing_plane` — which does its own `is_file` stat on
+        each ancestor and is documented as able to throw. Reached only from a caller that
+        IS in a nested plane, so the loop is entered before it fails."""
+        self._raising(root, "enclosing_plane")
+        self.assertIsNone(root.nested_plane_in(self.plane, self.clone))
+
+    def test_the_refusal_path_survives_it_too(self):
+        """The contract that matters to the caller: `charter save` degrades to committing
+        the plane, not to a traceback. `nested_plane_in` answering `None` means "no nested
+        plane I can see", and an unreadable tree is exactly that."""
+        self._raising(root, "enclosing_plane")
+        rc, said = self.save_from(self.clone)
+        self.assertEqual(rc, 0, said)
+        self.assertNotIn("Traceback", said)
 
 
 if __name__ == "__main__":

--- a/tests/test_save_from_a_nested_plane.py
+++ b/tests/test_save_from_a_nested_plane.py
@@ -282,8 +282,13 @@ class TestTheRefusalNamesBothTrees(PlaneInsideAPlane):
 
     def test_it_names_the_override(self):
         """A guard with no documented override is a guard people uninstall (#370). This one
-        is honoured — `TestAnExplicitRootIsHonoured` below runs it."""
-        self.assertIn(root.ENV_VAR, self.said)
+        is honoured — `TestAnExplicitRootIsHonoured` below runs it.
+
+        Hand-spelled, not `root.ENV_VAR`. Asserting a message against the constant that
+        spells it dies to nothing: rename the variable and the message, the docs and the news
+        entry all change together while this still passes. The words are the contract —
+        somebody is going to copy this line out of a terminal."""
+        self.assertIn("CHARTER_ROOT=", self.said)
 
     def test_it_does_not_call_the_clone_a_worktree(self):
         """The two refusals must not be interchangeable. Telling an agent standing in a


### PR DESCRIPTION
Closes #809.

## Reproduced first, on a throwaway plane

A real `git clone` of a plane into `workspaces/dev/charter` — where `charter clone` puts
clones — plus the `.gitignore` `charter init` writes. The operator is mid-edit in the outer
plane; the agent's own change sits in the clone. `charter save "agent: unrelated security
fix"`, typed in the clone, on `origin/main`:

```
✓ Committed a581f80 in /…/plane: agent: unrelated security fix  (1 file(s))
 NOTES.txt | 1 +
--- the agent's own work, in the clone ---
?? agent-work.txt
```

Exit 0. Both harms the issue names, confirmed rather than taken on trust:

1. the outer plane's untracked `NOTES.txt` committed under the agent's message;
2. the agent's own work not committed at all, and the clone's `HEAD` not moved.

**One thing the issue does not name, and it is not a harm.** A first fixture, without
`charter init`'s `/workspaces/*/*` ignore line, also recorded the clone as a **gitlink** in
the outer plane's index. Real planes ignore that path, so it cannot happen; the fixture now
asserts the ignore rule as a precondition so the case under test stays the one real planes
reach.

## The seam, and why the worktree route was not it

The issue's framing holds up under measurement, so this follows it.

`root.tree_of` is path arithmetic on the `.git` **file** git writes into a linked worktree.
A clone has a real `.git` **directory** — asserted in the fixture, not assumed:

```python
self.assertTrue((self.clone / ".git").is_dir())
self.assertIsNone(root.main_worktree_of(self.clone))
self.assertIsNone(root.tree_of(self.plane, self.clone))
```

So `tree_of` answers `None` here and **must keep doing so**: its own docstring says the
narrowness is the point, and widening it to "am I inside any other plane" is
`enclosing_plane`'s question, answered on purpose in a different way. This is a second
detector, `root.nested_plane_in`, sitting beside #808's in the same `stages_the_whole_tree`
block — not a widening of the first.

**`_outermost` is not the problem and is untouched.** It decides *identity* — vault,
personas, memory — and #200 measured what happens when identity lands in the inner clone.
What was wrong is `charter save` inheriting an answer meant for identity and using it to
pick a *working tree*, which is exactly the plane/tree distinction `tree_of`'s docstring
already draws.

## Refuse, not "commit the inner one"

The issue offered three answers. Committing the inner plane would make `save` disagree with
every other command about which plane it acts on — `persona remember`, the vault, the
dispatch tally and the workspace manifest all follow `config.ROOT` outward — and split the
plane in two. Committing the outer one is the defect. So charter names both trees:

```
✗ Refusing to stage all of /…/plane — you are standing in /…/plane/workspaces/dev/charter,
  a control plane of its own under that plane's workspaces/. charter resolves outward to the
  plane holding the vault, so committing every change there would take that tree's
  uncommitted work under your message, and leave your own work here unsaved.
•   your own work:   git -C /…/workspaces/dev/charter add -A && git -C /…/workspaces/dev/charter commit
•   the plane's own: run `charter save` from /…/plane
•   you really do mean this plane: CHARTER_ROOT=/…/workspaces/dev/charter charter save
```

## Two details that are load-bearing

**Root-relative, like `tree_of`.** The question is not "is this plane nested" but "is the
caller standing in a plane nested inside *the plane being committed*". Under
`CHARTER_ROOT=<the clone>` the plane being committed is the one they are standing in, so the
answer is `None` and the save proceeds — which it must, because the refusal prints that
hatch. A detector keyed on the existing `standing_in_nested_plane` would have refused there
too and made its own advice a lie.

**The chain is walked, not shortcut through `_outermost`.** `_outermost(inner) == plane`
looks equivalent and is not: three planes deep, under `CHARTER_ROOT=<the middle one>`, the
outermost is not the tree being committed, yet standing in the leaf still commits a tree the
caller is not in.

## What still works

Only the **unbounded** stage refuses. `charter save` is the only caller of `commit_push`
that stages the whole tree; reactive memory, the dispatch tally, the workspace manifest and
`version pin --push` all name plane-state files and keep committing to the plane from inside
a clone — pinned by `TestPlaneStateStillReachesThePlane`. Working inside a clone is the
ordinary way work happens on a charter plane and every agent doing it writes memory, so
refusing that would be a larger harm than the one being fixed. An ordinary (non-plane) repo
clone in a workspace is not refused either, for the same reason: there is no second plane
there, and `charter save` does what it says.

## Also in here

`docs/control-plane.md`'s "Nested planes" section said charter "takes the **innermost**
`charter.toml`" and that "the rule does not change". Measured, `find_root` answers the
**outer** plane — the page went stale when #140/#200 changed resolution. It is a
pre-existing defect, but it is the page a reader lands on after this refusal, whose message
says charter resolves outward, so it moves with the code.

## Verification

- Full suite the way CI loads it: `python3 -m unittest discover -s tests` → `Ran 10484 tests … OK (skipped=9)`.
- New test red before the fix (12 failures, 8 errors), green after (39 tests).
- #808's `test_save_commits_the_tree_you_are_standing_in.py` unchanged and green (32 tests).
- `git diff --diff-filter=D --name-only origin/main...` — empty.
- stdlib only; `unittest`, not pytest; news entry included.


## Deletion sweep

Final CI verdict — read off the check NAME, not the job conclusions, every one of which says
`success`:

```
no verdict: 1 not measured
gate: 0 unpinned, 0 in masked cluster(s), 0 platform-deferred,
      1 unresolved, 0 out of time, 0 not applied, 0 withheld, 8 pinned
```

It took three rounds to get there, and each survivor is accounted for rather than waved
through.

**Round 1 — 10 mutations, 5 survived.** Three were the `except` branches: `narrow-except`
changed nothing anywhere because no fixture could make the call under them fail, so "never
raises" was asserted only by paths that never throw. `TestTheDetectorNeverRaises` now makes
each throw separately, in the shape `test_doctor_absent_is_not_health.py` established —
`Path.cwd` → `FileNotFoundError` (deleted cwd), `Path.resolve` → `RuntimeError` (symlink loop,
*not* an `OSError`, which is why that catch names two types), `Path.is_file` →
`PermissionError` (unreadable ancestor), `enclosing_plane` → `OSError` on the walk outward.

Two more were **genuinely unreachable and were deleted**: `seen` and the `inner == target`
short-circuit. `enclosing_plane` answers an element of `here.resolve().parents`, so every hop
is a strictly *shorter* resolved path — the chain cannot revisit anything, and cannot arrive
back at `inner`. `_outermost`'s older copy of the same guard is charged to nobody and is left
alone; the docstring says why, so nobody restores a set that provably never holds a second
element. The `inner is None` half became `for/else`, so dropping it is a `NameError` instead
of a silent `enclosing_plane(None)` that consults the process cwd.

**Round 2 — CI said `2 survivors, 1 not measured` where macOS said none.** The pair was
`[drop-normalise]` on the two `resolve()` calls, classified `2 in masked cluster(s)`. This is
CONTRIBUTING's *"your machine is not the runner"* precisely: macOS `/tmp` is a symlink to
`/private/tmp`, so every fixture path there needs normalising and both calls looked pinned
for free; on Linux `mkdtemp()` is already canonical and dropping either changed nothing. Two
tests now build their **own** symlink, so the answer no longer depends on the platform's
tmpdir, and each reaches one call with the other satisfied — which is what unmasks a masked
pair. Verified by applying each mutation to that line alone.

**One mutation has no verdict, and it is not a survivor.** `if outer is None: return None` is
the loop's only exit; drop it and the run hangs rather than fails, which is what `UNRESOLVED`
means here — confirmed by hand. Bounding the loop so it terminates would convert a caught
mutant into a genuinely silent survivor, so `while True` stays and the sweep is left saying
truthfully that it could not measure this one.

## One CI flake, filed rather than papered over

`test_a_workspace_tab_opens_what_it_names.py` failed on the `push` runs of both pushes with
`AssertionError: 1 != 0 : server exited unexpectedly` — the fixture's own `tmux new-session`,
before any code under test. The `pull_request` runs at the *same shas* were green, and
`gh run rerun --failed` at `f8c9cef` turned all four red jobs green with nothing changed.
That is the shape #694 already named for a different file. Filed as #839 rather than edited
here, because the file exercises `charter/commands_frame.py`, which is being worked on
concurrently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014dq9Q2fGzos3iJ46PZFdMP
