### PR TITLE
A renamed workspace keeps its chats, and one that is gone stops being drawn as an empty one (#795, #752)

### DIFF
--- a/charter/commands_frame.py
+++ b/charter/commands_frame.py
@@ -8708,7 +8708,7 @@ def _reopen_one(c) -> "Reopening | None":
         return None
     util.info(f"  {c.chat} → {r.fid} · {leave.RESUMES if rest else 'empty'}"
               + (" · workspace is missing" if c.workspace
-                 and not workspace.workspace_dir(c.workspace).is_dir() else ""))
+                 and not workspace.exists(c.workspace) else ""))
     return r
 
 

--- a/charter/commands_workspace.py
+++ b/charter/commands_workspace.py
@@ -267,10 +267,11 @@ def cmd_workspace_remove(args) -> int:
 
 def cmd_workspace_rename(args) -> int:
     """Rename a workspace: move workspaces/<old>/ → workspaces/<new>/ (clones, memory,
-    refs, and manifest come along), fix the manifest name + liveness block, and repoint
+    refs, and manifest come along), fix the manifest name + liveness block, repoint
     the active session/terminal pointer + lock so a renamed active workspace stays
-    active. For a LIVE workspace, commit the tracked move (manifest + memory) so the
-    rename propagates to the team."""
+    active, and repoint every chat that says it is in the workspace (#795) so none of
+    them is orphaned. For a LIVE workspace, commit the tracked move (manifest + memory)
+    so the rename propagates to the team."""
     old, new = args.old, args.new
     if not workspace.valid_name(new):
         util.err(f"invalid workspace name '{new}' (use lowercase letters, digits, . _ -)")
@@ -293,8 +294,20 @@ def cmd_workspace_rename(args) -> int:
         r = _git(["ls-files", "-z", "--", f"workspaces/{old}"], cwd=config.ROOT)
         tracked_old = [p for p in r.stdout.split("\0") if p]
 
-    workspace.rename(old, new)
+    moved = workspace.rename(old, new)
     util.ok(f"Renamed workspace '{old}' → '{new}' (clones, memory, and manifest moved).")
+    if moved:
+        # #795: the chats came too. A rename that silently re-labels running conversations
+        # is one the operator finds out about from a panel; this is the sibling of the
+        # "this session's active workspace followed the rename" line below, for the noun
+        # that is a chat's identity rather than a session's work.
+        #
+        # A COUNT and not the ids. Every id in `moved` reached it through `contain.child`
+        # (`state.frame_dir`, which every reader in `rename_workspace` goes through), so a
+        # `contain.one_line` here would be a guard nothing could turn red — which this repo
+        # deletes rather than ships. `new` is `valid_name`-checked at the top of this
+        # function.
+        util.info(f"{len(moved)} chat(s) in '{old}' followed the rename → '{new}'.")
     if workspace.resolve() == new and workspace.source() in ("session", "active-file"):
         util.info(f"This session's active workspace followed the rename → '{new}' (still 🔒 locked).")
 

--- a/charter/frame/leave.py
+++ b/charter/frame/leave.py
@@ -89,8 +89,10 @@ class Doomed(NamedTuple):
     #: recorded and not brought back; it is listed by nothing and appears here only so
     #: :func:`plan` has one place that drops it.
     closed: bool
-    #: Whether the workspace this chat belongs to still has a directory on disk. §4j
-    #: forbids re-homing a chat, so a missing workspace is *reported*, never repaired.
+    #: Whether the workspace this chat belongs to still has a directory on disk
+    #: (`workspace.exists`, the one predicate the repo pane asks too — #752). §4j forbids
+    #: re-homing a chat, so a missing workspace is *reported*, never repaired; a RENAMED
+    #: one is not missing at all, because `workspace.rename` repoints the chat (#795).
     homeless: bool
     #: Whether the recorded cwd is still a directory.
     cwd_gone: bool
@@ -162,7 +164,7 @@ def plan(*, live, focus: str, only: str = "") -> Plan:
             active=False,
             exit_code=state.exit_code(fid),
             closed=False,
-            homeless=bool(ws) and not ws_mod.workspace_dir(ws).is_dir(),
+            homeless=bool(ws) and not ws_mod.exists(ws),
             cwd_gone=bool(cwd) and not os.path.isdir(cwd),
         ))
     return Plan(chats=tuple(out), focus=focus)

--- a/charter/frame/slots.py
+++ b/charter/frame/slots.py
@@ -720,8 +720,9 @@ class _Viewport:
         """Record which repo each row of the pane is about, the paint that just happened.
 
         Indexed by the PANE's row, not the table's: `_repos` puts a heading on row 0 and
-        the table under it, and the three one-line answers it draws instead of a table
-        (`_unknown_lines`, `_empty_lines`, `_too_narrow_lines`) publish nothing at all —
+        the table under it, and the one-line answers it draws instead of a table
+        (`_gone_lines`, `_unknown_lines`, `_unreadable_lines`, `_empty_lines`,
+        `_too_narrow_lines`) publish nothing at all —
         through :meth:`blank`, which is the one call that says so, because such a paint
         has a bound to record as well. So a click on the heading, on a message, or below
         the last row lands on ``None`` and is not a selection — which is the same rule
@@ -735,11 +736,12 @@ class _Viewport:
 
         **The two halves of a paint are recorded together, because a paint that recorded
         one and not the other is the defect this method exists to make unwriteable.**
-        `_repos` has four ways out and three of them draw a single sentence instead of a
-        table (`_too_narrow_lines`, `_unknown_lines`, `_empty_lines`). Each cleared the
-        click map and none of them touched the bound, so a pane that had been scrolled and
-        then lost its table — the terminal narrowed below `statusline._LEFT_W`, the gather
-        cache went away, the workspace's last clone was removed — kept whatever
+        `_repos` has five ways out and four of them draw a single sentence instead of a
+        table (`_too_narrow_lines`, `_gone_lines`, `_unknown_lines`, `_empty_lines`). Each
+        cleared the click map and none of them touched the bound, so a pane that had been
+        scrolled and then lost its table — the terminal narrowed below `statusline._LEFT_W`,
+        the gather cache went away, the workspace's last clone was removed, the workspace
+        itself was removed — kept whatever
         :meth:`settle` recorded for the TALLER table that was there before. The handler
         reads that bound and nothing else (§4f), so every wheel notch over the sentence
         answered truthy and the panel repainted a byte-identical line, once per notch:
@@ -1240,14 +1242,78 @@ def _unreadable_lines(fid: str, ws: str, width: int) -> list[str]:
     it. The pane says what is true and the operator decides.
 
     One line, bounded through `tui.truncate` like every other line in this module — *fid*
-    and *ws* are both arbitrary length, and `tui.sanitize` under that truncate is what
-    contains a `$CHARTER_WORKSPACE` no rung ever checked (see :func:`_empty_lines`).
+    and *ws* are both arbitrary length. **The bound is about that length and not about
+    content**, since #752: `_repos` reaches this branch only past `workspace.exists(ws)`,
+    which name-checks before it asks the filesystem, so a `$CHARTER_WORKSPACE` no rung ever
+    checked now reaches :func:`_gone_lines` instead and never this one. See
+    :func:`_empty_lines`, which says the same thing at length about the line beside it.
     """
     from .. import statusline as sl
 
     return [tui.truncate(
         f"  {sl._DIM}unreadable repo cache · charter frame-gather --session{sl._R} "
         f"{fid}{sl._DIM} --workspace{sl._R} {ws}", width)]
+
+
+def _gone_lines(ws: str, width: int) -> list[str]:
+    """What the `repos` pane draws when this frame's workspace is not on disk at all.
+
+    **The fourth state, and #752 is the cost of not having had one.** Every other sentence
+    this pane can say is about a workspace that is THERE: `_unknown_lines` is a gather that
+    has not landed in it, `_unreadable_lines` is a cache that will not read for it,
+    :func:`_empty_lines` is a scan of it that found no clones. A frame outlives the
+    directory it draws — `charter workspace remove`, a `git clean` on the plane, a
+    teammate's pull and a plain `mv` all take one away while a frame is running, and a
+    frame is by definition long-lived enough for that to happen — and absence was spelled
+    with whichever of those three the cache happened to reach. The reported reading is the
+    first: `0 todos`, no rows, and `⋯ gathering this workspace's repos…` for as long as the
+    frame stayed up, because a panel never gathers on its own and none of the four ways a
+    workspace can be taken away is something charter can hook.
+
+    **Asked from the two branches that were about to say "nothing here", and never above
+    the cache.** ``gather.json`` lives under `.charter/` and not under `workspaces/`, so a
+    removed workspace leaves its last scan exactly where it was — and this line does NOT
+    override it. A panel "never gathers on its own — it reads the cache or says it has
+    none" (`docs/frame.md`), so a renderer that contradicted its own cache from a `stat`
+    would be re-deriving, on every repaint of every frame, state the gather owns. What that
+    leaves is a table that is stale rather than a pane that is wrong about which state it
+    is in, and it converges on its own: `gather.scan` reads `workspace.clones`, which
+    answers nothing for a workspace with no directory, so the first refresh after the
+    removal empties the cache and this line is what the pane draws.
+
+    **A fact at the moment it is asked**, `workspace.exists` — which is `gather.unreadable`'s
+    rule for the noun one level up, and for the same reason: the alternative is to infer
+    absence from an empty scan, and "gathered, nothing there" and "there is nothing to
+    gather" are two different claims. #512 is what drawing two claims as one sentence
+    already cost this pane once.
+
+    **It names the command that makes the workspace exist again**, which is
+    :func:`_empty_lines`' shape and its reason — a line that names a problem and not its fix
+    costs a row and settles nothing. `charter workspace create <ws>` is the same remedy
+    `commands_workspace` already prints for this fact (`no workspace 'x' (create it: …)`),
+    and it is the one that works whether or not the workspace was LIVE; `restore` needs a
+    committed manifest, which a LOCAL workspace never has. No key is named, for
+    :func:`_unreadable_lines`' measured reason: a frame running as a window in an
+    operator's own tmux has no `F2` of charter's to offer.
+
+    **Nothing is repaired by drawing.** Re-creating the directory would put a write on the
+    repaint path #387 pinned at one `stat`, would hide whatever removed it, and would hand
+    back a workspace with none of the clones it had. The pane says what is true and the
+    operator decides — `_unreadable_lines`' rule, and the same one that makes a RENAMED
+    workspace a different answer entirely: `workspace.rename` repoints the chat, so this
+    line is never how a rename shows up (#795).
+
+    One line, bounded through `tui.truncate` like every other line in this module. *ws* is
+    arbitrary length AND arbitrary content — `state.workspace_for`'s last rung hands back
+    `$CHARTER_WORKSPACE` untouched (see :func:`_empty_lines` on exactly this) — so the
+    `tui.sanitize` under that truncate is what keeps a newline in the name from making this
+    pane two rows tall.
+    """
+    from .. import statusline as sl
+
+    return [tui.truncate(
+        f"  {sl._DIM}no workspace{sl._R} {ws}{sl._DIM} · charter workspace create "
+        f"{ws}{sl._R}", width)]
 
 
 def _empty_lines(ws: str, width: int) -> list[str]:
@@ -1271,26 +1337,28 @@ def _empty_lines(ws: str, width: int) -> list[str]:
     the same. That one is reached when `gather.cached` answers ``None``; this one when it
     answers a real scan with no rows in it.
 
-    **No `contain.one_line` over *ws*, and the reason is `tui.sanitize`, not the name
-    rungs.** It would be comfortable to say every rung of `state.workspace_for` checks its
-    answer against `instance.WORKSPACE_NAME_RE` (`^[A-Za-z0-9][A-Za-z0-9._-]*$`) — rung 0
-    does, through `valid_name` — but the LAST rung does not: it is `workspace.resolve()`,
-    which hands back `$CHARTER_WORKSPACE` stripped and otherwise untouched. Measured:
-    with `CHARTER_WORKSPACE='ev\\nil\\x1b[31m;rm -rf /'` and no session pointer and no
-    recorded launch workspace, rung 0 rejects it, rungs 1 and 2 have nothing, and rung 3
-    returns that exact string — which arrives here verbatim.
+    **No `contain.one_line` over *ws*, and since #752 the reason is LENGTH rather than
+    content.** It used to be neither, and the true reason is worth spelling twice. It was
+    never that every rung of `state.workspace_for` checks its answer against
+    `instance.WORKSPACE_NAME_RE` (`^[A-Za-z0-9][A-Za-z0-9._-]*$`) — rung 0 does, through
+    `valid_name`, and the LAST rung does not: it is `workspace.resolve()`, which hands back
+    `$CHARTER_WORKSPACE` stripped and otherwise untouched, so
+    `CHARTER_WORKSPACE='ev\\nil\\x1b[31m;rm -rf /'` really did arrive here verbatim.
 
-    What contains it is the `tui.truncate` call below, which runs `tui.sanitize` first:
-    the newline is not charter's markup, so it is replaced and the pane still gets ONE
-    line; the SGR is passed through as colour, which costs zero columns and cannot move a
-    cursor. That is the guarantee this module leans on everywhere — a value nobody has
-    thought about yet is contained at the point it is drawn, not by a rung nobody
-    re-checked. `_top` interpolates the same value on the same terms, and has since
-    before #515. Naming the wrong reason is how a guard gets deleted later for being
-    redundant against a property that was never true.
+    **It cannot any more, and that is a fact about the CALLER and not about this line.**
+    `_repos` reaches this branch only past `workspace.exists(ws)`, which asks `valid_name`
+    before it asks the filesystem (`workspaces/..` is a real directory, so a
+    filesystem-only predicate would answer "present" for a name that is not a workspace).
+    So the name in this sentence has passed the alphabet, which holds no newline and no
+    ESC — and :func:`_gone_lines` is where a name nobody checked now lands, and where the
+    `tui.sanitize` half of the argument moved with it.
 
-    What is NOT free either way is the WIDTH: the name is arbitrary length, so the line
-    is measured through `tui.truncate` like every other line in this module.
+    What is NOT bounded by that check is the WIDTH: a workspace name is arbitrary length,
+    and an untruncated line here is a pane wider than itself, which wraps into the second
+    row this slot must never have. So the line is measured through `tui.truncate` like
+    every other line in this module — for the reason stated, and not for one that stopped
+    being true, because naming the wrong reason is how a guard gets deleted later against
+    a property that was never the one it had.
     """
     from .. import statusline as sl
 
@@ -2820,13 +2888,13 @@ def _repos(fid: str) -> str:
     end (see :func:`_table_lines`), so a starved pane never claims one clean repo is the
     whole plane.
 
-    **Three states, three different sentences, because they are three different claims.**
-    A gather that has not run yet is `_unknown_lines`; a gather that ran and found
-    nothing is :func:`_empty_lines`; anything else is the table. #512 is the cost of
-    drawing the first two the same, and #515 is the cost of drawing the second one as an
-    empty rectangle — which is what an unmodified `_table_lines` returning `[]` would now
-    be, since this pane no longer has an attention row above it to make its emptiness
-    read as "nothing to add".
+    **Four states, four different sentences, because they are four different claims.** A
+    workspace that is not on disk at all is :func:`_gone_lines` and is asked FIRST (#752);
+    a gather that has not run yet is `_unknown_lines`; a gather that ran and found nothing
+    is :func:`_empty_lines`; anything else is the table. #512 is the cost of drawing two of
+    them the same, and #515 is the cost of drawing "nothing there" as an empty rectangle —
+    which is what an unmodified `_table_lines` returning `[]` would now be, since this pane
+    no longer has an attention row above it to make its emptiness read as "nothing to add".
 
     **One `gather.cached`, and no repo directory touched.** #387 pinned a panel's idle
     tick at exactly one `stat` — `panel._tick`'s single `state.version(fid)`, which every
@@ -2856,7 +2924,7 @@ def _repos(fid: str) -> str:
       three one-line answers below publish nothing, which is what makes a click on
       `gathering this workspace's repos…` not a selection.
 
-    **All four ways out record BOTH, and the three that draw no table say so in one call**
+    **All five ways out record BOTH, and the four that draw no table say so in one call**
     (:meth:`_Viewport.blank`). They used to clear the map and leave the bound where the
     last table put it, so a pane whose terminal had narrowed, whose cache had gone or whose
     workspace had lost its last clone still answered every wheel notch truthy — repainting
@@ -2921,8 +2989,28 @@ def _repos(fid: str) -> str:
         # repaints its way back to a readable cache. `gather.unreadable` is the second
         # question, asked ONLY here and only once `cached` has already said `None`: it is
         # a fact about a file on disk at the moment this line is drawn, never a timeout.
+        #
+        # **Three, not two** (#752). Both sentences below are about a workspace that is
+        # THERE — one gather has not landed, one never will — and neither is true of a
+        # workspace that is not on disk at all, which is the state a frame reaches by
+        # outliving its own directory (`charter workspace remove`, a `git clean`, a
+        # teammate's pull, a plain `mv`). Asked FIRST of the three, because "there is
+        # nothing to gather" is the reason the other two are waiting for something that is
+        # not coming. `workspace.exists` is `gather.unreadable`'s rule one noun up: a fact
+        # about the filesystem at the moment the pane is drawn, never a duration.
+        #
+        # `ws` is resolved HERE and in the `if not repos` branch below, rather than once
+        # above the cache, so that the path which draws a TABLE pays for neither: the
+        # `state.workspace_for` behind `_frame_workspace` is two file reads (`identity`
+        # and the launch record) and this pane is repainted on every version bump. That is
+        # exactly where it was resolved before #752 — the new question is asked beside the
+        # old ones and did not move them onto the hot path.
+        from .. import workspace as ws_mod
+        ws = _frame_workspace(fid)
+        if not ws_mod.exists(ws):
+            return "\n".join(_gone_lines(ws, w))
         if gather.unreadable(fid):
-            return "\n".join(_unreadable_lines(fid, _frame_workspace(fid), w))
+            return "\n".join(_unreadable_lines(fid, ws, w))
         return "\n".join(_unknown_lines(w))
     repos = data.get("repos") or []
     if not repos:
@@ -2930,7 +3018,19 @@ def _repos(fid: str) -> str:
         # empty bordered rectangle — see :func:`_empty_lines`. No heading: `▪ repos 0`
         # above "no clones in demo" is the same fact twice in a two-row pane.
         VIEWPORT.blank()
-        return "\n".join(_empty_lines(_frame_workspace(fid), w))
+        # The other half of the same question, and it is asked twice rather than once
+        # above the cache ON PURPOSE. Above it, this would override a table the cache
+        # still has — and a panel "never gathers on its own: it reads the cache or says it
+        # has none" (docs/frame.md), so a renderer that contradicted its own cache from a
+        # `stat` would be re-deriving state the gather owns, on every repaint of every
+        # frame. Here it costs nothing on the path that draws a table and separates the
+        # two claims that were one sentence: `no clones in <ws>` is a workspace with
+        # nothing cloned into it, which is not what an absent one is.
+        from .. import workspace as ws_mod
+        ws = _frame_workspace(fid)
+        if not ws_mod.exists(ws):
+            return "\n".join(_gone_lines(ws, w))
+        return "\n".join(_empty_lines(ws, w))
     # The heading takes the first row and the table spends what is left. Asked for fewer
     # ROWS rather than sliced afterwards, so what survives at `terse` (or in a pane a
     # resize starved) is still `_pick_rows`' ranked subset — the repo you are standing

--- a/charter/frame/state.py
+++ b/charter/frame/state.py
@@ -1065,6 +1065,26 @@ def rename_workspace(old: str, new: str) -> list[str]:
     frame's own session and nothing else is coming — #748's cost exactly: a record written
     in silence is a panel that goes on contradicting it for as long as the frame is idle.
 
+    **The read is `.strip()` and not `.lstrip()`, because it has to be the reading
+    :func:`own_workspace` makes.** That function answers the pin as
+    ``identity(fid).get("CHARTER_WORKSPACE", "").strip()``, and `_frame_identity_env` copies
+    the launcher's environment verbatim — so a shell that exported ``CHARTER_WORKSPACE=
+    "alpha "`` gives a chat whose recorded pin has a trailing space and whose MEMBERSHIP is
+    `alpha` all the same. Compared any other way, this walk repoints a different set from
+    the roster it claims to be following, and the chats it skipped are orphaned by the fix
+    for orphaning. The deletion sweep found it as a survivor and it is pinned rather than
+    softened; what goes back is the clean *new*, so a repoint also tidies the value.
+
+    **No ordering on the scan, and that is a deletion rather than an omission.** It was
+    `sorted(...)`, the sweep survived removing it, and the classification is *equivalent*
+    rather than *untested*: every frame is repointed independently of every other, each
+    writer swallows its own failures, and the only consumer of the answer is a COUNT
+    (`commands_workspace.cmd_workspace_rename`). There is no order for a test to observe,
+    so a test asserting one would be asserting the filesystem's. The list is still
+    materialised INSIDE the ``try``, and that is not incidental: `os.scandir` is lazy, so a
+    directory that becomes unreadable part-way through raises during iteration and not at
+    the call.
+
     **No `is_dir()` filter on the scan, and its absence is deliberate.** `leave.plane_chats`
     keeps one for a measured reason (#733) — a loose FILE called `api.2` in the frame root
     is a name that would otherwise reach a tmux target — and that reason does not exist
@@ -1081,7 +1101,7 @@ def rename_workspace(old: str, new: str) -> list[str]:
     """
     moved: list[str] = []
     try:
-        names = sorted(e.name for e in os.scandir(_root()))
+        names = [e.name for e in os.scandir(_root())]
     except OSError:
         return moved
     for fid in names:

--- a/charter/frame/state.py
+++ b/charter/frame/state.py
@@ -997,9 +997,14 @@ def own_workspace(fid: str) -> str | None:
 
     Two consequences, both deliberate. `docs/frame.md` no longer promises that `ws use`
     "moves the panels too", because it no longer does. And a chat with a pointer used to
-    follow a workspace RENAME (#752) while a chat without one was orphaned; every chat now
-    behaves like the second kind — more uniform, and a behaviour change rather than a
-    repair.
+    follow a workspace RENAME while a chat without one was orphaned; dropping the rung made
+    every chat behave like the second kind — more uniform, and worse in one respect,
+    because the repair route went with it (#795). **That is closed from the other end, by
+    :func:`rename_workspace`**: `workspace.rename` repoints both of the rungs below, so a
+    rename orphans nothing and needs no pointer to be a rung. §4j is untouched by it — a
+    rename does not move a chat between workspaces, it renames the one the chat is already
+    in — and a workspace that is GONE is the other answer, which `slots._repos` now says
+    out loud instead of drawing empty (#752).
 
     ``None`` where both rungs are empty, and that is a real answer rather than a failure:
     "this chat says nothing" belongs in nobody's roster, while :func:`workspace_for` still
@@ -1016,6 +1021,82 @@ def own_workspace(fid: str) -> str | None:
     if ws_mod.valid_name(pin):
         return pin
     return frame_workspace(fid)
+
+
+def rename_workspace(old: str, new: str) -> list[str]:
+    """Repoint every frame record that says ``old`` at ``new`` — the ids that moved.
+
+    **`workspace._rename_active_pointers`, one noun out, and #795 is the gap between the
+    two.** That function rewrites every per-session and per-terminal pointer whose VALUE is
+    the old name, so a renamed workspace stays the one its sessions act on. Since #791
+    those pointers are no longer rungs of :func:`own_workspace`, and nothing did the same
+    for the two rungs that are — so `charter workspace rename alpha alpha2` left every chat
+    in `alpha` still saying `alpha`: `chats.of_workspace("alpha2")` empty, and with it
+    `commands_frame._plane_session`, which is how a workspace tab and `charter -w` find a
+    plane's live session (BY its chats, never by a tmux session name). The chats were not
+    merely mislabelled; they were unreachable, and typing `charter workspace use alpha2`
+    inside one no longer repaired it because that pointer stopped being a rung.
+
+    **This is not §4j's "moving a chat between workspaces", and the design said so
+    first.** §4j forbids re-homing a chat because "the harness's own context — its cwd, its
+    files, its history — is suddenly about a different plane". A rename moves no chat: the
+    clones, the memory and the cwd travel with the directory, the siblings are the same
+    siblings, and the only thing that changed is what the workspace is called. Following it
+    is the chat KEEPING its identity, and :func:`new_chat_id` already reserved the mechanism
+    in as many words — "`frame_workspace` reads the workspace out of the frame's own
+    ``workspace`` file, **which can be repointed**, and the bars show that rather than the
+    prefix of the id". What §4j forbids and this does not do is rewrite the ID: `alpha.1`
+    stays `alpha.1` beside a later `alpha2.3`, because every `$CHARTER_SESSION_ID` already
+    exported into a live process spells the old one.
+
+    **Both rungs, each on its own value.** A frame's pin (`$CHARTER_WORKSPACE` as the launch
+    recorded it) outranks its launch record, so a walk that rewrote only the record would
+    leave a PINNED chat exactly as orphaned as before. They are matched independently for
+    `_rename_active_pointers`' reason: what moves is a record whose value is the old name,
+    not every record belonging to a frame that had one.
+
+    **A frame with no identity record is left without one.** :func:`identity` answers ``{}``
+    for a frame launched by a charter that predates it, and every reader treats that as "do
+    not take this frame's identity from here"; writing one here would hand a migration-era
+    frame a pin nobody set, which then outranks every rung below it.
+
+    **Each mover is :func:`bump`ed, because a panel repaints on a version bump and on
+    nothing else.** The rename is typed in ANOTHER terminal, so no hook fires inside the
+    frame's own session and nothing else is coming — #748's cost exactly: a record written
+    in silence is a panel that goes on contradicting it for as long as the frame is idle.
+
+    **No `is_dir()` filter on the scan, and its absence is deliberate.** `leave.plane_chats`
+    keeps one for a measured reason (#733) — a loose FILE called `api.2` in the frame root
+    is a name that would otherwise reach a tmux target — and that reason does not exist
+    here: nothing this function finds is handed to tmux, and the two questions it asks of a
+    name are :func:`frame_workspace` and :func:`identity`, both of which open a file INSIDE
+    the name and answer ``None``/``{}`` for a plain file (``NotADirectoryError`` is an
+    ``OSError``, which both already catch). So the filter could not change an outcome, and
+    a guard kept for a reason that is not the true one is how the real one gets deleted
+    later.
+
+    Best-effort at every step like the writers it calls: a frame root that cannot be listed
+    yields ``[]`` and a rename that could not repoint a chat is a chat that says the old
+    name, never a rename that half-happened.
+    """
+    moved: list[str] = []
+    try:
+        names = sorted(e.name for e in os.scandir(_root()))
+    except OSError:
+        return moved
+    for fid in names:
+        touched = False
+        if frame_workspace(fid) == old:
+            record_workspace(fid, new)
+            touched = True
+        ident = identity(fid)
+        if ident.get("CHARTER_WORKSPACE", "").strip() == old:
+            record_identity(fid, {**ident, "CHARTER_WORKSPACE": new})
+            touched = True
+        if touched:
+            bump(fid)
+            moved.append(fid)
+    return moved
 
 
 def workspace_for(fid: str) -> str:

--- a/charter/workspace.py
+++ b/charter/workspace.py
@@ -234,6 +234,40 @@ def workspace_dir(name: str) -> Path:
     return config.WORKSPACES_DIR / name
 
 
+def exists(name: str) -> bool:
+    """Whether *name* is a workspace this plane HAS — a fact about the filesystem, now.
+
+    **Named because it is asked on a REPAINT path, where the answer changes under the
+    reader** (#752). A frame is long-lived by definition, and `charter workspace remove`,
+    a `git clean`, a teammate's pull and a plain `mv` all take a workspace out from under
+    one that is drawing it. `frame/slots._repos` asks this the way it asks
+    `gather.unreadable`: of the filesystem, at the moment the pane is drawn, rather than
+    inferring absence from a scan that came back empty — which is a different claim, and
+    drawing the two the same is what #512 already cost this pane once.
+
+    **The name check is part of the predicate and not the caller's job, and that is what
+    is new here.** The same question was spelled inline in `frame/leave.plan` (`homeless`)
+    and in `commands_frame._reopen_one`'s `· workspace is missing`, and both are fed from
+    `state.own_workspace`, which name-checks every rung it returns — so a bare
+    `workspace_dir(ws).is_dir()` was safe *there* because of something true one call up.
+    The pane's name comes from `state.workspace_for`, whose LAST rung is a bare
+    :func:`resolve` handing back `$CHARTER_WORKSPACE` stripped and otherwise untouched.
+    Measured: with ``CHARTER_WORKSPACE=..`` that value reaches the renderer verbatim, and
+    ``WORKSPACES_DIR / ".."`` is the plane root — a directory, so a filesystem-only
+    predicate answers *present* for a name that is not a workspace and can never be one,
+    and the pane goes on drawing it. :func:`valid_name` is therefore asked FIRST, and a
+    name it refuses is absent by definition: no `ensure` will make it, so there is nothing
+    for the join to be right about.
+
+    Never creates and never raises: :func:`ensure` is the creator, the one caller that must
+    not write is the renderer, and :func:`_unreadable` is what keeps a `workspaces/` charter
+    is not allowed to look into from taking down a panel — the same reason every other
+    predicate in this module goes through it, said for a caller whose failure mode is a
+    dead pane rather than a blank footer.
+    """
+    return valid_name(name) and _unreadable(lambda: workspace_dir(name).is_dir())
+
+
 def from_path(path=None) -> str | None:
     """The workspace whose working tree *path* is inside, or ``None``.
 
@@ -863,11 +897,31 @@ def _rename_active_pointers(old: str, new: str) -> None:
                 pass
 
 
-def rename(old: str, new: str) -> None:
+def _rename_frame_records(old: str, new: str) -> list[str]:
+    """Repoint any frame that says it is in ``old`` — :func:`_rename_active_pointers`'
+    rule applied to the records that decide a chat's MEMBERSHIP rather than a session's
+    work, which is the half #795 found missing. Answers the chats that moved, so the
+    command can say how many: a rename that silently re-labels four running conversations
+    is a thing the operator who typed it is entitled to see happen.
+
+    The two are deliberately separate walks over separate directories rather than one
+    generic sweep, because they answer different questions and are read by different code:
+    a pointer says which workspace a session's `charter` commands act on, and
+    `.charter/frame/<fid>/` says which workspace a CHAT is in. `frame/state.rename_workspace`
+    owns the second — it is the module that writes those records, knows which of them are
+    rungs of `own_workspace`, and has to bump each frame's version so its panels repaint.
+    Imported here rather than at module scope: `frame.state` reads this module back.
+    """
+    from .frame import state as fstate
+    return fstate.rename_workspace(old, new)
+
+
+def rename(old: str, new: str) -> list[str]:
     """Rename a workspace: move its directory (clones + memory + refs come along),
-    update the manifest ``name``, move its liveness (gitignore block) if live, and
-    repoint active pointers/lock. Filesystem-level; the caller commits the tracked
-    move for a LIVE workspace. Assumes the caller validated old exists / new is free."""
+    update the manifest ``name``, move its liveness (gitignore block) if live, repoint
+    active pointers/lock, and repoint every chat that says it is in it (#795).
+    Filesystem-level; the caller commits the tracked move for a LIVE workspace. Assumes
+    the caller validated old exists / new is free. Answers the chats that followed."""
     was_live = is_live(old)
     workspace_dir(old).rename(workspace_dir(new))
     m = read_manifest(new)
@@ -878,6 +932,7 @@ def rename(old: str, new: str) -> None:
         set_live(old, False)
         set_live(new, True)
     _rename_active_pointers(old, new)
+    return _rename_frame_records(old, new)
 
 
 def manifest_path(name: str) -> Path:

--- a/docs/frame.md
+++ b/docs/frame.md
@@ -1046,9 +1046,17 @@ conversation wanted elsewhere is a new chat, opened with `charter <harness>` in 
 workspace. If you want the panels on another workspace, `F2 → workspace` moves your
 terminal to it and leaves every chat where it is.
 
-One consequence worth stating: a chat's workspace is now fixed at launch, so **renaming a
-workspace orphans its chats** — their record still names the old name. That was already
-true of any chat nobody had typed `workspace use` in, and it is now true of all of them.
+**Renaming a workspace does not orphan its chats, and that is not an exception to §4j.**
+For one release it did: a chat's workspace is fixed at launch, so `charter workspace rename
+alpha alpha2` left every chat in it still recording `alpha` — invisible to `alpha2`, and
+with no route back, because the pointer that used to repair it had stopped being a rung
+(#795). `rename` now repoints both of the records that ARE rungs, and bumps each frame so
+its panels repaint. §4j forbids moving a chat *between* workspaces, because that makes the
+harness's own cwd, files and history about a different plane; a rename moves no chat — the
+clones and the memory travel with the directory, and only the name changed — so following
+it is the chat keeping its identity. **Chat ids are not rewritten**, so after a rename you
+may see `alpha.1` beside a later `alpha2.3`. That is cosmetic and deliberate: rewriting ids
+would break every `$CHARTER_SESSION_ID` already exported into a live process.
 
 **That pointer, and everything else keyed on a chat, dies with the chat.** A chat id is
 `<workspace>.<n>` and the ordinal is handed back when the chat's state is reaped, so the
@@ -1097,6 +1105,28 @@ stays where it is.
 
 The wait and the failure are told apart by a fact rather than by a clock — the file is
 there and does not parse — so a gather that is merely slow is never called broken.
+
+**A workspace that is not on disk at all gets its own line, ahead of all three of those**,
+because all three are claims about a workspace that is there (#752). A frame outlives the
+directory it draws — `charter workspace remove`, a `git clean`, a teammate's pull, a plain
+`mv` — and none of those is something charter can hook, so the pane simply drew whichever
+"empty" the cache happened to reach, `⋯ gathering…` forever being the reported one. It now
+says what is true, with the command that changes it:
+
+```
+  no workspace <workspace> · charter workspace create <workspace>
+```
+
+Told apart by the same kind of fact as the line above it — `workspace.exists`, asked of the
+filesystem at the moment the pane is drawn — and nothing is repaired by drawing: the pane
+does not re-create the directory. A workspace that was *renamed* never reaches this line,
+because the chat followed the rename.
+
+The question is asked where the pane was about to say "nothing here" and **not** above the
+cache, so a table gathered before the workspace went stays on screen until the next gather
+empties it. That is deliberate: a panel reads its cache or says it has none, and a renderer
+that overrode its own cache from a `stat` would be re-deriving, on every repaint, state the
+gather owns.
 
 ## Configuring it
 

--- a/docs/news/unreleased-a-renamed-workspace-keeps-its-chats-and-a-deleted-one-says-so.md
+++ b/docs/news/unreleased-a-renamed-workspace-keeps-its-chats-and-a-deleted-one-says-so.md
@@ -1,0 +1,127 @@
+---
+version: unreleased
+headline: A renamed workspace keeps its chats, and one that is gone stops being drawn as an empty one
+---
+
+*"`charter workspace list` does not have `alpha` any more. My frame still says `⬢ alpha`,
+with nothing in it, and nothing anywhere says the workspace went."*
+
+Two ways a workspace changes under a frame that is drawing it, and charter drew both the
+same way. They are one subject and they get two different answers, because they are two
+different facts.
+
+## Renamed: the chat goes with it
+
+```
+$ charter claude --workspace alpha        # chat alpha.1
+$ charter workspace rename alpha alpha2   # from another terminal
+```
+
+`rename` already repointed every per-session and per-terminal pointer whose value was
+`alpha`. Since 0.55.0 those pointers are no longer what decides which workspace a **chat**
+is in — that is the frame's own two records, the `$CHARTER_WORKSPACE` the launch pinned and
+the workspace the launch resolved — and nothing repointed those. So:
+
+- `chats.of_workspace("alpha2")` was empty, and with it every surface built on it. That is
+  not cosmetic: it is how a workspace tab and `charter -w alpha2` find a plane's live
+  session — **by its chats**, never by a tmux session name — so `charter -w alpha2` opened
+  a *second* session beside the one already running those chats.
+- the running frame went on drawing `⬢ alpha`, a workspace the plane no longer had.
+- `charter workspace use alpha2` typed inside the orphaned chat did nothing, because that
+  pointer had stopped being a rung.
+
+Now both records follow the rename, and each frame that moved is bumped so its panels
+repaint straight away — the rename is typed in another terminal, so no hook fires inside
+the frame's own session and nothing else was coming.
+
+## Why that is not "moving a chat between workspaces"
+
+§4j settles the neighbouring question and is not relaxed here:
+
+> **A chat belongs to its workspace for life.** `{workspace}-{hash}` is identity, not a
+> property.
+
+What it forbids is re-homing — putting a chat in a *different* workspace, so that "the
+harness's own context, its cwd, its files, its history, is suddenly about a different
+plane". A rename moves no chat. `alpha.1` has the same clones, the same working directory
+and the same siblings before and after; the workspace it is in simply has a new name.
+Following that is the chat **keeping** its identity, not changing it.
+
+The mechanism was reserved in advance, in `state.new_chat_id`'s own words: *"`frame_workspace`
+reads the workspace out of the frame's own `workspace` file, **which can be repointed**, and
+the bars show that rather than the prefix of the id."*
+
+**Chat ids are still not rewritten**, and that is the half of §4j that stays literal. After a
+rename you may see `alpha.1` beside a later `alpha2.3`. That is cosmetic and deliberate:
+rewriting ids would break every `$CHARTER_SESSION_ID` already exported into a live process.
+
+## Gone: the frame says so
+
+Remove the directory instead — `charter workspace remove`, a `git clean` on the plane, a
+teammate's pull, or a plain `mv` — and the frame was the only surface on the machine still
+claiming the workspace existed. The repo pane had three sentences and all three are about a
+workspace that is **there**:
+
+| on disk | what the pane said | what it means |
+|---|---|---|
+| no cache yet | `⋯ gathering this workspace's repos…` | a gather that has not landed |
+| cache that will not read | `unreadable repo cache · …` | a gather that never will |
+| cache with no rows | `no clones in alpha · …` | gathered, nothing in it |
+| **workspace not on disk** | whichever of the three it reached | — |
+
+The reported reading is the first: `⋯ gathering…`, permanently, because a panel never
+gathers on its own — nothing was coming, and the pane had no other route out.
+
+There is now a fourth sentence, asked before the other three whenever the pane has no
+table to draw:
+
+```
+  no workspace alpha · charter workspace create alpha
+```
+
+**Told apart by a fact, not by an inference.** `workspace.exists` asks the filesystem at the
+moment the pane is drawn — the same rule `gather.unreadable` already uses one noun down, and
+for the same reason: "gathered, nothing there" and "there is nothing to gather" are two
+different claims, and #512 is what drawing two claims as one sentence cost this pane once
+already.
+
+**The name is checked before it is joined**, which is new and load-bearing. The pane's
+workspace comes from `state.workspace_for`, whose last rung hands back `$CHARTER_WORKSPACE`
+stripped and otherwise untouched — so with `CHARTER_WORKSPACE=..` that value reaches the
+renderer verbatim, and `workspaces/..` is the plane root, a real directory. A predicate that
+only asked the filesystem would answer *present* for a name that is not a workspace and never
+can be.
+
+## What did not change
+
+**A rename never produces the new line.** That is the whole point of settling the two
+together: a renamed workspace is still there, so the pane goes on saying whatever it was
+saying about it.
+
+**A cache with rows in it is still what the pane draws.** The question is asked where the
+pane was about to say "nothing here", not above the cache — a panel *reads the cache or
+says it has none*, so a renderer that contradicted its own cache from a `stat` would be
+re-deriving state the gather owns, on every repaint of every frame. So a table gathered a
+moment before the workspace went stays on screen until the next gather, and that gather
+empties it: `gather.scan` reads `workspace.clones`, which answers nothing for a workspace
+with no directory. Stale, and it converges — rather than a pane arguing with its own cache.
+
+**The top bar still says `⬢ alpha`, and the todo count still says `0`.** A chat belongs to
+its workspace for life, so the name on the bar is still true: that chat *is* in `alpha`.
+What was missing was anywhere saying `alpha` is not on disk, and one honest line is what
+the issue asked for — put where the empty ones were.
+
+**Nothing is repaired by drawing.** The renderer does not re-create the directory. That
+would put a write on the path pinned at one `stat` per idle tick, hide whatever removed the
+workspace, and hand back a workspace with none of the clones it had. The pane says what is
+true; you decide.
+
+**The cold-start line is untouched.** `⋯ gathering this workspace's repos…` still appears
+for the seconds it was always right for, in a workspace that exists.
+
+**One predicate, three surfaces.** `charter quit` already recorded a chat whose workspace had
+gone (`homeless`) and `charter reopen` already printed `· workspace is missing`. Both spelled
+the question inline; all three now ask `workspace.exists`, so the frame and the quit path
+cannot come to disagree about whether a workspace is there.
+
+Closes #752, #795.

--- a/tests/test_a_corrupt_repo_cache_is_not_a_gather_in_progress.py
+++ b/tests/test_a_corrupt_repo_cache_is_not_a_gather_in_progress.py
@@ -29,7 +29,7 @@ import unittest
 from unittest import mock
 
 from charter import statusline as sl
-from charter import commands_frame, tui, util
+from charter import commands_frame, config, tui, util
 from charter.frame import action as faction
 from charter.frame import builtin_actions, gather, slots, state
 
@@ -125,6 +125,16 @@ class TheRepoPaneSaysWhichStateItIsIn(PersonaIso, unittest.TestCase):
     """The renderer's half — through the real `slots.render("repos", …)`, because what
     #735 is about is what an operator READS, not what a helper returns."""
 
+    def setUp(self):
+        super().setUp()
+        # **The workspace these frames draw, on disk** — fixture rather than decoration
+        # since #752. `unreadable repo cache` is a claim about a gather that will never
+        # land IN A WORKSPACE; a workspace that is not on disk at all is a different
+        # sentence and is asked for first, because it is why nothing is coming. Without
+        # the directory, every case here would be measuring that other line.
+        (config.WORKSPACES_DIR / config.DEFAULT_WORKSPACE).mkdir(parents=True,
+                                                                 exist_ok=True)
+
     def _render(self, fid, *, cols=200, rows=24) -> str:
         with mock.patch("os.get_terminal_size",
                         return_value=os.terminal_size((cols, rows))), \
@@ -170,6 +180,10 @@ class TheRepoPaneSaysWhichStateItIsIn(PersonaIso, unittest.TestCase):
         the moment the truncate goes."""
         fid = "f-" + "w" * 60
         ws = "a" * 60
+        # On disk, since #752: this line is about a gather that will never land IN a
+        # workspace, and a workspace that is not there is a different sentence, asked
+        # first. Without the directory this measurement would be of that other line.
+        (config.WORKSPACES_DIR / ws).mkdir(parents=True, exist_ok=True)
         _corrupt(fid, "not json {{{")
         with mock.patch.dict(os.environ, {"CHARTER_WORKSPACE": ws}, clear=True):
             self.assertEqual(state.workspace_for(fid), ws)
@@ -179,11 +193,20 @@ class TheRepoPaneSaysWhichStateItIsIn(PersonaIso, unittest.TestCase):
             self.assertLessEqual(tui.width(tui.strip_ansi(line)), sl._LEFT_W, line)
 
     def test_a_workspace_name_the_rungs_never_checked_is_still_one_line(self):
-        """`_empty_lines`' hostile-name case, for the line beside it. `state.workspace_for`
-        rung 0 name-checks the pin, but its LAST rung is `workspace.resolve()`, which hands
-        back `$CHARTER_WORKSPACE` stripped and otherwise untouched — so a name with a
-        newline in it arrives at this renderer verbatim. `tui.truncate` runs `tui.sanitize`
-        first, which is what keeps a `repos` pane one row tall.
+        """The hostile-name case for this pane, which #752 moved one line over and which
+        is kept here because the property is the pane's rather than any one sentence's.
+        `state.workspace_for` rung 0 name-checks the pin, but its LAST rung is
+        `workspace.resolve()`, which hands back `$CHARTER_WORKSPACE` stripped and otherwise
+        untouched — so a name with a newline in it arrives at this renderer verbatim, and
+        `tui.truncate` runs `tui.sanitize` first, which is what keeps a `repos` pane one
+        row tall whatever it was handed.
+
+        **It lands on `_gone_lines` and not on this class's own line**, because a name no
+        rung checked cannot name a workspace that exists: `workspace.exists` asks
+        `valid_name` before the filesystem, so `unreadable repo cache` is now only ever
+        composed from a name that passed it. Asserted rather than left implied — a corrupt
+        cache in a workspace that is not there is a workspace that is not there, and saying
+        `charter frame-gather` about it would name a command that cannot help.
 
         The hostile value is asserted to have got THROUGH as well as to have been
         contained: containment alone would pass just as well on a build where a rung had
@@ -195,6 +218,7 @@ class TheRepoPaneSaysWhichStateItIsIn(PersonaIso, unittest.TestCase):
             out = self._render("f-hostile")
         self.assertEqual(len(out.split("\n")), 1, repr(out))
         self.assertIn("rm -rf /", tui.strip_ansi(out))
+        self.assertIn("no workspace", tui.strip_ansi(out))
 
     def test_a_gathered_cache_still_draws_its_table(self):
         """The other three states are untouched — the new branch is reached only from

--- a/tests/test_a_renamed_workspace_keeps_its_chats_and_a_gone_one_says_so.py
+++ b/tests/test_a_renamed_workspace_keeps_its_chats_and_a_gone_one_says_so.py
@@ -1,0 +1,528 @@
+"""#795 and #752 — the two halves of "the workspace under this frame changed".
+
+They are one subject with two answers, and #795 says so in as many words: *"a workspace
+that is gone is a different answer from one that was renamed, and the frame currently
+draws both the same way."*
+
+**Renamed — the chat follows, because nothing moved.** `workspace.rename` already repoints
+every per-session and per-terminal pointer whose value is the old name
+(`_rename_active_pointers`). Since #794 those pointers are no longer rungs of
+`state.own_workspace`, so the two rungs that ARE — the recorded `$CHARTER_WORKSPACE` pin
+and `state.record_workspace`'s launch record — kept spelling a name the plane no longer
+had. Measured on 0.55.0: after `charter workspace rename alpha alpha2`,
+`chats.of_workspace("alpha2")` is empty, every chat in it is invisible to
+`commands_frame._plane_session` (which finds a plane's live session BY its chats), and the
+frame goes on drawing `⬢ alpha`.
+
+**§4j is not in the way, and the design already said so.** *"A chat belongs to its
+workspace for life; `{workspace}-{hash}` is identity, not a property"* forbids **moving a
+chat between workspaces**. A rename moves no chat: `alpha.1` has the same clones, the same
+cwd and the same siblings before and after, and only the workspace's NAME changed.
+`state.new_chat_id`'s own docstring settles the mechanism in advance — *"`frame_workspace`
+reads the workspace out of the frame's own `workspace` file, **which can be repointed**,
+and the bars show that rather than the prefix of the id"* — and the cosmetic cost it names
+(chat `alpha.1` beside `alpha2.3`) is exactly what is kept here: **ids are not rewritten**,
+because that would break every `$CHARTER_SESSION_ID` already exported into a live process.
+
+**Gone — the frame says so, because something did move.** `_repos` had three sentences for
+a workspace that is present (`_unknown_lines`, `_unreadable_lines`, `_empty_lines`) and no
+sentence at all for one that is absent, so a removed workspace was drawn as an empty one:
+`0 todos`, no rows, and `⋯ gathering this workspace's repos…` forever, on a pane nothing
+was coming to correct. That is #735's shape one noun out, and it is answered the same way:
+a FACT asked of the filesystem at the moment the pane is drawn (`workspace.exists`), never
+a duration and never an inference from an empty scan.
+
+**Asked where the pane was about to say "nothing here", and not above the cache.** A panel
+reads its cache or says it has none, so a renderer that overrode a table it still had would
+be re-deriving state the gather owns on every repaint. The boundary is asserted rather than
+left implied, along with the convergence that makes it safe.
+
+`os.environ` is cleared in every case: `state.workspace_for` reads `$CHARTER_WORKSPACE` and
+`$CHARTER_SESSION_ID`, so a developer running the suite inside a live frame would otherwise
+be supplying half of every fixture (#519/#521/#528).
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import sys
+import unittest
+from unittest import mock
+
+from charter import config, statusline as sl, tui, workspace
+from charter.frame import chats, gather, slots, state
+
+from tests._isolation import PersonaIso
+
+
+def _plant(fid: str, *, ws: str, pane: str = "%1", pin: str = "") -> None:
+    """Make *fid* look like a chat charter launched into *ws*.
+
+    The production writers and never a hand-written file — `record_workspace` is what
+    `frame_workspace` reads back — which is `test_a_chat_belongs_to_its_workspace_for_life`'s
+    rule and the reason a fixture that stopped agreeing with the launcher fails here rather
+    than passing against itself. *pin* is what `_frame_identity_env` puts on the pane for a
+    launch that really was pinned; ``""`` is what it emits for one that was not, which is
+    the ordinary case and not a missing field.
+    """
+    state.frame_dir(fid, create=True)
+    state.record_workspace(fid, ws)
+    state.record_harness_pane(fid, pane)
+    state.record_identity(fid, {"CHARTER_HARNESS": "Claude Code",
+                                "CHARTER_WORKSPACE": pin, "CHARTER_PERSONA": ""})
+
+
+def _seed(fid: str, **overrides) -> None:
+    """A cache a renderer can read — the shape `gather.scan` writes."""
+    data = {"gathered_at": 0.0, "workspace": "w", "current_repo": None,
+            "repos": [], "worktrees": []}
+    data.update(overrides)
+    gather.save(fid, data)
+
+
+#: One repo row, spelled out because `_table_lines` indexes every field of it.
+ROW = {"name": "demo", "branch": "main", "dirty": False, "tracked_dirty": False,
+       "ahead": 0, "behind": 0, "ci": None, "change": None, "sigil": "",
+       "current": False, "worktree_count": 0}
+
+
+class AWorkspaceIsThereOrItIsNot(PersonaIso, unittest.TestCase):
+    """`workspace.exists` — the one predicate three surfaces now ask.
+
+    It was spelled inline twice before this (`frame/leave.plan`'s `homeless`, and the
+    `· workspace is missing` note `commands_frame._reopen_one` prints), both of them fed
+    from `state.own_workspace`, which name-checks its answer. The pane does NOT get its
+    workspace from there — `state.workspace_for`'s last rung is a bare
+    `workspace.resolve()`, which hands back `$CHARTER_WORKSPACE` stripped and otherwise
+    untouched — so the name check moves INTO the predicate rather than being assumed of
+    every caller.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.assertIn("edm-test-", str(config.STATE_DIR))
+
+    def test_a_workspace_with_a_directory_exists_and_one_without_does_not(self):
+        (config.WORKSPACES_DIR / "alpha").mkdir(parents=True, exist_ok=True)
+        self.assertTrue(workspace.exists("alpha"))
+        self.assertFalse(workspace.exists("beta"))
+
+    def test_it_is_a_fact_about_now(self):
+        """The whole reason the pane may ask it on the repaint path: the answer changes
+        under a running frame, which is what #752 is."""
+        (config.WORKSPACES_DIR / "alpha").mkdir(parents=True, exist_ok=True)
+        self.assertTrue(workspace.exists("alpha"))
+        shutil.rmtree(config.WORKSPACES_DIR / "alpha")
+        self.assertFalse(workspace.exists("alpha"))
+
+    def test_a_name_that_cannot_name_a_workspace_is_not_one_that_exists(self):
+        """**The name check is load-bearing, not decoration.** `WORKSPACES_DIR / ".."` is
+        the plane root and `WORKSPACES_DIR / "."` is the workspaces directory itself —
+        both real directories, so a predicate that only asked the filesystem would answer
+        True for two names that are not workspaces and never can be, and the pane would go
+        on drawing a workspace for them. Asserted with values that are DIRECTORIES on
+        purpose: a name that merely does not exist would pass either way."""
+        config.WORKSPACES_DIR.mkdir(parents=True, exist_ok=True)
+        self.assertTrue((config.WORKSPACES_DIR / "..").is_dir())
+        self.assertFalse(workspace.exists(".."))
+        self.assertTrue((config.WORKSPACES_DIR / ".").is_dir())
+        self.assertFalse(workspace.exists("."))
+        self.assertFalse(workspace.exists(""))
+
+    def test_a_file_where_a_workspace_would_be_is_not_a_workspace(self):
+        config.WORKSPACES_DIR.mkdir(parents=True, exist_ok=True)
+        (config.WORKSPACES_DIR / "afile").write_text("not a workspace\n")
+        self.assertFalse(workspace.exists("afile"))
+
+    def test_a_directory_charter_cannot_look_into_is_not_one_that_exists(self):
+        """`_unreadable`'s rule, said for a caller whose failure mode is a dead pane.
+        ``pathlib`` does not swallow ``EACCES`` — `is_dir()` RAISES on a parent the process
+        cannot enter, on Linux, and returns False on macOS, "which is how a suite green on
+        a laptop goes red on CI". A predicate that let it through would take a panel down
+        rather than draw a line."""
+        blocked = mock.Mock()
+        blocked.is_dir.side_effect = PermissionError("EACCES")
+        with mock.patch.object(workspace, "workspace_dir", return_value=blocked):
+            self.assertFalse(workspace.exists("alpha"))
+
+    def test_asking_creates_nothing(self):
+        """A predicate on a repaint path must not be `ensure` in disguise: a renderer that
+        made the directory it was asking about would repair #752 by hiding it, and would
+        put a write on the path #387 pinned."""
+        self.assertFalse(workspace.exists("ghost"))
+        self.assertFalse((config.WORKSPACES_DIR / "ghost").exists())
+
+
+class ARenameTakesItsChatsWithIt(PersonaIso, unittest.TestCase):
+    """#795 — the two rungs of `state.own_workspace`, repointed the way the pointers were.
+
+    No tmux here, deliberately: the strand is a state defect and reproduces on two
+    directories. What a rename must NOT do is asserted beside what it must.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.assertIn("edm-test-", str(config.STATE_DIR))
+        self.enterContext(mock.patch.dict(os.environ, {}, clear=True))
+        for n in ("alpha", "beta"):
+            (config.WORKSPACES_DIR / n).mkdir(parents=True, exist_ok=True)
+        _plant("alpha.1", ws="alpha", pane="%1")
+        _plant("alpha.2", ws="alpha", pane="%2")
+        _plant("beta.1", ws="beta", pane="%3")
+
+    def test_every_chat_in_the_renamed_workspace_is_still_in_it(self):
+        """The defect itself, asked of the MEMBERSHIP question (`chats.of_workspace`)
+        rather than of the files the rename writes. That is the function
+        `commands_frame._plane_session` uses to find a plane's live session — matched on
+        this plane's own chat directories and never on a tmux session name — so an empty
+        roster for `alpha2` is not cosmetic: `charter -w alpha2` opens a SECOND session
+        beside the one already running these chats."""
+        self.assertEqual(chats.of_workspace("alpha"), ["alpha.1", "alpha.2"])
+        workspace.rename("alpha", "alpha2")
+        self.assertEqual(chats.of_workspace("alpha2"), ["alpha.1", "alpha.2"])
+        self.assertEqual(chats.of_workspace("alpha"), [])
+
+    def test_the_chat_keeps_the_id_it_was_allocated(self):
+        """§4j, and the half of it that is NOT relaxed. `state.new_chat_id` says the
+        cosmetic mismatch is deliberate: rewriting ids "would break every
+        `$CHARTER_SESSION_ID` already exported into a live process". So the id, the frame
+        directory and everything keyed on either stay exactly where they were, and the
+        rename shows up only in what the frame SAYS."""
+        before = sorted(d.name for d in (config.STATE_DIR / "frame").iterdir())
+        workspace.rename("alpha", "alpha2")
+        self.assertEqual(chats.of_workspace("alpha2"), ["alpha.1", "alpha.2"])
+        self.assertEqual(sorted(d.name for d in (config.STATE_DIR / "frame").iterdir()),
+                         before)
+        self.assertEqual(before, ["alpha.1", "alpha.2", "beta.1"])
+
+    def test_both_rungs_move_and_the_pinned_chat_moves_too(self):
+        """`own_workspace` is the recorded pin, then the launch record — and a fix that
+        wrote only the record would leave a PINNED chat exactly as orphaned as before,
+        because the pin outranks it. Asserted per rung rather than through the ladder,
+        which would pass with either one of them repointed."""
+        _plant("alpha.3", ws="alpha", pane="%4", pin="alpha")
+        self.assertEqual(state.own_workspace("alpha.3"), "alpha")
+        workspace.rename("alpha", "alpha2")
+        self.assertEqual(state.frame_workspace("alpha.1"), "alpha2")
+        self.assertEqual(state.identity("alpha.3").get("CHARTER_WORKSPACE"), "alpha2")
+        self.assertEqual(state.own_workspace("alpha.3"), "alpha2")
+
+    def test_the_rest_of_a_chats_identity_is_not_lost_on_the_way(self):
+        """The pin is rewritten by re-writing the identity record, which holds three other
+        names a frame's new panes are launched with (`_relayout_pane_env`). A rewrite that
+        dropped them would pin another plane's harness onto every pane split after a
+        rename."""
+        _plant("alpha.3", ws="alpha", pane="%4", pin="alpha")
+        workspace.rename("alpha", "alpha2")
+        self.assertEqual(state.identity("alpha.3").get("CHARTER_HARNESS"), "Claude Code")
+
+    def test_a_chat_in_another_workspace_is_left_alone(self):
+        """`_rename_active_pointers`' rule, one noun out: what moves is every record whose
+        VALUE is the old name, and nothing else. A walk that repointed every frame it
+        found would sweep the whole plane into the renamed workspace."""
+        workspace.rename("alpha", "alpha2")
+        self.assertEqual(chats.of_workspace("beta"), ["beta.1"])
+        self.assertEqual(state.frame_workspace("beta.1"), "beta")
+
+    def test_a_chat_that_says_nothing_is_not_given_an_identity_it_never_had(self):
+        """`state.identity` answers `{}` for a frame launched by a charter that predates
+        the record, and that absence is read as "do not take this frame's identity from
+        here". A rename that wrote one would hand a migration-era frame a pin nobody set,
+        which outranks every rung below it."""
+        state.frame_dir("alpha.9", create=True)
+        state.record_workspace("alpha.9", "alpha")
+        workspace.rename("alpha", "alpha2")
+        self.assertEqual(state.identity("alpha.9"), {})
+        self.assertEqual(state.frame_workspace("alpha.9"), "alpha2")
+
+    def test_the_running_frame_repaints_instead_of_waiting_for_a_hook(self):
+        """A panel repaints on a version bump and on nothing else (`frame/panel.py`'s
+        contract). `charter workspace rename` is typed in ANOTHER terminal, so no
+        `posttooluse` hook fires in the frame's own session and nothing else is coming —
+        a repoint written in silence is a frame that goes on drawing the old name for as
+        long as it stays idle, which is #795's own screenshot."""
+        before = {f: state.version(f) for f in ("alpha.1", "alpha.2", "beta.1")}
+        workspace.rename("alpha", "alpha2")
+        self.assertNotEqual(state.version("alpha.1"), before["alpha.1"])
+        self.assertNotEqual(state.version("alpha.2"), before["alpha.2"])
+        self.assertEqual(state.version("beta.1"), before["beta.1"])
+
+    def test_the_session_and_terminal_pointers_still_follow(self):
+        """#794's own repoint, asserted here because this change adds a second walk beside
+        it and a refactor that folded one into the other could silently drop it. What it
+        buys is unchanged and is NOT membership: every `charter` command in that session
+        goes on acting on the workspace the operator renamed."""
+        config.SESSIONS_DIR.mkdir(parents=True, exist_ok=True)
+        (config.SESSIONS_DIR / "sid.workspace").write_text("alpha\n")
+        (config.SESSIONS_DIR / "sid.lock").write_text("alpha\n")
+        workspace.rename("alpha", "alpha2")
+        self.assertEqual((config.SESSIONS_DIR / "sid.workspace").read_text().strip(),
+                         "alpha2")
+        self.assertEqual((config.SESSIONS_DIR / "sid.lock").read_text().strip(), "alpha2")
+
+    def test_a_frame_root_that_cannot_be_listed_costs_the_rename_nothing(self):
+        """Every writer this walk calls is best-effort and never raises, and the walk keeps
+        that posture: `charter workspace rename` has ALREADY moved the directory by the
+        time it runs, so an exception here would leave a rename that half-happened and a
+        traceback where a receipt should be. The chats then say the old name, which is
+        exactly the state this function exists to leave behind less often — not a worse
+        one."""
+        with mock.patch.object(state.os, "scandir", side_effect=OSError("EACCES")):
+            self.assertEqual(workspace.rename("alpha", "alpha2"), [])
+        self.assertTrue((config.WORKSPACES_DIR / "alpha2").is_dir())
+        self.assertEqual(state.frame_workspace("alpha.1"), "alpha")
+
+    def test_the_command_says_how_many_chats_came_with_it(self):
+        """A rename that silently re-labels running conversations is one the operator finds
+        out about from a panel. Asserted through the real `cmd_workspace_rename`, because
+        what is being measured is the receipt an operator reads — and paired with the
+        no-chats case, since a line printed unconditionally would say `0 chat(s)` on every
+        rename of an empty workspace and mean nothing."""
+        import io
+        from contextlib import redirect_stderr
+        from types import SimpleNamespace
+        from charter import commands_workspace as cw
+
+        buf = io.StringIO()
+        with redirect_stderr(buf):
+            rc = cw.cmd_workspace_rename(SimpleNamespace(old="alpha", new="alpha2",
+                                                         message=None))
+        self.assertEqual(rc, 0)
+        self.assertIn("2 chat(s) in 'alpha' followed the rename", buf.getvalue())
+        self.assertIn("alpha2", buf.getvalue())
+
+        (config.WORKSPACES_DIR / "gamma").mkdir(parents=True, exist_ok=True)
+        quiet = io.StringIO()
+        with redirect_stderr(quiet):
+            self.assertEqual(cw.cmd_workspace_rename(
+                SimpleNamespace(old="gamma", new="gamma2", message=None)), 0)
+        self.assertNotIn("followed the rename", quiet.getvalue())
+
+    def test_a_rename_of_a_workspace_with_no_chats_moves_nothing(self):
+        """The ordinary case, and the pair that stops the walk being a no-op test: a
+        function that repointed every frame unconditionally would pass every assertion
+        above."""
+        workspace.rename("beta", "beta2")
+        self.assertEqual(state.frame_workspace("alpha.1"), "alpha")
+        self.assertEqual(chats.of_workspace("beta2"), ["beta.1"])
+
+
+class ARenamedWorkspaceIsDrawnUnderItsNewName(PersonaIso, unittest.TestCase):
+    """The two halves composed, which is the thing #795 asked to have settled: the frame
+    must tell a rename apart from a removal, and it now does — one follows, one is said."""
+
+    def setUp(self):
+        super().setUp()
+        self.assertIn("edm-test-", str(config.STATE_DIR))
+        self.enterContext(mock.patch.dict(os.environ, {}, clear=True))
+        (config.WORKSPACES_DIR / "alpha").mkdir(parents=True, exist_ok=True)
+        _plant("alpha.1", ws="alpha", pane="%1")
+        slots.VIEWPORT.forget()
+
+    def _render(self, slot, fid, *, cols=200, rows=24) -> str:
+        with mock.patch("os.get_terminal_size",
+                        return_value=os.terminal_size((cols, rows))), \
+             mock.patch.object(sys.stdout, "fileno", return_value=1, create=True):
+            return tui.strip_ansi(slots.render(slot, fid))
+
+    def test_the_top_bar_names_the_workspace_the_rename_produced(self):
+        workspace.rename("alpha", "alpha2")
+        out = self._render("top", "alpha.1")
+        self.assertIn("alpha2", out)
+
+    def test_the_repo_pane_does_not_call_a_renamed_workspace_gone(self):
+        """The line between the two issues, drawn at the pane. A rename leaves a workspace
+        that is THERE, so the pane goes on saying what it said about it — and a fix for
+        #752 alone, with no repoint, would have every rename produce this sentence."""
+        _seed("alpha.1", repos=[ROW])
+        workspace.rename("alpha", "alpha2")
+        out = self._render("repos", "alpha.1")
+        self.assertIn("demo", out)
+        self.assertNotIn("no workspace", out)
+
+
+class AWorkspaceThatIsGoneIsNotAnEmptyOne(PersonaIso, unittest.TestCase):
+    """#752, through the real `slots.render("repos", …)` — what an operator READS.
+
+    The pane's three existing sentences are all about a workspace that is present. Absent
+    is a fourth state and it is asked FIRST, above the cache, because a cache outlives the
+    directory it was gathered from: the worst reading is not the empty one the issue
+    reports, it is a full table of clones that are no longer on disk.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.assertIn("edm-test-", str(config.STATE_DIR))
+        self.enterContext(mock.patch.dict(os.environ, {}, clear=True))
+        (config.WORKSPACES_DIR / "alpha").mkdir(parents=True, exist_ok=True)
+        _plant("alpha.1", ws="alpha", pane="%1")
+        slots.VIEWPORT.forget()
+        self.addCleanup(slots.VIEWPORT.forget)
+
+    def _render(self, fid, *, cols=200, rows=24) -> str:
+        with mock.patch("os.get_terminal_size",
+                        return_value=os.terminal_size((cols, rows))), \
+             mock.patch.object(sys.stdout, "fileno", return_value=1, create=True):
+            return tui.strip_ansi(slots.render("repos", fid))
+
+    def _remove(self):
+        shutil.rmtree(config.WORKSPACES_DIR / "alpha")
+
+    def test_a_gather_that_never_landed_stops_being_the_answer(self):
+        """#752's own screenshot: the pane said `⋯ gathering this workspace's repos…` for
+        a workspace that is not there, and nothing was coming. Asserted as a PAIR against
+        the same frame with its directory intact — "says something else" alone would pass
+        on a renderer that had stopped saying `gathering` at all, which would make the
+        launch window silent."""
+        cold = self._render("alpha.1")
+        self.assertIn("gathering", cold)
+        self._remove()
+        gone = self._render("alpha.1")
+        self.assertNotIn("gathering", gone)
+        self.assertIn("no workspace alpha", gone)
+
+    def test_an_empty_scan_is_not_how_absence_is_reported(self):
+        """`no clones in alpha` is a claim about a workspace that HAS no clones, and
+        drawing it for one that is not there is #512's mistake in a new noun. The pair is
+        the assertion: an empty workspace that exists still says the old sentence."""
+        _seed("alpha.1")
+        present = self._render("alpha.1")
+        self.assertIn("no clones in alpha", present)
+        self._remove()
+        gone = self._render("alpha.1")
+        self.assertNotIn("no clones", gone)
+        self.assertIn("no workspace alpha", gone)
+
+    def test_a_cache_with_rows_in_it_is_still_what_the_pane_draws(self):
+        """**The boundary of the fix, asserted so it is a decision and not an oversight.**
+        `gather.json` is under `.charter/`, not under `workspaces/`, so removing a
+        workspace leaves its last scan exactly where it was — and the pane goes on drawing
+        it. The question is asked where the pane was about to say "nothing here", and NOT
+        above the cache, because a panel "never gathers on its own — it reads the cache or
+        says it has none" (docs/frame.md): a renderer that contradicted its own cache from
+        a `stat` would be re-deriving, every repaint of every frame, state the gather owns.
+
+        The residual is a table that is stale rather than a table that is wrong about which
+        state it is in, and it converges — `gather.scan` reads `workspace.clones`, which
+        answers `[]` for a workspace with no directory, so the first refresh after the
+        removal empties the cache and the pane says so. That is measured below rather than
+        asserted in prose."""
+        _seed("alpha.1", repos=[ROW])
+        self.assertIn("demo", self._render("alpha.1"))
+        self._remove()
+        self.assertIn("demo", self._render("alpha.1"))
+
+    def test_the_first_gather_after_the_removal_empties_the_cache_and_the_pane_says_so(self):
+        """The convergence the test above leaves to this one, through the real
+        `gather.refresh` — the call every `posttooluse` hook makes (`notify.plane_changed`)
+        — rather than by writing an empty cache by hand, which would prove nothing about
+        what a real gather of an absent workspace produces."""
+        _seed("alpha.1", repos=[ROW])
+        self._remove()
+        gather.refresh("alpha.1", workspace="alpha", cwd=str(config.ROOT))
+        self.assertEqual(gather.cached("alpha.1").get("repos"), [])
+        self.assertIn("no workspace alpha", self._render("alpha.1"))
+
+    def test_a_cache_that_cannot_be_read_is_still_reported_as_such(self):
+        """#735's sentence is about a file, and it survives — but only where the workspace
+        is there to gather. Both orders asserted, because "absent" is checked above the
+        cache and a pane that checked it below would answer this one wrongly."""
+        d = state.frame_dir("alpha.1", create=True)
+        assert d is not None
+        (d / "gather.json").write_text("not json {{{")
+        self.assertIn("unreadable repo cache", self._render("alpha.1"))
+        self._remove()
+        self.assertIn("no workspace alpha", self._render("alpha.1"))
+
+    def test_the_line_names_the_workspace_and_the_command_that_makes_it_exist(self):
+        """`_empty_lines`' shape, and its reason: a line that names a problem and not its
+        fix costs a row and settles nothing. The name is the FRAME's workspace, so the
+        command names the workspace the pane is about rather than whatever this process
+        would resolve for itself (#512). No key is named, for `_unreadable_lines`' reason
+        — a frame running as a window in an operator's own tmux has no `F2` of charter's
+        to offer."""
+        self._remove()
+        out = self._render("alpha.1")
+        self.assertIn("charter workspace create alpha", out)
+        self.assertNotIn("F2", out)
+
+    def test_it_is_one_line_and_it_fits_the_pane(self):
+        """Every line in this pane is one row bounded by `tui.truncate`, and a `repos`
+        pane that quietly became two rows tall pushes the attention strip off the bottom
+        of the window. Measured at `statusline._LEFT_W` with a name long enough that the
+        unbounded version overflows — `_unreadable_lines`' first version was vacuous
+        without exactly that, because a short name composes to well under the width."""
+        long = "a" * 60
+        with mock.patch.dict(os.environ, {"CHARTER_WORKSPACE": long}, clear=True):
+            self.assertEqual(state.workspace_for("alpha.1"), long)
+            out = self._render("alpha.1", cols=sl._LEFT_W)
+        self.assertEqual(len(out.split("\n")), 1, out)
+        self.assertLessEqual(tui.width(out), sl._LEFT_W, out)
+
+    def test_a_name_no_rung_ever_checked_is_absent_rather_than_stat_ed(self):
+        """**The reason `workspace.exists` name-checks before it joins.**
+        `state.workspace_for`'s last rung is a bare `workspace.resolve()`, which hands back
+        `$CHARTER_WORKSPACE` stripped and otherwise untouched — so a value that escapes the
+        workspaces directory reaches this pane verbatim. `..` is the plane root and it IS a
+        directory, so a predicate that only asked the filesystem would answer "present" and
+        the pane would go on drawing a workspace for a name that can never be one.
+
+        The hostile value is asserted to have got THROUGH as well as to have been contained:
+        containment alone would pass on a build where a rung had rejected it. It reaches
+        the pane on ONE frame — one that has recorded nothing, so `workspace_for` falls
+        past its own name-checked rungs to `workspace.resolve()`; `_plant`ed chats have a
+        record and never see it."""
+        for hostile in ("..", "ev\nil\x1b[31m;rm -rf /"):
+            with self.subTest(hostile), \
+                 mock.patch.dict(os.environ, {"CHARTER_WORKSPACE": hostile}, clear=True):
+                self.assertEqual(state.workspace_for("f-nothing-recorded"), hostile)
+                out = self._render("f-nothing-recorded")
+            self.assertEqual(len(out.split("\n")), 1, repr(out))
+            self.assertIn("no workspace", out)
+
+    def test_a_pane_too_narrow_for_the_table_says_that_instead(self):
+        """`_table_cap` answers 0 below `statusline._LEFT_W` and `_repos` composes nothing
+        on a budget of 0, so this line cannot appear where a table never will — the rule
+        every other line in the pane keeps, asserted for the new one because it is a new
+        early return past the same cap."""
+        self._remove()
+        out = self._render("alpha.1", cols=90)
+        self.assertNotIn("no workspace", out)
+        self.assertIn("too narrow", out)
+
+    def test_drawing_the_line_repairs_nothing(self):
+        """A renderer does not write. Re-creating the directory would put a write on the
+        path #387 pinned at one `stat` per idle tick, would hide whatever removed it, and
+        would hand back a workspace with none of the clones it had."""
+        self._remove()
+        self._render("alpha.1")
+        self.assertFalse((config.WORKSPACES_DIR / "alpha").exists())
+
+    def test_a_repaint_still_runs_no_gather_of_its_own(self):
+        """`gather.read`'s live-`scan` fallback is what `_repos` refuses (#512), and a new
+        branch that reached for it to "just find out" would put a git sweep on every
+        repaint of a frame whose workspace is gone."""
+        self._remove()
+        with mock.patch.object(gather, "scan",
+                               side_effect=AssertionError("a repaint gathered")):
+            self.assertIn("no workspace alpha", self._render("alpha.1"))
+
+    def test_a_click_or_a_wheel_notch_on_the_line_is_not_a_selection(self):
+        """The three existing one-line answers go through `_Viewport.blank`, which clears
+        the click map AND the scroll bound together — a paint that cleared one and left
+        the other is the defect that method exists to make unwriteable. A fourth early
+        return that skipped it would leave the bound the last TABLE wrote, and every wheel
+        notch over one static sentence would answer truthy and repaint it."""
+        _seed("alpha.1", repos=[ROW] * 12)
+        self._render("alpha.1", rows=6)
+        self._remove()
+        _seed("alpha.1")
+        self._render("alpha.1", rows=6)
+        self.assertEqual(slots.VIEWPORT.limit, 0)
+        self.assertFalse(slots.VIEWPORT.move(1))
+        self.assertIsNone(slots.VIEWPORT.repo_at(0))
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()

--- a/tests/test_a_renamed_workspace_keeps_its_chats_and_a_gone_one_says_so.py
+++ b/tests/test_a_renamed_workspace_keeps_its_chats_and_a_gone_one_says_so.py
@@ -208,6 +208,28 @@ class ARenameTakesItsChatsWithIt(PersonaIso, unittest.TestCase):
         self.assertEqual(state.identity("alpha.3").get("CHARTER_WORKSPACE"), "alpha2")
         self.assertEqual(state.own_workspace("alpha.3"), "alpha2")
 
+    def test_a_pin_is_read_exactly_the_way_membership_reads_it(self):
+        """**The deletion sweep found this one, as `strip` -> `lstrip` surviving.**
+        `state.own_workspace` answers the pin as
+        ``identity(fid).get("CHARTER_WORKSPACE", "").strip()``, and `_frame_identity_env`
+        copies the launcher's environment verbatim — so a shell that exported
+        ``CHARTER_WORKSPACE="alpha "`` produces a chat whose recorded pin carries a
+        trailing space and whose MEMBERSHIP is `alpha` regardless. A walk that compared it
+        any other way would repoint a different set from the roster it is following, and
+        the chats it skipped would be orphaned by the fix for orphaning.
+
+        Asserted as the pair that makes it a property rather than a spelling: the chat is
+        in `alpha`'s roster BEFORE (which is `own_workspace`'s reading) and in `alpha2`'s
+        after (which is this walk's). One assertion alone would pass on either function
+        being wrong in the same direction. Both ends of the value are exercised, because
+        `lstrip` and `rstrip` fail on opposite ones."""
+        _plant("alpha.4", ws="beta", pane="%5", pin=" alpha ")
+        self.assertEqual(state.own_workspace("alpha.4"), "alpha")
+        self.assertIn("alpha.4", chats.of_workspace("alpha"))
+        workspace.rename("alpha", "alpha2")
+        self.assertEqual(state.identity("alpha.4").get("CHARTER_WORKSPACE"), "alpha2")
+        self.assertIn("alpha.4", chats.of_workspace("alpha2"))
+
     def test_the_rest_of_a_chats_identity_is_not_lost_on_the_way(self):
         """The pin is rewritten by re-writing the identity record, which holds three other
         names a frame's new panes are launched with (`_relayout_pane_env`). A rewrite that

--- a/tests/test_frame_slots.py
+++ b/tests/test_frame_slots.py
@@ -1077,6 +1077,18 @@ class ReposTable(PersonaIso, unittest.TestCase):
     would satisfy a unit test of the helper and none of the promise.
     """
 
+    def setUp(self):
+        super().setUp()
+        # **The workspace these frames draw, on disk** — and it is fixture, not decoration
+        # (#752). Every "nothing here" sentence this pane can say is a claim about a
+        # workspace that EXISTS: `⋯ gathering this workspace's repos…` and `no clones in
+        # <ws>` are both waiting on something, and a workspace that is not there is not
+        # waiting on anything, so it now gets a line of its own instead. A fixture with no
+        # directory was asking this pane about a plane where neither sentence is the true
+        # answer, and the assertions below are about the ones where they are.
+        (config.WORKSPACES_DIR / config.DEFAULT_WORKSPACE).mkdir(parents=True,
+                                                                 exist_ok=True)
+
     def _render(self, fid="f-1", *, cols=200, rows=24) -> str:
         with mock.patch("os.get_terminal_size",
                         return_value=os.terminal_size((cols, rows))), \
@@ -1158,17 +1170,26 @@ class ReposTable(PersonaIso, unittest.TestCase):
         self.assertIn("charter clone", tui.strip_ansi(out))
 
     def test_a_workspace_name_the_rungs_never_checked_is_still_one_line(self):
-        """`_empty_lines` interpolates a workspace name with no `contain.one_line` over
-        it, and the reason has to be the true one. It is NOT that every rung of
-        `state.workspace_for` name-checks its answer: rung 0 does (`valid_name`), but the
-        last rung is `workspace.resolve()`, which returns `$CHARTER_WORKSPACE` stripped
-        and otherwise untouched — so a name with a newline in it reaches this renderer
-        verbatim, as this test's first assertion measures.
+        """A workspace name with no `contain.one_line` over it, and the reason has to be
+        the true one. It is NOT that every rung of `state.workspace_for` name-checks its
+        answer: rung 0 does (`valid_name`), but the last rung is `workspace.resolve()`,
+        which returns `$CHARTER_WORKSPACE` stripped and otherwise untouched — so a name
+        with a newline in it reaches this renderer verbatim, as this test's first
+        assertion measures.
 
         What contains it is `tui.truncate`, which runs `tui.sanitize` first: the newline
         is not charter's markup, so the pane still draws exactly ONE line — the property
         the whole slot is built on, since a `repos` pane that quietly became three rows
         tall would push the attention strip off the bottom of the window.
+
+        **The line it lands on is `_gone_lines` since #752, and that is the whole point of
+        naming it here.** A name no rung checked cannot name a workspace that EXISTS —
+        `workspace.exists` asks `valid_name` before it asks the filesystem, precisely
+        because `workspaces/..` is a real directory — so this state reaches the "not on
+        disk" sentence and can no longer reach `_empty_lines` at all. That makes
+        `_gone_lines` the one line in this pane that is interpolated with a value nobody
+        has checked, and the one whose `tui.truncate` is load-bearing for reasons of
+        CONTENT rather than of length.
 
         The hostile value is asserted to have got through as well as to have been
         contained. Asserting containment alone would pass just as well on a build where a
@@ -1181,6 +1202,28 @@ class ReposTable(PersonaIso, unittest.TestCase):
             out = self._render("f-known-empty")
         self.assertEqual(len(out.split("\n")), 1, repr(out))
         self.assertIn("rm -rf /", tui.strip_ansi(out))
+        self.assertIn("no workspace", tui.strip_ansi(out))
+
+    def test_a_workspace_name_longer_than_the_pane_is_cut_to_it(self):
+        """`_empty_lines`' own bound, measured with a name the pane cannot hold.
+
+        Since #752 this line is only ever reached with a name `workspace.exists` accepted,
+        so the `tui.sanitize` half of its `tui.truncate` has nothing left to do — the
+        alphabet `instance.WORKSPACE_NAME_RE` allows holds no newline and no ESC. What is
+        NOT bounded by that check is LENGTH: a workspace name is arbitrarily long, and an
+        untruncated line here is a `repos` pane wider than its own pane, which wraps and
+        becomes two rows. Measured at `statusline._LEFT_W`, the narrowest width this pane
+        draws anything at all at, with a name long enough that the unbounded version
+        overflows — the bound is red the moment the truncate goes."""
+        long = "w" * 90
+        (config.WORKSPACES_DIR / long).mkdir(parents=True, exist_ok=True)
+        with mock.patch.dict(os.environ, {"CHARTER_WORKSPACE": long}, clear=True):
+            self.assertEqual(state.workspace_for("f-long-empty"), long)
+            _seed("f-long-empty")
+            out = self._render("f-long-empty", cols=statusline._LEFT_W)
+        self.assertEqual(len(out.split("\n")), 1, repr(out))
+        self.assertIn("no clones", tui.strip_ansi(out))
+        self.assertLessEqual(tui.width(tui.strip_ansi(out)), statusline._LEFT_W, out)
 
     def test_a_frame_whose_repos_are_not_gathered_yet_says_so_rather_than_showing_none(self):
         """#512, at the renderer. `cmd_launch` deletes the cache before it draws anything


### PR DESCRIPTION
Closes #752. Closes #795.

Two issues, one subject: what happens to chats and frames when the workspace under them
changes. #795 asked for it to be settled next to #752 — *"a workspace that is gone is a
different answer from one that was renamed, and the frame currently draws both the same
way"* — so this is one PR with two answers.

Both reproduced on `origin/main` @ `77e12ec` (0.55.0) before anything was changed, in an
isolated plane (`PersonaIso`, `edm-test-` state dir), in-process.

## #795 — renamed: the chat follows

**Reproduced.** After `workspace.rename("alpha", "alpha2")` with `alpha.1`/`alpha.2`
planted by the production writers:

```
own_workspace(alpha.1) = alpha        # a workspace charter workspace list no longer has
of_workspace('alpha2') = []           # every chat orphaned
of_workspace('alpha')  = ['alpha.1', 'alpha.2']
top bar                 ⬢ alpha
```

The empty roster is the sharp end, and it is worse than a label. `commands_frame._plane_session`
finds a plane's live tmux session **by its chats** — matched on this plane's own chat
directories, never on a session name (§3.3) — so `charter -w alpha2` and a workspace tab
both miss the session already running those chats and open a **second one beside it**. The
repair route was gone with it: `charter workspace use alpha2` inside an orphaned chat
writes a pointer that stopped being a rung in #794.

**Fixed** by `state.rename_workspace`, which walks `.charter/frame/*` and repoints every
record whose VALUE is the old name — `_rename_active_pointers`' own rule, one noun out —
covering **both** rungs of `own_workspace` (the recorded `$CHARTER_WORKSPACE` pin and the
launch record), and bumps each frame it moved so the panels repaint. The rename is typed
in another terminal, so no hook fires in the frame's own session and nothing else was
coming (#748's cost). `charter workspace rename` now reports how many chats followed.

### §4j: verified, not assumed

§4j forbids **moving a chat between workspaces**, because that makes the harness's own
cwd, files and history about a different plane. A rename moves no chat: same clones, same
working directory, same siblings — only the workspace's name changed, so following it is
the chat *keeping* its identity.

Three pieces of evidence that this is the intended reading rather than a convenient one:

1. `state.new_chat_id`'s own docstring reserves the mechanism in advance — *"`frame_workspace`
   reads the workspace out of the frame's own `workspace` file, **which can be repointed**,
   and the bars show that rather than the prefix of the id"*.
2. `docs/news/0.55.0-typing-a-workspace-command-no-longer-moves-your-chat.md` says it
   explicitly: *"Making `rename` repoint the frame records is the fix and it is not in here
   — it is a decision … which deserves its own argument next to #752."*
3. `frame/leave.py` already distinguishes the two nouns: `homeless` is *"§4j forbids
   re-homing a chat, so a missing workspace is reported, never repaired"* — and a renamed
   workspace is not missing.

**Chat ids are not rewritten**, which is the half of §4j that stays literal: after a rename
you may see `alpha.1` beside a later `alpha2.3`, because every `$CHARTER_SESSION_ID`
already exported into a live process spells the old one.

## #752 — gone: the frame says so

**Reproduced.** With the workspace directory removed under a running frame, the pane says
`⋯ gathering this workspace's repos…` forever (no cache) or `no clones in alpha · charter
clone <repo> -w alpha` (empty cache), and the top bar keeps drawing `⬢ alpha`.

`slots._repos` had three sentences and all three are claims about a workspace that **is
there**. `_gone_lines` is the fourth:

```
  no workspace alpha · charter workspace create alpha
```

Told apart by a fact — `workspace.exists`, asked of the filesystem at the moment the pane
is drawn — which is `gather.unreadable`'s rule from #802 for the noun one level up. The
predicate **name-checks before it joins**, and that half is load-bearing: `state.workspace_for`'s
last rung hands back `$CHARTER_WORKSPACE` untouched, and `workspaces/..` is the plane root,
a real directory, so a filesystem-only predicate answers *present* for a name that is not a
workspace and never can be.

### Where the question is asked, and why not higher

It is asked from the two branches that were about to say "nothing here", **not** above the
cache. A panel *reads the cache or says it has none* (`docs/frame.md`), so a renderer that
contradicted its own cache from a `stat` would be re-deriving state the gather owns on
every repaint of every frame — and would put `state.workspace_for`'s two file reads on the
path that draws a table.

The measurement forced it: checking above the cache reddened **67 existing tests** across
`test_frame_slots` and `test_the_repo_table_scrolls_and_selects`, which is not fixture
churn but the codebase asserting, 67 times, that this pane draws its cache. The residual is
a table that is *stale* rather than a pane arguing with itself, and it converges —
`gather.scan` reads `workspace.clones`, which answers nothing for a workspace with no
directory, so the first refresh after the removal empties the cache and the line appears.
Both halves are asserted.

## Consequences named rather than left implied

* `_empty_lines` and `_unreadable_lines` are now only ever reached with a name that passed
  `valid_name`, so the `tui.sanitize` half of their bound has nothing left to do. Their
  docstrings said the opposite at length; both are corrected, the two hostile-`$CHARTER_WORKSPACE`
  tests moved onto `_gone_lines` (which is now the one line in the pane that can receive an
  unchecked name), and `_empty_lines` gets a new LENGTH bound measured with a 90-character
  name so its `tui.truncate` stays observable.
* `ReposTable` and the corrupt-cache renderer class now put the workspace they draw on
  disk. Both are about sentences that are claims about a workspace that exists.
* `workspace.exists` replaces the two inline spellings of the same question
  (`leave.plan`'s `homeless`, `commands_frame._reopen_one`'s `· workspace is missing`), so
  the frame and the quit path cannot come to disagree about whether a workspace is there.

## What did not change

* **The top bar still says `⬢ alpha`, and the todo count still says `0`.** A chat belongs
  to its workspace for life, so the name on the bar is still true. What was missing was
  anywhere saying `alpha` is not on disk — one honest line, put where the empty ones were,
  which is what the issue asked for.
* **Nothing is repaired by drawing.** The renderer does not re-create the directory.
* **The cold-start line is untouched** for a workspace that exists.

## Verification

* Both reproductions run before any change, in-process, isolated plane.
* Full suite the way CI runs it: `python3 -m unittest discover -s tests` →
  `Ran 10478 tests in 571.530s / OK (skipped=9)` at this head (10477 before the sweep
  follow-up added one test). Read off the trailer, never the exit code — macOS has no
  `timeout`, so `timeout N python3 -m unittest …` exits 0 with "command not found".
* `git diff --diff-filter=D --name-only origin/main...HEAD` is empty. (The two-dot form
  is not: it reports `docs/news/unreleased-a-random-directory-name-is-not-a-charter-spawn.md`
  as deleted, purely because main moved ahead of this branch's base.)

## Deletion sweep

First run: **`deletion sweep / 2 survivors`** — read off the check NAME; every shard job
was green. Both `swap-synonym`, both in `state.rename_workspace`, reported as a masked
cluster. The second-order run applied them together and stayed green, so neither was hiding
the other, and they were classified separately:

* `ident.get("CHARTER_WORKSPACE", "").strip` → `lstrip` — **pinned, and it was a real
  defect.** `own_workspace` reads the pin with `.strip()` and `_frame_identity_env` copies
  the launcher's environment verbatim, so `CHARTER_WORKSPACE="alpha "` gives a chat whose
  pin has a trailing space and whose membership is `alpha` anyway. Read any other way, the
  walk repoints a different set from the roster it is following and the chats it skips are
  orphaned by the fix for orphaning. Pinned with a chat pinned `" alpha "`, asserted from
  both ends (roster before, roster after), and verified red against `lstrip` *and* `rstrip`.
* `sorted` → `list` — **deleted, because the ordering is unobservable rather than
  untested.** Each frame is repointed independently, each writer swallows its own failures,
  and the only consumer of the answer is a count. A test asserting the order would be
  asserting the filesystem's. The list stays materialised inside the `try`, which is
  load-bearing and now says so: `os.scandir` is lazy.

Second run: **`deletion sweep / no survivors`**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014dq9Q2fGzos3iJ46PZFdMP
