### PR TITLE
A tab strip grows a row when its tabs overflow, and gives it back when they fit (#829)

### DIFF
--- a/charter/commands_frame.py
+++ b/charter/commands_frame.py
@@ -2091,6 +2091,23 @@ def _slot_sizes(fid: str, slots: list[str], *, window_rows: int, pane_cols: int,
     for `layout.repos_rows`' reason about *pinned_rows*: a policy applied at both ends is a
     bound one end cannot make observable.
 
+    **Every slot is asked, and there is deliberately no `slot in BARS` filter in front of
+    it.** There was one, and the deletion sweep reported dropping it as a survivor — the
+    two spellings of "a slot that draws no strip wants nothing" cannot both be observable,
+    and the one that stays is the one that DOES the answering. `bar_rows_wanted` answers
+    `1` for a name it has no strip for; no slot can ever be sized below one cell
+    (`component.cells` refuses it and `layout.repos_rows` floors the table at
+    `SLOT_SIZE["repos"]`), so a want of `1` is at or under every slot's own height and
+    `layout._grown` grows nothing for it. Measured over 3,648 sizings — four pin
+    configurations, three split orders, thirty-eight window heights and eight widths —
+    filtered and unfiltered answer the identical map every time, and an unfiltered
+    comprehension asks about `top`, `bottom`, `repos` and `right` exactly once each and is
+    told `1` for all four.
+
+    Deleting it is also what makes that answer REACHED: the refusal in `bar_rows_wanted` is
+    a production path now rather than a defensive line, and
+    `tests/test_a_tab_strip_grows_a_row_when_its_tabs_overflow` asks it directly.
+
     *order* is the split ORDER, which is not always *slots* — `_relayout` re-splits a
     permutation of the recorded panes and it is that permutation which decides how wide a
     pane ends up (#500). It is what the strips' own widths are derived from
@@ -2109,7 +2126,7 @@ def _slot_sizes(fid: str, slots: list[str], *, window_rows: int, pane_cols: int,
         bar_rows={slot: frame_slots.bar_rows_wanted(
             fid, slot, cap=layout.BAR_MAX_ROWS,
             pane_cols=layout.pane_cols(order, slot, window_cols=window_cols))
-            for slot in slots if slot in frame_slots.BARS})
+            for slot in slots})
 
 
 def _launch_sizes(fid: str, slots: list[str], *,

--- a/charter/commands_frame.py
+++ b/charter/commands_frame.py
@@ -2049,8 +2049,8 @@ def _spawn_gather(fid: str, ws: str) -> None:
         return
 
 
-def _slot_sizes(fid: str, slots: list[str], *,
-                window_rows: int, pane_cols: int) -> dict[str, int]:
+def _slot_sizes(fid: str, slots: list[str], *, window_rows: int, pane_cols: int,
+                order: list[str], window_cols: int) -> dict[str, int]:
     """`layout.slot_sizes` for a frame that has a plane behind it — the only place in
     charter where a committed arrangement becomes a pane height.
 
@@ -2082,11 +2082,34 @@ def _slot_sizes(fid: str, slots: list[str], *,
     the frame did not have, and `_reassert_sizes` on every `window-resized`. They differ
     only in how the table pane's width is arrived at, which is why that arrives here as
     *pane_cols* already measured rather than as a window to measure.
+
+    **A tab strip is a third such fact and it arrives the same way** (#829). How many rows
+    a strip needs is a function of the names this plane has — `chats.roster`,
+    `switch.workspaces` — so it is a plane read, which is what this function is the
+    boundary for, and `frame_slots.bar_rows_wanted` is the one place it is made. The
+    ceiling on it is `layout.BAR_MAX_ROWS`, carried down from here rather than read there,
+    for `layout.repos_rows`' reason about *pinned_rows*: a policy applied at both ends is a
+    bound one end cannot make observable.
+
+    *order* is the split ORDER, which is not always *slots* — `_relayout` re-splits a
+    permutation of the recorded panes and it is that permutation which decides how wide a
+    pane ends up (#500). It is what the strips' own widths are derived from
+    (`layout.pane_cols`), the same list the caller already hands `layout.repos_cols` for
+    the table's, and it is a separate argument rather than *slots* reused precisely because
+    those two lists differ on one of the three paths.
+
+    Nothing extra is read for a frame that places no bar, which is charter's own and very
+    nearly everyone's: the comprehension below is empty and `layout.slot_sizes` is handed
+    an empty map it does not spend.
     """
     return layout.slot_sizes(
         slots, window_rows=window_rows,
         content_rows=frame_slots.repos_rows_wanted(fid, pane_cols=pane_cols),
-        pinned_rows=layout.pinned_repo_rows())
+        pinned_rows=layout.pinned_repo_rows(),
+        bar_rows={slot: frame_slots.bar_rows_wanted(
+            fid, slot, cap=layout.BAR_MAX_ROWS,
+            pane_cols=layout.pane_cols(order, slot, window_cols=window_cols))
+            for slot in slots if slot in frame_slots.BARS})
 
 
 def _launch_sizes(fid: str, slots: list[str], *,
@@ -2129,7 +2152,8 @@ def _launch_sizes(fid: str, slots: list[str], *,
     Through :func:`_slot_sizes`, which is where the plane's own pinned height is read and
     why this is not a call to `layout.slot_sizes` directly.
     """
-    return _slot_sizes(fid, slots, window_rows=window_rows,
+    return _slot_sizes(fid, slots, window_rows=window_rows, order=slots,
+                       window_cols=window_cols,
                        pane_cols=layout.repos_cols(slots, window_cols=window_cols))
 
 
@@ -5533,7 +5557,8 @@ def _relayout(socket: str, *, fid: str, harness_pane: str, panels: dict[str, str
             socket, slots=missing, fid=fid, harness_pane=harness_pane, env=None,
             pane_env=pane_env, v=v,
             sizes=_slot_sizes(
-                fid, want, window_rows=window_rows,
+                fid, want, window_rows=window_rows, window_cols=window_cols,
+                order=list(keep) + missing,
                 pane_cols=layout.repos_cols(list(keep) + missing,
                                             window_cols=window_cols))))
         _arm_panel_respawn(socket, fid=fid,
@@ -5755,7 +5780,7 @@ def _reassert_sizes(socket: str, *, fid: str, panes: dict[str, str], harness_pan
     # for the tmux measurement that makes this an order rather than a preference.
     _apply_sizes(socket, panes=panes, sizes=layout.column_sizes(order), flag="-x")
     sizes = _slot_sizes(
-        fid, order, window_rows=window_rows,
+        fid, order, window_rows=window_rows, order=order, window_cols=window_cols,
         pane_cols=_variable_pane_cols(socket, panes=panes, window_cols=window_cols))
     # Pass two: the ROWS, and the harness below them.
     _apply_sizes(socket, panes=panes, sizes=sizes, flag="-y")

--- a/charter/frame/builtins.py
+++ b/charter/frame/builtins.py
@@ -432,9 +432,10 @@ def _bar_events(fid: str, command: tuple[str, ...], add: tuple[str, ...] | None 
     did not declare before it ever reaches here. A branch on a kind that cannot arrive is
     a line no input could turn red.
 
-    **`scroll` is not declared, and that is not an omission.** A bar is one row with
-    nothing to scroll; a handler for it could only ever answer False, and the wheel is not
-    a gesture to hang a switch on. `events.Dispatcher.open` charges the same
+    **`scroll` is not declared, and that is not an omission.** A strip draws into the rows
+    its pane has and counts what is left over, so there is nothing below its last row to
+    scroll to — a handler for it could only ever answer False, and the wheel is not a
+    gesture to hang a switch on. `events.Dispatcher.open` charges the same
     `overlay.MOUSE_ON` for one pointer kind as for two, so declaring it would cost nothing
     and mean nothing — which is precisely what makes it wrong to declare.
 
@@ -489,12 +490,12 @@ def _bar_events(fid: str, command: tuple[str, ...], add: tuple[str, ...] | None 
         from .builtin_actions import _spawn
         if not ev.pressed or ev.name != _ACT_BUTTON:
             return False
-        name = _slots.TABS.switch_to(ev.col)
+        name = _slots.TABS.switch_to(ev.row, ev.col)
         if name is None:
-            if add is not None and _slots.TABS.add_at(ev.col):
+            if add is not None and _slots.TABS.add_at(ev.row, ev.col):
                 _spawn(util.self_relaunch_argv(*add), fid=fid)
                 return False
-            if _slots.TABS.more_at(ev.col):
+            if _slots.TABS.more_at(ev.row, ev.col):
                 # The same argv `_strip_events` spawns for a door, for its reasons — one
                 # answer to "how does a frame surface open the palette", shared rather than
                 # copied. Falsy afterwards for this handler's own reason: the palette's
@@ -688,20 +689,27 @@ def _persona_events(fid: str):
 
 
 def _chats(ctx) -> list[str]:
-    """The chat bar — `slots.chats_bar` at this pane's OWN width.
+    """The chat bar — `slots.chats_bar` in this pane's OWN rectangle.
 
-    `ctx.width`, unlike the four wrapped whole-pane renderers (:func:`_panel`), which
-    measure their own tty and ignore it. A bar written for the contract can read the
-    geometry the contract carries, and this is the first charter component that does.
+    `ctx.width` and `ctx.height`, unlike the four wrapped whole-pane renderers
+    (:func:`_panel`), which measure their own tty and ignore both. A bar written for the
+    contract can read the geometry the contract carries, and this is the first charter
+    component that does.
+
+    **The height is not decoration** (#829). A strip is one row when its names fit on one
+    and as many rows as its pane was given when they do not, and the pane is that tall
+    because `layout.slot_sizes` was told what these same names need
+    (`slots.bar_rows_wanted`). Passing the width alone would leave the rows the launcher
+    just bought blank — the sizer-and-renderer disagreement #500 shipped one pane over.
     """
     from . import slots
-    return slots.chats_bar(ctx.fid, ctx.width)
+    return slots.chats_bar(ctx.fid, ctx.width, ctx.height)
 
 
 def _workspaces(ctx) -> list[str]:
-    """The workspace bar — `slots.workspaces_bar` at this pane's own width."""
+    """The workspace bar — `slots.workspaces_bar` in this pane's own rectangle."""
     from . import slots
-    return slots.workspaces_bar(ctx.fid, ctx.width)
+    return slots.workspaces_bar(ctx.fid, ctx.width, ctx.height)
 
 
 def _personas(ctx) -> list[str]:
@@ -885,9 +893,12 @@ def build(fid: str = "") -> Registry:
     # like from the outside. `_bar_events` is what receives them and why a click here
     # SWITCHES where a click on the table only selects.
     #
-    # `click` alone rather than `("scroll", "click")` like `repos`: a bar is one row and
-    # there is nothing to scroll it to, so a `scroll` declaration could only reach a
-    # handler that always answered False. `repos` declares both because it moves a
+    # `click` alone rather than `("scroll", "click")` like `repos`: a strip holds every
+    # name it has room for and counts the rest, so there is nothing to scroll it to and a
+    # `scroll` declaration could only reach a handler that always answered False. That is
+    # still true now a strip can be more than one row (#829): the rows it grows are the
+    # rows its PANE has, so there is never content below the last of them — what does not
+    # fit is a `+N`, and a `+N` opens the palette. `repos` declares both because it moves a
     # viewport; the shared reason that constant's comment gives — one `MOUSE_ON` serves
     # both — is why declaring the second one costs nothing, never a reason to declare one
     # that does nothing.

--- a/charter/frame/layout.py
+++ b/charter/frame/layout.py
@@ -229,6 +229,28 @@ SLOT_EDGE = _SHIPPED.edge
 #: granted, out of the one pane that matters.
 HARNESS_MIN_ROWS = 12
 
+#: The most rows a tab strip may be sized to when its names will not fit on one (#829).
+#:
+#: **A ceiling, and the budget is a separate question.** What a strip may actually spend
+#: is what the harness can spare above :data:`HARNESS_MIN_ROWS`, and :func:`slot_sizes` is
+#: where that is worked out; this is the statement that a strip is a strip however many
+#: rows are going spare. Both are needed: a plane with forty chats in a hundred-row window
+#: has rows to burn, and a forty-chat strip is not a readout any more — it is the list,
+#: and the list is `charter frame-palette`, which reaches every chat at every width.
+#:
+#: **Three, measured through the same cut `slots._bar` draws with**, over this
+#: repository's own fifteen workspaces: they need 2 rows at 160 columns, 3 at 120, 4 at
+#: 100 and 6 at 80. So three draws every workspace this plane has at every width #725
+#: measured an operator running at, and stops short of the width where the strip would be
+#: taking six rows off the harness to become a list.
+#:
+#: Read by `commands_frame._slot_sizes` and handed to `frame.slots.bar_rows_wanted` as its
+#: *cap*, never applied twice: this module caps a strip at what the harness can spare and
+#: the SIZER caps it at what a strip is, and a second `min` here would be a bound no input
+#: could make observable — the survivor `tools/sweep.py` reports and this repository
+#: deletes.
+BAR_MAX_ROWS = 3
+
 #: One row per pane border. tmux charges a horizontal split one row for the divider on
 #: top of the pane's own height — measured on 3.7c: a 50-row window split `-l 8` reads
 #: back as a 41-row harness and an 8-row panel, which is 49. Counted explicitly rather
@@ -589,13 +611,38 @@ def repos_cols(slots: list[str] | tuple[str, ...], *, window_cols: int) -> int:
 
     With no `repos` in *slots* this answers the width one WOULD be split to, which is
     what :func:`visible_slots` asks it before deciding whether the slot survives at all.
+
+    :func:`pane_cols` is the walk; this names the one slot charter's own geometry has
+    always asked it about, so the twenty-odd callers that say `repos_cols` keep saying it.
     """
+    return pane_cols(slots, "repos", window_cols=window_cols)
+
+
+def pane_cols(slots: list[str] | tuple[str, ...], slot: str, *,
+              window_cols: int) -> int:
+    """How wide *slot*'s pane is, split in *slots*' order in a *window_cols* window.
+
+    :func:`repos_cols` generalised to any slot, and generalised rather than copied because
+    the second caller wants the identical rule: a tab strip is sized from the names it can
+    draw at its own width (`slots.bar_rows_wanted`), and a strip split after `right` is
+    carved out of a pane the sidebar has already narrowed by 23 columns. That is #500 word
+    for word, one slot over — and #500 is what a second copy of this loop would be
+    reproducing rather than reusing.
+
+    Everything :func:`repos_cols` says about the walk holds here and is said there: order
+    in, order out; a slot split AFTER *slot* costs it nothing; a *slot* absent from the
+    list is answered with the width one WOULD be split to.
+
+    *slot* is resolved through :func:`_key` like every other name this module is handed, so
+    a caller may ask about `identity` or about `top` and get one answer rather than two.
+    """
+    stop = _key(slot)
     out = window_cols
-    for slot in slots:
-        if _key(slot) == "repos":
+    for name in slots:
+        if _key(name) == stop:
             break
-        if _edge_of(slot) in _COLUMN_EDGES:
-            out -= _size_of(slot) + _BORDER_COLS
+        if _edge_of(name) in _COLUMN_EDGES:
+            out -= _size_of(name) + _BORDER_COLS
     return max(0, out)
 
 
@@ -848,8 +895,63 @@ def resize_flag(slot) -> str | None:
     return "-y" if edge in _ROW_EDGES else None
 
 
+def _grown(sizes: dict[str, int], wanted: dict[str, int], *,
+           window_rows: int) -> dict[str, int]:
+    """*sizes* with each strip in *wanted* grown toward the rows its names need — as far
+    as the harness can spare and no further (#829).
+
+    **The budget is the harness's SURPLUS, and that is the whole of the row policy #740
+    settled.** A strip growing is a strip taking rows off the harness, so what it may take
+    is exactly what the harness has above :data:`HARNESS_MIN_ROWS` once every other pane
+    has the height :func:`slot_sizes` just gave it — :func:`harness_rows` of the ungrown
+    map, minus that floor. A window with nothing spare grows nothing, in silence, which is
+    the same degrade `visible_slots` makes one rung down.
+
+    **The repo table is NOT what pays**, and the ordering is `_DROP_ORDER`'s: the bars are
+    given up before `repos` when rows run short, so they cannot be fed from it when rows
+    are plentiful. `repos` already has its content's height by the time this is called and
+    keeps it; the rows come out of the harness's own slack and the harness keeps its floor
+    by construction, because that floor is what was subtracted to get the budget.
+
+    **A row at a time, in *sizes*' own order, so a short budget is SHARED.** Two strips
+    both wanting a second row with one row going spare is a real case — a plane that
+    places both bars in a window with one row of slack — and handing it all to whichever
+    was split first would leave the other looking broken for a reason nothing on screen
+    explains. Round-robin gives the first strip the first row, the second the second, and
+    both strips their second row before either gets a third.
+
+    *wanted* is a number a CALLER measured, never a policy read here — `slots
+    .bar_rows_wanted` is the measurement and `commands_frame._slot_sizes` is the one place
+    it is made, for the reason :func:`repos_rows` gives about *pinned_rows*. So there is no
+    :data:`BAR_MAX_ROWS` in this function: the ceiling is applied where the want is
+    measured, and applying it twice would be a bound no input could make observable.
+
+    Names *wanted* carries that *sizes* does not are dropped, on :func:`slot_sizes`'
+    filter-don't-refuse discipline — a slot that is not being drawn is not a pane to grow.
+
+    **This GROWS and never trims**, which is why the shortfall is tested for positivity in
+    the loop rather than filtered out of the map: a plane that pinned its strip to three
+    rows in its own `[[frame.component]]` table asked for three rows (#687), and a
+    measurement saying its names fit on one is not that operator changing their mind. There
+    is no early return for an empty map either — the loop does not run and the answer is
+    the map it was handed, so a guard in front of it is a line no input could make
+    observable, which is the survivor `tools/sweep.py` reports and this repository deletes.
+    """
+    short = {slot: n - sizes[slot] for slot, n in wanted.items() if slot in sizes}
+    budget = harness_rows(sizes, window_rows=window_rows) - HARNESS_MIN_ROWS
+    out = dict(sizes)
+    while budget > 0 and any(n > 0 for n in short.values()):
+        for slot in list(short):
+            if short[slot] > 0 and budget > 0:
+                out[slot] += 1
+                short[slot] -= 1
+                budget -= 1
+    return out
+
+
 def slot_sizes(slots: list[str], *, window_rows: int, content_rows: int,
-               pinned_rows: int | None = None) -> dict[str, int]:
+               pinned_rows: int | None = None,
+               bar_rows: dict[str, int] | None = None) -> dict[str, int]:
     """Every slot in *slots* mapped to the size it should be given — rows for the
     horizontal strips, columns for the side.
 
@@ -865,6 +967,14 @@ def slot_sizes(slots: list[str], *, window_rows: int, content_rows: int,
     arithmetic passes — is a plane that pinned nothing, which is charter's own and very
     nearly everyone's.
 
+    *bar_rows* is the same kind of value one slot family over: how many rows each tab
+    strip's own names need at its own pane width, measured by `slots.bar_rows_wanted` and
+    carried here rather than read, for exactly *pinned_rows*' reason. `None` — the default,
+    and what every caller asking about the arithmetic passes — is a frame with no strip
+    that overflows, which is every frame that places no bar and every plane whose names
+    fit. :func:`_grown` is what spends it, and what refuses to spend rows the harness has
+    not got.
+
     Unknown slot names are dropped rather than raised on, matching `visible_slots`'
     filter-don't-refuse discipline: `[frame] slots` is committed, untrusted input, and by
     the time a list reaches here it has already been through `instance.FRAME_SLOTS`.
@@ -878,7 +988,7 @@ def slot_sizes(slots: list[str], *, window_rows: int, content_rows: int,
         cells = _size_of(slot)
         if cells is not None:
             out[slot] = cells
-    return out
+    return _grown(out, bar_rows or {}, window_rows=window_rows)
 
 
 def harness_rows(sizes: dict[str, int], *, window_rows: int) -> int:

--- a/charter/frame/layout.py
+++ b/charter/frame/layout.py
@@ -967,9 +967,9 @@ def slot_sizes(slots: list[str], *, window_rows: int, content_rows: int,
     arithmetic passes — is a plane that pinned nothing, which is charter's own and very
     nearly everyone's.
 
-    *bar_rows* is the same kind of value one slot family over: how many rows each tab
-    strip's own names need at its own pane width, measured by `slots.bar_rows_wanted` and
-    carried here rather than read, for exactly *pinned_rows*' reason. `None` — the default,
+    *bar_rows* is the same kind of number one slot family over: how many rows a tab strip's
+    own names need at its own pane width, measured by `slots.bar_rows_wanted` and carried
+    here rather than read, for exactly *pinned_rows*' reason. `None` — the default,
     and what every caller asking about the arithmetic passes — is a frame with no strip
     that overflows, which is every frame that places no bar and every plane whose names
     fit. :func:`_grown` is what spends it, and what refuses to spend rows the harness has

--- a/charter/frame/layout.py
+++ b/charter/frame/layout.py
@@ -982,13 +982,15 @@ def slot_sizes(slots: list[str], *, window_rows: int, content_rows: int,
     arithmetic passes — is a plane that pinned nothing, which is charter's own and very
     nearly everyone's.
 
-    *bar_rows* is the same kind of number one slot family over: how many rows a tab strip's
-    own names need at its own pane width, measured by `slots.bar_rows_wanted` and carried
-    here rather than read, for exactly *pinned_rows*' reason. `None` — the default,
-    and what every caller asking about the arithmetic passes — is a frame with no strip
-    that overflows, which is every frame that places no bar and every plane whose names
-    fit. :func:`_grown` is what spends it, and what refuses to spend rows the harness has
-    not got.
+    *bar_rows* is the same kind of number one slot family over: how many rows a slot's own
+    content needs at its own pane width, measured by `slots.bar_rows_wanted` and carried
+    here rather than read, for exactly *pinned_rows*' reason. It may name every slot in
+    *slots*, and does: a slot with no strip to draw answers `1`, which is at or under every
+    slot's own height, so :func:`_grown` spends nothing on it. `None` — the default, and
+    what every caller asking about the arithmetic passes — is a frame with no strip that
+    overflows, which is every frame that places no bar and every plane whose names fit.
+    :func:`_grown` is what spends it, and what refuses to spend rows the harness has not
+    got.
 
     Unknown slot names are dropped rather than raised on, matching `visible_slots`'
     filter-don't-refuse discipline: `[frame] slots` is committed, untrusted input, and by

--- a/charter/frame/layout.py
+++ b/charter/frame/layout.py
@@ -920,6 +920,21 @@ def _grown(sizes: dict[str, int], wanted: dict[str, int], *,
     explains. Round-robin gives the first strip the first row, the second the second, and
     both strips their second row before either gets a third.
 
+    **The rounds are counted off the BUDGET rather than run under a `while`, and that is
+    the deletion sweep's finding rather than a preference.** One round hands out at least
+    one row while any demand and any budget remain, and no round may hand out a row the
+    budget has not got — so ``range(budget)`` is more rounds than the deal can ever need,
+    and a round past the last useful one is two guarded no-ops. Written as a `while` on
+    ``budget > 0 and any(n > 0 …)`` instead, FIVE mutations of that one line do not
+    terminate: dropping either conjunct, moving either boundary from `>` to `>=`, or
+    swapping `any` for `all` each leaves a loop whose body cannot change its own condition
+    (measured, with the state that hangs each one). A non-terminating mutant is CAUGHT —
+    but the sweep can only report it as unmeasured, and it pays the full per-mutation
+    timeout for each, which is what put nine other mutations of this branch out of time.
+    The bound here is DATA, not a guard: it is what the deal costs, so removing it or
+    moving it changes the answer rather than hiding a hang, and the two conditions below
+    stay exactly as observable as they were.
+
     *wanted* is a number a CALLER measured, never a policy read here — `slots
     .bar_rows_wanted` is the measurement and `commands_frame._slot_sizes` is the one place
     it is made, for the reason :func:`repos_rows` gives about *pinned_rows*. So there is no
@@ -940,8 +955,8 @@ def _grown(sizes: dict[str, int], wanted: dict[str, int], *,
     short = {slot: n - sizes[slot] for slot, n in wanted.items() if slot in sizes}
     budget = harness_rows(sizes, window_rows=window_rows) - HARNESS_MIN_ROWS
     out = dict(sizes)
-    while budget > 0 and any(n > 0 for n in short.values()):
-        for slot in list(short):
+    for _round in range(budget):
+        for slot in short:
             if short[slot] > 0 and budget > 0:
                 out[slot] += 1
                 short[slot] -= 1

--- a/charter/frame/slots.py
+++ b/charter/frame/slots.py
@@ -3846,8 +3846,20 @@ def _compose(head: str, names: list[str], here: str, width: int, *,
             lines.append(head_cells + before + body)
         return lines, cols, more, add
 
+    def row(body: str = "", drawn=(), before: str = "", more=(), add=()):
+        """A rung that draws ONE row, said the way three of the four rungs say it.
+
+        :func:`rung`'s single-row case, and a wrapper rather than a shape every rung has to
+        spell: three of the four draw exactly one row and said so before #829 gave the
+        fourth some more, and rewriting them to hand over a one-element list of triples
+        would be three call sites edited to say what they already said. An empty *body* is
+        the rung that draws nothing — rung 4, and a bar with no names — which is no rows at
+        all rather than one blank one.
+        """
+        return rung([(before, body, drawn)] if body else [], more, add)
+
     if not names:
-        return rung()
+        return row()
     # **Which row is yours is decided on the RAW names; only the drawing uses the
     # contained ones.** `choose.Roster` makes the same split one surface over and for the
     # same reason: `contain.one_line` is a repair, so two names that differ only in what
@@ -3883,10 +3895,10 @@ def _compose(head: str, names: list[str], here: str, width: int, *,
         # The affordance's own cells, measured off this composition — :func:`_span`'s
         # reason, and the same walk the counts get one rung down. It is drawn only where
         # the whole list is on the strip, which is why a `+` and a `+9` are never on one.
-        return rung([("", gap.join(painted) + gap + note, zip(names, marked))],
-                    add=_span(0, tui.width(lead + joined + gap), note))
+        return row(gap.join(painted) + gap + note, zip(names, marked),
+                   add=_span(0, tui.width(lead + joined + gap), note))
     if tui.width(joined) <= room:
-        return rung([("", gap.join(painted), zip(names, marked))])
+        return row(gap.join(painted), zip(names, marked))
     if at >= 0:
         # **No `if len(names) > 1` here, and it is unreachable rather than merely
         # untested.** With ONE name the page is that name, both counts are absent, and the
@@ -3900,8 +3912,8 @@ def _compose(head: str, names: list[str], here: str, width: int, *,
         # a function of the names, the width and the row count and of nothing that moves
         # when the operator switches. `rows == 1` makes every run one page, which is
         # exactly the answer this rung gave before it could grow.
-        page = bisect.bisect_right(cuts, at) - 1
-        run = (page // rows) * rows
+        marked_page = bisect.bisect_right(cuts, at) - 1
+        run = (marked_page // rows) * rows
         stop = min(run + rows, len(cuts) - 1)
         first, last = cuts[run], cuts[stop]
         # Neither count is a tab. `+9` stands for names that are not on the row, so there
@@ -3927,36 +3939,51 @@ def _compose(head: str, names: list[str], here: str, width: int, *,
         # starts at the head of the list and reaches its end, which is the multi-row form
         # of the rung above. A `+` beside a `+9` on two rows of one strip would be the two
         # `+` fields on screen together that the promise exists to prevent.
-        tail = note if note and not leading and not trailing else ""
+        # The affordance rides only a run that holds the WHOLE list — no leading count and
+        # no trailing one — which is `_Tabs.add_at`'s structural promise in the shape a
+        # strip with rows needs it: a `+` and a `+9` are never on screen together, and a
+        # second ROW is on screen with the first. `note` is already `""` where a caller
+        # passed none, so the conjunct testing it again was a line no input could make
+        # observable and is not written.
+        tail = note if not leading and not trailing else ""
+        # **Which row each field that is NOT a name goes on, decided ONCE and not per
+        # row.** The leading count belongs beside the first tab drawn and the trailing one
+        # after the last, because that is where the names they stand for actually are; on a
+        # one-row strip both land on the one row, which is the answer this rung gave before
+        # it could grow. Written as two edits to a list of blanks rather than as a
+        # `r == 0`/`last_row` test inside the loop: the loop below is then straight-line,
+        # and four conditional expressions that each had to be got right per row become two
+        # statements that are true of the run.
+        span = range(run, stop)
+        befores = [""] * len(span)
+        afters = [""] * len(span)
+        if leading:
+            befores[0] = f"{leading}{gap}"
+        if trailing or tail:
+            afters[-1] = f"{gap}{trailing or tail}"
         start = tui.width(lead)
-        plain, painted_rows = [], []
-        counts: list[tuple[int, int]] = []
-        add: list[tuple[int, int]] = []
-        for r, page in enumerate(range(run, stop)):
+        plain, painted_rows, ends = [], [], []
+        for r, page in enumerate(span):
             lo, hi = cuts[page], cuts[page + 1]
-            last_row = page == stop - 1
-            # The leading count goes on the FIRST row of the run and the trailing one on
-            # the LAST, because that is where the names they stand for actually are: what
-            # `+5` is about sits to the left of the first tab drawn, and what `+9` is about
-            # follows the last. On a one-row strip both land on the one row, which is the
-            # answer this rung gave before it could grow. The affordance takes the trailing
-            # field's place on the row that ends a run holding the whole list, which is the
-            # only run either of them can be on.
-            before = f"{leading}{gap}" if leading and r == 0 else ""
-            after = f"{gap}{trailing or tail}" if last_row and (trailing or tail) else ""
             tabs = gap.join(marked[lo:hi])
-            # Where the fields that are not names landed, taken from the composition above
-            # rather than searched for in the finished string — :func:`_tab_columns`'
-            # discipline for the names, kept for the rest. :func:`_span` answers an empty
-            # span for a field this row does not carry, so there is no branch here to get
-            # wrong: a row with no leading count contributes no cells.
-            at_end = start + tui.width(before + tabs + gap)
-            counts += _span(r, start, leading if before else "")
-            counts += _span(r, at_end, trailing if last_row else "")
-            add += _span(r, at_end, tail if last_row else "")
-            plain.append((before, tabs + after))
-            painted_rows.append((before, gap.join(painted[lo:hi]) + after,
+            ends.append(start + tui.width(befores[r] + tabs + gap))
+            plain.append((befores[r], tabs + afters[r]))
+            painted_rows.append((befores[r], gap.join(painted[lo:hi]) + afters[r],
                                  list(zip(names[lo:hi], marked[lo:hi]))))
+        # Where the fields that are not names landed, taken from the composition above
+        # rather than searched for in the finished string — :func:`_tab_columns`'
+        # discipline for the names, kept for the rest. **No branch here at all**:
+        # :func:`_span` answers an empty span for an empty string, and `leading`, `trailing`
+        # and `tail` are already `""` where this run does not carry them, so a run at the
+        # head of the list contributes no leading cells by arithmetic rather than by a
+        # test somebody has to keep true.
+        # **`bottom` and not `last`**, which is a name this rung already gave to the index
+        # one past the last NAME on the run: `trailing` is computed from that one and
+        # everything below is about a ROW, and two meanings for one word on a strip whose
+        # whole subject is which row a field is on is the reading error to refuse.
+        bottom = len(plain) - 1
+        counts = _span(0, start, leading) + _span(bottom, ends[bottom], trailing)
+        add = _span(bottom, ends[bottom], tail)
         # Measured, not assumed. :func:`_cuts` puts at least one name on a page, so a name
         # wider than the whole row composes a body that overflows — and this ladder gives a
         # rung up rather than drawing part of anything. Measured on the PLAIN rows for the
@@ -3974,8 +4001,8 @@ def _compose(head: str, names: list[str], here: str, width: int, *,
         # all. A frame narrow enough to fall here had a strip that could be pointed at and
         # not pressed; it opens the palette now, which is the surface that works at every
         # width.
-        return rung([("", counted, ())], more=_span(0, tui.width(lead), counted))
-    return rung()
+        return row(counted, more=_span(0, tui.width(lead), counted))
+    return row()
 
 
 #: The chat bar's add-chat affordance (§3.6) — a BUTTON now, and one cell of it.
@@ -4084,36 +4111,45 @@ def bar_rows_wanted(fid: str, slot: str, *, pane_cols: int, cap: int) -> int:
     so a padded pane's strip is planned for `pane_cols - 2 * pad` and asking the unpadded
     question would size this pane from a number the renderer never sees.
 
+    **The answer is the tallest height the strip FILLS, and there is deliberately no "does
+    it hold every name yet" test beside it.** There was one — an early ``return rows`` the
+    moment the map held every name — and the deletion sweep reported dropping it as a
+    SURVIVOR. Measured rather than argued: over 406,000 inputs (32 name lists, every mark,
+    every width from 0 to 300, five ceilings) the two answer the same number every time,
+    and they must. A run holds every name exactly when the cut has no more pages than the
+    strip has rows; at that height the run IS the whole list, so the strip fills every row
+    it was given and the line below records it. A greater height cannot beat it either —
+    there are no more pages to draw, so the strip draws fewer rows than it is offered and
+    that height is not recorded. An equivalent mutant and dead code are the same finding,
+    and this repository deletes rather than pins.
+
+    What is left says the whole rule, and it covers two shapes at once: the rungs below the
+    windowed one draw `2/3` or nothing whatever they are offered — a frame too narrow to
+    draw one name is too narrow to draw one on row two — and a run that falls at the end of
+    the cut can be shorter than the rows it was given (see :func:`_compose`). Measuring
+    ROWS rather than rungs is also what covers a rung added below this one on the day it is
+    written: what is being bought is rows.
+
     One for a *slot* that draws no strip — a caller that asked about `repos` gets the
     height the pane already has, which is `layout.slot_sizes`' own filter-don't-refuse
     degrade rather than a raise on a name out of a committed file. One, too, for a *cap*
     below one: `filled` is the floor and the loop simply does not run, so there is no
     `max` in front of the range for no input to make observable.
     """
-    strip = BARS.get(slot)
-    if strip is None:
+    # **Not spelled `strip`**, though it is the natural word for what a `BARS` entry
+    # answers about. `tools/sweep.py`'s `swap-synonym` operator reads `strip` as the string
+    # method and offers `lstrip` for it, so a local of that name spends a mutation on a
+    # question about nothing — the same word collision #842 records one guard over, where
+    # `tests/test_claims`' `_REDACT_VERB` reads `strip` as a promise to redact.
+    entry = BARS.get(slot)
+    if entry is None:
         return 1
-    head, names, here, note = strip(fid)
+    head, names, here, note = entry(fid)
     width = pane_cols - 2 * pad_for(slot, pane_cols)
     filled = 1
     for rows in range(1, cap + 1):
-        lines, cols, _, _ = _compose(head, names, here, width, note=note, rows=rows)
-        # **Every name is DRAWN, asked of the map rather than of the text.** A name that is
-        # a substring of another would answer yes to a search of the finished row while
-        # nothing on screen could be clicked to reach it — `_Tabs` is what the operator can
-        # actually press, so it is what "the strip holds them all" has to mean. A strip
-        # that draws nothing has no names to hold and falls out of this by answering the
-        # empty set of a list that is also empty, or by never filling a row below.
-        if set(cols.values()) >= set(names):
-            return rows
-        # **A row the strip does not FILL is a row off the harness for nothing**, so the
-        # answer is the tallest height it fills rather than the tallest it is allowed. Two
-        # shapes reach here and one number covers both: the rungs below the windowed one
-        # draw `2/3` or nothing whatever they are offered — a frame too narrow to draw one
-        # name is too narrow to draw one on row two — and a run that falls at the end of
-        # the cut can be shorter than the rows it was given (see :func:`_compose`).
-        # Measuring rows rather than rungs is what covers a rung added below this one on
-        # the day it is written: what is being bought is rows.
+        lines, _cols, _more, _add = _compose(head, names, here, width,
+                                             note=note, rows=rows)
         if len(lines) == rows:
             filled = rows
     return filled

--- a/charter/frame/slots.py
+++ b/charter/frame/slots.py
@@ -3270,12 +3270,20 @@ def _bar_gap() -> str:
 
 
 class _Tabs:
-    """Which name each COLUMN of a bar's row is about, and which of them you are on.
+    """Which name each CELL of a bar is about, and which of them you are on.
 
     :class:`_Viewport` one axis over, and it exists for the reason that class states for
-    the repo table: a pointer event arrives as a NUMBER (`frame/events.py`), and the only
-    thing that knows what is at that number is the pass that composed the row. For a
-    table the number is a row; a bar is horizontal, so here it is a column.
+    the repo table: a pointer event arrives as a pair of NUMBERS (`frame/events.py`), and
+    the only thing that knows what is at them is the pass that composed the strip.
+
+    **The key is `(row, col)` and it was `col` alone until #829.** A strip is one row when
+    its names fit on one and as many as its pane was given when they do not, so "which
+    name is at column 40" stopped having an answer the moment there could be a second row
+    of names under the first. A column-keyed map on a two-row strip does not degrade — it
+    answers the row above about a click on the row below, which is `component.EVENT_KINDS`'
+    *fires wrongly* rather than *never fires*, and the whole reason :data:`_BAR_RULE` is
+    ASCII. There is no default row for the same reason: a caller that forgot to say which
+    row it is asking about must be a `TypeError` here, not a switch to the wrong tab.
 
     **A bar needs it MORE than the table does, because the ladder is not invertible.**
     :func:`_bar` has four rungs and three of them draw a different set of names — every
@@ -3312,10 +3320,10 @@ class _Tabs:
     __slots__ = ("_cols", "_here", "_more", "_add")
 
     def __init__(self) -> None:
-        self._cols: dict[int, str] = {}
+        self._cols: dict[tuple[int, int], str] = {}
         self._here = ""
-        self._more: frozenset[int] = frozenset()
-        self._add: frozenset[int] = frozenset()
+        self._more: frozenset[tuple[int, int]] = frozenset()
+        self._add: frozenset[tuple[int, int]] = frozenset()
 
     def forget(self) -> None:
         """Back to a bar nobody has drawn — for a test, and only a test.
@@ -3327,12 +3335,13 @@ class _Tabs:
         self.publish({}, "")
 
     def publish(self, columns: dict, here: str, more=(), add=()) -> None:
-        """Record what the paint that just happened put on each column, and where you are.
+        """Record what the paint that just happened put in each cell, and where you are.
 
-        *columns* maps a column of the component's OWN canvas — the rectangle `ctx.width`
-        describes, which is what `events.Dispatcher._on_canvas` delivers a click in — to
-        the name of the tab drawn there. Absent means the operator clicked a cell this
-        bar drew no tab into: the heading, the gap between two tabs, EITHER `+N` count,
+        *columns* maps a ``(row, column)`` of the component's OWN canvas — the rectangle
+        `ctx.width` and `ctx.height` describe, which is what `events.Dispatcher._on_canvas`
+        delivers a click in — to the name of the tab drawn there. Absent means the operator
+        clicked a cell this bar drew no tab into: the heading, the blank under it on a
+        strip that grew a second row, the gap between two tabs, EITHER `+N` count,
         the `n/N`, the empty space past the last name. `events.Dispatcher._on_canvas` applies
         the identical rule one axis over for the pad, and `_Viewport.publish` applies it
         for the table's heading row.
@@ -3365,7 +3374,7 @@ class _Tabs:
         second question anyway to know which.
 
         A `frozenset` and not a range, because the two counts are two disjoint runs and
-        the narrow rung's is a third — and because :meth:`more_at` asks about ONE column,
+        the narrow rung's is a third — and because :meth:`more_at` asks about ONE cell,
         which is the same question `_cols` answers and should be the same kind of lookup.
         """
         self._cols = dict(columns)
@@ -3373,8 +3382,8 @@ class _Tabs:
         self._more = frozenset(more)
         self._add = frozenset(add)
 
-    def switch_to(self, col: int):
-        """The tab a click at canvas column *col* should switch this frame to, or ``None``.
+    def switch_to(self, row: int, col: int):
+        """The tab a click at canvas cell (*row*, *col*) should switch to, or ``None``.
 
         **The rule lives here rather than in the handler**, which is `_Viewport.move`'s
         choice for its own answer: "a click on the tab you are already on does nothing"
@@ -3386,16 +3395,17 @@ class _Tabs:
         again, all of it to arrive where you already were.
 
         **One comparison, and there is deliberately no `name is None` beside it.** A
-        column nothing drew into is absent from the mapping, so ``get`` answers ``None``,
+        cell nothing drew into is absent from the mapping, so ``get`` answers ``None``,
         and ``None`` is never a name any caller publishes — so the expression below
         already answers ``None`` for it. A guard in front of that is a line no input can
         make observable, which is exactly what the deletion sweep reports as a survivor.
         """
-        name = self._cols.get(col)
+        name = self._cols.get((row, col))
         return None if name == self._here else name
 
-    def more_at(self, col: int) -> bool:
-        """Whether column *col* is a field standing for names this row could not draw.
+    def more_at(self, row: int, col: int) -> bool:
+        """Whether cell (*row*, *col*) is a field standing for names the strip could not
+        draw.
 
         **The other half of "a click on a cell nothing was drawn into does nothing".** A
         `+9` is not nothing: the operator can see it, it says there are nine more, and it
@@ -3415,13 +3425,13 @@ class _Tabs:
         point: that method answers "which name", and every caller of it feeds the name to
         a command that switches. A count has no name — that is what makes it a count — so
         a sentinel would be a value every one of those callers would have to learn to not
-        switch to. Two questions, two methods, and a column that is neither answers no to
+        switch to. Two questions, two methods, and a cell that is neither answers no to
         both.
         """
-        return col in self._more
+        return (row, col) in self._more
 
-    def add_at(self, col: int) -> bool:
-        """Whether column *col* is the affordance that makes a NEW chat.
+    def add_at(self, row: int, col: int) -> bool:
+        """Whether cell (*row*, *col*) is the affordance that makes a NEW chat.
 
         *"`+` button not working for creating new session."* :data:`ADD_CHAT` was a
         SENTENCE — `+ charter <harness> opens another` — which is true, which names the
@@ -3432,15 +3442,16 @@ class _Tabs:
         switch to yet, which is the whole point of pressing it. It is not :meth:`more_at`
         either — that stands for chats that EXIST and are off the row, and opening a picker
         over them is the opposite of making a new one. Three questions, three methods, and
-        a column that is none of them answers no to all three.
+        a cell that is none of them answers no to all three.
 
-        **They cannot be drawn on one row, which is structural rather than lucky.**
-        :func:`_bar` draws the affordance only on the rung where every name fits, and draws
-        a `+N` only on the rung where they do not — so a row carrying `+` never carries
-        `+9`, and the two fields that both begin with a `+` are never on screen together to
-        be confused with each other.
+        **They cannot be drawn on one strip, which is structural rather than lucky.**
+        :func:`_bar` draws the affordance only where the whole list is on the strip — the
+        rung that fits every name on one row, or a grown strip whose rows hold them all —
+        and draws a `+N` only where it is not. So a strip carrying `+` never carries a
+        `+9` on any of its rows, and the two fields that both begin with a `+` are never on
+        screen together to be confused with each other.
         """
-        return col in self._add
+        return (row, col) in self._add
 
 
 #: The one tab strip this process's bar draws into. See :class:`_Tabs` for why there is
@@ -3450,12 +3461,14 @@ class _Tabs:
 TABS = _Tabs()
 
 
-def _tab_columns(start: int, drawn, gap: int) -> dict:
-    """Which canvas column each drawn tab owns — the map :meth:`_Tabs.publish` takes.
+def _tab_columns(row: int, start: int, drawn, gap: int) -> dict:
+    """Which canvas cell each drawn tab owns — the map :meth:`_Tabs.publish` takes.
 
-    *drawn* is the ``(name, field)`` pairs the rung actually put on the row, in the order
+    *drawn* is the ``(name, field)`` pairs the rung actually put on *row*, in the order
     it put them: the raw name a click switches to, and the text that was drawn for it.
-    *start* is the column the first field begins in, and *gap* is how many cells the rung
+    *row* is which row of the strip they were drawn on — 0 on a strip of one row, and the
+    reason the map is keyed by a pair (:class:`_Tabs`). *start* is the column the first
+    field begins in, and *gap* is how many cells the rung
     put between two of them (:func:`_bar_gap`). So this walks the composition once more
     rather than guessing at it, and the two things that could have been guessed wrong
     are settled here in one place: **the mark belongs to the tab it marks** (it is drawn
@@ -3483,49 +3496,58 @@ def _tab_columns(start: int, drawn, gap: int) -> dict:
     trade `builtin_actions._SELECT_STEPS` makes when it writes its two starting points
     down as data rather than deriving them from a sign.
     """
-    cols: dict[int, str] = {}
+    cols: dict[tuple[int, int], str] = {}
     at = start - gap
     for name, field in drawn:
         at += gap
         width = tui.width(field)
         for col in range(at, at + width):
-            cols[col] = name
+            cols[(row, col)] = name
         at += width
     return cols
 
 
-def _span(start: int, text: str) -> range:
-    """The columns *text* occupies when it is drawn starting at column *start*.
+def _span(row: int, start: int, text: str) -> list[tuple[int, int]]:
+    """The cells *text* occupies when it is drawn on *row* starting at column *start*.
 
     Two lines, and it exists so the fields that are NOT tabs are measured by the same rule
     the tabs are (:func:`_tab_columns`): `tui.width` and never `len`, off the string the
     rung actually composed and never off a search of the finished row.
 
-    **An absent field is an empty range rather than a special case.** ``_span(n, "")``
-    contributes no column, so :func:`_bar` can hand both counts to the same expression
+    **An absent field is an empty span rather than a special case.** ``_span(r, n, "")``
+    contributes no cell, so :func:`_bar` can hand both counts to the same expression
     whether or not the page it cut carries either — which is the branch that would
     otherwise have to be written twice and got right twice.
     """
-    return range(start, start + tui.width(text))
+    return [(row, col) for col in range(start, start + tui.width(text))]
 
 
-def _page(fields: list[str], at: int, room: int, gap: int) -> tuple[int, int]:
-    """The half-open run of *fields* the tab at index *at* is drawn with, inside *room*.
+def _cuts(fields: list[str], room: int, gap: int) -> list[int]:
+    """Where each row's worth of *fields* starts and stops, inside *room* — the page
+    boundaries the windowed rung is cut along.
 
     :func:`_bar`'s windowed rung. *fields* are the already-marked, already-contained tab
-    texts; the answer is a slice of them wide enough to draw, with room left for the two
-    counts that stand for what it leaves out.
+    texts; the answer is the cut points, ``[0, …, len(fields)]``, so page *i* is
+    ``fields[out[i]:out[i + 1]]`` and each page is wide enough to draw with room left for
+    the two counts that stand for what it leaves out.
+
+    **It answers the whole cut rather than one page, and that is #829.** A strip is one
+    row when its names fit on one and as many rows as its pane was given when they do not,
+    so `_bar` needs the page its mark falls in AND the pages next to it. Handing back one
+    page and calling this again for the next would be the same walk done twice with two
+    chances to disagree; the cut is one list and `_bar` takes a run out of it.
 
     *gap* is how many cells go between two fields — :func:`_bar_gap`, resolved once by
     :func:`_bar` and handed to the cut, the composition and the map together, so that a
     plane which draws its rules cannot cut a page for one gap and draw it with another.
 
-    **The pages do not depend on *at*, and that is the whole design.** The list is cut
-    into consecutive pages left to right — greedily, as many whole names as fit, then the
-    next page from where that one stopped — and this returns whichever page the marked tab
-    falls in. So the page is a pure function of the NAMES, the WIDTH and the gap, and
-    switching to a tab that is on the page redraws that page unchanged with only the `*`
-    moved. The gap belongs in that list and changes nothing about the property: it is
+    **The pages depend on nothing but the names, the width and the gap, and that is the
+    whole design.** The list is cut into consecutive pages left to right — greedily, as
+    many whole names as fit, then the next page from where that one stopped. Nothing about
+    WHERE THE MARK IS enters the cut, so switching to a tab that is on a drawn page redraws
+    that page unchanged with only the `*` moved. That is what :func:`_bar` then leans on
+    twice: to pick the page the mark falls in on a one-row strip, and to pick the RUN of
+    pages it falls in on a strip that grew. The gap belongs in that list and changes nothing about the property: it is
     fixed for the life of a frame, so it cannot move a page out from under a pointer — the
     same standard the WIDTH is held to, which moves only on a resize that redraws the row
     anyway.
@@ -3643,13 +3665,36 @@ def _page(fields: list[str], at: int, room: int, gap: int) -> tuple[int, int]:
     # guarantee is that the row is never reduced to the tab you are standing on while
     # there was room for another, which is the harm: at every width from 150 columns up,
     # the marked page holds at least two names where it used to hold one.
-    i = bisect.bisect_right(cuts, at) - 1
-    return cuts[i], cuts[i + 1]
+    return cuts
 
 
 def _bar(head: str, names: list[str], here: str, width: int, *,
-         note: str = "") -> list[str]:
-    """One bar row: *head*, then *names* with *here* marked, inside *width* columns.
+         note: str = "", rows: int = 1) -> list[str]:
+    """One bar: *head*, then *names* with *here* marked, in *rows* x *width* cells.
+
+    :func:`_compose` composes it and this is what PUBLISHES it — the one call that writes
+    :data:`TABS`, so "the map describes what is on screen" is a property of two lines
+    rather than an agreement between six returns. The split is #829's: the launcher has to
+    ask how many rows this strip's names need before any pane exists
+    (:func:`bar_rows_wanted`), and a sizing question that published a click map would have
+    the launcher's answer overwrite the panel's — a map describing a strip nobody is
+    looking at.
+    """
+    lines, cols, more, add = _compose(head, names, here, width, note=note, rows=rows)
+    TABS.publish(cols, here, more, add)
+    return lines
+
+
+def _compose(head: str, names: list[str], here: str, width: int, *,
+             note: str = "", rows: int = 1):
+    """The strip *head*/*names*/*here* composes to, and the cells its tabs landed in.
+
+    Answers ``(lines, columns, more, add)`` — the rows to draw, the ``(row, col)`` map
+    :meth:`_Tabs.publish` takes, and the two cell sets that are not tabs. :func:`_bar` is
+    the caller that publishes; nothing here writes anything down.
+
+    *rows* is how many rows the PANE has, which the strip grows into only as far as its
+    names need (#829). One is the shipped shape and every rung below is unchanged at it.
 
     **One function for both bars, so the two cannot degrade differently.** That is why it
     exists rather than each renderer composing its own: `workspaces` and `chats` sit on
@@ -3662,8 +3707,31 @@ def _bar(head: str, names: list[str], here: str, width: int, *,
     2. **The PAGE the one you are in falls on, plus a count at each end** (`+5  …  +9`).
        Every name on the row goes WHOLE, which is `_fit_fields`' own discipline one row
        over: a list cut off mid-name is a list where `api-staging` and `api-standby` are
-       the same string, and half a name is worse than an honest count. :func:`_page` is
+       the same string, and half a name is worse than an honest count. :func:`_cuts` is
        the cut and carries why it is a page rather than a window centred on *here*.
+
+       **On a strip of *rows* rows this rung draws *rows* consecutive pages**, and the run
+       is picked the way the page is: the pages are grouped into runs of *rows* from the
+       start of the list, and the strip draws the run its marked page falls in. That keeps
+       the property the single page has and the whole cut exists for — a run is a function
+       of the NAMES, the WIDTH and the row count alone, so switching to a tab that is drawn
+       redraws the same run with only the `*` moved, and no cell the operator just pressed
+       holds a different name a moment later. A leading `+N` goes on the FIRST row of the
+       run and a trailing one on the LAST, because that is where the names they stand for
+       actually are.
+
+       **The last run can be short, and that is a stated cost rather than an oversight.**
+       Runs are cut from the START of the list, so a list of four pages drawn three rows at
+       a time has a last run of one — and a frame standing on it draws one row in a
+       three-row pane. Filling that run by starting it at ``pages - rows`` instead was
+       measured and is the WRONG trade: it makes a run depend on which page the mark is on
+       at the boundary (from the tail run, pressing a tab drawn on page 2 would repaint as
+       the run starting at page 0), so the cell the operator just pressed holds a different
+       name a moment later — the double-press this whole cut exists to stop, arriving one
+       axis over. Blank rows at the bottom of a strip are what a short run costs; a switch
+       to the wrong tab is what filling it would. It is also only reachable while the row
+       count is CAPPED: `bar_rows_wanted` asks for the rows that hold the whole list, and a
+       run that is the whole list is never short.
 
        **This rung used to draw the marked name alone**, and on a real plane that made
        the whole bar inert: fifteen workspaces need 274 columns for rung 1, so every
@@ -3700,22 +3768,22 @@ def _bar(head: str, names: list[str], here: str, width: int, *,
     "add chat" affordance, and nothing else today. Dropped first, before any name, because
     it is a reminder and the names are the readout.
 
-    **Every rung publishes its own column map** (:data:`TABS`), which is what makes the
-    bar clickable at all and is the same discipline `_repos` keeps for the table's rows:
-    the handler resolves a click against WHAT WAS DRAWN rather than against what it
-    thinks would have been. Only the names actually on the row get columns — the heading,
-    the gaps, BOTH `+N` counts, the `n/N` and the affordance are cells this bar drew no
-    tab into and a click on one of them switches nothing. **The rungs that draw NOTHING
-    publish too**, and that is the half `_Viewport.blank` exists for one axis over: a bar
-    that kept its last map through a resize down to `2/3`, or down to no row at all, would
-    switch to a tab the operator can see is not on screen.
+    **Every rung answers with its own cell map**, which is what makes the bar clickable at
+    all and is the same discipline `_repos` keeps for the table's rows: the handler
+    resolves a click against WHAT WAS DRAWN rather than against what it thinks would have
+    been. Only the names actually on the strip get cells — the heading, the blank under it,
+    the gaps, BOTH `+N` counts, the `n/N` and the affordance are cells this bar drew no tab
+    into and a click on one of them switches nothing. **The rungs that draw NOTHING answer
+    too**, with an empty map, and that is the half `_Viewport.blank` exists for one axis
+    over: a bar that kept its last map through a resize down to `2/3`, down to one row, or
+    down to no row at all, would switch to a tab the operator can see is not on screen.
 
     **The windowed rung sharpens that rather than softening it.** It draws a different
-    slice of the names at every width, so a map kept across a resize would answer with a
-    name that is genuinely somewhere else on the row — not merely absent from it. The map
-    is published from the composition itself (`row`'s *before*, and :func:`_tab_columns`
-    walking the fields the rung actually joined), so there is no second walk of the ladder
-    to disagree with the first.
+    slice of the names at every width and at every row count, so a map kept across a resize
+    would answer with a name that is genuinely somewhere else on the strip — not merely
+    absent from it. The map is built from the composition itself (`rung`'s *before*, and
+    :func:`_tab_columns` walking the fields each row actually joined), so there is no
+    second walk of the ladder to disagree with the first.
     """
     # **`head` and `note` are NOT contained, and the deletion sweep is what settled it.**
     # Both are charter's own literals — `"chats"`, `"workspaces"`, :data:`ADD_CHAT` — and
@@ -3725,8 +3793,16 @@ def _bar(head: str, names: list[str], here: str, width: int, *,
     # contained, below, which is where the open alphabet actually is.
     from . import chrome
     lead = _inset() + head + " " * _BAR_GAP
+    # **The rows under the first start where the first row's tabs do.** The heading names
+    # the strip once — a `chats` repeated down the left of a three-row strip is the same
+    # word three times where names are competing for columns — and the blank under it is
+    # what keeps every row's tabs in one column, so a run of pages reads as one block
+    # rather than as three rows that happen to be adjacent. It is also what lets every page
+    # be cut against ONE `room`: a second row starting further left would be a wider row
+    # than the cut was made for, and the cut is what a click's stability rests on.
+    under = " " * tui.width(lead)
     # **Resolved ONCE, here, and handed to everything below it.** The cut
-    # (:func:`_page`), the composition and the map (:func:`_tab_columns`) all need to
+    # (:func:`_cuts`), the composition and the map (:func:`_tab_columns`) all need to
     # agree about how wide the seam between two tabs is, and `charter.toml` is re-read
     # behind :func:`_bar_gap` — so three readings is three chances for the map to describe
     # a row that was drawn with a different gap. This is `_Viewport.blank`'s discipline
@@ -3734,39 +3810,44 @@ def _bar(head: str, names: list[str], here: str, width: int, *,
     gap = _bar_gap()
     gapw = tui.width(gap)
 
-    def row(body: str = "", drawn=(), before: str = "", more=(), add=()) -> list[str]:
-        """This rung's row, and the column map for the tabs it actually drew.
+    def rung(drawn_rows=(), more=(), add=()):
+        """This rung's rows, and the cell map for the tabs they actually drew.
 
         **Every way out of the ladder goes through here**, which is what keeps "the map
-        describes the row" a property of one line rather than an agreement between six
-        returns. `_repos` learnt that the expensive way: three of its four exits cleared
-        the click map and none of them cleared the scroll bound, and `_Viewport.blank` is
-        the method that finding produced.
+        describes the strip" a property of one function rather than an agreement between
+        six returns. `_repos` learnt that the expensive way: three of its four exits
+        cleared the click map and none of them cleared the scroll bound, and
+        `_Viewport.blank` is the method that finding produced.
 
-        An empty *body* is the rung that draws nothing — rung 4, and a bar with no names.
-        It still publishes, for the reason the docstring above gives.
+        *drawn_rows* is one ``(before, body, drawn)`` per row of the strip, top down. No
+        rows at all is the rung that draws nothing — rung 4, and a bar with no names. It
+        still returns a map, an empty one, for the reason the docstring above gives.
 
-        *before* is what a rung draws between the heading and its FIRST tab — the leading
-        `+3` of the windowed rung, and nothing else today. It is passed rather than glued
-        onto *body* by the caller because the map is measured from where the first tab
-        starts: a rung that composed its own prefix would be publishing columns three
-        cells left of the names it drew, which is a click landing on the tab beside the one
-        the operator pressed. Every other rung starts its tabs at the lead and says so by
-        not passing it.
+        *before* is what a row draws between its lead and its FIRST tab — the leading `+3`
+        of the windowed rung, and nothing else today. It is passed rather than glued onto
+        *body* by the caller because the map is measured from where the first tab starts: a
+        rung that composed its own prefix would be publishing columns three cells left of
+        the names it drew, which is a click landing on the tab beside the one the operator
+        pressed. Every other row starts its tabs at the lead and says so by passing "".
 
-        *more* is the columns of the fields that stand for names this rung could NOT draw
+        *more* is the cells of the fields that stand for names this rung could NOT draw
         — both `+N` counts, and the `n/N`. Passed here rather than worked out inside
         :data:`TABS` for :func:`_tab_columns`' whole reason: the rung that composed the
-        row is the only thing that knows where it put them, and a second walk of the
-        ladder to find them again is a second answer to what is on the row.
+        strip is the only thing that knows where it put them, and a second walk of the
+        ladder to find them again is a second answer to what is on screen.
 
         *add* is the same for :data:`ADD_CHAT`, on the one rung that draws it.
         """
-        TABS.publish(_tab_columns(tui.width(lead + before), drawn, gapw), here, more, add)
-        return [lead + before + body] if body else []
+        cols: dict = {}
+        lines: list[str] = []
+        for r, (before, body, drawn) in enumerate(drawn_rows):
+            head_cells = lead if r == 0 else under
+            cols.update(_tab_columns(r, tui.width(head_cells + before), drawn, gapw))
+            lines.append(head_cells + before + body)
+        return lines, cols, more, add
 
     if not names:
-        return row()
+        return rung()
     # **Which row is yours is decided on the RAW names; only the drawing uses the
     # contained ones.** `choose.Roster` makes the same split one surface over and for the
     # same reason: `contain.one_line` is a repair, so two names that differ only in what
@@ -3799,20 +3880,30 @@ def _bar(head: str, names: list[str], here: str, width: int, *,
     room = width - tui.width(lead)
     joined = gap.join(marked)
     if note and tui.width(joined) + gapw + tui.width(note) <= room:
-        # The affordance's own columns, measured off this composition — :func:`_span`'s
-        # reason, and the same walk the counts get one rung down. It is the ONLY rung that
-        # draws it, which is why a `+` and a `+9` are never on one row.
-        return row(gap.join(painted) + gap + note, zip(names, marked),
-                   add=_span(tui.width(lead + joined + gap), note))
+        # The affordance's own cells, measured off this composition — :func:`_span`'s
+        # reason, and the same walk the counts get one rung down. It is drawn only where
+        # the whole list is on the strip, which is why a `+` and a `+9` are never on one.
+        return rung([("", gap.join(painted) + gap + note, zip(names, marked))],
+                    add=_span(0, tui.width(lead + joined + gap), note))
     if tui.width(joined) <= room:
-        return row(gap.join(painted), zip(names, marked))
+        return rung([("", gap.join(painted), zip(names, marked))])
     if at >= 0:
         # **No `if len(names) > 1` here, and it is unreachable rather than merely
         # untested.** With ONE name the page is that name, both counts are absent, and the
         # body this composes IS `joined` — so the rung above asks exactly what this one
         # asks and always answers first. The sweep found the old conditional as a survivor
         # for that reason and the shape has not changed.
-        first, last = _page(marked, at, room, gapw)
+        cuts = _cuts(marked, room, gapw)
+        # **The run of pages this strip's *rows* rows draw, and the page the mark is on is
+        # in it by construction.** The pages are grouped from the start of the list into
+        # runs of *rows*, so the run is `bisect`'s page index divided by the row count —
+        # a function of the names, the width and the row count and of nothing that moves
+        # when the operator switches. `rows == 1` makes every run one page, which is
+        # exactly the answer this rung gave before it could grow.
+        page = bisect.bisect_right(cuts, at) - 1
+        run = (page // rows) * rows
+        stop = min(run + rows, len(cuts) - 1)
+        first, last = cuts[run], cuts[stop]
         # Neither count is a tab. `+9` stands for names that are not on the row, so there
         # is nothing there to switch to and saying so is better than picking one of them —
         # `_Viewport.publish`'s rule for `…(+N more)`, one axis over. **Two of them, and
@@ -3830,28 +3921,51 @@ def _bar(head: str, names: list[str], here: str, width: int, *,
         # about what a `+9` looks like it does.
         leading = f"+{first}" if first else ""
         trailing = f"+{len(names) - last}" if last < len(names) else ""
-        before = f"{leading}{gap}" if leading else ""
-        tabs = gap.join(marked[first:last])
-        after = f"{gap}{trailing}" if trailing else ""
-        body = tabs + after
-        # Where the two counts landed, taken from the composition above rather than
-        # searched for in the finished string — :func:`_tab_columns`' discipline for the
-        # names, kept for the fields that are not names. :func:`_span` answers an empty
-        # range for a count this page does not carry, so there is no branch here to get
-        # wrong: a page at the start of the list has no leading count and contributes no
-        # columns.
+        # **The affordance rides the run that holds the WHOLE list**, and only that one.
+        # `_Tabs.add_at`'s structural promise is that a strip carrying `+` carries no `+N`
+        # anywhere, and this is where it is kept: neither count exists exactly when the run
+        # starts at the head of the list and reaches its end, which is the multi-row form
+        # of the rung above. A `+` beside a `+9` on two rows of one strip would be the two
+        # `+` fields on screen together that the promise exists to prevent.
+        tail = note if note and not leading and not trailing else ""
         start = tui.width(lead)
-        counts = [*_span(start, leading),
-                  *_span(start + tui.width(before + tabs + gap), trailing)]
-        # Measured, not assumed. :func:`_page` puts at least one name on a page, so a name
+        plain, painted_rows = [], []
+        counts: list[tuple[int, int]] = []
+        add: list[tuple[int, int]] = []
+        for r, page in enumerate(range(run, stop)):
+            lo, hi = cuts[page], cuts[page + 1]
+            last_row = page == stop - 1
+            # The leading count goes on the FIRST row of the run and the trailing one on
+            # the LAST, because that is where the names they stand for actually are: what
+            # `+5` is about sits to the left of the first tab drawn, and what `+9` is about
+            # follows the last. On a one-row strip both land on the one row, which is the
+            # answer this rung gave before it could grow. The affordance takes the trailing
+            # field's place on the row that ends a run holding the whole list, which is the
+            # only run either of them can be on.
+            before = f"{leading}{gap}" if leading and r == 0 else ""
+            after = f"{gap}{trailing or tail}" if last_row and (trailing or tail) else ""
+            tabs = gap.join(marked[lo:hi])
+            # Where the fields that are not names landed, taken from the composition above
+            # rather than searched for in the finished string — :func:`_tab_columns`'
+            # discipline for the names, kept for the rest. :func:`_span` answers an empty
+            # span for a field this row does not carry, so there is no branch here to get
+            # wrong: a row with no leading count contributes no cells.
+            at_end = start + tui.width(before + tabs + gap)
+            counts += _span(r, start, leading if before else "")
+            counts += _span(r, at_end, trailing if last_row else "")
+            add += _span(r, at_end, tail if last_row else "")
+            plain.append((before, tabs + after))
+            painted_rows.append((before, gap.join(painted[lo:hi]) + after,
+                                 list(zip(names[lo:hi], marked[lo:hi]))))
+        # Measured, not assumed. :func:`_cuts` puts at least one name on a page, so a name
         # wider than the whole row composes a body that overflows — and this ladder gives a
-        # rung up rather than drawing part of anything. Measured on the PLAIN body for the
-        # reason `painted` states: the two are the same width, and the one that is the same
-        # width by construction is the one to hold a refusal on.
-        if tui.width(before + body) <= room:
-            return row(gap.join(painted[first:last]) + after,
-                       zip(names[first:last], marked[first:last]), before=before,
-                       more=counts)
+        # rung up rather than drawing part of anything. Measured on the PLAIN rows for the
+        # reason `painted` states: they are the same width as the painted ones, and the one
+        # that is the same width by construction is the one to hold a refusal on. EVERY row
+        # is measured, not just the first: a run whose second page overflows is a strip
+        # drawing part of a name on a row nothing else would have looked at.
+        if all(tui.width(before + body) <= room for before, body in plain):
+            return rung(painted_rows, more=counts, add=add)
     counted = f"{at + 1}/{len(names)}" if at >= 0 else str(len(names))
     if tui.width(counted) <= room:
         # **The narrow rung is a count too, and it is the one where this matters most.**
@@ -3860,8 +3974,8 @@ def _bar(head: str, names: list[str], here: str, width: int, *,
         # all. A frame narrow enough to fall here had a strip that could be pointed at and
         # not pressed; it opens the palette now, which is the surface that works at every
         # width.
-        return row(counted, more=_span(tui.width(lead), counted))
-    return row()
+        return rung([("", counted, ())], more=_span(0, tui.width(lead), counted))
+    return rung()
 
 
 #: The chat bar's add-chat affordance (§3.6) — a BUTTON now, and one cell of it.
@@ -3895,27 +4009,20 @@ def _bar(head: str, names: list[str], here: str, width: int, *,
 ADD_CHAT = "+"
 
 
-def chats_bar(fid: str, width: int) -> list[str]:
-    """Which chats this workspace holds and which one you are typing in.
-
-    **A readout, never the mechanism** (§3.6). The palette reaches every chat in two
-    keystrokes at every width, including widths where this row cannot be drawn at all —
-    which is why the row may degrade to a count and then to nothing, and why
-    `layout._DROP_ORDER` gives it up before `top`.
+def _chats_strip(fid: str):
+    """What the chat strip is a strip OF — its heading, its names, the one you are typing
+    in, and its note.
 
     Never raises for a plane it cannot read: `chats.roster` already answers with the chat
     asking and nothing else for a frame root it could not scan, and `_bar` answers `[]`
     for an empty list.
     """
     from . import chats as chats_mod
-    names = [c.id for c in chats_mod.roster(fid)]
-    return _bar("chats", names, fid, width, note=ADD_CHAT)
+    return "chats", [c.id for c in chats_mod.roster(fid)], fid, ADD_CHAT
 
 
-def workspaces_bar(fid: str, width: int) -> list[str]:
-    """Which workspaces this plane has and which one this frame is drawing.
-
-    :func:`chats_bar`'s rules and its ladder, one noun over. The name is the FRAME's
+def _workspaces_strip(fid: str):
+    """:func:`_chats_strip` one noun over. The name is the FRAME's
     (`switch.current_workspace` → `state.workspace_for`), never one this pane resolved for
     itself — #512, and the same rung order `_top` reads two rows up.
 
@@ -3928,8 +4035,114 @@ def workspaces_bar(fid: str, width: int) -> list[str]:
     thing a one-row strip can be.
     """
     from . import switch as switch_mod
-    return _bar("workspaces", switch_mod.workspaces(),
-                switch_mod.current_workspace(fid), width)
+    return ("workspaces", switch_mod.workspaces(),
+            switch_mod.current_workspace(fid), "")
+
+
+#: The slots that draw a TAB STRIP, mapped to what each one is a strip of.
+#:
+#: :data:`SLOTS` one component family over, and a table rather than a pair of literals for
+#: that constant's reason: it is what makes "which slots have a height that follows their
+#: content" a question :func:`bar_rows_wanted` can answer for a name, and what makes a
+#: third strip added to charter reach the sizer on the day it is written rather than the
+#: day somebody remembers this file. The deletion sweep can see an entry removed from
+#: here; it could see nothing at all in a comment.
+BARS = {"chats": _chats_strip, "workspaces": _workspaces_strip}
+
+
+def bar_rows_wanted(fid: str, slot: str, *, pane_cols: int, cap: int) -> int:
+    """How many rows *slot*'s tab strip needs to draw every name it has, in a
+    *pane_cols*-column PANE — never fewer than one and never more than *cap* (#829).
+
+    *"panes are resizable — and user can resize and it should show more tabs opened on new
+    resized rows."* A strip cannot make its own pane taller: tmux owns pane geometry and
+    both bars declare `Fixed(1)`, so the row an overflowing strip needs has to be asked for
+    by the LAUNCHER (`layout.slot_sizes`, through `commands_frame._slot_sizes`) and this is
+    the question it asks.
+
+    **One answer to "how tall is this strip", read by both sides of it** —
+    :func:`repos_rows_wanted`'s whole argument, one slot family over, and it is stronger
+    here because this asks the renderer itself. The rung a strip lands on is a four-step
+    ladder with a greedy cut inside it; a second arithmetic that predicted the row count
+    from the names and the width would be a second implementation of that ladder, and the
+    two would disagree the first time a rung moved. :func:`_compose` is the ladder, so what
+    this counts is what the pane will actually hold.
+
+    It composes and never publishes, which is what :func:`_compose` exists for: this runs
+    in the LAUNCHER's process and in the `frame-resize` child, and a sizing question that
+    wrote :data:`TABS` would leave a map describing a strip nobody is looking at.
+
+    *cap* is a caller's, never a policy read here — `layout.BAR_MAX_ROWS`, threaded exactly
+    the way `layout.repos_rows` takes *pinned_rows* and for the same reason: applying a
+    ceiling here AND in `layout._grown` would be a bound no input could make observable,
+    which is the survivor `tools/sweep.py` reports and this repository deletes. It also
+    bounds the loop, so a plane with two hundred chats costs *cap* compositions and not
+    two hundred.
+
+    **The component's own pad comes off *pane_cols* first**, for the reason
+    :func:`repos_rows_wanted` gives about #500: `_chats` composes at :func:`content_width`,
+    so a padded pane's strip is planned for `pane_cols - 2 * pad` and asking the unpadded
+    question would size this pane from a number the renderer never sees.
+
+    One for a *slot* that draws no strip — a caller that asked about `repos` gets the
+    height the pane already has, which is `layout.slot_sizes`' own filter-don't-refuse
+    degrade rather than a raise on a name out of a committed file. One, too, for a *cap*
+    below one: `filled` is the floor and the loop simply does not run, so there is no
+    `max` in front of the range for no input to make observable.
+    """
+    strip = BARS.get(slot)
+    if strip is None:
+        return 1
+    head, names, here, note = strip(fid)
+    width = pane_cols - 2 * pad_for(slot, pane_cols)
+    filled = 1
+    for rows in range(1, cap + 1):
+        lines, cols, _, _ = _compose(head, names, here, width, note=note, rows=rows)
+        # **Every name is DRAWN, asked of the map rather than of the text.** A name that is
+        # a substring of another would answer yes to a search of the finished row while
+        # nothing on screen could be clicked to reach it — `_Tabs` is what the operator can
+        # actually press, so it is what "the strip holds them all" has to mean. A strip
+        # that draws nothing has no names to hold and falls out of this by answering the
+        # empty set of a list that is also empty, or by never filling a row below.
+        if set(cols.values()) >= set(names):
+            return rows
+        # **A row the strip does not FILL is a row off the harness for nothing**, so the
+        # answer is the tallest height it fills rather than the tallest it is allowed. Two
+        # shapes reach here and one number covers both: the rungs below the windowed one
+        # draw `2/3` or nothing whatever they are offered — a frame too narrow to draw one
+        # name is too narrow to draw one on row two — and a run that falls at the end of
+        # the cut can be shorter than the rows it was given (see :func:`_compose`).
+        # Measuring rows rather than rungs is what covers a rung added below this one on
+        # the day it is written: what is being bought is rows.
+        if len(lines) == rows:
+            filled = rows
+    return filled
+
+
+def chats_bar(fid: str, width: int, rows: int = 1) -> list[str]:
+    """Which chats this workspace holds and which one you are typing in.
+
+    **A readout, never the mechanism** (§3.6). The palette reaches every chat in two
+    keystrokes at every width, including widths where this row cannot be drawn at all —
+    which is why the row may degrade to a count and then to nothing, and why
+    `layout._DROP_ORDER` gives it up before `top`.
+
+    *rows* is the pane's height, which the strip grows into only as far as its names need.
+    It defaults to one because one is the shape every caller had before #829 and the shape
+    a strip whose names fit still has.
+    """
+    head, names, here, note = _chats_strip(fid)
+    return _bar(head, names, here, width, note=note, rows=rows)
+
+
+def workspaces_bar(fid: str, width: int, rows: int = 1) -> list[str]:
+    """Which workspaces this plane has and which one this frame is drawing.
+
+    :func:`chats_bar`'s rules and its ladder, one noun over — see :func:`_workspaces_strip`
+    for what it draws and why it draws no `+`.
+    """
+    head, names, here, note = _workspaces_strip(fid)
+    return _bar(head, names, here, width, note=note, rows=rows)
 
 
 #: Which slots draw something that CHANGES ON ITS OWN, with no version bump and no

--- a/docs/frame.md
+++ b/docs/frame.md
@@ -538,14 +538,28 @@ it.
 
 ### The two bars, and why they are off unless you ask
 
-`chats` and `workspaces` are one-row components: the chat bar names every chat in this
-workspace with yours marked, and the workspace bar does the same for the plane. Where the
-names do not all fit the bar draws the page yours falls on and counts what is off each end
+`chats` and `workspaces` are tab strips: the chat bar names every chat in this workspace
+with yours marked, and the workspace bar does the same for the plane. Where the names do
+not all fit the bar draws the page yours falls on and counts what is off each end
 (`+5  *harness-wrapper   news-dispatch-guard  …  +7`); narrower still it says only where you
 are (`2/3`). It never shows half a name.
 
 Fifteen workspaces need 274 columns to fit on one row, so on a real terminal the bar is
 usually drawing a page. At 120 columns it draws six of them, at 160 eight, at 200 ten.
+
+**A strip that cannot fit its names on one row is given another one — up to three.** It is
+one row whenever the names fit, so a plane whose strip is not overflowing never loses a row
+to this; and the rows it does take come out of what your session has above its own 12-row
+floor, so a short terminal grows nothing at all. Fifteen workspaces take two rows at 160
+columns and three at 120, and every name on every row is clickable. Resize the terminal and
+the strip follows: widen it past 274 columns and the strip gives its extra rows back.
+
+Below tmux 3.3 that last part does not happen on its own. `window-resized` is a hook tmux
+added in 3.3, so charter has nothing to trigger a recompute on and the strip keeps the
+height it was given when the frame was launched — which is still the right height for the
+width it launched at. `charter frame-resize`, run in the frame's own window, puts every
+panel back at once, and it is the same command the frame already tells you about in that
+band.
 
 **The tab you are on is drawn as a block**, in reverse video — your own terminal's two
 colours exchanged, so it is right on every theme and needs no `[frame] chrome`. The `*`
@@ -1920,10 +1934,11 @@ charter cannot honour.
 **The chat and workspace bars take a real height too, by the same rule.** Charter places
 neither of them by default, so neither has a slot whose geometry is derived at import;
 their height is read off your arrangement at every launch, exactly like the repo table's
-pin. So `size = 3` on `chats` gives you a three-row bar. They draw one row of names — the
-rest is empty surface, which is a thing you may want under a `bg` and is otherwise a waste
-of rows. The same whole-number rule applies: anything charter cannot turn into cells takes
-the arrangement out of play.
+pin. So `size = 3` on `chats` gives you a three-row bar. It is a FLOOR rather than a
+ceiling: a strip whose names need more rows than you pinned still grows into what the
+window can spare, and a strip whose names fit on one row still draws one and leaves the
+rest as empty surface — a thing you may want under a `bg`. The same whole-number rule
+applies: anything charter cannot turn into cells takes the arrangement out of play.
 
 **Your pin is still capped so your session keeps its 12 rows.** tmux does not refuse an
 over-large pane height, it grants it out of the neighbour, and the neighbour is your agent

--- a/docs/news/unreleased-a-tab-strip-grows-a-row-when-its-tabs-overflow.md
+++ b/docs/news/unreleased-a-tab-strip-grows-a-row-when-its-tabs-overflow.md
@@ -1,0 +1,99 @@
+---
+version: unreleased
+headline: a tab strip whose names will not fit on one row is given another one — and gives it back when the pane is widened again
+---
+
+*"panes are resizable — and user can resize and it should show more tabs opened on new
+resized rows."*
+
+On this repository's own plane, fifteen workspaces need **274 columns** to draw every name
+on one row. At 160 columns the strip drew seven of them and counted the rest; at 120,
+five. Widening the pane bought a name or two and widening the terminal bought nothing at
+all, because the pane was one row and stayed one row however much space there was around
+it.
+
+It is one row no longer. A strip is now as many rows as its own names need, up to three,
+and exactly one row when they fit.
+
+```
+before, 160 columns
+  workspaces   authority-audit   autonomy   charter-update-skill   default   fleet  *harness-wrapper   news-dispatch-guard   opencode-integration  +7
+
+after, 160 columns
+  workspaces   authority-audit   autonomy   charter-update-skill   default   fleet  *harness-wrapper   news-dispatch-guard   opencode-integration
+               plane-shape   relations-and-delegations   showcase   statusline-improvements   todos   tracking-github-issues   user-reporting
+```
+
+## A panel cannot make its own pane taller, so this is a size and not a setting
+
+tmux owns pane geometry and both bars declare `size = Fixed(1)`, so a renderer that wanted
+a second row had nothing to draw it into. The row is asked for by the LAUNCHER —
+`layout.slot_sizes`, through the one boundary where a plane becomes a pane height
+(`commands_frame._slot_sizes`) — and the same recompute runs on every `window-resized`.
+That is the seam the repo table has had since #488, and a strip is the second thing to use
+it.
+
+What decides the number is `slots.bar_rows_wanted`, and it asks the RENDERER rather than
+predicting it: it composes the strip at one row, then two, then three, and stops at the
+first height that holds every name. So the pane is never taller than what is drawn into it
+and never shorter — the sizer-and-renderer disagreement #500 shipped twice one pane over
+cannot happen here, because there is only one arithmetic.
+
+## It grows only when the tabs overflow, and only into rows the harness can spare
+
+Two shapes were on the table and the second one is deliberately not what shipped.
+
+**A fixed two-row launch** would cost a row off the harness permanently, on every plane
+that places a bar, whether or not the names overflow. That is a real cost paid by everyone
+for a case only some planes hit, and rows against the harness are exactly what #740 settled
+once already. A plane whose names fit never loses a row now.
+
+**And a strip that does overflow may only take what the harness has above
+`layout.HARNESS_MIN_ROWS`.** The budget is `layout.harness_rows` of the ungrown map minus
+that floor, so a short window grows nothing — silently, the way `layout.visible_slots`
+already drops both bars whole when rows are the tight dimension. The repo table is not what
+pays either: `layout._DROP_ORDER` gives the bars up BEFORE `repos`, so they cannot be fed
+from it when rows are plentiful. Verified against real tmux, because tmux does not refuse
+an over-large `resize-pane -y` — it grants it out of the neighbour.
+
+Three rows is the ceiling. Measured through the same cut the strip draws with, these
+fifteen names need 2 rows at 160 columns, 3 at 120, 4 at 100 and 6 at 80 — so three draws
+every workspace this plane has at every width #725 measured an operator running at, and
+stops short of the width where the strip would be taking six rows off the harness to become
+the list `charter frame-palette` already is.
+
+## Every row is clickable, and that is the half that had to be got right
+
+`slots.TABS` mapped a COLUMN to a tab. On a two-row strip that does not degrade to
+answering nothing — it answers the row above about a click on the row below, which is
+`component.EVENT_KINDS`' *fires wrongly* rather than *never fires*, and the same harm
+`slots._BAR_RULE` is ASCII to avoid. The map is keyed by `(row, col)` now, with no default
+row: a caller that forgot to say which row it is asking about is a `TypeError` rather than
+a switch to the wrong tab.
+
+The rows are cut the way the single row always was. The names are cut into pages, the pages
+are grouped into runs of as many as the strip has rows, and the strip draws the run its
+marked tab falls in — so a run is a function of the names, the width and the row count
+alone, and pressing a tab that is drawn redraws the same run with only the `*` moved. That
+is the property #767 restored for one row, kept for three: no cell the operator just
+pressed holds a different name a moment later.
+
+The `+` that makes a chat is still there when the whole list is on the strip, and a `+N`
+count still appears only when it is not — so the two fields that both begin with a `+` are
+never on screen together, which is what `_Tabs.add_at` promised when there was only one row
+to promise it about.
+
+## At the 3.2 floor
+
+The launch is not gated: `split-window -l 3` works on every tmux charter supports, so a
+strip is born at the height its names need at the floor exactly as it is on 3.7c —
+measured on `tmux-3.2`, where the same `_reassert_sizes` this change routes through leaves
+the strip 3 rows and the harness 25 in a 120x40 window, byte for byte what 3.7c does.
+
+What the floor does not have is the trigger. `window-resized` is a tmux 3.3 hook — on 3.2,
+`set-hook -w window-resized …` answers `invalid option: window-resized`, rc 1, and
+`commands_frame._install_resize_hook` issues no command at all below
+`tmuxctl.RESIZE_HOOK_FLOOR`. So dragging the divider there re-lays-out nothing and the
+strip keeps the height it was born with, until `charter frame-resize` is run in the frame's
+own window — which is the recovery `tmuxctl.below_resize_hook_message` already names for
+every panel in that band, and which really does re-size the strip on 3.2.

--- a/tests/test_a_click_on_a_tab_bar_switches.py
+++ b/tests/test_a_click_on_a_tab_bar_switches.py
@@ -154,7 +154,7 @@ class AClickOnAChatTabStartsTheChatSwitch(_ABarThatWasDrawn, unittest.TestCase):
         row = slots.chats_bar("api.1", self.WIDTH)[0]
         self.assertNotIn("web.1", row)
         for col in range(0, self.WIDTH):
-            self.assertNotEqual(slots.TABS.switch_to(col), "web.1", f"column {col}")
+            self.assertNotEqual(slots.TABS.switch_to(0, col), "web.1", f"column {col}")
 
     def test_a_tab_the_command_will_refuse_is_still_handed_to_the_command(self):
         """**The refusal belongs where it can be SAID**, which is not here.
@@ -214,7 +214,7 @@ class AClickOnAWorkspaceTabStartsTheWorkspaceSwitch(_ABarThatWasDrawn,
         process would have resolved for itself out of a shared server's environment."""
         self.assertIn("*beta", self.row)
         for col in range(0, self.WIDTH):
-            self.assertNotEqual(slots.TABS.switch_to(col), "beta", f"column {col}")
+            self.assertNotEqual(slots.TABS.switch_to(0, col), "beta", f"column {col}")
         self.assertEqual(self.spawned, [])
 
 
@@ -579,13 +579,13 @@ class APressOnThePlusMakesAChat(_ABarThatWasDrawn, unittest.TestCase):
         The chat bar is asked the same question with the same hand-made map, so this is
         not "the workspaces handler ignores everything" wearing an assertion.
         """
-        slots.TABS.publish({}, "", add=[7])
+        slots.TABS.publish({}, "", add=[(0, 7)])
         self.spawned.clear()
         self._handler("workspaces", "f1")(_press(7))
         self.assertEqual(self.spawned, [],
                          "the workspace bar's handler makes chats — it is only the "
                          "renderer that is stopping it")
-        slots.TABS.publish({}, "", add=[7])
+        slots.TABS.publish({}, "", add=[(0, 7)])
         self._handler("chats", "f1")(_press(7))
         self.assertEqual([argv[-1] for argv, _fid in self.spawned], ["frame-new-chat"],
                          "the control failed: the chat bar's handler is not wired either")

--- a/tests/test_a_pinned_repo_strip_keeps_its_height.py
+++ b/tests/test_a_pinned_repo_strip_keeps_its_height.py
@@ -552,7 +552,8 @@ class TheBoundaryIsWhereThePlaneIsRead(unittest.TestCase):
         answer is plausible."""
         with mock.patch.dict(config.FRAME, _arrangement(size=15)), \
                 mock.patch("charter.frame.slots.repos_rows_wanted", return_value=3):
-            got = commands_frame._slot_sizes("f-1", SLOTS, window_rows=50, pane_cols=200)
+            got = commands_frame._slot_sizes("f-1", SLOTS, window_rows=50, pane_cols=200,
+                                             order=SLOTS, window_cols=200)
         self.assertEqual(got["repos"], 15)
 
     def test_a_plane_that_pins_nothing_still_gets_its_clone_count_through(self):
@@ -560,7 +561,8 @@ class TheBoundaryIsWhereThePlaneIsRead(unittest.TestCase):
         passed `pinned_rows` and dropped `content_rows` would pass the case above."""
         with mock.patch.dict(config.FRAME, _arrangement()), \
                 mock.patch("charter.frame.slots.repos_rows_wanted", return_value=3):
-            got = commands_frame._slot_sizes("f-1", SLOTS, window_rows=50, pane_cols=200)
+            got = commands_frame._slot_sizes("f-1", SLOTS, window_rows=50, pane_cols=200,
+                                             order=SLOTS, window_cols=200)
         self.assertEqual(got["repos"], 3)
 
     def test_the_resize_hook_sizes_the_strip_from_the_pin_and_not_the_clone_count(self):

--- a/tests/test_a_real_resize_gives_a_real_strip_another_row.py
+++ b/tests/test_a_real_resize_gives_a_real_strip_another_row.py
@@ -1,0 +1,149 @@
+"""A real window resize gives a real tab strip a real second row — and takes it back.
+
+*"panes are resizable — and user can resize and it should show more tabs opened on new
+resized rows."*
+
+**This is pane geometry, so it is asked of tmux.** `tests/test_a_tab_strip_grows_a_row_
+when_its_tabs_overflow.py` says what charter's arithmetic decides and what the renderer
+draws into the rows it is given; neither can say that `resize-pane -y 3` on a pane that was
+split `-l 1` actually leaves a three-row pane, or that the harness gives up exactly those
+rows and no others. tmux redistributes every pane proportionally on a window resize and
+grants an over-large height out of the neighbour rather than refusing it, which is why
+`layout.HARNESS_MIN_ROWS` exists at all — so the one authority on whether a strip that grew
+took its rows from the right place is the server.
+
+**`commands_frame._reassert_sizes` is driven directly**, which is the same choice
+`TmuxIntegration.test_the_frames_panes_keep_their_sizes_across_a_window_resize` makes and
+for its reason: the `window-resized` hook's whole job is to run `charter frame-resize`,
+which calls this, and a test that installed the hook would be measuring tmux's dispatch
+rather than charter's answer.
+
+**Verified by hand at the 3.2 floor as well**, which no test in this file can do — the
+fixture runs the `tmux` on `$PATH`. On `~/.local/share/charter-testing/tmux-3.2`,
+`set-hook -w window-resized …` answers `invalid option: window-resized`, rc 1, so nothing
+re-lays-out on a resize there; the same `resize-pane -y` this file asserts on does work,
+which is why `charter frame-resize` typed by hand is the recovery
+`tmuxctl.below_resize_hook_message` already names.
+"""
+
+from __future__ import annotations
+
+import os
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from charter import config, instance
+from charter.frame import state
+
+from tests._isolation import PersonaIso
+from tests.test_frame_tmux_integration import (
+    _HAS_TMUX, SOCKET, _TmuxServerFixture, _tmux,
+)
+from charter import commands_frame
+
+#: The fifteen workspaces this repository's own plane has — the list #725 measured the
+#: windowed rung against. At 120 columns they need three rows and at 300 they need one,
+#: which is exactly the band a resize crosses.
+NAMES = sorted([
+    "authority-audit", "autonomy", "charter-update-skill", "default", "fleet",
+    "harness-wrapper", "news-dispatch-guard", "opencode-integration", "plane-shape",
+    "relations-and-delegations", "showcase", "statusline-improvements", "todos",
+    "tracking-github-issues", "user-reporting",
+])
+
+
+@unittest.skipUnless(_HAS_TMUX, "tmux is not installed")
+class AResizeGivesTheStripTheRowsItsNamesNeed(_TmuxServerFixture, PersonaIso):
+    """One real server, one real window, and `_reassert_sizes` driven across a resize."""
+
+    def setUp(self):
+        super().setUp()
+        for name in NAMES:
+            (Path(config.WORKSPACES_DIR) / name).mkdir(parents=True, exist_ok=True)
+        self.placed = instance.frame_of({"frame": {"component": [
+            {"use": "identity"}, {"use": "workspaces", "edge": "top", "size": 1},
+            {"use": "attention"}, {"use": "repos"}]}})
+        self.assertIn("workspaces", self.placed["slots"],
+                      "the arrangement did not place the strip, so nothing below is "
+                      "about a placed component")
+
+    def _window(self, session, cols, rows):
+        """A real window with a harness pane and the four panels split off it, in the
+        arrangement's own order — every strip one row, which is what a launch that had
+        never measured its names would produce."""
+        r = _tmux("new-session", "-d", "-s", session, "-x", str(cols), "-y", str(rows),
+                  "-P", "-F", "#{pane_id}")
+        self.assertEqual(r.returncode, 0, r.stderr)
+        harness = r.stdout.strip()
+        panes = {}
+        for slot, args in (("top", ("-v", "-b", "-l", "1")),
+                           ("workspaces", ("-v", "-b", "-l", "1")),
+                           ("bottom", ("-v", "-l", "1")),
+                           ("repos", ("-v", "-l", "6"))):
+            out = _tmux("split-window", "-t", harness, *args,
+                        "-P", "-F", "#{pane_id}", "--", "sleep", "600")
+            self.assertEqual(out.returncode, 0, out.stderr)
+            panes[slot] = out.stdout.strip()
+        return harness, panes
+
+    def _height(self, pane):
+        return int(_tmux("display-message", "-p", "-t", pane,
+                         "#{pane_height}").stdout.strip())
+
+    def _reassert(self, session, harness, panes, cols, rows):
+        self.assertEqual(_tmux("resize-window", "-t", session,
+                               "-x", str(cols), "-y", str(rows)).returncode, 0)
+        fid = state.frame_id(session, os.getpid())
+        with mock.patch.dict(config.FRAME, self.placed), \
+                mock.patch("charter.frame.slots.repos_rows_wanted", return_value=6):
+            commands_frame._reassert_sizes(SOCKET, fid=fid, panes=panes,
+                                           harness_pane=harness,
+                                           window_cols=cols, window_rows=rows)
+
+    def test_a_narrow_window_leaves_the_strip_the_rows_its_names_need(self):
+        """120 columns cuts these fifteen names into three pages, so the strip that was
+        split one row tall comes back three rows tall — and the operator can press twelve
+        workspaces where one row reached five."""
+        harness, panes = self._window("grow-strip", 120, 40)
+        self._reassert("grow-strip", harness, panes, 120, 40)
+        self.assertEqual(self._height(panes["workspaces"]), 3)
+
+    def test_the_rows_come_off_the_harness_and_not_off_the_table(self):
+        """`layout._DROP_ORDER` gives the bars up BEFORE `repos` when rows run short, so
+        they may not be fed from it when rows are plentiful. Asked of tmux because the
+        table pane is the one `_reassert_sizes` never asserts a height for — it takes the
+        remainder, so it is where a mis-charged row would land."""
+        harness, panes = self._window("grow-budget", 120, 40)
+        self._reassert("grow-budget", harness, panes, 120, 40)
+        self.assertEqual(self._height(panes["repos"]), 6)
+        self.assertEqual(self._height(panes["top"]), 1)
+        self.assertEqual(self._height(panes["bottom"]), 1)
+        # 40 rows, five panes, four borders: 3 + 1 + 1 + 6 + 4 = 15 spent on panels.
+        self.assertEqual(self._height(harness), 25)
+
+    def test_widening_the_window_takes_the_rows_back(self):
+        """The gesture in both directions, which is the half a launch-time-only answer
+        cannot have. 300 columns draws all fifteen names on one row, so the strip that
+        grew to three gives two of them back to the harness rather than keeping a height
+        it no longer needs."""
+        harness, panes = self._window("shrink-strip", 120, 40)
+        self._reassert("shrink-strip", harness, panes, 120, 40)
+        self.assertEqual(self._height(panes["workspaces"]), 3)
+        self._reassert("shrink-strip", harness, panes, 300, 40)
+        self.assertEqual(self._height(panes["workspaces"]), 1)
+        self.assertEqual(self._height(harness), 27)
+
+    def test_a_short_window_keeps_its_harness_and_the_strip_stays_one_row(self):
+        """The bound, against the server that would otherwise grant it. A 22-row window
+        has nothing above `layout.HARNESS_MIN_ROWS` to spend, so the strip stays where it
+        is — measured here rather than argued, because tmux does not refuse an over-large
+        `resize-pane -y`: it takes the rows out of the neighbour."""
+        harness, panes = self._window("short-window", 120, 22)
+        self._reassert("short-window", harness, panes, 120, 22)
+        self.assertEqual(self._height(panes["workspaces"]), 1)
+        self.assertGreaterEqual(self._height(harness), 12)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_a_real_resize_gives_a_real_strip_another_row.py
+++ b/tests/test_a_real_resize_gives_a_real_strip_another_row.py
@@ -29,18 +29,32 @@ which is why `charter frame-resize` typed by hand is the recovery
 from __future__ import annotations
 
 import os
+import time
 import unittest
 from pathlib import Path
 from unittest import mock
 
-from charter import config, instance
-from charter.frame import state
+from charter import commands_frame, config, instance
+from charter.frame import layout, state
 
-from tests._isolation import PersonaIso
+from tests._isolation import PersonaIso, make_plane
 from tests.test_frame_tmux_integration import (
-    _HAS_TMUX, SOCKET, _TmuxServerFixture, _tmux,
+    _HAS_TMUX, SOCKET, _REPO_ROOT, _TmuxServerFixture, _tmux,
 )
-from charter import commands_frame
+
+#: How long a real panel process is given to come up and repaint. Polled, never slept
+#: through: `_await` returns the moment the pane says what it was asked about, so a fast
+#: machine pays a few hundredths and a loaded one still passes.
+_DEADLINE = 30.0
+
+
+def _await(predicate, timeout: float = _DEADLINE) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(0.05)
+    return predicate()
 
 #: The fifteen workspaces this repository's own plane has — the list #725 measured the
 #: windowed rung against. At 120 columns they need three rows and at 300 they need one,
@@ -133,6 +147,67 @@ class AResizeGivesTheStripTheRowsItsNamesNeed(_TmuxServerFixture, PersonaIso):
         self._reassert("shrink-strip", harness, panes, 300, 40)
         self.assertEqual(self._height(panes["workspaces"]), 1)
         self.assertEqual(self._height(harness), 27)
+
+    def test_a_real_panel_fills_the_row_the_resize_gave_it(self):
+        """The last link, and the only one a fake cannot stand in for: a real
+        `charter panel workspaces` process, in a real pane, redrawing into a row it did not
+        have a moment ago.
+
+        Everything else here is charter deciding a number and tmux honouring it. This is
+        the panel LEARNING the number — `SIGWINCH` for its own pane, `panel._watch`'s
+        repaint, `events.Dispatcher.note_resize`, and `ctx.height` reaching
+        `slots.chats_bar`'s sibling. A renderer handed the width alone would leave the row
+        the resize just bought blank, and nothing above would notice.
+
+        Asserted on what the pane SHOWS, captured from tmux: the `+7` that stood for the
+        seven workspaces one row could not draw is gone, and the seven names are there.
+        """
+        plane = make_plane(self)
+        for name in NAMES:
+            (Path(config.WORKSPACES_DIR) / name).mkdir(parents=True, exist_ok=True)
+        fid = "real-strip.1"
+        state.frame_dir(fid, create=True)
+        state.record_workspace(fid, "harness-wrapper")
+
+        # **The pane's own environment, stated with `-e` rather than inherited.** A tmux
+        # pane is born out of the SERVER's environment, not the client's, and `PYTHONPATH`
+        # is in no `update-environment` list — so a panel started without these two either
+        # imports the installed charter or resolves the developer's real plane, and this
+        # case would be measuring neither the tree it is in nor the plane it built.
+        existing = os.environ.get("PYTHONPATH", "")
+        pythonpath = os.pathsep.join([str(_REPO_ROOT)]
+                                     + ([existing] if existing else []))
+
+        r = _tmux("new-session", "-d", "-s", "real-strip", "-x", "160", "-y", "30",
+                  "-P", "-F", "#{pane_id}", "--", "sleep", "600")
+        self.assertEqual(r.returncode, 0, r.stderr)
+        harness = r.stdout.strip()
+        env = dict(os.environ, CHARTER_ROOT=str(plane), PYTHONPATH=pythonpath)
+        env.pop("CHARTER_HOME", None)
+        env.pop("CHARTER_WORKSPACE", None)
+        r = _tmux("split-window", "-t", harness, "-v", "-b", "-l", "1",
+                  "-e", f"CHARTER_ROOT={plane}", "-e", f"PYTHONPATH={pythonpath}",
+                  "-P", "-F", "#{pane_id}", "--",
+                  *layout.panel_command(slot="workspaces", session=fid), env=env)
+        self.assertEqual(r.returncode, 0, r.stderr)
+        pane = r.stdout.strip()
+
+        def shown():
+            return _tmux("capture-pane", "-p", "-t", pane).stdout
+
+        self.assertTrue(_await(lambda: "harness-wrapper" in shown()),
+                        f"the panel never drew its strip: {shown()!r}")
+        one = shown()
+        self.assertIn("+7", one, f"160 columns drew every name on one row: {one!r}")
+
+        self.assertEqual(_tmux("resize-pane", "-t", pane, "-y", "2").returncode, 0)
+        self.assertTrue(_await(lambda: "+7" not in shown()),
+                        f"the panel kept one row's worth of names in a two-row pane: "
+                        f"{shown()!r}")
+        two = shown()
+        for name in NAMES:
+            self.assertIn(name, two, f"{name} is on neither row: {two!r}")
+        self.assertEqual(len([ln for ln in two.splitlines() if ln.strip()]), 2, two)
 
     def test_a_short_window_keeps_its_harness_and_the_strip_stays_one_row(self):
         """The bound, against the server that would otherwise grant it. A 22-row window

--- a/tests/test_a_tab_strip_grows_a_row_when_its_tabs_overflow.py
+++ b/tests/test_a_tab_strip_grows_a_row_when_its_tabs_overflow.py
@@ -1,0 +1,652 @@
+"""#829 item 2: a strip whose names will not fit on one row is given another one.
+
+*"panes are resizable — and user can resize and it should show more tabs opened on new
+resized rows."*
+
+**A panel cannot make its own pane taller.** tmux owns pane geometry and both bars declare
+`Fixed(1)` (`frame/builtins.py`), so the second row is not a renderer setting — it is a
+size the LAUNCHER asks for, which is `layout.slot_sizes` and the three `commands_frame`
+call sites that go through `_slot_sizes`. That is the same seam `repos` has had since #488
+and the reason this file's cases are spread across three modules: what the names need
+(`slots.bar_rows_wanted`), what the frame can afford (`layout._grown`), and what tmux is
+then told (`layout.panel_argvs`, `commands_frame._reassert_sizes`).
+
+**It grows only when the tabs actually overflow**, which is the refinement #829's decision
+carries over the two shapes the issue named. A fixed two-row launch costs a row off the
+harness on every plane that places a bar whether or not the names overflow — a cost
+everyone pays for a case only some hit, and rows against the harness are what #740 settled
+once already. The strip already knows when it is overflowing: that is what `+N` counts.
+
+**And it grows only into rows the harness can spare.** The budget is `layout.harness_rows`
+of the ungrown map minus `layout.HARNESS_MIN_ROWS`, so a window with nothing spare grows
+nothing and says so by leaving the strip exactly as it was.
+
+**What the 3.2 floor gets, stated rather than assumed.** The launch path has no version
+gate: a strip is born at the height its names need at every tmux charter runs on, floor
+included. What `tmuxctl.RESIZE_HOOK_FLOOR` gates is the RE-computation — `window-resized`
+does not exist below tmux 3.3 (`set-hook -w window-resized` answers `invalid option`,
+rc 1, measured), so at the floor a strip keeps the height it was born with until the frame
+is relaunched. `tmuxctl.below_resize_hook_message` is the band that already tells the
+operator so — and it names the recovery, which is `charter frame-resize` typed by hand.
+`TheFloorKeepsTheHeightItWasBornWith` is what pins both halves.
+"""
+
+from __future__ import annotations
+
+import unittest
+from unittest import mock
+
+from charter import commands_frame, config, instance, tui
+from charter.frame import layout, slots, tmuxctl
+from tests._isolation import PersonaIso
+from tests.test_frame_chat_switch import _plant
+
+#: The fifteen workspaces this repository's own plane has — the list #725 measured the
+#: windowed rung against, kept here for the same reason `test_frame_bars` keeps it: the
+#: greedy cut is about the widths names actually have, and a fixture of even-width ones
+#: would measure neither `relations-and-delegations` (25 cells) nor `todos` (5).
+NAMES = sorted([
+    "authority-audit", "autonomy", "charter-update-skill", "default", "fleet",
+    "harness-wrapper", "news-dispatch-guard", "opencode-integration", "plane-shape",
+    "relations-and-delegations", "showcase", "statusline-improvements", "todos",
+    "tracking-github-issues", "user-reporting",
+])
+HERE = "harness-wrapper"
+
+#: A frame that draws both strips and the table, in the order `[[frame.component]]`
+#: places them.
+#:
+#: **A bar has to be PLACED for `layout` to have any geometry for it at all**, and that is
+#: not a fixture detail — it is the whole reason `max_rows` cannot be a renderer setting.
+#: Neither bar is in `builtins.SLOT_OF`, so neither is in `layout.SLOT_SIZE` and
+#: `layout._size_of` answers for one only out of the arrangement this plane committed
+#: (#687). `slot_sizes` therefore drops a bar nothing placed, and a case that patched no
+#: arrangement would be asserting about a slot that is not in the answer.
+SLOTS = ["top", "chats", "workspaces", "bottom", "repos", "right"]
+
+
+def _placed(*, style=None, **sizes):
+    """The resolved arrangement that places both bars, built the way an operator's
+    `charter.toml` reaches `config.FRAME` — through `instance.frame_of`, never by hand.
+
+    *sizes* pins a slot to a committed height, which is the one route a bar's own
+    `[[frame.component]]` table has (#687); *style* carries the pane keys (`pad`, `bg`)
+    for one slot.
+    """
+    tables = []
+    for use in ("identity", "chats", "workspaces", "attention", "repos", "sidebar"):
+        table = {"use": use}
+        if use in sizes:
+            table.update(edge="top", size=sizes[use])
+        if style and use in style:
+            table.update(style[use])
+        tables.append(table)
+    return instance.frame_of({"frame": {"component": tables}})
+
+
+def _strip(names=NAMES, here=HERE, note=""):
+    """A `slots.BARS` entry that answers *names* without touching a plane.
+
+    The seam the sizer reads through, used as one. `TheRealStripsGoThroughTheSameSeam`
+    is what says charter's own two entries reach it, so this is a fixture for the
+    arithmetic rather than a stand-in for the feature.
+    """
+    return lambda fid: ("workspaces", list(names), here, note)
+
+
+class TheStripAsksForTheRowsItsNamesNeed(unittest.TestCase):
+    """`slots.bar_rows_wanted` — the measurement the launcher sizes the pane from.
+
+    Asked through `slots.BARS` rather than a plane, for `test_frame_bars`'
+    `TheLadderGivesUpWholeThings` reason: the arithmetic is the thing that has to be right
+    at every width, and a case that needed a frame to ask it would be measuring the
+    fixture as much as the answer.
+    """
+
+    def _want(self, cols, cap=3, names=NAMES, here=HERE, note="", slot="probe"):
+        with mock.patch.dict(slots.BARS, {slot: _strip(names, here, note)}):
+            return slots.bar_rows_wanted("f-1", slot, pane_cols=cols, cap=cap)
+
+    def test_a_strip_whose_names_all_fit_on_one_row_asks_for_one(self):
+        """274 columns is where rung 1 draws all fifteen (`test_frame_bars` pins the
+        number), and a strip that is not overflowing must not take a row off the harness
+        — which is the whole argument against the fixed two-row launch #829 rejected."""
+        self.assertEqual(self._want(274), 1)
+        self.assertEqual(self._want(400), 1)
+
+    def test_a_strip_that_overflows_asks_for_the_rows_its_pages_need(self):
+        """The widths #725 measured an operator running at, and the answers are the page
+        counts the same cut produces: two rows at 160 and three at 120."""
+        self.assertEqual(self._want(160), 2)
+        self.assertEqual(self._want(120), 3)
+
+    def test_the_want_is_the_rows_the_renderer_then_actually_fills(self):
+        """The property the whole seam exists for, and the one #500 shipped broken twice
+        one pane over: the launcher sizes the pane and the renderer spends it, so a want
+        the renderer does not fill is blank rows off the harness, and a want it overflows
+        is names cut off with nothing saying so.
+
+        Asked at EVERY mark as well as every width, because the run a strip draws depends
+        on which page the mark is on and a want measured for one mark sizes the pane for
+        all of them.
+        """
+        for here in NAMES:
+            for cols in range(0, 320, 3):
+                for cap in (layout.BAR_MAX_ROWS, 40):
+                    with self.subTest(here=here, cols=cols, cap=cap):
+                        want = self._want(cols, cap=cap, here=here)
+                        slots.TABS.forget()
+                        lines = slots._bar("workspaces", list(NAMES), here, cols,
+                                           rows=want)
+                        if lines:
+                            self.assertEqual(
+                                len(lines), want,
+                                f"{cols} columns asked for {want} rows and filled "
+                                f"{len(lines)} — the rest come off the harness blank")
+
+    def test_a_want_the_ceiling_did_not_stop_reaches_every_name(self):
+        """The other half: where the strip was allowed all the rows it asked for, it holds
+        the whole list. Below the ceiling this is what growing a row BUYS, and a want that
+        stopped short of it would be rows spent for nothing."""
+        for cols in range(40, 320, 7):
+            want = self._want(cols, cap=40)
+            if want >= 40:
+                continue
+            slots.TABS.forget()
+            lines = slots._bar("workspaces", list(NAMES), HERE, cols, rows=want)
+            drawn = {slots.TABS.switch_to(r, c)
+                     for r in range(want) for c in range(cols)} - {None}
+            if lines and len(drawn) > 1:
+                with self.subTest(cols=cols):
+                    self.assertEqual(drawn | {HERE}, set(NAMES),
+                                     f"{cols} columns asked for {want} rows and still "
+                                     f"cannot reach every workspace")
+
+    def test_a_strip_too_narrow_to_draw_a_name_asks_for_one_row_and_not_the_ceiling(self):
+        """The `2/3` rung and the rung below it. A frame that cannot draw one name cannot
+        draw one on a second row either, so spending rows there would be taking them off
+        the harness for a count — the exact trade `layout.visible_slots` refuses one rung
+        down when it drops both bars whole.
+
+        30 columns is the `6/15` rung and 0 is the rung that draws nothing. Both were 3
+        before the "did it fill what it was given" test went in beside the coverage one,
+        which is two rows of harness spent on a count.
+        """
+        self.assertEqual(self._want(30), 1)
+        self.assertEqual(self._want(0), 1)
+        self.assertEqual(self._want(30, cap=8), 1)
+
+    def test_the_ceiling_is_the_callers_and_it_bounds_the_answer(self):
+        """Carried rather than read, `layout.repos_rows`' discipline for *pinned_rows*:
+        applying `BAR_MAX_ROWS` here AND in `layout._grown` would be a bound no input
+        could make observable. 80 columns wants six rows and gets what it is allowed."""
+        self.assertEqual(self._want(80, cap=8), 6)
+        self.assertEqual(self._want(80, cap=3), 3)
+        self.assertEqual(self._want(80, cap=1), 1)
+
+    def test_the_shipped_ceiling_is_three(self):
+        """Spelled, because it is a number with a measurement behind it rather than a
+        derived one: this plane's fifteen workspaces need 2 rows at 160 columns, 3 at 120,
+        4 at 100 and 6 at 80, and three is where a strip stops being a strip."""
+        self.assertEqual(layout.BAR_MAX_ROWS, 3)
+
+    def test_the_panes_own_pad_comes_off_the_width_before_the_names_are_measured(self):
+        """#500's half of this, and it is the same argument `repos_rows_wanted` makes: the
+        renderer composes at `slots.content_width`, so a padded pane's strip is planned for
+        `pane_cols - 2 * pad` and asking the unpadded question would size the pane from a
+        number the renderer never sees.
+
+        The two-row band for these names starts at 150 columns, so a 152-column pane with a
+        two-cell pad each side is a three-row strip and the same pane without one is a
+        two-row strip. Asked through a real `[[frame.component]]` table, because a pad only
+        exists where an operator committed one.
+        """
+        with mock.patch.dict(config.FRAME, _placed(style={"chats": {"pad": 2}})):
+            self.assertEqual(self._want(152, slot="chats"), 3)
+        with mock.patch.dict(config.FRAME, _placed()):
+            self.assertEqual(self._want(152, slot="chats"), 2)
+
+    def test_a_slot_that_draws_no_strip_is_answered_rather_than_raised_at(self):
+        """`layout.slot_sizes`' filter-don't-refuse discipline: the slot list is committed,
+        untrusted input, and a name that is not a strip has the height its pane already
+        has."""
+        self.assertEqual(slots.bar_rows_wanted("f-1", "repos", pane_cols=200, cap=3), 1)
+        self.assertEqual(slots.bar_rows_wanted("f-1", "top", pane_cols=200, cap=3), 1)
+
+    def test_measuring_a_strip_does_not_publish_a_map_for_it(self):
+        """The reason `slots._compose` was split out of `slots._bar` (#829). This runs in
+        the LAUNCHER's process and in the `frame-resize` child; a sizing question that
+        wrote `slots.TABS` would leave a map describing a strip nobody is looking at, and
+        in a test process it would describe one another case had just drawn."""
+        slots.TABS.forget()
+        slots._bar("chats", ["api.1", "api.2"], "api.1", 200)
+        before = slots.TABS.switch_to(0, tui.width(slots._inset() + "chats  ") + 1)
+        self._want(120)
+        self.assertEqual(slots.TABS.switch_to(0, tui.width(slots._inset() + "chats  ") + 1),
+                         before, "the sizing question overwrote the paint's own map")
+
+
+class EveryRowOfAGrownStripIsClickable(unittest.TestCase):
+    """`slots._bar` with rows to spend, and `slots.TABS` under it.
+
+    **The map is keyed by `(row, col)` and that is the load-bearing half.** A column-keyed
+    map on a two-row strip does not degrade to answering nothing — it answers the row above
+    about a click on the row below, which is `component.EVENT_KINDS`' *fires wrongly* and
+    the same harm `slots._BAR_RULE` is ASCII to avoid.
+    """
+
+    def setUp(self):
+        slots.TABS.forget()
+        self.addCleanup(slots.TABS.forget)
+
+    def _strip(self, width, rows, names=NAMES, here=HERE, note=""):
+        return slots._bar("workspaces", list(names), here, width, note=note, rows=rows)
+
+    def test_a_second_row_draws_the_names_the_first_could_not(self):
+        """The operator's own sentence, measured: 160 columns reaches seven workspaces on
+        one row and every one of the fifteen on two."""
+        one = self._strip(160, 1)
+        reachable_one = {slots.TABS.switch_to(0, c) for c in range(160)} - {None}
+        two = self._strip(160, 2)
+        reachable_two = {slots.TABS.switch_to(r, c)
+                         for r in range(2) for c in range(160)} - {None}
+        self.assertEqual(len(one), 1)
+        self.assertEqual(len(two), 2)
+        self.assertEqual(len(reachable_one), 7)
+        self.assertEqual(reachable_two | {HERE}, set(NAMES))
+
+    def test_every_drawn_tab_answers_at_its_own_row_and_at_no_other(self):
+        """Walked off the drawn rows rather than off the ladder, `test_frame_bars`'
+        `AClickResolvesAgainstWhatWasDrawn` discipline: the paint is what a click is
+        resolved against, so the paint is what the case reads."""
+        rows = self._strip(120, 3)
+        self.assertEqual(len(rows), 3)
+        for r, line in enumerate(rows):
+            plain = tui.strip_ansi(line)
+            for name in NAMES:
+                at = plain.find(name)
+                if at < 0 or name == HERE:
+                    continue
+                with self.subTest(row=r, name=name):
+                    self.assertEqual(slots.TABS.switch_to(r, at), name)
+                    others = [o for o in range(len(rows)) if o != r]
+                    self.assertNotIn(name, [slots.TABS.switch_to(o, at) for o in others],
+                                     "a column answers with a name from another row")
+
+    def test_the_blank_under_the_heading_is_not_a_tab(self):
+        """The heading names the strip once and the rows under it are indented to line up
+        with the first row's tabs. Those cells are charter's, no name was drawn in them,
+        and a click there switches nothing — `_Tabs`' rule for the heading itself, one
+        row down."""
+        rows = self._strip(120, 3)
+        lead = tui.width(slots._inset() + "workspaces" + "  ")
+        for r in range(1, len(rows)):
+            for c in range(lead):
+                with self.subTest(row=r, col=c):
+                    self.assertIsNone(slots.TABS.switch_to(r, c))
+                    self.assertFalse(slots.TABS.more_at(r, c))
+                    self.assertFalse(slots.TABS.add_at(r, c))
+
+    def test_a_row_the_strip_did_not_draw_answers_nothing(self):
+        """A pane taller than the names need draws fewer rows than it has, and the rows
+        below the last are cells nothing was drawn into. `panel._write` leaves them to
+        tmux; this says a click on one reaches no tab."""
+        rows = self._strip(200, 3)
+        for r in range(len(rows), 6):
+            for c in range(0, 200, 7):
+                with self.subTest(row=r, col=c):
+                    self.assertIsNone(slots.TABS.switch_to(r, c))
+
+    def test_the_counts_land_on_the_rows_the_names_they_stand_for_are_next_to(self):
+        """A leading `+N` says the run starts partway into the list, so it belongs beside
+        the FIRST tab drawn; a trailing one says the list goes on past the last, so it
+        belongs after it. On a grown strip those are two different rows, and each is
+        clickable where it was drawn.
+
+        120 columns cuts these fifteen into three pages. Two rows draw the first two of
+        them for a mark on either, so the only count is a trailing one on the second row;
+        a mark on the third page draws that page alone, with a leading count on it.
+        """
+        rows = self._strip(120, 2, here=NAMES[8])
+        self.assertEqual(len(rows), 2)
+        first, second = (tui.strip_ansi(r) for r in rows)
+        self.assertNotIn("+", first, f"a leading count on a run that starts at 0: {first!r}")
+        self.assertIn("+", second, f"the names past this run went uncounted: {second!r}")
+        self.assertTrue(slots.TABS.more_at(1, second.rindex("+")),
+                        "the trailing count is inert on the row it was drawn on")
+        self.assertFalse(slots.TABS.more_at(0, second.rindex("+")),
+                         "the count answers for a row it was not drawn on")
+
+        tail = self._strip(120, 2, here=NAMES[13])
+        self.assertEqual(len(tail), 1)
+        only = tui.strip_ansi(tail[0])
+        self.assertIn("+", only, f"a run that starts mid-list went uncounted: {only!r}")
+        self.assertTrue(slots.TABS.more_at(0, only.index("+")),
+                        "the leading count is inert")
+
+    def test_a_grown_strip_that_holds_the_whole_list_still_offers_the_plus(self):
+        """The affordance is drawn where the whole list is on the strip — one row's worth
+        on the rung that fits them all, or a grown strip whose rows hold them. An operator
+        who widened their pane and lost the `+` would have been given rows and charged a
+        button for them."""
+        rows = self._strip(160, 2, note=slots.ADD_CHAT)
+        self.assertEqual(len(rows), 2)
+        last = tui.strip_ansi(rows[-1])
+        self.assertTrue(last.rstrip().endswith(slots.ADD_CHAT), repr(last))
+        self.assertTrue(slots.TABS.add_at(1, last.rstrip().rindex(slots.ADD_CHAT)))
+
+    def test_a_plus_and_a_count_are_never_on_one_strip(self):
+        """`_Tabs.add_at`'s structural promise, restated for a strip that has rows: the
+        two fields that both begin with `+` must never be on screen together, and a
+        second ROW is on screen with the first."""
+        for cols in range(20, 300, 3):
+            for rows in (1, 2, 3):
+                with self.subTest(cols=cols, rows=rows):
+                    drawn = self._strip(cols, rows, note=slots.ADD_CHAT)
+                    plain = "\n".join(tui.strip_ansi(r) for r in drawn)
+                    counts = [f for f in plain.replace("\n", " ").split()
+                              if f.startswith("+") and f[1:].isdigit()]
+                    if slots.ADD_CHAT in plain.split():
+                        self.assertEqual(counts, [],
+                                         f"a `+` shares a strip with a count: {plain!r}")
+
+    def test_a_run_whose_SECOND_row_would_overflow_gives_the_rung_up(self):
+        """The ladder's refusal is measured on every row, not on the first. `slots._cuts`
+        puts at least one field on a page whatever it costs, so a name wider than the whole
+        row composes a page that overflows — and a run can have that page second, where a
+        check on the first row alone would never look.
+
+        The list is built so that row one fits and row two cannot: a short name and a name
+        wider than the pane, in a width where the short one is a page of its own.
+        """
+        wide = "w" * 90
+        rows = self._strip(40, 2, names=["api.1", wide], here="api.1")
+        for line in rows:
+            self.assertLessEqual(tui.width(line), 40, repr(line))
+        self.assertNotIn(wide, "".join(tui.strip_ansi(r) for r in rows))
+
+    def test_no_row_of_a_grown_strip_is_wider_than_the_pane(self):
+        """The ladder's own refusal, applied to every row rather than the first: a run
+        whose second page overflows is a strip drawing part of a name on a row nothing
+        else would have looked at."""
+        for cols in range(0, 300):
+            for rows in (1, 2, 3):
+                for drawn in self._strip(cols, rows, note=slots.ADD_CHAT):
+                    with self.subTest(cols=cols, rows=rows):
+                        self.assertLessEqual(tui.width(drawn), cols, repr(drawn))
+
+    def test_nothing_a_grown_strip_draws_is_outside_ascii(self):
+        """`test_frame_bars`' own property, asked of every row rather than of the one.
+        A click on this strip is resolved by COLUMN, so a glyph a terminal may draw two
+        cells wide moves every field after it and the operator presses `fleet` and lands
+        on `default`."""
+        with mock.patch.dict(config.FRAME, {"look": {"rules": "visible"}}):
+            for cols in range(0, 261):
+                for rows in (1, 2, 3):
+                    for drawn in self._strip(cols, rows, note=slots.ADD_CHAT):
+                        with self.subTest(cols=cols, rows=rows):
+                            self.assertTrue(tui.strip_ansi(drawn).isascii(), repr(drawn))
+
+    def test_switching_to_a_tab_that_is_drawn_leaves_every_row_where_it_was(self):
+        """The property the cut exists for (`slots._cuts`), which a strip that grew has to
+        keep: the run of pages is a function of the names, the width and the row count, so
+        pressing a drawn tab redraws the same run with only the `*` moved. A run that
+        moved would put a different name under the cell the operator just pressed."""
+        def shape(drawn):
+            """The rows with the mark taken out — every cell in its own column, and the
+            one thing switching is allowed to change removed.
+
+            The two entries of `slots._BAR_MARK` are one cell each and neither a name nor
+            a count can contain a `*` (`workspace.valid_name`, `chats.ID_RE`), so blanking
+            it is exact rather than approximate. Comparing the map instead would not work:
+            `_Tabs.switch_to` answers `None` for the tab you are on, so the marked name
+            drops out of it and every switch would look like a move.
+            """
+            return [tui.strip_ansi(line).replace(slots._BAR_MARK[0], slots._BAR_MARK[1])
+                    for line in drawn]
+
+        for rows in (1, 2, 3):
+            for cols in (100, 120, 160, 200, 240):
+                before = self._strip(cols, rows)
+                drawn = {slots.TABS.switch_to(r, c)
+                         for r in range(rows) for c in range(cols)} - {None}
+                for name in drawn:
+                    with self.subTest(rows=rows, cols=cols, name=name):
+                        self.assertEqual(
+                            shape(self._strip(cols, rows, here=name)), shape(before),
+                            "switching to a drawn tab moved the strip under the pointer")
+
+    def test_a_strip_that_shrinks_back_to_one_row_forgets_the_rows_it_lost(self):
+        """`_Viewport.blank`'s half, one axis over and one row down. A strip that kept its
+        second row's map through a resize would switch to a tab the operator can see is
+        not on screen."""
+        self._strip(160, 2)
+        self.assertTrue({slots.TABS.switch_to(1, c) for c in range(160)} - {None})
+        self._strip(160, 1)
+        self.assertEqual({slots.TABS.switch_to(1, c) for c in range(160)}, {None})
+
+
+class AStripGrowsOnlyIntoRowsTheHarnessCanSpare(unittest.TestCase):
+    """`layout.slot_sizes` and `layout._grown` — arithmetic, no plane and no tmux.
+
+    #740 settled the competition for rows against the harness once. A strip growing is a
+    strip taking rows off it, so what it may take is exactly what the harness has above
+    `layout.HARNESS_MIN_ROWS` and nothing else.
+    """
+
+    def setUp(self):
+        self.enterContext(mock.patch.dict(config.FRAME, _placed()))
+
+    def _sizes(self, window_rows, bar_rows=None, slots_=None):
+        return layout.slot_sizes(slots_ or SLOTS, window_rows=window_rows,
+                                 content_rows=4, bar_rows=bar_rows)
+
+    def test_a_frame_with_no_strip_that_overflows_is_sized_exactly_as_before(self):
+        """The default, and the argument against the fixed two-row launch: a plane whose
+        names fit never loses a row. `bar_rows=None` and an empty map are the same
+        answer, because a map naming nothing to grow is a frame with nothing to grow."""
+        self.assertEqual(self._sizes(50), self._sizes(50, {}))
+        self.assertEqual(self._sizes(50, {"chats": 1, "workspaces": 1}),
+                         self._sizes(50))
+        self.assertEqual(self._sizes(50)["chats"], 1)
+
+    def test_a_strip_that_overflows_is_given_the_rows_it_asked_for(self):
+        got = self._sizes(50, {"chats": 3, "workspaces": 2})
+        self.assertEqual(got["chats"], 3)
+        self.assertEqual(got["workspaces"], 2)
+
+    def test_the_harness_keeps_its_floor_however_many_rows_a_strip_wants(self):
+        """The bound, asked of `harness_rows` rather than of the growth: a strip that grew
+        past this would be `resize-pane -y` taking rows out of the one pane the frame is
+        drawn around, which tmux grants without complaint."""
+        for window_rows in range(14, 60):
+            with self.subTest(window_rows=window_rows):
+                got = self._sizes(window_rows, {"chats": 3, "workspaces": 3})
+                ungrown = self._sizes(window_rows)
+                harness = layout.harness_rows(got, window_rows=window_rows)
+                if layout.harness_rows(ungrown,
+                                       window_rows=window_rows) >= layout.HARNESS_MIN_ROWS:
+                    self.assertGreaterEqual(harness, layout.HARNESS_MIN_ROWS)
+                self.assertLessEqual(got["chats"], 3)
+
+    def test_a_window_with_nothing_spare_grows_nothing_at_all(self):
+        """And it degrades in silence, which is `visible_slots`' own manner one rung up:
+        the strip is drawn, at the height it always had."""
+        got = self._sizes(21, {"chats": 3, "workspaces": 3})
+        self.assertEqual(got["chats"], 1)
+        self.assertEqual(got["workspaces"], 1)
+
+    def test_two_strips_share_a_short_budget_rather_than_one_taking_it_all(self):
+        """A row at a time in split order. Handing the whole budget to whichever was split
+        first would leave the other looking broken for a reason nothing on screen
+        explains."""
+        rows = next(r for r in range(14, 60)
+                    if layout.harness_rows(self._sizes(r), window_rows=r)
+                    == layout.HARNESS_MIN_ROWS + 1)
+        got = self._sizes(rows, {"chats": 3, "workspaces": 3})
+        self.assertEqual(sorted([got["chats"], got["workspaces"]]), [1, 2])
+        got = self._sizes(rows + 1, {"chats": 3, "workspaces": 3})
+        self.assertEqual([got["chats"], got["workspaces"]], [2, 2])
+
+    def test_the_repo_table_is_not_what_pays_for_a_grown_strip(self):
+        """`layout._DROP_ORDER` gives the bars up BEFORE `repos` when rows run short, so
+        they cannot be fed from it when rows are plentiful. The table keeps its content's
+        height and the harness's own slack is what is spent."""
+        ungrown = self._sizes(50)
+        grown = self._sizes(50, {"chats": 3, "workspaces": 3})
+        self.assertEqual(grown["repos"], ungrown["repos"])
+        self.assertEqual(layout.harness_rows(grown, window_rows=50),
+                         layout.harness_rows(ungrown, window_rows=50) - 4)
+
+    def test_a_name_nothing_is_drawing_is_dropped_rather_than_grown(self):
+        """The filter `slot_sizes` already applies to its own list, applied to this one:
+        a slot that is not being drawn is not a pane to grow."""
+        got = self._sizes(50, {"chats": 3, "acme.metrics": 4})
+        self.assertNotIn("acme.metrics", got)
+        self.assertEqual(got["chats"], 3)
+
+    def test_a_want_below_the_height_a_strip_already_has_never_shrinks_it(self):
+        """This grows and never trims. A plane that pinned its strip to three rows in its
+        own `[[frame.component]]` table asked for three rows (#687); a measurement saying
+        its names fit on one is not that operator changing their mind."""
+        with mock.patch.dict(config.FRAME, _placed(chats=3)):
+            got = layout.slot_sizes(SLOTS, window_rows=50, content_rows=4,
+                                    bar_rows={"chats": 1})
+            self.assertEqual(got["chats"], 3)
+            grown = layout.slot_sizes(SLOTS, window_rows=50, content_rows=4,
+                                      bar_rows={"chats": 5})
+        self.assertEqual(grown["chats"], 5)
+
+
+class TheLauncherSplitsThePaneTheStripAskedFor(PersonaIso, unittest.TestCase):
+    """The seam end to end, with a real plane under it and no tmux.
+
+    `commands_frame._slot_sizes` is the boundary where a plane becomes a pane height, and
+    `layout.panel_argvs` is where a pane height becomes `split-window -l`. Both launch
+    paths and the `window-resized` recompute go through the first.
+    """
+
+    def setUp(self):
+        super().setUp()
+        for name in NAMES:
+            (config.WORKSPACES_DIR / name).mkdir(parents=True, exist_ok=True)
+        self.enterContext(mock.patch.dict(config.FRAME, _placed()))
+
+    def test_the_boundary_asks_the_strip_and_hands_the_answer_to_the_arithmetic(self):
+        got = commands_frame._slot_sizes("f-1", SLOTS, window_rows=50, pane_cols=200,
+                                         order=SLOTS, window_cols=160)
+        self.assertEqual(got["workspaces"], 2, got)
+
+    def test_a_wide_window_leaves_the_strip_at_one_row(self):
+        got = commands_frame._slot_sizes("f-1", SLOTS, window_rows=50, pane_cols=300,
+                                         order=SLOTS, window_cols=300)
+        self.assertEqual(got["workspaces"], 1, got)
+
+    def test_the_height_the_strip_asked_for_reaches_split_window(self):
+        """The measurement #687 filed for the pinned height, asked for the measured one:
+        a number that stopped at `slot_sizes` would be the inert value the whole seam is
+        written against."""
+        sizes = commands_frame._launch_sizes("f-1", SLOTS, window_cols=160,
+                                             window_rows=50)
+        argvs = layout.panel_argvs(slots=SLOTS, session="s", socket="k",
+                                   harness_pane="%1", sizes=sizes)
+        bar, = [a for a in argvs if "workspaces" in a]
+        self.assertEqual(bar[bar.index("-l") + 1], "2")
+
+    def test_the_strips_own_pane_width_is_what_it_is_measured_at(self):
+        """#500 one slot over. A strip split AFTER the sidebar is carved out of a pane the
+        sidebar has already narrowed by 23 columns, so measuring it at the window's width
+        would size it for names its own pane cannot draw."""
+        inset = ["right", "top", "workspaces", "bottom", "repos"]
+        self.assertEqual(layout.pane_cols(inset, "workspaces", window_cols=160), 137)
+        self.assertEqual(layout.pane_cols(SLOTS, "workspaces", window_cols=160), 160)
+        wide = commands_frame._slot_sizes("f-1", SLOTS, window_rows=50, pane_cols=200,
+                                          order=SLOTS, window_cols=274)
+        narrow = commands_frame._slot_sizes(
+            "f-1", inset, window_rows=50, pane_cols=200, order=inset,
+            window_cols=274)
+        self.assertEqual(wide["workspaces"], 1)
+        self.assertEqual(narrow["workspaces"], 2,
+                         "the strip was sized from the window rather than its pane")
+
+    def test_a_pane_width_is_asked_for_by_either_of_a_components_two_names(self):
+        """`layout._key`'s contract, kept by the walk that generalised out of
+        `repos_cols`: a component id and its committed slot name are one component
+        (`builtins.component_id`), so they must reach one answer and not two."""
+        inset = ["right", "top", "workspaces", "bottom", "repos"]
+        self.assertEqual(layout.pane_cols(inset, "identity", window_cols=160),
+                         layout.pane_cols(inset, "top", window_cols=160))
+        self.assertEqual(layout.pane_cols(inset, "repos", window_cols=160),
+                         layout.repos_cols(inset, window_cols=160))
+
+    def test_the_real_strips_go_through_the_same_seam(self):
+        """`slots.BARS` is charter's own two entries and not a fixture: the chat strip
+        reads `chats.roster` and the workspace strip reads `switch.workspaces`, and both
+        are what `bar_rows_wanted` measures."""
+        self.assertEqual(sorted(slots.BARS), ["chats", "workspaces"])
+        for i in range(12):
+            _plant(f"api.{i}", workspace="api")
+        with mock.patch.dict(config.FRAME, {"components": ()}):
+            self.assertGreater(
+                slots.bar_rows_wanted("api.0", "chats", pane_cols=60,
+                                      cap=layout.BAR_MAX_ROWS), 1)
+
+
+class TheFloorKeepsTheHeightItWasBornWith(unittest.TestCase):
+    """What tmux 3.2 gets, stated rather than assumed.
+
+    **The launch has no version gate.** `layout.panel_argvs` writes `split-window -l <n>`
+    and that has worked on every tmux charter supports, so a strip whose names overflow is
+    born the right height at the floor exactly as it is at 3.7c.
+
+    **What the floor loses is the RE-computation.** `window-resized` is a hook tmux 3.3
+    added; on 3.2 `set-hook -w window-resized` answers `invalid option`, rc 1 — measured
+    here on `~/.local/share/charter-testing/tmux-3.2` and recorded by
+    `tmuxctl.RESIZE_HOOK_FLOOR`. So dragging the divider on a 3.2 frame re-lays out
+    nothing, and the strip keeps the height it was born with until the frame is
+    relaunched. That is a degradation and an honest one: it is the band
+    `tmuxctl.below_resize_floor_message` already tells the operator about, and it is what
+    #829's decision took over a fixed two-row launch that would cost every plane a row.
+    """
+
+    def test_the_resize_hook_floor_sits_above_the_floor_charter_supports(self):
+        self.assertGreater(tmuxctl.RESIZE_HOOK_FLOOR, tmuxctl.FLOOR)
+        self.assertEqual(tmuxctl.FLOOR, (3, 2))
+        self.assertEqual(tmuxctl.RESIZE_HOOK_FLOOR, (3, 3))
+
+    def test_below_that_floor_nothing_is_armed_and_nothing_is_written(self):
+        """`_install_resize_hook`'s gate, which is why a 3.2 frame never recomputes. Not
+        an error and not a warning on the launch path — the operator is told once, by
+        `below_resize_floor_message`, and the frame comes up."""
+        wrote = []
+        with mock.patch.object(tmuxctl, "version", return_value=(3, 2)), \
+                mock.patch.object(tmuxctl, "run", side_effect=lambda *a, **k: wrote.append(a)):
+            commands_frame._install_resize_hook(
+                "sock", harness_pane="%1", panes={"chats": "%2"}, v=(3, 2),
+                env=None, fid="f-1")
+        self.assertEqual(wrote, [])
+
+    def test_the_operator_is_told_what_the_band_costs_them(self):
+        """The sentence the degradation lives in, read rather than spelled — a strip that
+        stops re-sizing on a resize is exactly the thing this message is about."""
+        said = tmuxctl.below_resize_hook_message((3, 2))
+        self.assertIn("3.3", said)
+        self.assertIn("window-resized", said)
+        self.assertIn("charter frame-resize", said,
+                      "the band names no way out, so a strip stuck at one row is final")
+
+    def test_a_launch_at_the_floor_still_splits_the_pane_the_names_need(self):
+        """The half that is NOT gated. `panel_argvs` is version-free, so the strip is born
+        at its measured height on 3.2 as on 3.7c — which makes the floor's loss "it does
+        not follow a resize", never "it is one row forever"."""
+        sizes = layout.slot_sizes(SLOTS, window_rows=50, content_rows=4,
+                                  bar_rows={"workspaces": 2})
+        argvs = layout.panel_argvs(slots=SLOTS, session="s", socket="k",
+                                   harness_pane="%1", sizes=sizes)
+        bar, = [a for a in argvs if "workspaces" in a]
+        self.assertEqual(bar[bar.index("-l") + 1], "2")
+        self.assertNotIn("3.3", " ".join(bar))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_a_tab_strip_grows_a_row_when_its_tabs_overflow.py
+++ b/tests/test_a_tab_strip_grows_a_row_when_its_tabs_overflow.py
@@ -508,14 +508,25 @@ class AStripGrowsOnlyIntoRowsTheHarnessCanSpare(unittest.TestCase):
     def test_a_want_below_the_height_a_strip_already_has_never_shrinks_it(self):
         """This grows and never trims. A plane that pinned its strip to three rows in its
         own `[[frame.component]]` table asked for three rows (#687); a measurement saying
-        its names fit on one is not that operator changing their mind."""
+        its names fit on one is not that operator changing their mind.
+
+        **Asked BESIDE a strip that is growing**, which is what makes the shortfall test in
+        `layout._grown` observable at all: the deal runs for as many rounds as the growing
+        strip needs, so a round that stopped asking whether this one still wants a row
+        would hand it one on every one of them.
+        """
         with mock.patch.dict(config.FRAME, _placed(chats=3)):
             got = layout.slot_sizes(SLOTS, window_rows=50, content_rows=4,
                                     bar_rows={"chats": 1})
             self.assertEqual(got["chats"], 3)
             grown = layout.slot_sizes(SLOTS, window_rows=50, content_rows=4,
                                       bar_rows={"chats": 5})
-        self.assertEqual(grown["chats"], 5)
+            self.assertEqual(grown["chats"], 5)
+            beside = layout.slot_sizes(SLOTS, window_rows=50, content_rows=4,
+                                       bar_rows={"chats": 1, "workspaces": 3})
+        self.assertEqual((beside["chats"], beside["workspaces"]), (3, 3),
+                         "a strip that wanted nothing was dealt the rows its neighbour "
+                         "asked for")
 
 
 class TheLauncherSplitsThePaneTheStripAskedFor(PersonaIso, unittest.TestCase):

--- a/tests/test_a_tab_strip_grows_a_row_when_its_tabs_overflow.py
+++ b/tests/test_a_tab_strip_grows_a_row_when_its_tabs_overflow.py
@@ -287,6 +287,32 @@ class EveryRowOfAGrownStripIsClickable(unittest.TestCase):
                     self.assertFalse(slots.TABS.more_at(r, c))
                     self.assertFalse(slots.TABS.add_at(r, c))
 
+    def test_the_heading_names_the_strip_once_and_not_once_per_row(self):
+        """The rows under the first are BLANK to the width of the heading, not the heading
+        again — `chats` repeated down the left of a three-row strip is the same word three
+        times where names are competing for columns.
+
+        **Nothing else here can see this**, which is why it is its own case and why the
+        deletion sweep found it: `slots._compose` blanks those cells with
+        ``" " * tui.width(lead)``, so the heading and its blank are the same WIDTH by
+        construction and every column assertion in this class is unmoved by drawing one in
+        place of the other. Only the text tells them apart.
+        """
+        for cols, rows in ((120, 3), (160, 2), (100, 3)):
+            drawn = [tui.strip_ansi(r) for r in self._strip(cols, rows)]
+            with self.subTest(cols=cols, rows=rows):
+                self.assertGreater(len(drawn), 1, "this width drew no second row")
+                head = "workspaces"
+                self.assertIn(head, drawn[0])
+                self.assertEqual([r for r in drawn if head in r], [drawn[0]],
+                                 f"the heading is drawn on more than the first row: "
+                                 f"{drawn!r}")
+                lead = tui.width(slots._inset() + head + "  ")
+                for r, line in enumerate(drawn[1:], start=1):
+                    self.assertEqual(line[:lead], " " * lead,
+                                     f"row {r} does not start with the heading's blank: "
+                                     f"{line!r}")
+
     def test_a_row_the_strip_did_not_draw_answers_nothing(self):
         """A pane taller than the names need draws fewer rows than it has, and the rows
         below the last are cells nothing was drawn into. `panel._write` leaves them to
@@ -364,6 +390,44 @@ class EveryRowOfAGrownStripIsClickable(unittest.TestCase):
         for line in rows:
             self.assertLessEqual(tui.width(line), 40, repr(line))
         self.assertNotIn(wide, "".join(tui.strip_ansi(r) for r in rows))
+
+    def test_a_run_that_starts_mid_list_carries_no_add_chat_affordance(self):
+        """`_Tabs.add_at`'s structural promise, at the one shape that can break it.
+
+        The affordance rides only a run holding the WHOLE list — neither count drawn. A run
+        that reaches the END of the list but starts partway into it has no trailing count
+        and a leading one, and that is the state where "is there a `+N` anywhere" and "is
+        there a trailing field" stop being the same question. 120 columns cuts these
+        fifteen into three pages, so a mark on the third draws that page alone with `+11`
+        in front of it and nothing after it.
+        """
+        rows = self._strip(120, 1, here=NAMES[13], note=slots.ADD_CHAT)
+        drawn = tui.strip_ansi(rows[0])
+        self.assertIn("+11", drawn, f"this is not the run the case is about: {drawn!r}")
+        self.assertFalse(drawn.rstrip().endswith(slots.ADD_CHAT),
+                         f"a `+` rode a run that starts mid-list: {drawn!r}")
+        self.assertEqual({c for c in range(120) if slots.TABS.add_at(0, c)}, set(),
+                         "the affordance claims a cell on a run it is not drawn on")
+
+    def test_no_cell_that_stands_for_names_off_the_strip_also_makes_a_chat(self):
+        """*Two questions, three methods, and a cell that is neither answers no to both* —
+        held over every width and every row count rather than at the one width the rung
+        happens to be tested at.
+
+        **The harm is `EVENT_KINDS`' "fires wrongly" and it is silent**: `_bar_events` asks
+        `switch_to` first and `add_at` second, so a `+9` that also answered `add_at` would
+        MAKE A CHAT where the operator asked to see the ones they have — and the row would
+        look exactly the same either way, because both fields are drawn as a `+`.
+        """
+        for cols in range(20, 300, 3):
+            for rows in (1, 2, 3):
+                for here in (NAMES[0], NAMES[5], NAMES[13]):
+                    self._strip(cols, rows, here=here, note=slots.ADD_CHAT)
+                    both = {(r, c) for r in range(rows) for c in range(cols)
+                            if slots.TABS.more_at(r, c) and slots.TABS.add_at(r, c)}
+                    with self.subTest(cols=cols, rows=rows, here=here):
+                        self.assertEqual(both, set(),
+                                         "a count cell also makes a chat")
 
     def test_no_row_of_a_grown_strip_is_wider_than_the_pane(self):
         """The ladder's own refusal, applied to every row rather than the first: a run

--- a/tests/test_builtin_components.py
+++ b/tests/test_builtin_components.py
@@ -122,9 +122,15 @@ class Declared(unittest.TestCase):
         sidebar rather than a pane: it is bounded like `todos` and for the same reason —
         a column that is one list has no room to let a second one grow without end.
 
-        The two bars are `Fixed(1)` on `top`, §3.6's own literals: a bar is one row or it
-        is nothing, and a `Content()` bar would be a row that appeared and disappeared as
-        a sibling chat opened, moving every pane below it."""
+        The two bars are `Fixed(1)` on `top`, §3.6's own literals: one row is what a strip
+        starts at, and a `Content()` bar would be a row that appeared and disappeared as a
+        sibling chat opened, moving every pane below it. **A strip that overflows is taller
+        than this and it is still `Fixed(1)` here** (#829): the extra rows are a size
+        `layout.slot_sizes` grants out of the harness's own slack, so the declaration stays
+        the floor and the growth stays somewhere a short window can refuse it. A `Content()`
+        declaration would put both bars in `layout.VARIABLE_ROW_SLOTS`, which is also which
+        pane `commands_frame._apply_sizes` leaves unasserted — three such panes in one stack
+        and only one may be the remainder."""
         got = {c.id: (c.edge, c.size) for c in self.reg.all()}
         self.assertEqual(got, {
             "identity": ("top", component.Fixed(1)),

--- a/tests/test_frame_bars.py
+++ b/tests/test_frame_bars.py
@@ -516,7 +516,7 @@ class AClickResolvesAgainstWhatWasDrawn(unittest.TestCase):
         row = self._draw(200, here="nowhere")
         for name in self.NAMES:
             for col in self._cells(row, name):
-                self.assertEqual(slots.TABS.switch_to(col), name,
+                self.assertEqual(slots.TABS.switch_to(0, col), name,
                                  f"column {col} of {row!r}")
 
     def test_the_mark_belongs_to_the_tab_it_marks(self):
@@ -532,12 +532,12 @@ class AClickResolvesAgainstWhatWasDrawn(unittest.TestCase):
         """
         row = self._draw(200, here="api.2")
         blank = self._cells(row, " api.3").start
-        self.assertEqual(slots.TABS.switch_to(blank), "api.3",
+        self.assertEqual(slots.TABS.switch_to(0, blank), "api.3",
                          "the blank mark in front of an inactive tab is not part of it")
         star = self._cells(row, "*api.2").start
-        self.assertIsNone(slots.TABS.switch_to(star), "the tab you are on switched")
+        self.assertIsNone(slots.TABS.switch_to(0, star), "the tab you are on switched")
         self._draw(200, here="nowhere")
-        self.assertEqual(slots.TABS.switch_to(star), "api.2",
+        self.assertEqual(slots.TABS.switch_to(0, star), "api.2",
                          "the marked tab's own mark column belongs to no tab")
 
     def test_the_gap_between_two_tabs_resolves_to_nothing(self):
@@ -547,7 +547,7 @@ class AClickResolvesAgainstWhatWasDrawn(unittest.TestCase):
         row = self._draw(200, here="nowhere")
         end = self._cells(row, "api.1").stop
         for col in range(end, end + slots._BAR_GAP):
-            self.assertIsNone(slots.TABS.switch_to(col), f"column {col} of {row!r}")
+            self.assertIsNone(slots.TABS.switch_to(0, col), f"column {col} of {row!r}")
 
     def test_the_heading_resolves_to_nothing(self):
         """`  chats  ` is about no chat, exactly as the repo table's heading row is about
@@ -557,7 +557,7 @@ class AClickResolvesAgainstWhatWasDrawn(unittest.TestCase):
         # tab (`test_the_mark_belongs_to_the_tab_it_marks`), so a heading measured to the
         # first letter would assert the opposite of that case one cell over.
         for col in range(self._cells(row, " api.1").start):
-            self.assertIsNone(slots.TABS.switch_to(col), f"column {col} of {row!r}")
+            self.assertIsNone(slots.TABS.switch_to(0, col), f"column {col} of {row!r}")
 
     def test_the_empty_space_past_the_last_tab_resolves_to_nothing(self):
         """Most of a wide bar is blank. A click out there has to answer falsy rather than
@@ -565,7 +565,7 @@ class AClickResolvesAgainstWhatWasDrawn(unittest.TestCase):
         index counting from the end — would do."""
         row = self._draw(200, here="nowhere")
         for col in range(len(row), 200):
-            self.assertIsNone(slots.TABS.switch_to(col), f"column {col} of {row!r}")
+            self.assertIsNone(slots.TABS.switch_to(0, col), f"column {col} of {row!r}")
 
     def test_the_tab_you_are_already_on_resolves_to_nothing(self):
         """Re-selecting what is already selected is not news — `_repos_events`' sentence,
@@ -574,7 +574,7 @@ class AClickResolvesAgainstWhatWasDrawn(unittest.TestCase):
         double-click from switching twice."""
         row = self._draw(200, here="api.2")
         for col in self._cells(row, "api.2"):
-            self.assertIsNone(slots.TABS.switch_to(col), f"column {col} of {row!r}")
+            self.assertIsNone(slots.TABS.switch_to(0, col), f"column {col} of {row!r}")
 
     def test_neither_overflow_count_switches_to_anything(self):
         """A `+N` stands for names that are NOT on the row, so there is nothing there to
@@ -596,7 +596,7 @@ class AClickResolvesAgainstWhatWasDrawn(unittest.TestCase):
         self.assertEqual(len(counts), 2, f"this width is not a page in the middle: {row!r}")
         for count in counts:
             for col in self._cells(row, count):
-                self.assertIsNone(slots.TABS.switch_to(col), f"column {col} of {row!r}")
+                self.assertIsNone(slots.TABS.switch_to(0, col), f"column {col} of {row!r}")
 
     def test_both_overflow_counts_are_a_cell_that_opens_the_picker(self):
         """*"when workspaces are more we are showing `+N` now in tabs — but user can't
@@ -618,7 +618,7 @@ class AClickResolvesAgainstWhatWasDrawn(unittest.TestCase):
         self.assertEqual(len(counts), 2, f"this width is not a page in the middle: {row!r}")
         for count in counts:
             for col in self._cells(row, count):
-                self.assertTrue(slots.TABS.more_at(col),
+                self.assertTrue(slots.TABS.more_at(0, col),
                                 f"the {count} is still inert at column {col}: {row!r}")
 
     def test_nothing_but_a_count_is_a_cell_that_opens_the_picker(self):
@@ -630,7 +630,7 @@ class AClickResolvesAgainstWhatWasDrawn(unittest.TestCase):
         row = _plain(self._draw(80, names=names, here="workspace-07"))
         counts = [f.strip() for f in row.split(" " * slots._BAR_GAP)
                   if f.strip().startswith("+")]
-        opening = {c for c in range(200) if slots.TABS.more_at(c)}
+        opening = {c for c in range(200) if slots.TABS.more_at(0, c)}
         expected = {col for count in counts for col in self._cells(row, count)}
         self.assertEqual(opening, expected,
                          f"a cell that is not a count opens the picker: {row!r}")
@@ -658,7 +658,7 @@ class AClickResolvesAgainstWhatWasDrawn(unittest.TestCase):
         self.assertTrue(drawn, f"no switchable tab on the page: {row!r}")
         for name in drawn:
             for col in self._cells(row, name):
-                self.assertEqual(slots.TABS.switch_to(col), name,
+                self.assertEqual(slots.TABS.switch_to(0, col), name,
                                  f"column {col} of {row!r}")
 
     def test_the_rung_that_says_only_where_you_are_has_no_tabs_at_all(self):
@@ -666,7 +666,7 @@ class AClickResolvesAgainstWhatWasDrawn(unittest.TestCase):
         row = _plain(self._draw(16, here="api.2"))
         self.assertEqual(row.strip(), "chats  2/3", repr(row))
         for col in range(0, 200):
-            self.assertIsNone(slots.TABS.switch_to(col), f"column {col} of {row!r}")
+            self.assertIsNone(slots.TABS.switch_to(0, col), f"column {col} of {row!r}")
 
     def test_the_rung_that_says_only_where_you_are_still_opens_the_picker(self):
         """**The width where this matters most.** A frame narrow enough to fall to `2/3`
@@ -679,10 +679,10 @@ class AClickResolvesAgainstWhatWasDrawn(unittest.TestCase):
         measured rather than the whole row being made live."""
         row = _plain(self._draw(16, here="api.2"))
         for col in self._cells(row, "2/3"):
-            self.assertTrue(slots.TABS.more_at(col), f"column {col} of {row!r}")
+            self.assertTrue(slots.TABS.more_at(0, col), f"column {col} of {row!r}")
         for col in self._cells(row, "chats"):
-            self.assertFalse(slots.TABS.more_at(col), f"the heading opened a picker")
-        self.assertFalse(slots.TABS.more_at(tui.width(row) + 5),
+            self.assertFalse(slots.TABS.more_at(0, col), f"the heading opened a picker")
+        self.assertFalse(slots.TABS.more_at(0, tui.width(row) + 5),
                          "the space past the row opened a picker")
 
     def test_a_rung_that_draws_nothing_opens_nothing(self):
@@ -692,9 +692,9 @@ class AClickResolvesAgainstWhatWasDrawn(unittest.TestCase):
         is empty."""
         self._draw(80, names=[f"workspace-{i:02d}" for i in range(15)],
                    here="workspace-07")
-        self.assertTrue(any(slots.TABS.more_at(c) for c in range(80)))
+        self.assertTrue(any(slots.TABS.more_at(0, c) for c in range(80)))
         self.assertEqual(self._draw(11), "")
-        self.assertEqual([c for c in range(200) if slots.TABS.more_at(c)], [],
+        self.assertEqual([c for c in range(200) if slots.TABS.more_at(0, c)], [],
                          "a bar that drew no row kept the counts it is no longer drawing")
 
     def test_a_narrowed_bar_forgets_the_tabs_it_is_no_longer_drawing(self):
@@ -704,10 +704,10 @@ class AClickResolvesAgainstWhatWasDrawn(unittest.TestCase):
         screen. Every rung publishes, including the two that draw no tab."""
         wide = self._draw(200, here="nowhere")
         col = self._cells(wide, "api.3").start
-        self.assertEqual(slots.TABS.switch_to(col), "api.3")
+        self.assertEqual(slots.TABS.switch_to(0, col), "api.3")
         for width in (30, 16, 11):
             self._draw(width, here="api.2")
-            self.assertIsNone(slots.TABS.switch_to(col),
+            self.assertIsNone(slots.TABS.switch_to(0, col),
                               f"width {width} kept a stale tab")
 
     def test_a_bar_with_no_names_at_all_publishes_no_tabs(self):
@@ -717,7 +717,7 @@ class AClickResolvesAgainstWhatWasDrawn(unittest.TestCase):
         self._draw(200, here="nowhere")
         self.assertEqual(slots._bar("chats", [], "api.1", 200), [])
         for col in range(0, 200):
-            self.assertIsNone(slots.TABS.switch_to(col), f"column {col}")
+            self.assertIsNone(slots.TABS.switch_to(0, col), f"column {col}")
 
     def test_the_add_chat_affordance_is_not_a_tab(self):
         """It makes a chat; it does not switch to one. There is no chat there yet, which
@@ -726,7 +726,7 @@ class AClickResolvesAgainstWhatWasDrawn(unittest.TestCase):
                                 note=slots.ADD_CHAT))
         self.assertTrue(row.rstrip().endswith(slots.ADD_CHAT), repr(row))
         for col in self._cells(row, slots.ADD_CHAT):
-            self.assertIsNone(slots.TABS.switch_to(col), f"column {col} of {row!r}")
+            self.assertIsNone(slots.TABS.switch_to(0, col), f"column {col} of {row!r}")
 
     def test_the_add_chat_affordance_is_a_cell_that_makes_a_chat(self):
         """*"`+` button not working for creating new session."*
@@ -737,10 +737,10 @@ class AClickResolvesAgainstWhatWasDrawn(unittest.TestCase):
         row = _plain(self._draw(120, names=["api.1"], here="nowhere",
                                 note=slots.ADD_CHAT))
         cells = list(self._cells(row, slots.ADD_CHAT))
-        self.assertEqual([c for c in range(200) if slots.TABS.add_at(c)], cells,
+        self.assertEqual([c for c in range(200) if slots.TABS.add_at(0, c)], cells,
                          f"the `+` is not the one cell that makes a chat: {row!r}")
         for col in cells:
-            self.assertFalse(slots.TABS.more_at(col),
+            self.assertFalse(slots.TABS.more_at(0, col),
                              "the `+` was published as an overflow count as well")
 
     def test_a_plus_and_a_plus_n_are_never_on_the_same_row(self):
@@ -768,9 +768,9 @@ class AClickResolvesAgainstWhatWasDrawn(unittest.TestCase):
         its `+` cell through a resize would make a chat from a column the operator can see
         holds a name."""
         self._draw(120, names=["api.1"], here="api.1", note=slots.ADD_CHAT)
-        self.assertTrue(any(slots.TABS.add_at(c) for c in range(120)))
+        self.assertTrue(any(slots.TABS.add_at(0, c) for c in range(120)))
         self._draw(120, names=["api.1"], here="api.1")
-        self.assertEqual([c for c in range(200) if slots.TABS.add_at(c)], [],
+        self.assertEqual([c for c in range(200) if slots.TABS.add_at(0, c)], [],
                          "the bar kept an affordance it stopped drawing")
 
     def test_no_row_at_any_width_ever_draws_or_maps_a_column_left_of_zero(self):
@@ -799,7 +799,7 @@ class AClickResolvesAgainstWhatWasDrawn(unittest.TestCase):
                                      f"{names} at {width}: a count went negative: {row!r}")
                     for col in range(-4, 0):
                         self.assertIsNone(
-                            slots.TABS.switch_to(col),
+                            slots.TABS.switch_to(0, col),
                             f"{names} at {width}: column {col} is a tab: {row!r}")
 
     def test_a_column_nothing_drew_answers_nothing_however_far_out(self):
@@ -808,10 +808,10 @@ class AClickResolvesAgainstWhatWasDrawn(unittest.TestCase):
         would have answered with the LAST tab, hiding a wrong reading behind a plausible
         name, and the row's last column IS a tab here so that wrong answer is available."""
         row = self._draw(200, here="nowhere")
-        self.assertEqual(slots.TABS.switch_to(len(row) - 1), "api.3",
+        self.assertEqual(slots.TABS.switch_to(0, len(row) - 1), "api.3",
                          "the last drawn column is not a tab, so -1 measures nothing")
         for col in (-1, -99, 10_000):
-            self.assertIsNone(slots.TABS.switch_to(col), f"column {col} of {row!r}")
+            self.assertIsNone(slots.TABS.switch_to(0, col), f"column {col} of {row!r}")
 
     def test_the_map_carries_the_name_on_disk_and_not_the_repaired_one(self):
         """`contain.one_line` is a REPAIR for drawing (#472), and what a click has to hand
@@ -825,7 +825,7 @@ class AClickResolvesAgainstWhatWasDrawn(unittest.TestCase):
         self.assertNotEqual(drawn, raw, "this name needs no repair, so it measures none")
         at = row.index(drawn)
         for col in range(at, at + tui.width(drawn)):
-            self.assertEqual(slots.TABS.switch_to(col), raw,
+            self.assertEqual(slots.TABS.switch_to(0, col), raw,
                              f"column {col} of {row!r} carries the drawn name")
 
     def test_a_second_press_on_the_column_you_just_switched_from_does_nothing(self):
@@ -850,12 +850,12 @@ class AClickResolvesAgainstWhatWasDrawn(unittest.TestCase):
                     # Redrawn each time round: the strip is one object, so the paint the
                     # first press resolves against has to be the one in front of it.
                     self._draw(width, names=names, here="workspace-07")
-                    self.assertEqual(slots.TABS.switch_to(col), name)
+                    self.assertEqual(slots.TABS.switch_to(0, col), name)
                     after = self._draw(width, names=names, here=name)
                     self.assertIsNone(
-                        slots.TABS.switch_to(col),
+                        slots.TABS.switch_to(0, col),
                         f"{width}: pressing column {col} twice switched twice — "
-                        f"{name} then {slots.TABS.switch_to(col)}\n"
+                        f"{name} then {slots.TABS.switch_to(0, col)}\n"
                         f"  before {row!r}\n  after  {after!r}")
 
 
@@ -911,11 +911,11 @@ class TheTabYouAreOnIsDrawnAsOne(unittest.TestCase):
         self.assertEqual(painted, "*api.2")
         start = tui.width(row[:row.index(self.ON)])
         for col in range(start, start + tui.width(painted)):
-            self.assertIsNone(slots.TABS.switch_to(col),
+            self.assertIsNone(slots.TABS.switch_to(0, col),
                               f"column {col} is inside the block and is not the tab you "
                               f"are on: {row!r}")
-        self.assertEqual(slots.TABS.switch_to(start - 1), None)
-        self.assertEqual(slots.TABS.switch_to(start + tui.width(painted)), None)
+        self.assertEqual(slots.TABS.switch_to(0, start - 1), None)
+        self.assertEqual(slots.TABS.switch_to(0, start + tui.width(painted)), None)
 
     def test_the_paint_costs_the_row_no_cell_at_all(self):
         """Which is why it could be added to a strip that is already competing for columns.
@@ -965,7 +965,7 @@ class TheTabYouAreOnIsDrawnAsOne(unittest.TestCase):
                     at = plain.index(name) - tui.width(slots._BAR_MARK[0])
                     want = None if name == "workspace-07" else name
                     for col in range(at, at + 1 + tui.width(name)):
-                        self.assertEqual(slots.TABS.switch_to(col), want,
+                        self.assertEqual(slots.TABS.switch_to(0, col), want,
                                          f"{width}: column {col} of {plain!r}")
 
 
@@ -1046,7 +1046,7 @@ class TheSeamBetweenTwoTabsIsThePlanesOwnAnswer(unittest.TestCase):
         self.assertIn(slots._BAR_RULE, plain)
         for col, ch in enumerate(plain):
             if ch == slots._BAR_RULE:
-                self.assertIsNone(slots.TABS.switch_to(col),
+                self.assertIsNone(slots.TABS.switch_to(0, col),
                                   f"the seam at column {col} answered for a tab: {plain!r}")
 
     def test_every_column_of_a_ruled_row_answers_for_the_tab_under_it(self):
@@ -1066,7 +1066,7 @@ class TheSeamBetweenTwoTabsIsThePlanesOwnAnswer(unittest.TestCase):
                     at = plain.index(name) - tui.width(slots._BAR_MARK[0])
                     want = None if name == "workspace-07" else name
                     for col in range(at, at + 1 + tui.width(name)):
-                        self.assertEqual(slots.TABS.switch_to(col), want,
+                        self.assertEqual(slots.TABS.switch_to(0, col), want,
                                          f"{width}: column {col} of {plain!r}")
 
     def test_the_ladder_pays_for_the_rules_rather_than_overflowing(self):
@@ -1124,7 +1124,7 @@ class ThisPlaneIsWhyTheRungIsWindowed(unittest.TestCase):
         rows = slots._bar("workspaces", list(self.NAMES), self.HERE, width)
         row = rows[0] if rows else ""
         self.assertLessEqual(tui.width(row), width, repr(row))
-        return row, {slots.TABS.switch_to(col) for col in range(width)} - {None}
+        return row, {slots.TABS.switch_to(0, col) for col in range(width)} - {None}
 
     def test_rung_one_still_needs_two_hundred_and_seventy_four_columns(self):
         """The number the whole change is about. Measured off the ladder, so it follows
@@ -1212,7 +1212,7 @@ class TheChatBarReadsThePlane(PersonaIso, unittest.TestCase):
                 row = _plain(rows[0]) if rows else ""
                 self.assertFalse(row.rstrip().endswith(slots.ADD_CHAT),
                                  f"{width}: the workspace bar drew a `+`: {row!r}")
-                self.assertEqual([c for c in range(width) if slots.TABS.add_at(c)], [],
+                self.assertEqual([c for c in range(width) if slots.TABS.add_at(0, c)], [],
                                  f"{width}: the workspace bar published an affordance")
 
     def test_only_this_workspaces_chats_are_on_the_bar(self):

--- a/tests/test_frame_bars.py
+++ b/tests/test_frame_bars.py
@@ -58,7 +58,10 @@ class TheLadderGivesUpWholeThings(unittest.TestCase):
 
     def _row(self, width, names=None, here="api.2", **kw):
         rows = slots._bar("chats", list(names or self.NAMES), here, width, **kw)
-        self.assertLessEqual(len(rows), 1, "a bar is one row or it is none")
+        self.assertLessEqual(
+            len(rows), 1,
+            "a strip given one row draws one row or none — the rungs below are what it "
+            "gives up, never a second row it was not given (#829)")
         return rows[0] if rows else ""
 
     def test_a_wide_row_shows_every_name_with_the_one_you_are_in_marked(self):

--- a/tests/test_the_keyboard_walks_the_tab_strips.py
+++ b/tests/test_the_keyboard_walks_the_tab_strips.py
@@ -170,7 +170,7 @@ class AWalkStartsTheSwitchATabClickStarts(_AStripAKeyboardCanWalk):
         row = builtins.build(FID).get("chats").on_event
         from charter.frame import overlay, slots
         slots.chats_bar(FID, 200)
-        col = next(c for c in range(200) if slots.TABS.switch_to(c) == "api.3")
+        col = next(c for c in range(200) if slots.TABS.switch_to(0, c) == "api.3")
         row(overlay.Event(overlay.CLICK, "left", row=0, col=col, pressed=True))
         self.assertEqual(by_keyboard, self.spawned.pop())
 


### PR DESCRIPTION
Closes item **2** of #829.

> *"panes are resizable — and user can resize and it should show more tabs opened on new resized rows."*

On this plane's own fifteen workspaces, rung 1 needs **274 columns**. At 160 the strip drew seven names and counted the rest; at 120, five. Widening the terminal bought nothing, because the pane was one row and stayed one row.

```
before, 160 columns
  workspaces   authority-audit   autonomy   charter-update-skill   default   fleet  *harness-wrapper   news-dispatch-guard   opencode-integration  +7

after, 160 columns
  workspaces   authority-audit   autonomy   charter-update-skill   default   fleet  *harness-wrapper   news-dispatch-guard   opencode-integration
               plane-shape   relations-and-delegations   showcase   statusline-improvements   todos   tracking-github-issues   user-reporting
```

## The shape

A panel cannot make its own pane taller, so this is a **launcher size** and not a renderer setting:

* `slots.bar_rows_wanted(fid, slot, *, pane_cols, cap)` — how many rows the names need. It **asks the renderer**: it composes the strip at 1, 2, 3 rows and stops at the first height that holds every name, so the sizer and the renderer cannot come apart the way #500 shipped twice one pane over. Measured over every mark × every width × two caps: the pane is **never** sized taller than the strip fills.
* `layout.slot_sizes(..., bar_rows=...)` → `layout._grown` — spends the harness's **surplus** (`harness_rows` of the ungrown map minus `HARNESS_MIN_ROWS`), a row at a time in split order so two strips share a short budget. `repos` is not what pays: `_DROP_ORDER` gives the bars up before it.
* `layout.BAR_MAX_ROWS = 3` — measured through the same cut: these fifteen need 2 rows at 160, 3 at 120, 4 at 100, 6 at 80.
* `layout.pane_cols(order, slot, *, window_cols)` — `repos_cols` generalised, so a strip split after `right` is measured at its own pane's width (#500, one slot over). `repos_cols` delegates to it.
* `commands_frame._slot_sizes` gains `order` and `window_cols`; all three call sites (both launches, `_relayout`, `_reassert_sizes`) already had them.

**It grows only when the tabs overflow.** A fixed two-row launch would cost a row off the harness on every plane that places a bar whether or not the names overflow — a cost everyone pays for a case only some hit, and rows against the harness are what #740 settled once already.

## Clicks

`slots.TABS` was keyed by COLUMN. On a two-row strip that does not degrade to answering nothing — it answers the row above about a click on the row below, which is `EVENT_KINDS`' *fires wrongly*. The map is `(row, col)` now, **with no default row**: a caller that forgot which row it is asking about is a `TypeError`, not a switch to the wrong tab.

Rows are cut the way the single row always was: `_cuts` gives the page boundaries, pages are grouped into runs of `rows`, and the strip draws the run holding the mark. A run is a function of the names, the width and the row count alone, so pressing a drawn tab redraws the same run with only the `*` moved (pinned at 1/2/3 rows × 5 widths × every drawn name).

**At `rows=1` the renderer is byte-identical to `main`** — differentially checked over 7 name lists × every `here` × both note settings × widths 0–299, rows and click map together.

## The 3.2 floor, measured rather than assumed

* The launch is **not gated**: `split-window -l 3` is version-free, so a strip is born at the height its names need on 3.2 as on 3.7c.
* `_install_resize_hook` issues **no command at all** below `RESIZE_HOOK_FLOOR` — confirmed on `~/.local/share/charter-testing/tmux-3.2`, where `set-hook -w window-resized …` answers `invalid option: window-resized`, rc 1.
* Driving `_reassert_sizes` against a real 3.2 server gives `{top: 1, workspaces: 3, bottom: 1, repos: 6}`, harness 25 — **byte for byte what 3.7c does**. So the floor loses only the automatic trigger; `charter frame-resize`, which `tmuxctl.below_resize_hook_message` already names, re-sizes the strip there.

## Tests

* `tests/test_a_tab_strip_grows_a_row_when_its_tabs_overflow.py` — 40 cases: the want, the growth budget, the harness floor, the ceiling, the pad, the ASCII property at every width × every row count, and the run-stability property.
* `tests/test_a_real_resize_gives_a_real_strip_another_row.py` — 5 cases on a **real tmux server**, including a real `charter panel workspaces` process redrawing into a row it did not have. Without `ctx.height` that case fails with the `+7` still on screen in a two-row pane.

## Two things the issue got slightly wrong

* The constant is `tmuxctl.below_resize_hook_message`, not `below_resize_floor_message`.
* `chats`/`workspaces` are **not** in `layout.SLOT_SIZE` — `_PLACED` filters on `c.id in SLOT_OF` — so `layout` derives no geometry for them at all; their height comes from the committed arrangement (#687). The effect is what the issue says; the mechanism is the arrangement echo, and it is why a bar has to be *placed* for any of this to be about it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016VxfcoaaCZBq3rTNeb6e2R
