### PR TITLE
Right-click a chat tab and charter draws a menu about that tab (#846)

### DIFF
--- a/charter/cli.py
+++ b/charter/cli.py
@@ -861,6 +861,17 @@ def _add_frame_parsers(sub) -> None:
     # `--chat` at all. Empty falls back to `$CHARTER_SESSION_ID`, which is what that frame
     # always resolved through — see `commands_frame._pressers_chat`.
     pal.add_argument("--chat", dest="chat", default="")
+    # Which TAB the menu is about, and it is a different question from `--chat` above:
+    # that one says which chat the keypress happened in — which frame's harness the pane
+    # is carved off — and this says which chat the two rows in it act on. A right-click on
+    # another chat's tab opens a menu over the frame the operator is looking at (#846).
+    #
+    # Not a positional, for `frame-switch`'s reason: the `client` positional above is a
+    # compatibility surface for binds installed by older charters, and a second one would
+    # be ambiguous with it. Optional, for `--chat`'s reason exactly — every invocation
+    # that is not a tab menu carries none, and `frame/tabmenu.wanted` reads an absent or
+    # unspellable value as "this is the ordinary palette" rather than as an error.
+    pal.add_argument("--tab", dest="tab", default="")
     pal.set_defaults(func=commands_frame.cmd_palette)
 
     # Internal, and a top-level sibling for the same `_split_frame_argv` reason as the

--- a/charter/commands_frame.py
+++ b/charter/commands_frame.py
@@ -150,7 +150,7 @@ import time
 from . import config, contain, harness, inflight, instance, tui, util, workspace
 from .frame import (actions as frame_actions, builtin_actions, chats, choose, component,
                     gather, layout, leave, overlay, pane, palette, picker, state, switch,
-                    tmuxctl)
+                    tabmenu, tmuxctl)
 # Aliased because `cmd_reopen` is a function in this module and `reopen` reads as one: the
 # module answers what a quit RECORDED and the command is what puts it back, and a bare
 # `reopen.read()` beside `cmd_reopen` invites a reader to think one is the other.
@@ -7261,6 +7261,15 @@ def cmd_palette(args) -> int:
     ``--pane`` this runs as the hotkey bind's `run-shell` child and does nothing but carve
     the overlay's pane off the harness; with it, this IS the program inside that pane.
 
+    **``--tab`` makes it a third thing, and deliberately not a third subcommand** (#846).
+    A right-click on a chat tab opens a menu about THAT chat, and a menu is this pane with
+    a different row source: the same split off the same harness, the same
+    :func:`_close_open_overlays` sweep in front of it, the same escape hatch armed before
+    anything can capture input. So it travels as an option on this command, is forwarded
+    into the pane by :func:`_open_palette`, and is read back here to decide which surface
+    this process is. `frame/tabmenu.py` owns the rows and the routing; a value that cannot
+    name a chat is not an error but an ordinary palette.
+
     **The bind carries the presser's client and nothing else** (see `conf_text`). The
     frame is resolved from `$CHARTER_SESSION_ID` at the moment the key fires, exactly as
     `cmd_density`, `cmd_switch` and `cmd_respawn` resolve theirs, because one bind is
@@ -7307,6 +7316,15 @@ def cmd_palette(args) -> int:
     if getattr(args, "pane", False):
         held = pane.claim()
         try:
+            # **`--tab` is which surface this pane is, and it is asked here rather than
+            # inside `_draw_palette`** (#846). A tab menu is the palette's pane, its
+            # overlay, its hatch and its raw-mode loop over a different row source — but
+            # every line of `_draw_palette` is about the frame this pane belongs to, and a
+            # menu is about one CHAT that is very often not the one the frame is on. An
+            # unspellable `--tab` answers `""` and the ordinary palette opens, which is
+            # `frame/tabmenu.wanted`'s whole degradation promise: never a refusal.
+            if tabmenu.wanted(args):
+                return tabmenu.draw(args)
             return _draw_palette(args)
         finally:
             pane.release(held)
@@ -7346,8 +7364,12 @@ def _open_palette(args) -> int:
     _close_open_overlays(socket, harness=harness)
     argv = overlay.open_argv(
         socket, harness=harness,
-        command=util.self_relaunch_argv("frame-palette",
-                                        "--pane"),
+        # `frame/tabmenu.forward` splices `--tab <chat>` in for a right-click on a tab and
+        # NOTHING for `F2`, so the ordinary palette's argv is byte-identical to what it was
+        # (#846). The pane is still carved off THIS frame's harness whichever it is: the
+        # menu is about another tab, but the operator is looking at this one.
+        command=util.self_relaunch_argv("frame-palette", "--pane",
+                                        *tabmenu.forward(args)),
         env=_relayout_pane_env(fid, v))
     if argv is None:
         return 0

--- a/charter/frame/builtins.py
+++ b/charter/frame/builtins.py
@@ -237,17 +237,68 @@ def _panel(slot: str):
     return render
 
 
-#: Which mouse button charter acts on. One, and it is named rather than "whatever came":
-#: middle-click is paste on every terminal an operator has ever used and right-click opens
-#: their emulator's own menu, so acting on either would be charter taking a gesture that
-#: already means something else. `overlay._SGR_BUTTONS` is where the three get their names,
-#: and the ones §4f named no kind for never arrive here at all.
+#: Which mouse button ACTS. One, and it is named rather than "whatever came": middle-click
+#: is paste on every terminal an operator has ever used, so acting on it would be charter
+#: taking a gesture that already means something else. `overlay._SGR_BUTTONS` is where the
+#: three get their names, and the ones §4f named no kind for never arrive here at all.
 #:
-#: **One constant for the table and for both bars**, because "which button did the operator
-#: mean" is one question — a second answer to it would be a frame where the same gesture
-#: works on one pane and does nothing on the next, which is the thing an operator reports
-#: as a bug and is right to.
+#: **One constant for the table, both bars and both strips**, because "which button did the
+#: operator mean" is one question — a second answer to it would be a frame where the same
+#: gesture works on one pane and does nothing on the next, which is the thing an operator
+#: reports as a bug and is right to.
 _ACT_BUTTON = "left"
+
+#: Which mouse button opens a MENU about the thing under it — #846, and it is a second
+#: question rather than a second answer to the first.
+#:
+#: **Right-click already reaches charter's panels, and it needs no tmux bind.** That is the
+#: opposite of what this constant's absence assumed, and it is measured on tmux 3.2 and
+#: 3.7c against a pane requesting exactly what `overlay.MOUSE_ON` requests, with SGR
+#: button 2 injected into a real client::
+#:
+#:     mouse=off  custombind=no   PRESS ^[[<2;50;7M  RELEASE ^[[<2;50;7m  bind fired: no
+#:     mouse=on   custombind=no   PRESS ^[[<2;50;7M  RELEASE ^[[<2;50;7m  bind fired: no
+#:     mouse=on   custombind=yes  PRESS —           RELEASE ^[[<2;50;7m  bind fired: YES
+#:
+#: With `mouse off` — charter's shipped default — no mouse `bind -n` fires at all and tmux
+#: routes the report straight to the pane, pane-relative. With `mouse on` and tmux's own
+#: DEFAULT `MouseDown3Pane` in place the press still reaches the pane and tmux's menu does
+#: not appear, because that binding tests `#{mouse_any_flag}` — which is 1 precisely
+#: because this pane asked for reporting — and takes its `send-keys -M` branch. **A custom
+#: `bind -n MouseDown3Pane` that omits `send -M` is the one thing that would swallow the
+#: press**, so charter binds nothing: `commands_frame.conf_text` names no mouse key, and
+#: adding one is what would break this rather than what would enable it.
+#:
+#: **It is deliberately NOT read by three of the four handlers below.** Right-click is a
+#: menu gesture and a menu needs something to be about; the repo table's rows, the two
+#: strips' doorways and the persona column's badges each already have their one meaning,
+#: and giving a second button a second one there would be inventing surfaces nobody asked
+#: for. `_bar_events` is the only reader, and only on the bar whose tabs are chats.
+#:
+#: **What the press DOES cost, measured here rather than assumed away.** tmux's default
+#: binding forwards the report, but it selects the pane first — read back off a real 3.7c
+#: with `list-keys -T root`, the forwarding branch is `{ select-pane -t = ; send-keys -M }`.
+#: So with `[frame] mouse = true` a right-click on any charter panel moves the keyboard to
+#: that panel before the byte arrives. **That is #634's defect one button over, it is
+#: pre-existing, and this change does not close it.** It costs nothing on the gesture this
+#: constant is for — a menu that opens takes the keyboard anyway, and
+#: `commands_frame._close_palette` selects the harness on the way out — and it costs a MISS
+#: one left click on the harness, or `overlay.HATCH_KEY`.
+#:
+#: Closing it is a change of its own and not a line here. `MouseDown1Pane`'s fix works
+#: because tmux's default for THAT key is two commands charter can write out verbatim in
+#: the else-branch (`commands_frame.conf_text`); button 3's else-branch is a `display-menu`
+#: a page long, built out of `#{mouse_word}`, `#{pane_marked}` and a dozen other formats,
+#: and it differs between the versions charter supports. A bind that dropped it would take
+#: tmux's own pane menu away from the harness and from the operator's own splits, inside
+#: charter's window, to fix a focus steal that a click puts right.
+#:
+#: **And on a terminal that eats button 2 this constant simply never matches.** The
+#: measurement above injected bytes into a pty, which bypasses the terminal EMULATOR;
+#: whether one forwards button 2 to a mouse-reporting application or serves its own
+#: context menu is emulator-dependent and configurable. Every path behind this degrades to
+#: *never fires* — `component.EVENT_KINDS`' own direction — and `F2` keeps every row.
+_MENU_BUTTON = "right"
 
 
 def _repos_events(fid: str):
@@ -348,8 +399,28 @@ _WORKSPACE_SWITCH = ("frame-switch", "--workspace")
 #: :data:`_CHAT_SWITCH` carries no `--chat` either.
 _NEW_CHAT = ("frame-new-chat",)
 
+#: What a right press on a chat tab opens — the menu about THAT tab (`frame/tabmenu.py`),
+#: with the tab's own id appended by the handler.
+#:
+#: **`frame-palette` and not a subcommand of its own**, because a tab menu IS the palette:
+#: the same pane, carved off the same harness, by the same argv, behind the same
+#: `_close_open_overlays` sweep (so a right-click while `F2` is up replaces it rather than
+#: leaving an invisible pane holding a live process — #739) and the same escape hatch,
+#: armed before the surface can capture anything. `frame/tabmenu.TAB_OPTION` is the whole
+#: of the difference, and it is read twice: by the process that splits the pane, to pass it
+#: on, and by the process inside it, to decide which surface to be.
+#:
+#: **Charter-drawn, and NOT `display-menu`**, which `frame/tabmenu.py` re-measures at the
+#: 3.2 floor: no styling flags at all, a key as well as a command per item, per-client,
+#: totally modal at the server (every panel on the window goes blind while it is up), and
+#: a `client_height − 2` item cap past which it draws nothing and exits 0. `frame/menu.py`
+#: was deleted rather than deprecated when `frame/palette.py` arrived, and nothing about a
+#: pointer makes that call worth reversing.
+_TAB_MENU = ("frame-palette", "--tab")
 
-def _bar_events(fid: str, command: tuple[str, ...], add: tuple[str, ...] | None = None):
+
+def _bar_events(fid: str, command: tuple[str, ...], add: tuple[str, ...] | None = None,
+                menu: bool = False):
     """A tab bar's handler: a left click on a tab switches this frame to it.
 
     **A click here SWITCHES, where a click on the repo table only ever SELECTS, and that
@@ -466,6 +537,32 @@ def _bar_events(fid: str, command: tuple[str, ...], add: tuple[str, ...] | None 
     the renderer happened to draw, which is what keeps the two bars from degrading
     differently the day one of them starts drawing a note it did not have.
 
+    **A RIGHT press on a chat tab opens a menu about that tab** (#846) — the fourth
+    gesture, the second button, and the one that had to argue for itself hardest, because
+    §4i's rule is about exactly this: the irreversible half of an interaction is never
+    driven by a pointer event.
+
+    It is met the same way the `+` meets it and then once more. The press is still the
+    half that is never delivered unpaired, so a drag that began elsewhere and releases
+    over the bar opens nothing. And what the press starts is not the irreversible thing:
+    it is a SURFACE. `charter frame-palette --tab <chat>` splits the overlay pane, draws
+    two rows, and stops — `chat: close` on it is a doorway onto `leave.confirm_rows`, so
+    the chat is stopped by a keypress, on a warning that names it, exactly as `F2 → chat:
+    close` stops one today. A pointer opens the question; the keyboard answers it.
+
+    **Which tab it is about comes from `slots._Tabs.tab_at` and not from
+    :meth:`~slots._Tabs.switch_to`**, and the one cell they disagree about is the point:
+    the tab you are ON. Switching to it is 41 tmux calls to arrive where you already are,
+    so `switch_to` refuses it; closing it is the ordinary case of closing a chat, so a
+    menu that refused it would refuse the commonest right-click there is.
+
+    **`menu` is False for the workspaces bar, and that is `add`'s structural argument one
+    noun over.** Both rows the menu holds — the transcript and the close — are about a
+    CHAT. A workspace has neither, and the palette's own catalogue by scope is what says
+    so: nothing else charter offers is about one tab at all. So the workspaces bar is
+    handed no menu command, exactly as it is handed no `+`, rather than being handed one
+    and relying on a resolution that would happen to answer nothing.
+
     *command* is which of the two switches this bar starts (:data:`_CHAT_SWITCH`,
     :data:`_WORKSPACE_SWITCH`). One handler and two lines of data rather than two
     handlers, because everything above is true of both bars and a second copy would be
@@ -488,7 +585,21 @@ def _bar_events(fid: str, command: tuple[str, ...], add: tuple[str, ...] | None 
         from .. import util
         from . import slots as _slots
         from .builtin_actions import _spawn
-        if not ev.pressed or ev.name != _ACT_BUTTON:
+        if not ev.pressed:
+            return False
+        if ev.name == _MENU_BUTTON:
+            # **The menu button is asked about FIRST and answers on its own**, rather than
+            # widening the guard below: the two gestures read two different maps
+            # (`tab_at` here, `switch_to` there) and they disagree about exactly one cell,
+            # so a single guard would make a right-click on the tab you are on fall
+            # through to `add_at`/`more_at` — a menu button that could reach the `+`.
+            # Falsy afterwards for the same reason every other spawn here is: the pane the
+            # menu carves comes off the harness, so nothing in THIS rectangle changed.
+            tab = _slots.TABS.tab_at(ev.row, ev.col) if menu else None
+            if tab is not None:
+                _spawn(util.self_relaunch_argv(*_TAB_MENU, tab), fid=fid)
+            return False
+        if ev.name != _ACT_BUTTON:
             return False
         name = _slots.TABS.switch_to(ev.row, ev.col)
         if name is None:
@@ -905,7 +1016,8 @@ def build(fid: str = "") -> Registry:
     reg.register(Component(
         id="chats", title="chats", edge="top", size=Fixed(1),
         needs=(), render=_chats,
-        events=("click",), on_event=_bar_events(fid, _CHAT_SWITCH, add=_NEW_CHAT)))
+        events=("click",),
+        on_event=_bar_events(fid, _CHAT_SWITCH, add=_NEW_CHAT, menu=True)))
     reg.register(Component(
         id="workspaces", title="workspaces", edge="top", size=Fixed(1),
         needs=(), render=_workspaces,

--- a/charter/frame/slots.py
+++ b/charter/frame/slots.py
@@ -3403,6 +3403,36 @@ class _Tabs:
         name = self._cols.get((row, col))
         return None if name == self._here else name
 
+    def tab_at(self, row: int, col: int):
+        """The tab drawn at cell (*row*, *col*) — **including the one you are on**.
+
+        **The same map :meth:`switch_to` reads, without its one subtraction**, and the
+        difference between the two is the difference between the two gestures rather than
+        a relaxation of a rule. A left click SWITCHES, so "the tab you are already on"
+        answers nothing: re-switching is 41 tmux invocations and ~360 ms of panes being
+        torn down and split again, all of it to arrive where you already were. A right
+        click opens a menu ABOUT a tab (`frame/tabmenu.py`), and the commonest chat an
+        operator closes is the one they are in — `F2 → chat: close` has always meant
+        exactly that — so a menu that refused the marked tab would refuse the ordinary
+        click.
+
+        **It is a second method and not a flag on the first**, for :meth:`add_at`'s
+        reason: they are different questions with different answers, and a caller told
+        "this cell is special" would have to ask a second question anyway to know which.
+        Every caller of `switch_to` feeds what it answers to a command that switches; a
+        `switch_to(..., here=True)` would put the tab you are on into that argv on the day
+        somebody passed the flag by mistake.
+
+        **A cell nothing drew into is still nothing**, structurally rather than by a
+        guard: `_cols` is a mapping, so a column the strip drew no tab into is absent
+        whether it is `-1`, `4096`, a `_BAR_GAP`, either `+N` count or the `+` that makes
+        a chat — see the class docstring, and :meth:`more_at` and :meth:`add_at` for the
+        two fields that are drawn there and are deliberately not tabs. No cell answers two
+        of the three, which `_bar` makes true by building all four sets from one walk of
+        one composition.
+        """
+        return self._cols.get((row, col))
+
     def more_at(self, row: int, col: int) -> bool:
         """Whether cell (*row*, *col*) is a field standing for names the strip could not
         draw.

--- a/charter/frame/tabmenu.py
+++ b/charter/frame/tabmenu.py
@@ -132,8 +132,26 @@ def wanted(args) -> str:
     it already refuses the empty string, and a second guard nothing could turn red is the
     line this repository deletes (`commands_frame._pressers_chat` says so about the
     identical shape).
+
+    **And no `strip`, unlike `_pressers_chat` and `cmd_close`, which read the same kind of
+    value on a different trip.** Those two take `#{@charter_chat}` expanded by tmux INTO A
+    SHELL-QUOTED `run-shell` string, where padding is a thing a format can produce. This
+    one cannot be padded and the deletion sweep is what asked the question. Measured: the
+    only producer is `slots._Tabs.tab_at`, whose names come off `chats.of_workspace`,
+    which reaches them through `chats.is_chat` — *"the id is held to `ID_RE` here, because
+    this is where a name off `os.scandir` enters charter's vocabulary"*. A directory
+    literally named ``api.2 `` beside `api.1` and `api.2`, with this workspace recorded on
+    it, is excluded from the roster, is drawn on no bar and is answered by no cell. From
+    there the value travels in an argv list (`util.self_relaunch_argv`, `builtin_actions
+    ._spawn`'s `Popen`) and as separate `split-window --` arguments, neither of which is
+    shell-interpreted.
+
+    So a `strip` here would be a repair for damage that cannot arrive — and worse than
+    idle: if a padded name ever did reach it, stripping would silently retarget the menu
+    at a DIFFERENT chat, which is #838's defect exactly. Refusing is the answer that
+    cannot act on the wrong one.
     """
-    tab = (getattr(args, "tab", None) or "").strip()
+    tab = getattr(args, "tab", None) or ""
     return tab if chats.ID_RE.fullmatch(tab) else ""
 
 
@@ -271,10 +289,18 @@ def opens(row, target: str, *, live) -> "palette.Palette | None":
 def act(row, target: str, *, fid: str) -> None:
     """Act on the row Enter landed on, and say the reason when it could not run.
 
-    **One function because the two halves are one decision**, and because the surface a
+    **One function because the three halves are one decision**, and because the surface a
     refusal would otherwise be drawn on is the pane :func:`draw` is about to kill. The
     frame's own attention row is a different pane and a different process, so the sentence
     survives this one (`commands_frame._say_on_screen`).
+
+    **A ``None`` row is a cancel and is answered here rather than at the call site.**
+    `overlay.Surface.run` answers ``None`` for Escape, for `overlay.HATCH_KEY`, and for
+    the pane's writer going away — the one answer that can never become a wedge — and it
+    is the commonest way this surface ends, because the row under the cursor when Escape
+    is pressed is one keypress from a confirmation that stops a harness. Nothing was
+    chosen, so there is nothing to start and nothing to say. Keeping it here rather than
+    in :func:`draw` is what makes it a line a test can turn red: `draw` needs a tty.
 
     **A row with nothing to say says nothing**, and the guard is not tidiness: the notice
     is a WRITE, so an empty one would blank whatever the attention row was already
@@ -285,7 +311,7 @@ def act(row, target: str, *, fid: str) -> None:
     other.
     """
     from .. import commands_frame
-    if chose(row, target, fid=fid):
+    if row is None or chose(row, target, fid=fid):
         return
     if row.note:
         commands_frame._say_on_screen(fid, row.note)
@@ -377,12 +403,10 @@ def draw(args) -> int:
                          live=commands_frame._plane_live(
                              commands_frame._plane_servers())[0])
 
-        chosen = palette.own_the_tty(surface, then=_then)
-        if chosen is not None:
-            # `None` is Escape, `F12`, or the pane's writer going away — `Surface.run`'s
-            # cancel, and the one answer that can never become a wedge. Nothing was
-            # chosen, so there is nothing to act on and nothing to say.
-            act(chosen, target, fid=fid)
+        # `act` takes the cancel too (`own_the_tty` answers `None` for Escape, for the
+        # hatch, and for a pane whose writer is gone), so there is no branch here that a
+        # test would need a tty to reach.
+        act(palette.own_the_tty(surface, then=_then), target, fid=fid)
     finally:
         commands_frame._close_palette(socket, harness=harness,
                                       overlay_pane=overlay_pane)

--- a/charter/frame/tabmenu.py
+++ b/charter/frame/tabmenu.py
@@ -1,0 +1,349 @@
+"""The tab menu: right-click a chat tab, and act on THAT tab — #846.
+
+**This is `frame/palette.py` with a different row source, and that is the whole design.**
+Not `display-menu`, and not a fourth surface: :func:`draw` builds an `overlay.Surface`
+through `palette.Palette` and hands it `palette.own_the_tty`, so everything the overlay
+already decided holds here unchanged — full-pane rather than `display-popup`, modal, one
+key (`overlay.HATCH_KEY`) that always leaves, a scrolling window, containment before width
+arithmetic, and a doorway that replaces the surface in the pane the operator is already
+looking at.
+
+**`display-menu` was measured and lost, twice.** `frame/menu.py` was deleted rather than
+deprecated when the palette arrived (`overlay.py`'s module docstring, `palette.py`'s), and
+nothing about a right-click makes it a better answer than it was:
+
+* at `tmuxctl.FLOOR` (3.2) it has **no styling flags at all** — `-s`, `-S`, `-H` and `-b`
+  each answer rc 1 — so a menu drawn there cannot mark a row, dim a refused one or say why
+  one is refused, which is #512's rule broken by the surface rather than by charter;
+* every item needs a **key as well as a command**, which is the digit shortcut that ran out
+  at nine coming back;
+* it is **per-client**, so the two-client frame `commands_frame._say_on_screen` already
+  reasons about gets one menu and one operator wondering why nothing happened;
+* it is **totally modal at the server**: every panel process on the window stops being
+  drawn while it is up, which is the frame going blind for as long as the operator reads;
+* and it has a hard `client_height − 2` item cap past which it **draws nothing and exits
+  0** — a surface that silently succeeds at nothing, which is exactly the failure this
+  repository spends its guards on.
+
+---
+
+**What a right-click resolves to is a TAB, and the resolution is free.** `slots._Tabs`
+already maps every cell of the strip to the name drawn in it; :meth:`slots._Tabs.tab_at`
+is that map read without `switch_to`'s one subtraction — the tab you are ON answers itself
+here, because closing the chat you are in is the ordinary case of closing a chat, where
+switching to the chat you are in is 41 tmux calls to arrive where you already were.
+
+**Exactly two rows have a tab to sit on**, which is a catalogue of the whole palette by
+scope rather than a choice: `chat: previous transcript` and `chat: close` are about one
+chat; detach, both next/previous pairs, the densities, the chromes, the todo row and the
+regather are about the FRAME; the pickers and `charter: quit` are about the PLANE. There is
+no `stop` distinct from close and no rename anywhere in the frame. So this module removes
+nothing from `F2` — the palette keeps every row it had, and this is a second, faster route
+to two of them, which matters because **a right-click menu is invisible until you try it**.
+
+**Close goes LAST and stays confirmed.** `frame/leave.open_rows` puts the destructive rows
+at the bottom of the palette so that a destructive row is never one `F2 Enter` away, and a
+gesture that reaches close in one pointer press makes that reasoning stronger rather than
+weaker. The doorway starts nothing: it opens `leave.confirm_rows` over
+`leave.plan(only=<tab>)` — the same plan, the same warning and the same teardown as
+`F2 → chat: close`, with one target — and the keypress that commits is the row that
+module mints, so the two routes cannot come to disagree about which one that is.
+
+**And if the terminal never sends button 2, nothing happens.** The proof that tmux routes
+it to a reporting pane was made by injecting SGR bytes into a real client over a real pty,
+which bypasses the terminal EMULATOR; whether a given emulator forwards button 2 to a
+mouse-reporting application or serves its own context menu is emulator-dependent and
+configurable (iTerm2 3.6.11 ships `"Button,1,1,," -> kContextMenuPointerAction` beside a
+profile with `Mouse Reporting` on, and the precedence between them is not determinable
+from the plist). So every path here degrades to *never fires* and none to *fires wrongly*
+or to a refusal: an absent or unspellable `--tab` is not an error, it is
+:func:`wanted` answering `""` and the ordinary palette opening instead.
+"""
+
+from __future__ import annotations
+
+import os
+
+from .. import util
+from . import chats, leave, overlay, palette
+
+#: The option that carries which tab a menu is about, from the panel that decoded the
+#: press, through the `frame-palette` process the panel spawns, to the process inside the
+#: pane it splits.
+#:
+#: **On `frame-palette` rather than a command of its own**, because a tab menu IS the
+#: palette: the same pane is carved off the same harness by the same argv, the same
+#: `_close_open_overlays` sweep runs in front of it so a right-click while `F2` is up
+#: replaces it rather than leaving an invisible pane holding a live process (#739), and
+#: the same hatch is armed before the surface can capture anything. A second subcommand
+#: would be a second copy of all of that, drifting.
+TAB_OPTION = "--tab"
+
+#: The two rows, by id. **Not action ids**, and the colon is what makes that structural:
+#: `frame/action.py` holds every action id to `component.usable_id` — lower-case letters,
+#: digits, underscores, at most one dot — so a provider cannot ship an action called
+#: `tab:close` and take this keypress. `frame/choose.py` and `frame/leave.py` use the same
+#: trick for the same reason. Neither is ever drawn.
+TRANSCRIPT_ID = "tab:transcript"
+CLOSE_ID = "tab:close"
+
+
+def label(target: str) -> str:
+    """What the menu's header says before the operator types.
+
+    The chat's own id, because that is what they right-clicked and because this surface
+    may be about a tab the frame is NOT on — `palette.HEADING`'s bare `charter` would
+    leave a `chat: close` row over an unnamed target, which is the palette's row wearing a
+    menu's clothes.
+    """
+    return f"chat {target}"
+
+
+def transcript_title(target: str) -> str:
+    """The transcript row's title. Named, for :func:`label`'s reason."""
+    return f"chat: previous transcript — {target}"
+
+
+def close_title(target: str) -> str:
+    """The close doorway's title.
+
+    `leave.OPEN_CLOSE` says *this chat*, which is true of a palette opened IN the chat it
+    is about and is exactly what cannot be said here: the tab under the pointer is very
+    often not the tab the frame is on. So the id is spelled out, and the rest of the
+    sentence is `leave.OPEN_CLOSE`'s promise unchanged — the operator is being told the
+    same thing by both routes.
+    """
+    return f"chat: close {target} — stop it and do not bring it back"
+
+
+def wanted(args) -> str:
+    """Which tab this invocation is about, or ``""`` for *this is not a tab menu*.
+
+    **An unspellable value is not an error, it is no menu**, and that is the whole
+    degradation promise of this feature stated at its entry point. This value arrives
+    from a panel process that read it out of a click map, travels through an argv and a
+    tmux `split-window`, and ends up in `state.frame_dir` and a `charter frame-close`
+    positional — so it is held to `chats.ID_RE`, the alphabet a chat id reaches tmux
+    under, exactly as `commands_frame.cmd_close` holds its own positional. What a value
+    outside it produces is the ordinary palette, which is what `F2` produces, which is
+    never wrong and never says anything an operator did not ask for.
+
+    ``fullmatch`` alone, with no truthiness test in front of it: `chats.ID_RE` is `+`, so
+    it already refuses the empty string, and a second guard nothing could turn red is the
+    line this repository deletes (`commands_frame._pressers_chat` says so about the
+    identical shape).
+    """
+    tab = (getattr(args, "tab", None) or "").strip()
+    return tab if chats.ID_RE.fullmatch(tab) else ""
+
+
+def forward(args) -> tuple[str, ...]:
+    """:data:`TAB_OPTION` and its value for a tab menu, and nothing at all for `F2`.
+
+    **The empty tuple is load-bearing.** `commands_frame._open_palette` splices this into
+    the argv the overlay pane runs, so a version that emitted `("--tab", "")` would make
+    every `F2` a tab menu about no chat — and :func:`wanted` would answer `""` for it one
+    process later, which is a surface that draws the ordinary palette after paying for an
+    option it could not use. Emitting nothing keeps the `F2` argv byte-identical to what
+    it was before this module existed.
+    """
+    tab = wanted(args)
+    return (TAB_OPTION, tab) if tab else ()
+
+
+def catalogue(target: str) -> tuple[overlay.Row, ...]:
+    """The menu's rows: the transcript, then close.
+
+    **Two rows, and the order is the guard.** `frame/leave.open_rows` puts the destructive
+    row last because a palette's cursor starts on the first row that can run, so a
+    destructive row at the top is one Enter from a surface that has only just appeared.
+    This menu appears under the pointer rather than under a keypress, so it arrives with
+    even less warning — the placement is inherited rather than re-argued, and the row is
+    a DOORWAY either way (:func:`chose`).
+
+    **A tab with no capture is listed with its reason and not dropped** — #512's rule,
+    and `builtin_actions.NO_TRANSCRIPT`'s own sentence rather than a second one: a chat
+    that has never been quit has no transcript, which is the ordinary state of a chat
+    running normally, and an operator cannot ask about an option they cannot see.
+
+    No plan is built here and nothing is scanned. `frame/leave.open_rows` makes the same
+    promise for the same reason: the operator is not deciding while a menu is merely open,
+    and the warning belongs at the moment they are (§4f).
+    """
+    from . import builtin_actions
+    has = builtin_actions._has_transcript(target)
+    return (
+        overlay.Row(id=TRANSCRIPT_ID, title=transcript_title(target),
+                    note="" if has else builtin_actions.NO_TRANSCRIPT, refused=not has),
+        overlay.Row(id=CLOSE_ID, title=close_title(target)),
+    )
+
+
+def confirm_rows(target: str, *, live) -> tuple[overlay.Row, ...]:
+    """What the close doorway opens: `leave`'s own warning, narrowed to *target*.
+
+    **The same plan, the same rows and the same confirming id as `F2 → chat: close`.**
+    `leave.plan(only=…)` is the seam that already existed for exactly this, and a second
+    enumeration for this route would be a second answer to *what does stopping this cost*
+    — two sentences about one chat that drift the first time either is edited.
+
+    *live* is `commands_frame._live_chats`' tri-state, carried through rather than
+    collapsed: ``None`` is *the server would not answer*, which is not the same as *no
+    chats*, and `leave.plan` is what knows the difference.
+
+    ``focus=""``, and it is not a fallback. `Plan.focus` is read by the manifest a QUIT
+    writes (`commands_frame._record_the_plane`); a confirmation draws rows and writes no
+    manifest, and close is the one verb that is deliberately never recorded at all
+    (`leave._close_summary`). A value here would be one nothing on this path can observe,
+    which is the shape the deletion sweep reports — `commands_frame._picker` already
+    removed the `or ""` beside its own for the same finding.
+    """
+    return leave.confirm_rows(leave.plan(live=live, focus="", only=target),
+                              verb=leave.CLOSE)
+
+
+def chose(row, target: str, *, fid: str) -> bool:
+    """Act on the row Enter landed on. Answers whether anything was started.
+
+    **The close DOORWAY is not here, and its absence is the confirmation.** `chose` starts
+    work; a doorway starts none — it replaces the surface (`palette.own_the_tty`'s *then*,
+    :func:`draw`) — so a row this function does not recognise answers ``False`` and the
+    caller says its note. A version that closed the chat on :data:`CLOSE_ID` would put the
+    one irreversible thing charter's frame can do exactly one keypress from a pointer
+    gesture, which is what `frame/leave.py`'s row ordering exists to prevent and what a
+    right-click makes more reachable rather than less.
+
+    **A refused row starts nothing**, which is not merely tidy: `overlay.Surface` lets
+    Enter land on any row and it is the caller that knows a refusal (the palette says the
+    note on the operator's own screen). Handing `charter frame-transcript` a chat with no
+    capture would open an empty pager for an operator who was told there was nothing to
+    open.
+
+    **`builtin_actions._spawn`, never a bare `Popen`.** The menu closes the instant a row
+    has been chosen — `commands_frame._close_palette` is one chained tmux command — and
+    `kill-pane` hands SIGHUP to this process's group, so work started in-process dies with
+    the pane it was started from. That is measured at `builtin_actions._spawn`, and it is
+    also why `$CHARTER_SESSION_ID` is STATED for the child rather than inherited.
+
+    *target* is the tab, and *fid* is the chat this menu was opened over. **They are two
+    different questions and close needs both**: `charter frame-close <target>` says which
+    chat to stop, and `--chat <fid>` says where the keypress came from, which is what
+    puts `cmd_close`'s sentence on the screen the operator is actually looking at rather
+    than on the one that is about to stop existing.
+    """
+    from .builtin_actions import _spawn
+    if row.refused:
+        return False
+    if row.id == TRANSCRIPT_ID:
+        _spawn(util.self_relaunch_argv("frame-transcript", "--chat", target), fid=fid)
+        return True
+    if leave.goes_through(row, leave.CLOSE):
+        _spawn(util.self_relaunch_argv("frame-close", target, "--chat", fid), fid=fid)
+        return True
+    return False
+
+
+def opens(row, target: str, *, live) -> "palette.Palette | None":
+    """The surface *row* opens, or ``None`` when it opens none.
+
+    `commands_frame._picker`'s job on this menu, and the same two-line shape: a doorway is
+    told apart from everything else by its id, and what comes back replaces the surface in
+    the pane the operator is already looking at (`palette.own_the_tty`'s *then*) rather
+    than starting a second one — which would race this pane's own teardown.
+
+    **The plan is built HERE and not when the menu opened**, which is §4f's *at the moment
+    the operator is deciding*: the rows describe the plane as it is under the keypress
+    rather than as it was when the pointer landed, and a right-click that never reaches
+    the doorway pays for no scan of the frame root at all — `catalogue` is one `is_file`.
+
+    One test of the id and no test of `refused`: neither row this menu draws can be a
+    refused doorway — the close row is never refused, because the tab is a name the panel
+    resolved off a strip it had just painted, where `leave.open_rows`' own doorway can be
+    (a palette that cannot tell which chat it was opened in has no chat to close). A guard
+    for a state that cannot arrive is the line the deletion sweep reports.
+    """
+    if row.id != CLOSE_ID:
+        return None
+    return palette.Palette(catalogue=confirm_rows(target, live=live), label=leave.CLOSE,
+                           mouse=True)
+
+
+def act(row, target: str, *, fid: str) -> None:
+    """Act on the row Enter landed on, and say the reason when it could not run.
+
+    **One function because the two halves are one decision**, and because the surface a
+    refusal would otherwise be drawn on is the pane :func:`draw` is about to kill. The
+    frame's own attention row is a different pane and a different process, so the sentence
+    survives this one (`commands_frame._say_on_screen`).
+
+    **A row with nothing to say says nothing**, and the guard is not tidiness: the notice
+    is a WRITE, so an empty one would blank whatever the attention row was already
+    carrying. The rows that reach here having started nothing are the transcript row on a
+    chat with no capture (which carries `builtin_actions.NO_TRANSCRIPT`), the warning's own
+    per-chat rows (which carry `leave.note`) and its *nothing left to stop* row, which
+    carries none — so both branches are reachable and neither is a restatement of the
+    other.
+    """
+    from .. import commands_frame
+    if chose(row, target, fid=fid):
+        return
+    if row.note:
+        commands_frame._say_on_screen(fid, row.note)
+
+
+def draw(args) -> int:
+    """Be the tab menu: draw the rows, take a choice, act on it, hand the pane back.
+
+    `commands_frame._draw_palette`'s shape, and deliberately its shape rather than a
+    branch inside it: everything below is about ONE chat that is not necessarily this
+    frame's, where every line of that function is about the frame itself.
+
+    **The close is a ``finally``**, one layer up from `overlay.Surface.run`'s own: a menu
+    that raised must still give the operator their harness back, and whatever went wrong
+    is one traceback into a pane that is about to stop existing — the one place charter
+    may print one.
+
+    **The frame is read out of the environment and the tab off the argv**, which is the
+    split this whole feature turns on. `commands_frame._relayout_pane_env` told this pane
+    which frame it belongs to, because one tmux server is shared by every frame on the
+    machine; the tab travels on the argv because it is not the frame — it is a name the
+    panel resolved out of a click map, and the pane the menu is drawn in was carved off
+    THIS frame's harness so that a menu about another tab still appears where the operator
+    is looking.
+
+    **Always 0**, for `cmd_palette`'s reason: a non-zero return from a `run-shell` child
+    is printed INTO THE HARNESS PANE and drops it into copy-mode, which is charter drawing
+    in the one rectangle ADR 0018 says it never draws.
+    """
+    from .. import commands_frame
+    from . import state
+    fid = os.environ.get("CHARTER_SESSION_ID", "")
+    target = wanted(args)
+    socket = state.frame_server(fid) or commands_frame.SOCKET
+    harness = state.harness_pane(fid) or ""
+    try:
+        surface = palette.Palette(catalogue=catalogue(target), label=label(target),
+                                  mouse=True)
+
+        def _then(row):
+            # **This runs on a keypress, never on the open**, which is what makes reading
+            # the plane here affordable: `leave.open_rows`' rule is that a menu merely
+            # being up must cost no scan, and it does not — `catalogue` reads one
+            # `is_file`. One `list-windows` per server on the Enter that was pressed is
+            # the same round trip `commands_frame._picker` makes for the identical
+            # doorway, and it is what makes the warning describe the plane as it is under
+            # the keypress rather than as it was when the pointer landed.
+            return opens(row, target,
+                         live=commands_frame._plane_live(
+                             commands_frame._plane_servers())[0])
+
+        chosen = palette.own_the_tty(surface, then=_then)
+        if chosen is not None:
+            # `None` is Escape, `F12`, or the pane's writer going away — `Surface.run`'s
+            # cancel, and the one answer that can never become a wedge. Nothing was
+            # chosen, so there is nothing to act on and nothing to say.
+            act(chosen, target, fid=fid)
+    finally:
+        commands_frame._close_palette(socket, harness=harness,
+                                      overlay_pane=os.environ.get("TMUX_PANE", ""))
+    return 0

--- a/charter/frame/tabmenu.py
+++ b/charter/frame/tabmenu.py
@@ -291,6 +291,47 @@ def act(row, target: str, *, fid: str) -> None:
         commands_frame._say_on_screen(fid, row.note)
 
 
+def handback(env) -> tuple[str, str, str, str]:
+    """Who this pane is, and the three ids that give the harness back.
+
+    ``(fid, socket, harness, overlay_pane)``: which frame this pane belongs to, which
+    tmux it is on, which pane the keyboard goes back to, and which pane to kill —
+    `commands_frame._close_palette`'s three arguments, resolved in one place so that
+    :func:`draw` can put the whole of them in a ``finally`` that cannot itself raise.
+
+    **Every one of the four falls back, and not one fallback is decorative.**
+
+    * `$CHARTER_SESSION_ID` is absent whenever the pane was split with no ``-e`` payload,
+      which is every tmux below `tmuxctl.PANE_ENV_FLOOR` — `commands_frame
+      ._relayout_pane_env` answers ``None`` there and `overlay.open_argv` sets nothing, so
+      the pane inherits whatever the shared server happens to hold. ``""`` is what every
+      charter reader already treats as absent.
+    * The socket falls back to charter's own for `builtin_actions._server`'s reason: a
+      frame with no recorded server is one launched by a charter that predates
+      `state.record_server`, and charter's own socket is where it will be — never
+      "nowhere", which would aim the teardown at no server at all.
+    * `state.harness_pane` answers ``None`` for a frame charter has lost the record of,
+      and ``None`` is not ``""``: it would be formatted into a tmux target as the four
+      characters `None`, naming a pane that cannot exist. `frame/overlay.py` measured what
+      an EMPTY target costs instead — `kill-pane -t ""` kills the pane the command is
+      running against — which is why `overlay.hatch_command` emits no `kill-pane` at all
+      rather than one with nothing in it.
+    * `$TMUX_PANE` is absent in any process tmux did not start, which is every test of
+      this function and would be a hand-typed `charter frame-palette --pane`.
+
+    *env* is passed rather than read, so all four are reachable from a test — the reason
+    `commands_frame._relayout_pane_env` takes *fid* as an argument instead of reading it
+    back out of a variable one tmux server shares between every frame on the machine.
+    """
+    from .. import commands_frame
+    from . import state
+    fid = env.get("CHARTER_SESSION_ID", "")
+    return (fid,
+            state.frame_server(fid) or commands_frame.SOCKET,
+            state.harness_pane(fid) or "",
+            env.get("TMUX_PANE", ""))
+
+
 def draw(args) -> int:
     """Be the tab menu: draw the rows, take a choice, act on it, hand the pane back.
 
@@ -309,18 +350,17 @@ def draw(args) -> int:
     machine; the tab travels on the argv because it is not the frame — it is a name the
     panel resolved out of a click map, and the pane the menu is drawn in was carved off
     THIS frame's harness so that a menu about another tab still appears where the operator
-    is looking.
+    is looking. :func:`handback` is the whole of the first half, resolved before the
+    ``try`` so the ``finally`` below has nothing left to compute and nothing left to
+    raise.
 
     **Always 0**, for `cmd_palette`'s reason: a non-zero return from a `run-shell` child
     is printed INTO THE HARNESS PANE and drops it into copy-mode, which is charter drawing
     in the one rectangle ADR 0018 says it never draws.
     """
     from .. import commands_frame
-    from . import state
-    fid = os.environ.get("CHARTER_SESSION_ID", "")
+    fid, socket, harness, overlay_pane = handback(os.environ)
     target = wanted(args)
-    socket = state.frame_server(fid) or commands_frame.SOCKET
-    harness = state.harness_pane(fid) or ""
     try:
         surface = palette.Palette(catalogue=catalogue(target), label=label(target),
                                   mouse=True)
@@ -345,5 +385,5 @@ def draw(args) -> int:
             act(chosen, target, fid=fid)
     finally:
         commands_frame._close_palette(socket, harness=harness,
-                                      overlay_pane=os.environ.get("TMUX_PANE", ""))
+                                      overlay_pane=overlay_pane)
     return 0

--- a/docs/frame.md
+++ b/docs/frame.md
@@ -228,6 +228,31 @@ and putting them back to arrive where you were. So does clicking the heading, th
 two names, or the empty space past the last tab: those are cells no tab was drawn into, and
 charter will not pick the nearest name for you.
 
+**Right-click a chat tab and you get a menu about that chat.** Two rows — `chat: previous
+transcript` and, last, `chat: close` — both about the tab under the pointer rather than the
+chat you happen to be in, so you can close a chat from its own tab without switching to it
+first. Close is a doorway, not a button: pressing it draws the same warning `F2 → chat:
+close` draws, naming the chat and what stopping it costs, and the keypress on *that* is what
+stops the harness. Escape leaves, `F12` always leaves, and nothing is stopped by a pointer.
+
+Right-click on the tab you *are* on works too — closing the chat you are in is the ordinary
+case of closing one. Right-click on the heading, on the `+`, on a `+N` count or on empty
+space does nothing at all, and the `workspaces` bar has no menu: a workspace has neither a
+transcript nor a chat to close.
+
+**`F2` still has every one of those rows**, and that is deliberate: a right-click menu is
+invisible until you try it, so it is a faster route to two things and never the only one.
+
+**And whether right-click reaches charter at all is your terminal's decision.** tmux
+forwards it — measured on 3.2 and 3.7c, with `[frame] mouse` off and on, with no binding
+involved — but many terminal emulators serve their own context menu on button 2 instead of
+sending it to the application. iTerm2's default profile is one. If yours does, nothing
+breaks and nothing is refused: the menu simply never appears, and `F2` is unchanged. One
+cost worth knowing with `mouse = true`: tmux selects the pane under the pointer before
+forwarding a right-click, so a right-click that lands on a panel and opens nothing leaves
+your keyboard on that panel. A click on the harness, or `F12`, puts it back. (Left clicks
+have not done this since charter rebound `MouseDown1Pane` — see above.)
+
 **The `+N` counts are the exception, and they open the palette.** A `+9` stands for names
 that are not on the row, so there is nothing there to switch *to* — but it is the field
 you are most likely to try, and charter now hands off to the surface that can answer:

--- a/docs/news/unreleased-right-click-a-chat-tab-to-act-on-that-chat.md
+++ b/docs/news/unreleased-right-click-a-chat-tab-to-act-on-that-chat.md
@@ -1,0 +1,104 @@
+---
+version: unreleased
+headline: right-click a chat tab and charter draws a menu about that tab — its transcript, and closing it
+---
+
+*"All functionality in the F2 menu — extract them and integrate the features on
+components. Tabs should have right-click context-menu support."*
+
+Right-click a tab on the `chats` bar and charter draws two rows about **that** chat:
+
+```
+  chat api.2
+  > chat: previous transcript — api.2
+    chat: close api.2 — stop it and do not bring it back
+```
+
+Both were already in `F2`, and both were about the chat you were *in*. On a tab they are
+about the tab, so closing another chat no longer means switching to it first.
+
+## Two findings decided the shape, and both were the opposite of what was expected
+
+**Right-click already reached charter's panels. It needed no tmux binding.** Measured on
+tmux 3.2 and 3.7c against a pane requesting exactly what charter's panels request, with an
+SGR button-2 report injected into a real client:
+
+```
+mouse=off  custombind=no   PRESS ^[[<2;50;7M  RELEASE ^[[<2;50;7m  bind fired: no
+mouse=on   custombind=no   PRESS ^[[<2;50;7M  RELEASE ^[[<2;50;7m  bind fired: no
+mouse=on   custombind=yes  PRESS —           RELEASE ^[[<2;50;7m  bind fired: YES
+```
+
+With tmux's own mouse off no mouse binding fires at all. With it on, tmux's *default*
+`MouseDown3Pane` tests `#{mouse_any_flag}` — which is 1 precisely because the panel asked
+for reporting — and takes its `send-keys -M` branch, so tmux's own menu does not appear
+either. The third row is the trap: **a custom `bind -n MouseDown3Pane` that omits `send -M`
+swallows the press.** Binding is what would have broken this. Charter binds nothing.
+
+The events were already decoded, already delivered and already named `right`; they were
+dropped by one comparison.
+
+**And exactly two rows in the whole palette are about a tab.** Catalogued by scope: detach,
+both next/previous pairs, the densities, the chromes, the todo row and the regather are
+about the FRAME; the workspace, persona and chat pickers and `charter: quit` are about the
+PLANE. There is no `stop` distinct from close, and no rename in the frame at all. So this
+is not a reduction of `F2` — the palette keeps every row it had, because none of the others
+has a tab to sit on.
+
+## Charter draws it, not `display-menu`
+
+`frame/menu.py` was deleted rather than deprecated when the palette arrived, and re-measured
+at charter's 3.2 floor `display-menu` is worse than it was then: **no styling flags at all**
+(`-s`, `-S`, `-H`, `-b` each rc 1, so a refused row cannot be dimmed or explained), a key as
+well as a command per item, per-client, totally modal at the server — every panel process on
+the window stops being drawn while it is up — and a hard `client_height − 2` item cap past
+which it **draws nothing and exits 0**.
+
+So the menu is `frame/palette.py` over a different row source: the same overlay pane, carved
+off the same harness, by the same argv, behind the same sweep that stops a second `F2`
+leaving an invisible pane holding a live process, and with the same `F12` armed before the
+surface can capture anything.
+
+## Close is last, and it is still confirmed
+
+Charter puts destructive rows at the bottom of a list because a palette's cursor starts on
+the first row that can run. A menu that opens under the pointer arrives with even less
+warning than one that opens under a keypress, so that placement matters more here, not less.
+
+`chat: close` starts nothing. It opens the same warning `F2 → chat: close` opens — the same
+plan, narrowed to one chat, naming what stopping it costs and what will not come back — and
+the keypress on *that* is what stops the harness. A chat with nothing left to stop gets a row
+saying so and no confirming row at all, so there is no Enter that quietly succeeds at
+nothing.
+
+`F2` keeps every row either way. A right-click menu is invisible until you try it, so it is
+a faster route to two things and never the only one.
+
+## If your terminal keeps button 2, nothing happens — and that is the whole failure mode
+
+The measurement above injected bytes into a pty, which **bypasses the terminal emulator**.
+Whether a given emulator forwards button 2 to a mouse-reporting application or serves its own
+context menu is emulator-dependent and configurable — iTerm2 3.6.11 ships
+`"Button,1,1,," -> kContextMenuPointerAction` beside a profile with `Mouse Reporting` on, and
+which wins is not determinable from its plist.
+
+So every path degrades to *never fires*: an absent or unspellable tab is not an error, it is
+the ordinary palette opening instead. Nothing is refused, nothing is half-drawn, and `F2`
+still reaches both rows.
+
+## One cost, measured and left open
+
+With `[frame] mouse = true`, tmux's forwarding branch for button 3 is
+`{ select-pane -t = ; send-keys -M }` — it **selects the pane before forwarding**. That is
+the focus steal charter already fixed for the left button, one button over, and it is not
+closed here: a right-click that lands on a panel and opens nothing leaves the keyboard on
+that panel until you click the harness or press `F12`. It costs the gesture this change is
+for nothing, because a menu that opens takes the keyboard anyway and gives it back on the way
+out.
+
+The left button's fix works because tmux's default for that key is two commands charter can
+write out verbatim in the else-branch. Button 3's else-branch is a `display-menu` a page long
+built out of a dozen formats, and it differs between the tmux versions charter supports — so
+replacing it would take tmux's own pane menu away from the harness and from panes you split
+yourself, inside charter's window, to fix a steal that one click puts right. It is written up
+where it lives rather than fixed in passing.

--- a/tests/test_a_real_click_on_a_real_tab_bar_switches.py
+++ b/tests/test_a_real_click_on_a_real_tab_bar_switches.py
@@ -482,16 +482,12 @@ class ARealClickOnTheWorkspaceBarReachesTheSwitch(_ARealFrameWithBars,
         self.assertEqual(state.frame_workspace(self.fid), self.HERE)
 
 
-@unittest.skipUnless(_HAS_TMUX, "no tmux on this machine")
-class ARealClickOnTheChatBarMovesTheClient(_ARealFrameWithBars, unittest.TestCase):
-    """The `chats` bar: click a name, the client is on that chat's window.
+class _ARealChatBarOverTwoChats(_ARealFrameWithBars):
+    """One frame, one `chats` bar, two chats — the fixture both buttons are pressed on.
 
-    **This is the half that moves a CLIENT rather than a file**, and it is the one #684 is
-    about: membership comes from this plane's own chat directories (`state.frame_workspace`,
-    a file), the target is a recorded pane ID and never a session NAME, and `cmd_chat`
-    establishes where both chats actually are before it aims anything anywhere — because
-    `select-window` at another session's pane returns 0 and moves that session while this
-    client stays put.
+    Held apart from the cases so the two gestures are measured against ONE frame rather
+    than two: same bar, same chats, same client, same `mouse = true` config out of
+    `conf_text`. It has no test methods of its own, so it is discovered and runs nothing.
     """
 
     WS = "alpha"
@@ -528,6 +524,19 @@ class ARealClickOnTheChatBarMovesTheClient(_ARealFrameWithBars, unittest.TestCas
             _await(lambda: self.there in self._bar_row(self.bar)),
             f"the chat bar never painted both chats: {self._bar_row(self.bar)!r}")
         self.assertEqual(self._active(), self.harness)
+
+
+@unittest.skipUnless(_HAS_TMUX, "no tmux on this machine")
+class ARealClickOnTheChatBarMovesTheClient(_ARealChatBarOverTwoChats, unittest.TestCase):
+    """The `chats` bar: click a name, the client is on that chat's window.
+
+    **This is the half that moves a CLIENT rather than a file**, and it is the one #684 is
+    about: membership comes from this plane's own chat directories (`state.frame_workspace`,
+    a file), the target is a recorded pane ID and never a session NAME, and `cmd_chat`
+    establishes where both chats actually are before it aims anything anywhere — because
+    `select-window` at another session's pane returns 0 and moves that session while this
+    client stays put.
+    """
 
     def test_clicking_the_other_chats_tab_moves_the_client_to_its_window(self):
         """`select-window` at the target chat's own harness PANE — a pane id resolves to
@@ -606,6 +615,163 @@ class ARealClickOnTheChatBarMovesTheClient(_ARealFrameWithBars, unittest.TestCas
         time.sleep(2.0)
         self.assertEqual(self._current_window(self.WS), window)
         self.assertEqual(self._active(), self.harness)
+
+
+@unittest.skipUnless(_HAS_TMUX, "no tmux on this machine")
+class ARealRightClickOnTheChatBarOpensARealMenu(_ARealChatBarOverTwoChats,
+                                               unittest.TestCase):
+    """Button 2 on a real tab, through a real client, really draws a menu — #846.
+
+    **This is the link no unit test can stand in for, and it is the only claim in this
+    feature that was ever in doubt.** That charter's handler answers a `right` event is
+    `tests/test_a_right_click_on_a_tab_acts_on_that_tab.py`; what could not be settled
+    there is whether button 2 ever arrives at all. tmux might route it to a binding, or
+    swallow it, or hand it over as X10 — and `#{mouse_any_flag}` is what decides, on a
+    pane in another window that this test's own client is not looking at.
+
+    It arrives. Measured here on a real server, a real client on a real pty, a real
+    `charter panel chats` holding the pane, and a real detached `charter frame-palette
+    --tab <chat>` that splits a real overlay pane and paints a real menu into it.
+
+    **Nothing here presses Enter, and that is deliberate rather than incidental.** The
+    last row of the surface these cases draw is `chat: close`, and going through with it
+    stops a harness. What is asserted is the surface — that it exists, that it is about
+    the tab that was pressed, and that opening it moved nothing.
+
+    The class inherits its whole fixture from the left-click cases above, so the two
+    gestures are measured against one frame: same bar, same two chats, same client, same
+    `mouse = true` config out of `conf_text`.
+    """
+
+    #: SGR's number for the right button. `overlay._SGR_BUTTONS` maps it to `right`, and
+    #: this is the far end of the same trip: what the terminal writes is what tmux
+    #: forwards, and 2 is what a real right-click is spelled with.
+    BUTTON = 2
+
+    def _menu_pane(self) -> str:
+        """The pane the menu opened in, or `""` — whatever this window has that the frame
+        did not.
+
+        Off tmux's own listing and never off charter's record: `state.panes` names the
+        PANELS a re-layout wrote, and an overlay is deliberately not one of them
+        (`overlay.OVERLAY_OPTION` is a pane option, so the answer dies with the pane). A
+        pane appearing is the same observable `tests/test_a_real_click_opens_the_real
+        _palette.py` uses for the doorway on the attention row.
+        """
+        for pane in self._panes(self.WS):
+            if pane not in (self.harness, self.bar):
+                return pane
+        return ""
+
+    def _await_menu(self, tab: str) -> str:
+        self.assertTrue(
+            _await(lambda: bool(self._menu_pane())),
+            "no pane was ever opened, so button 2 never reached the panel")
+        pane = self._menu_pane()
+        self.assertTrue(
+            _await(lambda: f"chat: close {tab}" in self._shown(pane)),
+            f"the pane that opened never drew {tab}'s menu: {self._shown(pane)!r}")
+        return pane
+
+    def test_a_right_press_on_another_chats_tab_opens_that_chats_menu(self):
+        """The whole chain: a button-2 report written to the client's pty, decoded by a
+        `charter panel chats` process, resolved through `slots._Tabs.tab_at`, spawned as
+        `charter frame-palette --tab <chat>`, split into an overlay pane by a THIRD
+        process, and painted."""
+        self._click(self.bar, col=self._column_of(self.bar, f" {self.there}"),
+                    button=self.BUTTON)
+        shown = self._shown(self._await_menu(self.there))
+        self.assertIn(f"chat {self.there}", shown)
+        self.assertIn("chat: previous transcript", shown)
+
+    def test_a_right_press_on_the_tab_you_are_ON_opens_its_menu(self):
+        """`slots._Tabs.tab_at`'s one difference from `switch_to`, end to end. The left
+        click on this same cell is asserted three cases up to move nothing at all."""
+        self._click(self.bar, col=self._column_of(self.bar, f"*{self.here}"),
+                    button=self.BUTTON)
+        self.assertIn(f"chat {self.here}", self._shown(self._await_menu(self.here)))
+
+    def test_opening_the_menu_switches_nothing(self):
+        """A right-click is not a slow left-click. The client stays on the window it was
+        on, and the chat the menu is ABOUT keeps its own harness — the tab is still there
+        to be closed, or not, by the keypress that has not happened."""
+        window = self._current_window(self.WS)
+        self._click(self.bar, col=self._column_of(self.bar, f" {self.there}"),
+                    button=self.BUTTON)
+        self._await_menu(self.there)
+        self.assertEqual(self._current_window(self.WS), window)
+        self.assertIn(self.other_harness,
+                      self._tmux("list-panes", "-a", "-F", "#{pane_id}").stdout.split())
+
+    def test_the_menu_takes_the_keyboard_and_the_harness_survives(self):
+        """**A menu is modal, and this is the one gesture on a bar that is.** A switch
+        leaves the keyboard on a harness (#634); a menu must take it, or the rows it just
+        drew could not be chosen from — `overlay.modal_argvs` selects the overlay pane and
+        zooms it over the window. The harness is not touched: it is still a pane, and
+        `overlay.HATCH_KEY` is what gives it back."""
+        self._click(self.bar, col=self._column_of(self.bar, f" {self.there}"),
+                    button=self.BUTTON)
+        pane = self._await_menu(self.there)
+        self.assertTrue(_await(lambda: self._active() == pane),
+                        f"the menu drew but the keyboard stayed on {self._active()}")
+        self.assertIn(self.harness, self._panes(self.WS))
+
+    def test_escape_closes_the_menu_and_stops_nothing(self):
+        """**The way out, and the assertion that the menu commits nothing by existing.**
+
+        `overlay.Surface.run` treats Escape as a cancel and answers no row, so
+        `frame/tabmenu.act` is never reached — which matters more on this surface than on
+        any other, because the row under the cursor when Escape is pressed is one keypress
+        from a confirmation that stops a harness. What comes back is the pane:
+        `commands_frame._close_palette` selects the harness, kills the overlay and re-arms
+        the hatch, as one chained tmux command.
+        """
+        self._click(self.bar, col=self._column_of(self.bar, f" {self.there}"),
+                    button=self.BUTTON)
+        pane = self._await_menu(self.there)
+        os.write(self.fd, b"\x1b")
+        self.assertTrue(
+            _await(lambda: pane not in self._panes(self.WS)),
+            "Escape left the menu's pane standing, holding a live process")
+        self.assertTrue(_await(lambda: self._active() == self.harness),
+                        f"the menu closed but the keyboard stayed on {self._active()}")
+        self.assertIn(self.other_harness,
+                      self._tmux("list-panes", "-a", "-F", "#{pane_id}").stdout.split())
+
+    def test_a_right_press_on_the_heading_opens_nothing(self):
+        """`  chats  ` is about no chat. A cell the strip drew no tab into is absent from
+        `slots._Tabs`' map whatever asks about it, so this costs not even an interpreter
+        start — which is what makes the empty pane list below a real assertion rather than
+        a race this case happened to win.
+
+        **What this case deliberately does NOT assert is where the keyboard ended up, and
+        that is a measurement rather than an omission.** tmux's own default binding for
+        this key, read back off a real 3.7c with `list-keys -T root`, is::
+
+            MouseDown3Pane if-shell -F -t = "#{||:#{mouse_any_flag},…}"
+                             { select-pane -t = ; send-keys -M }
+                             { display-menu … }
+
+        The branch that forwards the report **selects the pane first**. That is #634's
+        defect, one button over and still open: with `[frame] mouse = true`, a right-click
+        on any charter panel moves the keyboard to it before the byte arrives. It is
+        pre-existing — it is what tmux has always done to button 3 — and it costs nothing
+        on the gesture this feature is for, because a menu that opens takes the keyboard
+        anyway and `commands_frame._close_palette` selects the harness on the way out. It
+        costs a MISS one left click, or `overlay.HATCH_KEY`.
+
+        Charter binds nothing here, which is `frame/builtins._MENU_BUTTON`'s own note:
+        `MouseDown1Pane`'s fix works because its else-branch is tmux's own two commands
+        written out, and button 3's else-branch is a `display-menu` a page long that
+        differs between versions. Asserting the steal here would enshrine it; asserting
+        its absence would be red. So this asserts what is contractual — nothing opened —
+        and says why the third line is missing.
+        """
+        self._click(self.bar, col=self._column_of(self.bar, "chats"),
+                    button=self.BUTTON)
+        time.sleep(2.0)
+        self.assertEqual(self._menu_pane(), "")
+        self.assertIn(self.harness, self._panes(self.WS))
 
 
 @unittest.skipUnless(_HAS_TMUX, "no tmux on this machine")

--- a/tests/test_a_right_click_on_a_tab_acts_on_that_tab.py
+++ b/tests/test_a_right_click_on_a_tab_acts_on_that_tab.py
@@ -33,7 +33,8 @@ import unittest
 from unittest import mock
 
 from charter import commands_frame, tui, util
-from charter.frame import builtin_actions, builtins, leave, overlay, slots, tabmenu
+from charter.frame import (builtin_actions, builtins, component, leave, overlay,
+                           palette, slots, state, tabmenu)
 
 from tests._isolation import PersonaIso
 from tests.test_frame_chat_switch import _plant
@@ -451,6 +452,60 @@ class CloseIsConfirmedAndItNamesTheTabYouClicked(_AWatchedSpawn, unittest.TestCa
         self.assertEqual([r.refused for r in rows], [True])
         self.assertFalse(tabmenu.chose(rows[0], "api.9", fid=self.FID))
         self.assertEqual(self.spawned, [])
+
+
+class TheRowIdsAreNotActionIdsAndTheFallbacksAreReachable(PersonaIso, unittest.TestCase):
+    """The two things nobody reads and both of which decide something.
+
+    `tests/test_what_a_quit_says_is_spelled_where_it_is_asserted.py` makes the identical
+    pair of claims about `frame/leave.py`'s ids, and this is that file's argument one
+    surface over: the properties that are load-bearing first, the literals second, because
+    the sweep's re-tuning preserves punctuation and every shape assertion below holds for
+    `ubc:dmptf` too.
+    """
+
+    def test_no_menu_row_id_can_be_an_action_id(self):
+        """The `:` is the whole mechanism. A provider that shipped an action called
+        `tab:close` could take the keypress that closes a chat; `component.usable_id` is
+        what makes that unsayable, and it is what `palette.matches` gates id-matching on —
+        so neither id is reachable by typing either."""
+        for rid in (tabmenu.TRANSCRIPT_ID, tabmenu.CLOSE_ID):
+            self.assertFalse(component.usable_id(rid), rid)
+        for row in tabmenu.catalogue("api.2"):
+            self.assertFalse(palette.matches(row.id, row))
+
+    def test_the_two_shapes_are_these_two_strings(self):
+        """The hand-spelled half, and the only thing that kills a `retune-string` mutant."""
+        self.assertEqual(tabmenu.TRANSCRIPT_ID, "tab:transcript")
+        self.assertEqual(tabmenu.CLOSE_ID, "tab:close")
+        self.assertEqual(tabmenu.TAB_OPTION, "--tab")
+
+    def test_the_two_titles_and_the_heading_are_these_words(self):
+        """Operator-visible prose, spelled where it is asserted. A menu that stopped naming
+        the tab would still pass every `assertIn(TAB, …)` above if the name were the only
+        thing left in the string."""
+        self.assertEqual(tabmenu.label("api.2"), "chat api.2")
+        self.assertEqual(tabmenu.transcript_title("api.2"),
+                         "chat: previous transcript — api.2")
+        self.assertEqual(tabmenu.close_title("api.2"),
+                         "chat: close api.2 — stop it and do not bring it back")
+
+    def test_a_pane_that_was_told_nothing_still_hands_the_harness_back(self):
+        """**Every fallback in `handback` is reachable, and this is the state that reaches
+        them.** A pane split below `tmuxctl.PANE_ENV_FLOOR` is given no `-e` payload at
+        all, so `$CHARTER_SESSION_ID` is whatever the shared server holds — which may be
+        nothing — and a frame charter has lost the record of answers `None` for its
+        harness pane. `None` is not `""`: it would reach a tmux target as the four
+        characters `None`, naming a pane that cannot exist, where `""` is what every
+        charter reader already treats as absent."""
+        self.assertEqual(tabmenu.handback({}), ("", commands_frame.SOCKET, "", ""))
+
+    def test_a_pane_that_was_told_everything_uses_what_it_was_told(self):
+        _plant("api.1", workspace="api", pane="%7")
+        state.record_server("api.1", "sock-of-its-own")
+        self.assertEqual(
+            tabmenu.handback({"CHARTER_SESSION_ID": "api.1", "TMUX_PANE": "%9"}),
+            ("api.1", "sock-of-its-own", "%7", "%9"))
 
 
 class AnEmulatorThatEatsButtonTwoCostsNothing(_ABarThatWasDrawn, unittest.TestCase):

--- a/tests/test_a_right_click_on_a_tab_acts_on_that_tab.py
+++ b/tests/test_a_right_click_on_a_tab_acts_on_that_tab.py
@@ -1,0 +1,528 @@
+"""Right-click a chat tab and charter draws a menu about THAT tab — #846.
+
+*"All functionality in the F2 menu — extract them and integrate the features on
+components. Tabs should have right-click context-menu support."*
+
+Two measurements shape every case here and neither is what was expected.
+
+**Right-click already reaches charter's panels and needs no tmux bind.** Measured on tmux
+3.2 and 3.7c with tmux's own `mouse` off — charter's shipped default — and with it on: a
+pane that requests what `overlay.MOUSE_ON` requests is handed button 2's press and its
+release, pane-relative, and no `bind -n` fires at all. With `mouse on`, tmux's *default*
+`MouseDown3Pane` tests `#{mouse_any_flag}`, which is 1 precisely because this pane asked
+for reporting, so it takes the `send-keys -M` branch and tmux's own menu never appears. A
+custom `bind -n MouseDown3Pane` that omitted `send -M` is the one thing that would swallow
+the press, so charter binds nothing.
+
+**And exactly two palette rows are about a specific tab** — `chat: previous transcript`
+and `chat: close`. Everything else charter offers is about the frame (detach, the
+densities, the chromes, next/previous) or about the plane (the pickers, `charter: quit`),
+and none of those has a tab to sit on. So this is not a reduction of the palette: `F2`
+keeps every row it had, and this is a second, faster route to two of them.
+
+The real-tmux half — that a button-2 report injected into a real client really reaches a
+real panel pane and really opens a pane — is in
+`tests/test_a_real_click_on_a_real_tab_bar_switches.py`, beside the left-click cases it
+is the counterpart of.
+"""
+
+from __future__ import annotations
+
+import os
+import unittest
+from unittest import mock
+
+from charter import commands_frame, tui, util
+from charter.frame import builtin_actions, builtins, leave, overlay, slots, tabmenu
+
+from tests._isolation import PersonaIso
+from tests.test_frame_chat_switch import _plant
+
+
+def _click(row: int, col: int, *, name: str, pressed: bool = True):
+    """One decoded button press at (*row*, *col*) of the component's own canvas.
+
+    `overlay.Event` and not a stand-in: `events.Dispatcher._on_canvas` hands the handler
+    exactly this, with the operator's `[frame] pad` already subtracted, so a case that
+    invented its own record would be asserting against a shape nothing produces. The
+    button NAME is `overlay._SGR_BUTTONS`' own — `right` is what a decoded button 2 has
+    become since #607, and it has been dropped by one comparison ever since.
+    """
+    return overlay.Event(overlay.CLICK, name, row=row, col=col, pressed=pressed)
+
+
+class _AWatchedSpawn(PersonaIso):
+    """Every case in this file records what was started instead of starting it.
+
+    **`chat: close` stops a harness.** Nothing here may reach a real `charter frame-close`,
+    so `builtin_actions._spawn` — the one door every one of these paths goes through — is
+    the seam, and what is asserted is the argv that would have run.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.spawned = []
+        self.enterContext(mock.patch.object(
+            builtin_actions, "_spawn",
+            side_effect=lambda argv, *, fid: self.spawned.append((argv, fid))))
+
+
+class _ABarThatWasDrawn(_AWatchedSpawn):
+    """A workspace with three chats, and the bar painted over it before every click.
+
+    **The bar is DRAWN, never hand-published**, for `test_a_click_on_a_tab_bar_switches`'
+    reason: the column map is the paint's own output (`slots._bar`), and a case that
+    published a map by hand would be measuring a fixture rather than the strip the
+    operator pressed.
+    """
+
+    #: Wide enough for every name on rung 1. The narrow rungs have their own cases in
+    #: `tests/test_frame_bars.py`; this file is about what happens once a tab is resolved.
+    WIDTH = 200
+
+    FID = "api.1"
+
+    def setUp(self):
+        super().setUp()
+        slots.TABS.forget()
+        self.addCleanup(slots.TABS.forget)
+        self.enterContext(mock.patch.dict(os.environ, {"CHARTER_WORKSPACE": "api"},
+                                          clear=False))
+        for chat in ("api.1", "api.2", "api.3"):
+            _plant(chat, workspace="api")
+        self.row = slots.chats_bar(self.FID, self.WIDTH)[0]
+
+    def _handler(self, cid: str):
+        """*cid*'s handler out of the REAL registry, closed over :attr:`FID`.
+
+        `builtins.build(fid)` rather than a handler reached directly, so every case here
+        also asserts that `Component.__post_init__` accepted the declaration: it refuses
+        an `on_event` with no `events` and `events` with no `on_event`.
+        """
+        return builtins.build(self.FID).get(cid).on_event
+
+    def _column_of(self, field: str, row: str | None = None) -> int:
+        """Which COLUMN of the drawn row *field* starts in.
+
+        **`tui.width` of what comes before it, never the character index**: the tab you
+        are on is drawn as a reverse-video block, so every field to its right sits further
+        into the STRING than into the pane.
+        """
+        row = self.row if row is None else row
+        at = row.index(field)
+        self.assertNotIn(field, row[at + 1:], f"{field!r} is not unique in {row!r}")
+        return tui.width(row[:at])
+
+
+class ARightClickResolvesToTheTabItLandedOn(_ABarThatWasDrawn, unittest.TestCase):
+    """`slots._Tabs.tab_at`: which tab a cell holds, including the one you are on."""
+
+    def test_the_tab_you_are_on_answers_itself(self):
+        """**The one place this differs from `switch_to`, and the whole reason it is a
+        second method.** Switching to the tab you are already on is 41 tmux calls to
+        arrive where you already are, so `switch_to` refuses it. Closing the chat you are
+        IN is the ordinary case of closing a chat — it is what `F2 → chat: close` has
+        always meant — so a menu that refused the marked tab would refuse the commonest
+        click there is.
+        """
+        at = self._column_of("*" + self.FID)
+        self.assertIsNone(slots.TABS.switch_to(0, at))
+        self.assertEqual(slots.TABS.tab_at(0, at), self.FID)
+
+    def test_every_other_tab_answers_the_name_it_was_drawn_with(self):
+        for name in ("api.2", "api.3"):
+            at = self._column_of(" " + name)
+            self.assertEqual(slots.TABS.tab_at(0, at), name)
+
+    def test_no_cell_answers_two_kinds_of_question(self):
+        """**A cell that can answer two kinds of question is a defect, not a test gap.**
+
+        #840 found `add_at` claiming the cell a `+N` count is drawn in, on a row that
+        looked identical either way — so a click asking to *see* the other chats would
+        have *made* one. The same hazard arrives here with a third reader of the same map:
+        a `+` or a `+9` that also answered `tab_at` would put a CLOSE menu behind a field
+        that means "make one" or "show me the rest".
+        """
+        for row in range(3):
+            for col in range(self.WIDTH):
+                kinds = [k for k, hit in (
+                    ("tab", slots.TABS.tab_at(row, col) is not None),
+                    ("more", slots.TABS.more_at(row, col)),
+                    ("add", slots.TABS.add_at(row, col))) if hit]
+                self.assertLessEqual(len(kinds), 1, f"({row}, {col}) answers {kinds}")
+
+    def test_a_cell_no_tab_was_drawn_into_answers_nothing(self):
+        """The heading, and every column past the last name. `switch_to` already promises
+        this and `tab_at` reads the identical mapping, so the promise is structural: a
+        cell nothing drew into is absent from the map, whatever asks about it."""
+        for col in range(self._column_of("chats")):
+            self.assertIsNone(slots.TABS.tab_at(0, col), f"column {col}")
+        for col in range(tui.width(self.row) + 1, self.WIDTH):
+            self.assertIsNone(slots.TABS.tab_at(0, col), f"column {col}")
+
+
+class ARightClickOpensTheMenuAndNothingElse(_ABarThatWasDrawn, unittest.TestCase):
+    """What the press starts, and every gesture and surface where it starts nothing."""
+
+    def test_a_right_press_on_a_tab_opens_that_tabs_menu(self):
+        self._handler("chats")(_click(0, self._column_of(" api.3"), name="right"))
+        self.assertEqual(
+            self.spawned,
+            [(util.self_relaunch_argv("frame-palette", "--tab", "api.3"), self.FID)])
+
+    def test_a_right_press_on_the_tab_you_are_on_opens_its_menu_too(self):
+        self._handler("chats")(_click(0, self._column_of("*" + self.FID), name="right"))
+        self.assertEqual(
+            self.spawned,
+            [(util.self_relaunch_argv("frame-palette", "--tab", self.FID), self.FID)])
+
+    def test_the_child_is_told_which_frame_it_is_rather_than_inheriting_one(self):
+        """`_spawn`'s `fid=` is the child's own `$CHARTER_SESSION_ID`. One tmux server is
+        shared by every frame on the machine, so a child left to read that variable out of
+        an inherited environment can act on somebody else's frame. The pane the menu is
+        carved off is the one the operator is LOOKING at — this frame's harness — even
+        though the menu is about another tab."""
+        self._handler("chats")(_click(0, self._column_of(" api.3"), name="right"))
+        self.assertEqual([fid for _argv, fid in self.spawned], [self.FID])
+
+    def test_the_release_starts_nothing(self):
+        """**The PRESS is acted on and the release is dropped**, kept word for word from
+        every other handler in `frame/builtins.py`: a drag begun on a pane border delivers
+        exactly one release (`frame/overlay.py` measured it), so the release is the half
+        that can arrive unpaired."""
+        self._handler("chats")(
+            _click(0, self._column_of(" api.3"), name="right", pressed=False))
+        self.assertEqual(self.spawned, [])
+
+    def test_a_right_press_switches_nothing(self):
+        """A right-click is not a slower left-click. Which chat this frame is on may not
+        move on a gesture that opened a menu about a different one."""
+        self._handler("chats")(_click(0, self._column_of(" api.3"), name="right"))
+        self.assertNotIn(util.self_relaunch_argv("frame-chat", "api.3"),
+                         [argv for argv, _fid in self.spawned])
+
+    def test_a_left_press_is_exactly_what_it_was(self):
+        """**The neighbour assertion.** Changing which buttons reach this handler changes
+        which events reach the branch below it, and that is not something any tool
+        reports. A left click still switches — same argv, same fid, nothing extra."""
+        self._handler("chats")(_click(0, self._column_of(" api.3"), name="left"))
+        self.assertEqual(
+            self.spawned, [(util.self_relaunch_argv("frame-chat", "api.3"), self.FID)])
+
+    def test_a_left_press_on_the_tab_you_are_on_is_still_nothing(self):
+        """`slots._Tabs.switch_to`'s rule, which `tab_at` deliberately does not share:
+        re-switching is 41 tmux calls to arrive where you are. A handler that had started
+        reading the new map for the old gesture would fail here."""
+        self._handler("chats")(_click(0, self._column_of("*" + self.FID), name="left"))
+        self.assertEqual(self.spawned, [])
+
+    def test_a_middle_press_on_a_tab_does_nothing(self):
+        """Middle-click is paste on every terminal an operator has used, and charter takes
+        no gesture that already means something else. `overlay._SGR_BUTTONS` names it, so
+        it really is decoded and delivered — and dropped here."""
+        self._handler("chats")(_click(0, self._column_of(" api.3"), name="middle"))
+        self.assertEqual(self.spawned, [])
+
+    def test_a_right_press_on_the_workspaces_bar_does_nothing(self):
+        """**Structural, not a branch.** A workspace has no `chat: close` and no
+        transcript — both rows this menu holds are about a CHAT — so the workspaces bar is
+        handed no menu command at all, exactly as it is handed no `+`
+        (`slots.workspaces_bar` publishes no add column, and `frame/builtins._bar_events`
+        takes the answer as data rather than deriving it from what the renderer drew)."""
+        slots.TABS.forget()
+        row = slots.workspaces_bar(self.FID, self.WIDTH)[0]
+        for col in range(self.WIDTH):
+            self._handler("workspaces")(_click(0, col, name="right"))
+        self.assertEqual(self.spawned, [], row)
+
+    def test_a_right_press_on_a_cell_that_is_not_a_tab_does_nothing(self):
+        for col in (0, self._column_of("chats"), tui.width(self.row) + 5):
+            self._handler("chats")(_click(0, col, name="right"))
+        self.assertEqual(self.spawned, [])
+
+    def test_a_right_press_on_the_add_affordance_makes_no_chat_and_no_menu(self):
+        """The `+` is the one cell on this bar where a wrong answer CREATES something.
+        Neither gesture may reach the other's field."""
+        self._handler("chats")(_click(0, self._column_of(slots.ADD_CHAT), name="right"))
+        self.assertEqual(self.spawned, [])
+
+
+class TheMenuIsTheTwoRowsThatHaveATabToSitOn(_AWatchedSpawn, unittest.TestCase):
+    """`frame/tabmenu.py`'s catalogue: what a right-click draws, and in what order."""
+
+    FID = "api.1"
+    TAB = "api.2"
+
+    def setUp(self):
+        super().setUp()
+        for chat in ("api.1", "api.2"):
+            _plant(chat, workspace="api")
+
+    def test_it_holds_the_transcript_row_and_the_close_doorway_and_nothing_else(self):
+        self.assertEqual([r.id for r in tabmenu.catalogue(self.TAB)],
+                         [tabmenu.TRANSCRIPT_ID, tabmenu.CLOSE_ID])
+
+    def test_close_is_last(self):
+        """`frame/leave.open_rows` puts the destructive row last so it is never one
+        `F2 Enter` away — a palette's cursor starts on the first row that can run. A
+        right-click menu makes close MORE reachable than `F2` ever did, so that reasoning
+        applies more strongly here, not less."""
+        self.assertEqual(tabmenu.catalogue(self.TAB)[-1].id, tabmenu.CLOSE_ID)
+
+    def test_every_row_names_the_tab_that_was_clicked(self):
+        """A menu that said *this chat* over a tab you are not on would be the palette's
+        own row wearing a menu's clothes. The operator right-clicked one tab precisely
+        because they meant that one."""
+        for row in tabmenu.catalogue(self.TAB):
+            self.assertIn(self.TAB, row.title)
+        self.assertIn(self.TAB, tabmenu.label(self.TAB))
+
+    def test_the_transcript_row_opens_the_clicked_tabs_transcript(self):
+        """The palette's own `chat: transcript` acts on the chat the palette was opened
+        in; this one acts on the tab the pointer landed on, which is the whole difference
+        between the two routes."""
+        from charter.frame import reopen
+        path = reopen.transcript_path(self.TAB)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("what was on screen\n", encoding="utf-8")
+        row = tabmenu.catalogue(self.TAB)[0]
+        self.assertFalse(row.refused)
+        self.assertTrue(tabmenu.chose(row, self.TAB, fid=self.FID))
+        self.assertEqual(
+            self.spawned,
+            [(util.self_relaunch_argv("frame-transcript", "--chat", self.TAB), self.FID)])
+
+    def test_a_tab_with_no_transcript_is_listed_with_its_reason_and_starts_nothing(self):
+        """#512's rule, which this surface does not get to relax: an operator cannot ask
+        about an option they cannot see. A chat that has never been quit has no capture,
+        which is the ordinary state of a chat running normally rather than a fault — so
+        the row is drawn, it says so, and pressing it starts nothing."""
+        row = tabmenu.catalogue(self.TAB)[0]
+        self.assertTrue(row.refused)
+        self.assertEqual(
+            row.note,
+            "no previous transcript for this chat — one is captured when a plane is quit "
+            "(`F2 → charter: quit`) and offered on the chat that comes back")
+        self.assertFalse(tabmenu.chose(row, self.TAB, fid=self.FID))
+        self.assertEqual(self.spawned, [])
+
+    def test_a_tab_that_cannot_be_named_gets_no_menu_at_all(self):
+        """`--tab` reaches a state path, so it is held to the alphabet a chat id travels
+        under (`chats.ID_RE`) — and a value outside it degrades to *there is no tab menu*
+        rather than to a refusal. Nothing in this feature may ever answer an operator with
+        an error they did not ask for."""
+        for bad in ("", "   ", "../../etc", "api 2", "api/2", "$(id)"):
+            self.assertEqual(tabmenu.wanted(_Args(tab=bad)), "",
+                             f"{bad!r} was taken for a chat id")
+        self.assertEqual(tabmenu.forward(_Args(tab="../../etc")), ())
+
+    def test_a_tab_that_can_be_named_is_carried_to_the_pane(self):
+        self.assertEqual(tabmenu.wanted(_Args(tab=self.TAB)), self.TAB)
+        self.assertEqual(tabmenu.forward(_Args(tab=self.TAB)), ("--tab", self.TAB))
+
+    def test_the_palette_that_is_not_a_tab_menu_forwards_nothing(self):
+        """`F2` carries no `--tab`, so `frame-palette --pane` is spelled exactly as it was
+        and `_draw_palette` is what runs. A forward that emitted an empty option would
+        make every `F2` a tab menu about no chat."""
+        self.assertEqual(tabmenu.forward(_Args()), ())
+        self.assertEqual(tabmenu.wanted(_Args()), "")
+
+
+class CloseIsConfirmedAndItNamesTheTabYouClicked(_AWatchedSpawn, unittest.TestCase):
+    """The doorway, the warning it opens, and the argv that goes through."""
+
+    FID = "api.1"
+    TAB = "api.2"
+
+    def setUp(self):
+        super().setUp()
+        for chat in ("api.1", "api.2"):
+            _plant(chat, workspace="api")
+
+    def test_the_close_row_starts_nothing_by_itself(self):
+        """**A doorway, not an action.** Pressing it replaces the surface with the
+        warning; a version that closed the chat here would put the one irreversible thing
+        charter's frame can do exactly one keypress from a pointer gesture."""
+        self.assertFalse(tabmenu.chose(tabmenu.catalogue(self.TAB)[-1], self.TAB,
+                                       fid=self.FID))
+        self.assertEqual(self.spawned, [])
+
+    def test_the_confirmation_is_about_the_clicked_tab_alone(self):
+        """`leave.plan(only=…)` — the same plan, the same warning and the same teardown as
+        `F2 → chat: close`, with one target. A second enumeration for this route would be
+        a second answer to *what does stopping this cost*."""
+        rows = tabmenu.confirm_rows(self.TAB, live={"api.1", "api.2"})
+        titles = " ".join(r.title for r in rows)
+        self.assertIn(self.TAB, titles)
+        self.assertNotIn(self.FID, titles)
+
+    def test_the_confirming_row_is_the_one_leave_mints(self):
+        """Same id as the palette's, so the two routes cannot come to disagree about which
+        keypress commits — and so a row that merely describes stays `refused`."""
+        rows = tabmenu.confirm_rows(self.TAB, live={"api.1", "api.2"})
+        self.assertTrue(leave.goes_through(rows[0], leave.CLOSE))
+        self.assertFalse(rows[0].refused)
+        for row in rows[1:]:
+            self.assertTrue(row.refused, row)
+
+    def test_going_through_closes_the_tab_and_says_where_the_key_was_pressed(self):
+        """`charter frame-close <tab> --chat <this frame>`: the POSITIONAL is which chat
+        to close and `--chat` is where the keypress came from, which is what puts
+        `cmd_close`'s sentence on the screen the operator is actually looking at."""
+        rows = tabmenu.confirm_rows(self.TAB, live={"api.1", "api.2"})
+        self.assertTrue(tabmenu.chose(rows[0], self.TAB, fid=self.FID))
+        self.assertEqual(
+            self.spawned,
+            [(util.self_relaunch_argv("frame-close", self.TAB, "--chat", self.FID),
+              self.FID)])
+
+    def test_a_row_that_only_describes_closes_nothing(self):
+        rows = tabmenu.confirm_rows(self.TAB, live={"api.1", "api.2"})
+        for row in rows[1:]:
+            self.assertFalse(tabmenu.chose(row, self.TAB, fid=self.FID), row)
+        self.assertEqual(self.spawned, [])
+
+    def test_the_doorway_opens_the_confirmation_and_nothing_else_opens_anything(self):
+        """`palette.own_the_tty`'s *then*: a doorway replaces the surface in the pane the
+        operator is already looking at, and every other row ends the menu. A second pane
+        would race this one's teardown — `commands_frame._close_palette` selects the
+        harness, kills this pane and re-arms the hatch as ONE chained tmux command."""
+        rows = tabmenu.catalogue(self.TAB)
+        self.assertIsNone(tabmenu.opens(rows[0], self.TAB, live=set()))
+        nxt = tabmenu.opens(rows[-1], self.TAB, live={"api.1", "api.2"})
+        self.assertIsNotNone(nxt)
+        self.assertEqual(nxt.catalogue,
+                         tabmenu.confirm_rows(self.TAB, live={"api.1", "api.2"}))
+        self.assertEqual(nxt.label, leave.CLOSE)
+
+    def test_the_confirmations_own_rows_open_nothing_further(self):
+        """A two-level tree and not an open one: the warning's rows describe or commit,
+        and neither opens a third surface."""
+        for row in tabmenu.confirm_rows(self.TAB, live={"api.1", "api.2"}):
+            self.assertIsNone(tabmenu.opens(row, self.TAB, live=set()), row)
+
+    def test_a_row_that_could_not_run_says_why_on_the_frames_own_row(self):
+        """The pane a refusal would otherwise be drawn in is the one the menu is about to
+        kill, so the sentence goes to the frame's attention row — a different pane and a
+        different process (`commands_frame._say_on_screen`)."""
+        said = []
+        self.enterContext(mock.patch.object(
+            commands_frame, "_say_on_screen",
+            side_effect=lambda fid, message, **kw: said.append((fid, message))))
+        tabmenu.act(tabmenu.catalogue(self.TAB)[0], self.TAB, fid=self.FID)
+        self.assertEqual(self.spawned, [])
+        self.assertEqual(
+            said,
+            [(self.FID,
+              "no previous transcript for this chat — one is captured when a plane is "
+              "quit (`F2 → charter: quit`) and offered on the chat that comes back")])
+
+    def test_a_row_with_nothing_to_say_writes_no_notice(self):
+        """The notice is a WRITE, so an empty one would blank whatever the attention row
+        was already carrying. `leave`'s *nothing left to stop* row starts nothing and
+        carries no note, which is the row that makes this reachable."""
+        said = []
+        self.enterContext(mock.patch.object(
+            commands_frame, "_say_on_screen",
+            side_effect=lambda fid, message, **kw: said.append((fid, message))))
+        row = tabmenu.confirm_rows("api.9", live=set())[0]
+        self.assertEqual(row.note, "")
+        tabmenu.act(row, "api.9", fid=self.FID)
+        self.assertEqual(said, [])
+        self.assertEqual(self.spawned, [])
+
+    def test_a_row_that_ran_says_nothing_at_all(self):
+        """What a started action surfaces through is `inflight`, the frame's existing
+        spinner, and never a second sentence here — `_draw_palette`'s rule kept."""
+        said = []
+        self.enterContext(mock.patch.object(
+            commands_frame, "_say_on_screen",
+            side_effect=lambda fid, message, **kw: said.append((fid, message))))
+        tabmenu.act(tabmenu.confirm_rows(self.TAB, live={"api.1", "api.2"})[0], self.TAB,
+                    fid=self.FID)
+        self.assertEqual(said, [])
+        self.assertEqual(len(self.spawned), 1)
+
+    def test_a_tab_with_nothing_to_stop_offers_no_keypress_that_commits(self):
+        """`leave.confirm_rows`' own promise, inherited whole: a plan with nothing in it
+        draws one refused row and NO confirming row, so there is no Enter that quietly
+        succeeds at nothing."""
+        rows = tabmenu.confirm_rows("api.9", live=set())
+        self.assertEqual([r.refused for r in rows], [True])
+        self.assertFalse(tabmenu.chose(rows[0], "api.9", fid=self.FID))
+        self.assertEqual(self.spawned, [])
+
+
+class AnEmulatorThatEatsButtonTwoCostsNothing(_ABarThatWasDrawn, unittest.TestCase):
+    """The risk this feature is built around, as a property rather than a hope.
+
+    tmux forwards button 2 to a reporting pane — measured on 3.2 and 3.7c by injecting SGR
+    bytes into a real client over a real pty. That injection **bypasses the terminal
+    emulator**, and whether an emulator forwards button 2 to a mouse-reporting application
+    or serves its own context menu is emulator-dependent and configurable: iTerm2 3.6.11
+    ships `"Button,1,1,," -> kContextMenuPointerAction` alongside a profile whose
+    `Mouse Reporting` is on, and the precedence between those two is not determinable from
+    the plist.
+
+    So on some machines the press will simply never arrive, and the only acceptable
+    failure mode is *nothing happens* — never a refusal, never a traceback, never a
+    half-open menu.
+    """
+
+    def test_nothing_new_is_asked_of_the_terminal(self):
+        """A feature that needed 1002 or 1003 to see a right-click would change what every
+        panel writes to its own tty. It does not: button 2 arrives in the same 1000+1006
+        report a left click does, so a panel's request is byte-for-byte what it was."""
+        from charter.frame import events
+        self.assertEqual(events.wanted(builtins.build(self.FID).get("chats")),
+                         (overlay.CLICK,))
+        self.assertEqual(overlay.MOUSE_ON, "\x1b[?1006h\x1b[?1000h")
+
+    def test_charter_binds_no_mouse_key_for_the_menu_button(self):
+        """**Binding is what would break this, not what enables it.** tmux's own default
+        `MouseDown3Pane` takes its `send -M` branch because `#{mouse_any_flag}` is 1 for a
+        pane that asked for reporting; a custom `bind -n MouseDown3Pane` that omitted
+        `send -M` would swallow the press instead. charter's config text names no button-2
+        or button-3 key at all, and this is what would notice if one appeared.
+
+        **The cost of binding nothing is measured and is not nothing** — tmux's forwarding
+        branch is `{ select-pane -t = ; send-keys -M }`, so with `[frame] mouse = true` a
+        right-click on a panel takes the keyboard before the byte arrives. That is #634 one
+        button over, it is pre-existing, and `frame/builtins._MENU_BUTTON` records why
+        closing it is a change of its own rather than a line in this one."""
+        from charter import commands_frame
+        text = commands_frame.conf_text(hotkey="F2", mouse=True, history_limit=2000,
+                                        session=self.FID)
+        for key in ("MouseDown3Pane", "MouseDown2Pane", "MouseUp3Pane"):
+            self.assertNotIn(key, text)
+
+    def test_the_palette_keeps_every_row_this_menu_holds(self):
+        """**`F2` stays complete.** A right-click menu is invisible until you try it, so
+        it is a shortcut and never the only route. Both rows are still reachable exactly
+        the way they always were, and this file removes nothing from the palette."""
+        reg = builtin_actions.build(self.FID, current_density="normal",
+                                    current_chrome="off")
+        titles = [o.title for o in reg.offers(fid=self.FID, snapshot={})]
+        self.assertIn("chat: previous transcript", titles)
+        self.assertIn("chat: close — stop this chat and do not bring it back",
+                      [r.title for r in leave.open_rows(self.FID)])
+
+    def test_a_button_charter_has_no_name_for_starts_nothing(self):
+        """`overlay._SGR_BUTTONS` names three buttons and drops every other number, so a
+        thumb button cannot arrive wearing `left`'s name. If one ever did, the handler
+        answers nothing rather than acting on it."""
+        for name in ("up", "down", ""):
+            self._handler("chats")(_click(0, self._column_of(" api.3"), name=name))
+        self.assertEqual(self.spawned, [])
+
+
+class _Args:
+    """The parsed argv `frame-palette` hands its two halves, as a stand-in for one.
+
+    `argparse.Namespace` in production; a plain object here so a case can spell the one
+    attribute it is about without building a parser that would then also be under test.
+    """
+
+    def __init__(self, **kw):
+        for name, value in kw.items():
+            setattr(self, name, value)

--- a/tests/test_a_right_click_on_a_tab_acts_on_that_tab.py
+++ b/tests/test_a_right_click_on_a_tab_acts_on_that_tab.py
@@ -288,6 +288,8 @@ class TheMenuIsTheTwoRowsThatHaveATabToSitOn(_AWatchedSpawn, unittest.TestCase):
         path.write_text("what was on screen\n", encoding="utf-8")
         row = tabmenu.catalogue(self.TAB)[0]
         self.assertFalse(row.refused)
+        self.assertEqual(row.note, "",
+                         "a row that CAN run carries no reason it cannot")
         self.assertTrue(tabmenu.chose(row, self.TAB, fid=self.FID))
         self.assertEqual(
             self.spawned,
@@ -320,6 +322,34 @@ class TheMenuIsTheTwoRowsThatHaveATabToSitOn(_AWatchedSpawn, unittest.TestCase):
     def test_a_tab_that_can_be_named_is_carried_to_the_pane(self):
         self.assertEqual(tabmenu.wanted(_Args(tab=self.TAB)), self.TAB)
         self.assertEqual(tabmenu.forward(_Args(tab=self.TAB)), ("--tab", self.TAB))
+
+    def test_a_padded_name_is_refused_rather_than_trimmed_into_another_chat(self):
+        """**No `strip`, and that is a decision the sweep asked for.**
+
+        `commands_frame._pressers_chat` and `cmd_close` do strip, because their value is a
+        tmux format expanded into a shell-quoted `run-shell` string. This one cannot be
+        padded: its only producer is `slots._Tabs.tab_at`, and `chats.is_chat` holds every
+        name off `os.scandir` to `chats.ID_RE` before it reaches a roster. Trimming would
+        therefore repair nothing — and if a padded name ever did arrive, it would silently
+        retarget the menu at a DIFFERENT chat, which is #838's defect. Refusing cannot.
+        """
+        self.assertEqual(tabmenu.wanted(_Args(tab=f" {self.TAB} ")), "")
+        self.assertEqual(tabmenu.wanted(_Args(tab=f"{self.TAB}\t")), "")
+
+    def test_a_padded_directory_never_reaches_the_menu_in_the_first_place(self):
+        """The measurement the case above rests on, asserted rather than asserted-about:
+        `chats.of_workspace` is where a name off `os.scandir` enters charter's vocabulary,
+        and it refuses one `ID_RE` cannot spell — so no cell of any bar answers it."""
+        from charter.frame import chats, slots
+        state.frame_dir(f"{self.TAB} ", create=True)
+        state.record_workspace(f"{self.TAB} ", "api")
+        self.assertNotIn(f"{self.TAB} ", chats.of_workspace("api"))
+        slots.TABS.forget()
+        self.addCleanup(slots.TABS.forget)
+        with mock.patch.dict(os.environ, {"CHARTER_WORKSPACE": "api"}, clear=False):
+            slots.chats_bar(self.FID, 200)
+        self.assertNotIn(f"{self.TAB} ",
+                         {slots.TABS.tab_at(0, c) for c in range(200)})
 
     def test_the_palette_that_is_not_a_tab_menu_forwards_nothing(self):
         """`F2` carries no `--tab`, so `frame-palette --pane` is spelled exactly as it was
@@ -432,6 +462,20 @@ class CloseIsConfirmedAndItNamesTheTabYouClicked(_AWatchedSpawn, unittest.TestCa
         self.assertEqual(said, [])
         self.assertEqual(self.spawned, [])
 
+    def test_a_cancel_starts_nothing_and_says_nothing(self):
+        """**Escape, `F12`, or the pane's writer going away** — `overlay.Surface.run`
+        answers `None` for all three, and it is the commonest way this surface ends,
+        because the row under the cursor when Escape is pressed is one keypress from a
+        confirmation that stops a harness. Nothing was chosen, so nothing is started and
+        nothing is said."""
+        said = []
+        self.enterContext(mock.patch.object(
+            commands_frame, "_say_on_screen",
+            side_effect=lambda fid, message, **kw: said.append((fid, message))))
+        tabmenu.act(None, self.TAB, fid=self.FID)
+        self.assertEqual(said, [])
+        self.assertEqual(self.spawned, [])
+
     def test_a_row_that_ran_says_nothing_at_all(self):
         """What a started action surfaces through is `inflight`, the frame's existing
         spinner, and never a second sentence here — `_draw_palette`'s rule kept."""
@@ -499,6 +543,25 @@ class TheRowIdsAreNotActionIdsAndTheFallbacksAreReachable(PersonaIso, unittest.T
         characters `None`, naming a pane that cannot exist, where `""` is what every
         charter reader already treats as absent."""
         self.assertEqual(tabmenu.handback({}), ("", commands_frame.SOCKET, "", ""))
+
+    def test_the_reachable_half_is_a_frame_id_that_came_back_empty(self):
+        """**Which of these fallbacks production really reaches, measured rather than
+        assumed.** `layout._env_argv` emits `-e NAME=` for every name including an empty
+        one, and tmux exports it — measured on 3.7c, the name is present in the split
+        pane's environment with an empty value — and `_relayout_pane_env` never declines
+        to build the payload at all, because `tmuxctl.PANE_ENV_FLOOR` is 3.0 and charter's
+        own floor is 3.2. So the two `env` names are always PRESENT; what is reachable is
+        an empty VALUE, which is what `commands_frame._pressers_chat` answers for a frame
+        whose `--chat` arrived empty and whose `$CHARTER_SESSION_ID` did too.
+
+        That state is this case, and it is what reaches the other two fallbacks: charter's
+        own socket for a frame with no recorded server (`builtin_actions._server`'s rule),
+        and `""` rather than `None` for a harness pane charter has lost the record of —
+        the state `builtin_actions.NO_LAYOUT` exists to describe.
+        """
+        self.assertEqual(
+            tabmenu.handback({"CHARTER_SESSION_ID": "", "TMUX_PANE": "%3"}),
+            ("", commands_frame.SOCKET, "", "%3"))
 
     def test_a_pane_that_was_told_everything_uses_what_it_was_told(self):
         _plant("api.1", workspace="api", pane="%7")


### PR DESCRIPTION
Closes part of #846 — the right-click plumbing and the two tab-scoped rows. **Rename is not here**: it needs free text submitted through the palette and is a separate change.

Right-click a tab on the `chats` bar:

```
  chat api.2
  > chat: previous transcript — api.2
    chat: close api.2 — stop it and do not bring it back
```

Both rows were already in `F2` and both were about the chat you were *in*. On a tab they are about the tab, so another chat can be closed from its own tab without switching to it first.

## The two findings the issue measured, confirmed and extended

**Right-click already reached charter's panels and needed no tmux binding.** Measured on tmux 3.2 and 3.7c against a pane requesting exactly what `overlay.MOUSE_ON` requests, with SGR button 2 injected into a real client:

```
mouse=off  custombind=no   PRESS ^[[<2;50;7M  RELEASE ^[[<2;50;7m  bind fired: no
mouse=on   custombind=no   PRESS ^[[<2;50;7M  RELEASE ^[[<2;50;7m  bind fired: no
mouse=on   custombind=yes  PRESS -           RELEASE ^[[<2;50;7m  bind fired: YES
```

Charter binds nothing. The events were already decoded, delivered and named `right`; they were dropped by one comparison.

**Exactly two palette rows are about a tab.** Everything else is about the frame or the plane. `F2` keeps every row it had — this is a shortcut, never the only route, because a right-click menu is invisible until you try it.

## How it is built

* **Which tab** — `slots._Tabs.tab_at`, the map `switch_to` already reads without its one subtraction: the tab you are ON answers itself here, because closing the chat you are in is the ordinary case of closing one. A case walks every cell of every row and asserts no cell answers two of `tab_at` / `more_at` / `add_at` — #840's defect shape, with a third reader on the same map.
* **The menu** — `charter/frame/tabmenu.py`, a `palette.Palette` in the overlay pane `F2` already uses: same split off the same harness, same `_close_open_overlays` sweep (a right-click while `F2` is up replaces it), same `F12` armed first. **Not `display-menu`**, re-measured at the 3.2 floor: no styling flags at all, a key as well as a command per item, per-client, totally modal at the server, and a `client_height - 2` item cap past which it draws nothing and exits 0. `frame/menu.py` was deleted rather than deprecated for these reasons and nothing about a pointer reverses that.
* **Close** — last, and a doorway. It opens `leave.confirm_rows` over `leave.plan(only=<tab>)` — the same plan, warning, teardown and confirming row id as `F2 -> chat: close`, with one target. No pointer gesture stops a harness. A tab with nothing left to stop gets a row saying so and no confirming row at all.
* **`_ACT_BUTTON` stays `left`.** `_MENU_BUTTON` is a second constant read by one handler on one bar, so which events reach the repo table, both strips and the persona column is byte-for-byte unchanged — and a case pins that a left click still switches, and that the tab you are on still switches nothing.
* **Degradation** — an absent or unspellable `--tab` is not an error, it is the ordinary palette. `--tab` is held to `chats.ID_RE` because it reaches a state path and a `frame-close` positional.

## Tests

`tests/test_a_right_click_on_a_tab_acts_on_that_tab.py` (38 cases) and six new real-tmux cases in `tests/test_a_real_click_on_a_real_tab_bar_switches.py` — real server, real client on a real pty, real `charter panel chats` holding the pane, real detached `charter frame-palette --tab <chat>` splitting a real overlay pane and painting a real menu. Nothing anywhere presses Enter on `chat: close`; every path is asserted through a recorded `builtin_actions._spawn` argv.

Full suite: **10621 tests, OK (9 skipped)**, `python3 -m unittest discover -s tests`.

## One cost measured and deliberately left open

tmux's forwarding branch for button 3, read back off a real 3.7c with `list-keys -T root`, is `{ select-pane -t = ; send-keys -M }` — it **selects the pane before forwarding**. So with `[frame] mouse = true`, a right-click that lands on a panel and opens nothing leaves the keyboard on that panel until a click on the harness or `F12`. That is #634 one button over; it is pre-existing, and it costs the gesture this PR is for nothing, because a menu that opens takes the keyboard anyway and gives it back on the way out.

It is not closed here because `MouseDown1Pane`'s fix works by writing tmux's own else-branch out verbatim, and button 3's else-branch is a `display-menu` a page long built from a dozen formats that differ between the supported versions — replacing it would take tmux's own pane menu away from the harness and from panes the operator split themselves. `frame/builtins._MENU_BUTTON` and the news entry record it; a follow-up issue is filed.

## Files another agent is live on

Three additive hunks were unavoidable and are as small as the design allows: `charter/cli.py` gains one `add_argument`, and `charter/commands_frame.py` forwards it into the overlay pane and reads it back to decide which surface the pane is. Everything else — the rows, the routing, the confirmation, the resolution — is in `charter/frame/tabmenu.py`, `builtins.py` and `slots.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Us4MbwkSCJCxwt1CjAd1sf
