### PR TITLE
charter records the plane as it changes, and `charter` puts it back (#845)

### DIFF
--- a/charter/cli.py
+++ b/charter/cli.py
@@ -742,6 +742,21 @@ def _add_frame_parsers(sub) -> None:
         parser.add_argument("--pick", action="store_true",
                             help="Choose the workspace before the harness starts, even "
                                  "if one is already selected.")
+        # #845. Shares `--no-frame`'s `_OWN_FLAGS` treatment below for the same reason:
+        # this is charter's own word and must not be grafted onto the harness's verbatim
+        # argv, where `claude --fresh` would be an unknown flag to Claude Code.
+        #
+        # **It says "this run does not participate", in both directions.** Once bare
+        # `charter` puts the recorded plane back, a plane an operator wanted to abandon
+        # comes back on every launch and the only escape is deleting a file they have to
+        # know about first. Skipping the restore alone would not be that escape: the same
+        # run would go on RECORDING, and two seconds later the record it declined to act on
+        # is the one it just overwrote — a loss nothing makes visible until the operator
+        # asks for the plane back. So the flag turns both halves off, and `[frame] record`
+        # is what a plane sets when it wants a fresh plane recorded from the start.
+        parser.add_argument("--fresh", action="store_true",
+                            help="Do not restore the recorded plane, and do not record "
+                                 "over it: start one chat and leave the record alone.")
         parser.set_defaults(harness=name, func=commands_frame.cmd_launch)
 
     # Snapshot, not a live read of `sub.choices` inside the loop — see this function's
@@ -1679,7 +1694,19 @@ def _frame_command_names() -> set[str]:
 #: harness named `""`, bare `frame`) hands `["--probe"]` to `bypass`, which
 #: `os.execvp("--probe", ...)` turns into a `FileNotFoundError` — confirmed by running
 #: `charter frame --probe` with this entry left out before adding it.
-_OWN_FLAGS = ("--no-frame", "--probe", "--pick", "-h", "--help")
+_OWN_FLAGS = ("--no-frame", "--probe", "--pick", "--fresh", "-h", "--help")
+
+#: The launcher flags bare ``charter`` may carry — the ones that are about the LAUNCH
+#: rather than about a harness that has not been named yet (#845). `_bare_launch` rewrites
+#: ``charter --fresh`` into ``charter <default> --fresh``, so the flag is parsed by exactly
+#: the parser that declares it and nothing here needs to know what it means.
+#:
+#: Deliberately not `_OWN_FLAGS`: `--probe`, `-h` and `--help` all have answers of their own
+#: on a bare `charter` (argparse's usage message), and rewriting them into a harness launch
+#: would take those answers away. `--workspace` is absent for a different reason — it takes
+#: a value, so it is two tokens, and `charter -w foo` is a launch that names something,
+#: which is exactly the shape `_restores_the_plane` excludes anyway.
+_BARE_FLAGS = ("--fresh",)
 
 #: The launcher's own flags that take a VALUE — `--workspace <name>` (#518). Kept apart
 #: from `_OWN_FLAGS` because the two are consumed differently and getting that wrong is
@@ -1810,6 +1837,13 @@ def _bare_launch(argv: list[str]) -> tuple[list[str], int | None]:
     picker, `$CHARTER_HARNESS`, `--probe` and the frame, all of which are already settled
     for the typed form.
 
+    **It carries :data:`_BARE_FLAGS`, and nothing else** (#845). ``charter --fresh`` is a
+    launch that opts out of #845's record, and there is no harness name in front of it for
+    the flag to belong to — so the rewrite puts one there and the flag rides along behind
+    it, in the one position `_split_frame_argv` reads charter's own flags in. That is the
+    whole widening: an argv holding anything else, `--fresh` alongside a subcommand
+    included, is a command the operator typed and is returned untouched.
+
     **Four things stop it, and each is reachable on its own.**
 
     *A subcommand was typed.* Nothing here runs, `--version` included. It is a flag on the
@@ -1843,7 +1877,7 @@ def _bare_launch(argv: list[str]) -> tuple[list[str], int | None]:
     second, looser condition here is how the two come to disagree about what "interactive"
     means.
     """
-    if argv:
+    if argv and not all(tok in _BARE_FLAGS for tok in argv):
         return argv, None
     from . import config
 
@@ -1869,7 +1903,12 @@ def _bare_launch(argv: list[str]) -> tuple[list[str], int | None]:
         return argv, None
     if not sys.stdout.isatty():
         return argv, None
-    return [default], None
+    # The flags the operator typed ride along, after the harness name rather than before
+    # it: `_split_frame_argv` recognises `_OWN_FLAGS` only in the run immediately following
+    # `charter <name>`, which is the same position a typed `charter claude --fresh` puts
+    # them in. So the rewrite produces tokens indistinguishable from the typed form, which
+    # is this function's whole contract.
+    return [default, *argv], None
 
 
 def main(argv=None) -> int:

--- a/charter/cli.py
+++ b/charter/cli.py
@@ -1877,7 +1877,11 @@ def _bare_launch(argv: list[str]) -> tuple[list[str], int | None]:
     second, looser condition here is how the two come to disagree about what "interactive"
     means.
     """
-    if argv and not all(tok in _BARE_FLAGS for tok in argv):
+    # `all` over an empty iterable is True, so bare `charter` falls through this without
+    # an `argv and` in front of it — and the deletion sweep found that conjunct as a
+    # survivor for exactly that reason. A guard that only restates what the next one
+    # already says is the shape this repository deletes.
+    if not all(tok in _BARE_FLAGS for tok in argv):
         return argv, None
     from . import config
 

--- a/charter/commands_frame.py
+++ b/charter/commands_frame.py
@@ -8815,6 +8815,43 @@ def _restore_recorded_chat(rec, fid: str) -> None:
         return
 
 
+#: What `charter reopen` says when this plane is already running, and #845 is what made it
+#: reachable. The record used to exist only after a quit, so there was never a live plane
+#: for it to describe; it is written as the plane CHANGES now, so a `charter reopen` typed
+#: out of habit — after closing a terminal, say, which only detaches — would put a second
+#: copy of every running chat on the plane. A reopened chat gets a fresh ordinal, so nothing
+#: on screen would tell the copies from the originals, and for Claude Code both copies would
+#: `--resume` the same conversation.
+#:
+#: It names the two things that ARE what the operator wanted, because "already running" on
+#: its own reads as a refusal to do the thing rather than as an answer.
+REOPEN_ON_A_LIVE_PLANE = (
+    "charter reopen: this plane is already running — reopening it would open a second copy "
+    "of every chat, and a reopened chat gets a new id, so nothing on screen would tell the "
+    "copies apart. Attach to what is there (`tmux -L charter attach`), or quit it first "
+    "(`F2 → charter: quit`). Nothing was reopened, and the record is left in place.")
+
+
+def _plane_is_running() -> bool:
+    """Whether any chat on this plane is live right now.
+
+    **The disk is asked first**, and it is a complete answer rather than an optimisation: a
+    live chat always has a directory, because `state.new_chat_id` claims its ordinal with
+    the `mkdir` (see that function). No directories is no chats, and it costs a `scandir`
+    instead of a `list-windows` per server.
+
+    **A server that will not answer reads as "nothing live", which is the opposite of
+    `leave.plan`'s direction and is right here for the opposite reason.** A quit must not
+    silently record nothing, so an unanswerable server makes it assume the worst. A reopen
+    is wanted precisely when there is no server at all — after a restart — so assuming the
+    worst there would refuse the command in the one situation it exists for.
+    """
+    if not leave.plane_chats():
+        return False
+    live, _windows, _active = _plane_live(_plane_servers())
+    return bool(live)
+
+
 #: What `charter reopen` says when there is nothing recorded. It names the thing that
 #: writes one, because "nothing to reopen" on its own reads like a defect to an operator who
 #: has just restarted their machine and lost a frame — the honest answer is that a plane is
@@ -8926,6 +8963,15 @@ def _reopen_plane(args) -> int:
                  "awake for the life of each frame, so reopening several chats would stop "
                  "at the first. Run it from an ordinary shell. Nothing was reopened, and "
                  "the record is left in place.")
+        return 1
+    # **After the two refusals above and before anything is started** (#845). It is last of
+    # the three because it is the only one that costs a tmux round trip, and it is asked at
+    # all because the record is no longer a relic of a quit: see
+    # :data:`REOPEN_ON_A_LIVE_PLANE`. Bare `charter`'s own restore reaches this function
+    # only with nothing live (`cmd_launch`'s `not live_before`), so this is a second reading
+    # of one rule rather than a second rule.
+    if _plane_is_running():
+        util.err(REOPEN_ON_A_LIVE_PLANE)
         return 1
     quiet = getattr(args, "quiet", False)
     back: list[Reopening] = []

--- a/charter/commands_frame.py
+++ b/charter/commands_frame.py
@@ -4706,13 +4706,37 @@ def _restores_the_plane(args) -> bool:
 #: less than it should.
 RESTORED_ALL = "charter: restored the {n} chat(s) this plane last recorded"
 
-#: The same line when part of the plane did not come back. It says how much, and where the
-#: rest of the answer is — `_consume` leaves precisely the chats still owed in the record,
-#: so `charter reopen` is both the detail and the retry. Refusing the whole restore over
-#: one chat was the alternative, and it makes one dead workspace cost the other five.
+#: The same line when part of the plane did not come back — **the rest, named, on the one
+#: line**. Refusing the whole restore over one chat was the alternative, and it makes one
+#: dead workspace cost the other five; saying nothing is #752's defect.
+#:
+#: **It does not offer `charter reopen` as a retry, and that is measured rather than
+#: cautious.** `_consume` does leave exactly the chats still owed in the record — but this
+#: process is now also RECORDING, so about :data:`frame.record.QUIET` seconds later the
+#: record is the plane that is running and the leftovers are gone. An operator sitting
+#: inside the frame this restore just attached them to cannot type anything in that window,
+#: so a line pointing there would be pointing at something that is not there by the time it
+#: is read. The names are what the line can carry truthfully.
 RESTORED_SOME = ("charter: restored {n} of the {total} chats this plane last recorded — "
-                 "the rest are still recorded; `charter reopen` says which could not come "
-                 "back, and retries them")
+                 "{missing} did not come back")
+
+#: How many of the missing are named before the line starts counting instead. Three, because
+#: this is the compact line and the names are `chats.ID_RE` short — `alpha.1` — so three of
+#: them and a count is still one readable line at any terminal width.
+MISSING_NAMED = 3
+
+
+def _named_briefly(names) -> str:
+    """*names*, joined for one line, with anything past :data:`MISSING_NAMED` counted.
+
+    The values are chat ids off the record, and `reopen._usable` has already held every one
+    of them to `chats.ID_RE` on the way in — so this is a join rather than a boundary, and a
+    hostile manifest cannot reach the line through it.
+    """
+    kept = list(names)
+    if len(kept) <= MISSING_NAMED:
+        return ", ".join(kept)
+    return ", ".join(kept[:MISSING_NAMED]) + f" and {len(kept) - MISSING_NAMED} more"
 
 #: What a launch says when the record could not be acted on at all. It opens a chat anyway:
 #: the operator asked for a terminal, and refusing to give them one because a record is
@@ -8912,8 +8936,12 @@ def _reopen_plane(args) -> int:
     # #752's defect and the reason `_restore_the_plane` can fall through to a launch and
     # still have told the operator something.
     if quiet:
+        done = {r.chat.chat for r in back}
         util.ok(RESTORED_ALL.format(n=len(back)) if len(back) == total
-                else RESTORED_SOME.format(n=len(back), total=total))
+                else RESTORED_SOME.format(
+                    n=len(back), total=total,
+                    missing=_named_briefly(c.chat for c in m.all_chats()
+                                           if c.chat not in done)))
     else:
         util.ok(f"charter: reopened {len(back)} of {total} chats")
     _consume(m, {r.chat.chat for r in back}, quiet=quiet)

--- a/charter/commands_frame.py
+++ b/charter/commands_frame.py
@@ -4653,6 +4653,16 @@ def _records_the_plane(args) -> bool:
     exactly when the record matters. What is left is the launcher that stays awake for the
     life of the frame — this function's whole job is to say when that is what this is.
 
+    **`.get(key, True)` and not a bare subscript**, and the deletion sweep is what settled
+    it — as a survivor first and then as a measurement. `instance.frame_of` starts from
+    `FRAME_DEFAULTS`, so every config it RESOLVES carries the key and the fallback looks
+    dead. `config.FRAME` is a module attribute, though, and a caller that assigns a whole
+    mapping over it is not resolving anything: `tests/test_frame_border_surface._frame`
+    builds `{"components": [...]}` and patches it in, and a bare subscript there is a
+    `KeyError` out of the launcher's entry path — which is `_bare_launch`'s own recorded
+    reason for `config.HARNESS or {}`, one setting over. The default is what the fallback
+    spells, and it is pinned rather than assumed (see the tests named for this).
+
     Five ways of not being it, and none of them is implied by another:
 
     * `--probe` answers before the launcher touches anything (`cmd_launch`'s first line);

--- a/charter/commands_frame.py
+++ b/charter/commands_frame.py
@@ -149,8 +149,8 @@ import time
 
 from . import config, contain, harness, inflight, instance, tui, util, workspace
 from .frame import (actions as frame_actions, builtin_actions, chats, choose, component,
-                    gather, layout, leave, overlay, pane, palette, picker, state, switch,
-                    tabmenu, tmuxctl)
+                    gather, layout, leave, overlay, pane, palette, picker, record, state,
+                    switch, tabmenu, tmuxctl)
 # Aliased because `cmd_reopen` is a function in this module and `reopen` reads as one: the
 # module answers what a quit RECORDED and the command is what puts it back, and a bare
 # `reopen.read()` beside `cmd_reopen` invites a reader to think one is the other.
@@ -3187,6 +3187,11 @@ def _launch_in_operator_tmux(socket: str, session: str, *, ws: str,
     # `state.record_workspace`), so this launcher is the only thing that ever knows.
     state.record_workspace(fid, ws)
     state.bump(fid)
+    # And the record this process keeps, if it is keeping one (#845), now knows which chat
+    # this terminal is on. This path is a frame process too — it stays awake for the life of
+    # the frame, reading the harness's exit status itself — so it records exactly as the
+    # private-server path does, and the id is allocated here for the same reason.
+    record.focus_on(fid)
     # Kicked here, before a single tmux split — the child gathers while tmux is still
     # carving panes, so on an ordinary launch the cache is already on disk by the time
     # the first panel process paints. See `_spawn_gather`.
@@ -4536,6 +4541,10 @@ def _focus_workspace(session_id: str, chat: str, *, ws: str, picked: bool) -> in
     same way `cmd_launch`'s own attach is.
     """
     _pin_workspace(ws, chat, picked)
+    # Which chat this terminal is on, for the record this process is now keeping (#845).
+    # A focus opens nothing, so this is the only place its answer can come from — without
+    # it a focused launch would record the plane with no focus at all.
+    record.focus_on(chat)
     attach_cmd = tmuxctl.server_argv(SOCKET, "attach", "-t", session_id)
     attached = tmuxctl.interact(attach_cmd)
     if attached.returncode != 0:
@@ -4635,7 +4644,125 @@ def _launch_size(args) -> tuple[int, int] | None:
     return (cols, rows) if cols > 0 and rows > 0 else None
 
 
+def _records_the_plane(args) -> bool:
+    """Whether THIS launch is the process that writes the plane down (#845).
+
+    **The frame process, and nothing else.** Panels are separate processes and six of them
+    notice one bump, so recording where a bump is noticed is six writers racing one file; a
+    designated panel is worse, because it stops recording when that panel dies, which is
+    exactly when the record matters. What is left is the launcher that stays awake for the
+    life of the frame — this function's whole job is to say when that is what this is.
+
+    Five ways of not being it, and none of them is implied by another:
+
+    * `--probe` answers before the launcher touches anything (`cmd_launch`'s first line);
+    * `--no-frame` is an `os.execvp`, so there is no frame and, a moment later, no charter;
+    * a non-tty stdout is `bypass`, the same exec, and is how `charter 2>&1 | head` asks
+      whether charter is installed (#687/#690);
+    * `_wants_attach` is false for a launch that was never going to be anybody's terminal —
+      `_open_workspace`'s detached `frame-switch`, and every chat a reopen builds;
+    * `[frame] record = false` is the operator saying not to.
+
+    And `--fresh`, which is a decision rather than a category: *this run does not
+    participate*. Recording under it would destroy, on a debounce timer, the record the same
+    run declined to restore from — and nothing would say so until the operator asked for the
+    plane back and found yesterday's instead of the day before's.
+    """
+    return (bool(config.FRAME.get("record", True))
+            and not getattr(args, "fresh", False)
+            and not getattr(args, "probe", False)
+            and not getattr(args, "no_frame", False)
+            and _wants_attach(args)
+            and sys.stdout.isatty())
+
+
+def _restores_the_plane(args) -> bool:
+    """Whether this launch may put the recorded plane back instead of opening a chat.
+
+    **Its own key, and its own question.** `[frame] restore` is not `[frame] record` read
+    twice: recording costs a little I/O and changes nothing an operator sees, while
+    restoring changes what happens when they type `charter` — so a plane may reasonably
+    record without resurrecting, and this predicate never consults the other key.
+
+    A launch carrying a `rest` is excluded because it asked for something in particular:
+    `charter claude --resume <id>` and `charter frame -- <cmd>` name a command, and
+    answering either with six other chats is an override rather than a restore. It is the
+    same gate `_workspace_to_focus`'s own `if not rest` keeps, for the same reason.
+
+    **What this does NOT ask is whether the plane is live** — that is the caller's, because
+    the answer costs two tmux round trips it has already paid for. See :func:`cmd_launch`.
+    """
+    return (bool(config.FRAME.get("restore", True))
+            and not getattr(args, "fresh", False)
+            and not getattr(args, "rest", None)
+            and _wants_attach(args))
+
+
+#: What an automatic restore says when the whole recorded plane came back. **One line**,
+#: and that is the decision rather than the formatting: `charter reopen` is a deliberate
+#: act, so its per-chat report is read; this happens when somebody typed `charter` and
+#: wanted a terminal, and a wall of text there is noise at the worst possible moment.
+#: Silence is not the alternative — that is #752's defect exactly, a frame quietly drawing
+#: less than it should.
+RESTORED_ALL = "charter: restored the {n} chat(s) this plane last recorded"
+
+#: The same line when part of the plane did not come back. It says how much, and where the
+#: rest of the answer is — `_consume` leaves precisely the chats still owed in the record,
+#: so `charter reopen` is both the detail and the retry. Refusing the whole restore over
+#: one chat was the alternative, and it makes one dead workspace cost the other five.
+RESTORED_SOME = ("charter: restored {n} of the {total} chats this plane last recorded — "
+                 "the rest are still recorded; `charter reopen` says which could not come "
+                 "back, and retries them")
+
+#: What a launch says when the record could not be acted on at all. It opens a chat anyway:
+#: the operator asked for a terminal, and refusing to give them one because a record is
+#: unusable would be the restore taking the launch hostage.
+NOT_RESTORED = ("charter: nothing this plane recorded could be started — opening a chat "
+                "instead. The record is left in place; `charter reopen` says why.")
+
+
+def _restore_the_plane(args) -> int | None:
+    """Put the recorded plane back. The launch's return code, or ``None`` to carry on.
+
+    ``None`` for a plane with nothing recorded — the ordinary first launch — and for a
+    restore that started nothing, which falls through to opening one chat rather than
+    leaving an operator who asked for a terminal without one.
+
+    `cmd_reopen` drives it, unchanged and in full: a second implementation of "put a
+    recorded chat back" would be a second answer to the workspace, the persona, the resume
+    flag and the cwd, and it would drift on the first change to either. The only thing this
+    adds is `quiet`, which is what turns its per-chat report into the one line above.
+    """
+    from types import SimpleNamespace
+    m = reopen_state.read()
+    if m is None or not m.frames:
+        return None
+    rc = cmd_reopen(SimpleNamespace(quiet=True))
+    if rc == 0:
+        return 0
+    util.warn(NOT_RESTORED)
+    return None
+
+
 def cmd_launch(args) -> int:
+    """One launcher, shared by every registered harness and by `charter frame --`.
+
+    The body is :func:`_launch`; this is the wrapper that makes the process holding the
+    operator's terminal the plane's recorder for as long as it holds it (#845). Expressed
+    as a wrapper rather than as a `try`/`finally` inside the launcher because the launcher
+    returns from a dozen places — a recorder started on one of them and stopped on another
+    is how a watch outlives the frame it was watching.
+
+    Stopped on the way out, and joined there (`record.Recorder.stop`): the launcher's own
+    last act is `state.reap`, which removes the very directories the watch reads.
+    """
+    if not _records_the_plane(args):
+        return _launch(args)
+    with record.recording(record_the_plane_now):
+        return _launch(args)
+
+
+def _launch(args) -> int:
     """One launcher, shared by every registered harness and by `charter frame --`."""
     if getattr(args, "probe", False):
         # First, and read-only: nothing below this line — resolving a harness, touching
@@ -4801,6 +4928,30 @@ def cmd_launch(args) -> int:
     if can_reap:
         state.reap(live_before, server=SOCKET)
 
+    # **Put the recorded plane back** (#845), and the gate that matters is `not
+    # live_before` rather than anything about this workspace. With recording on, the record
+    # is CURRENT instead of a relic of the last quit — so a second terminal typing `charter`
+    # while the plane runs would reopen every chat it can already see, and a reopened chat
+    # gets a fresh ordinal, so nothing on screen would tell the duplicates from the
+    # originals. Nothing live anywhere on this plane is the only reading under which a
+    # restore cannot double something.
+    #
+    # `not live_before` also implies `can_reap` — an empty `live_sessions` makes it true —
+    # so the wedged-server case (sessions listed, windows refused) is excluded by the same
+    # expression rather than by a second guard.
+    #
+    # **After the reap** for the reason the reap itself is here: `cmd_reopen` allocates a
+    # fresh ordinal per chat, and the directories the record describes are dead ones a reap
+    # is entitled to take. The manifest is a FILE and survives it (`frame/reopen.py`).
+    #
+    # **Before open-or-focus**, which is unreachable on this branch anyway — nothing is live
+    # for a client to be looking at — but stated in this order because it is the order the
+    # two questions are asked in: is there a plane to put back, then is there one to join.
+    if not live_before and _restores_the_plane(args):
+        rc = _restore_the_plane(args)
+        if rc is not None:
+            return rc
+
     # **Open or focus** (§4k), and it is asked HERE — after the reap, before the
     # allocation — for both of its neighbours' reasons. After the reap, so the chat
     # directories `_workspace_to_focus` reads are the ones that survived it rather than
@@ -4923,6 +5074,11 @@ def cmd_launch(args) -> int:
         _restore_recorded_chat(restoring.chat, fid)
     state.clear_respawn(fid)
     state.bump(fid)
+    # And the record this process keeps now knows which chat it is standing in (#845) —
+    # `Reopening.fid`'s own shape and for its own reason: the id is allocated here and
+    # nowhere earlier, and inferring it from the frame root would be reading back a fact
+    # this function has in hand. A no-op on every launch that is not recording.
+    record.focus_on(fid)
     # Kicked before tmux is asked for anything, so the gather runs alongside the session
     # start rather than in front of it. See `_spawn_gather`.
     _spawn_gather(fid, ws)
@@ -5327,10 +5483,15 @@ def cmd_launch(args) -> int:
     # rather than a tidiness. `new_chat_id` walks upward from 1 and `reap` frees the ordinals
     # a quit's chats held, so a reopen very often gets the SAME ids back — and every one of
     # its own launches would then find itself named in the manifest it is in the middle of
-    # acting on, and print "this plane was quit; put it back with `charter reopen`" while
-    # `charter reopen` was putting it back.
+    # acting on, and name `charter reopen` while `charter reopen` was putting it back.
+    #
+    # **And only for a chat that is actually over** (#845). The record now names every chat
+    # that is RUNNING as well, so without the second half an operator who detached from a
+    # live harness would be told their plane was recorded and offered `charter reopen`, one
+    # line above the launcher's own "detached — the harness is still running". `live_after`
+    # is the same reading that decides which of those two lines is printed below.
     if _wants_attach(args):
-        _say_it_was_quit(fid)
+        _say_the_plane_is_recorded(fid, over=fid not in live_after)
     if code is not None:
         return code
     if refused_to_attach:
@@ -8352,7 +8513,8 @@ def cmd_quit(args) -> int:
     return 0
 
 
-def _record_the_plane(doomed, *, focus: str, active, windows) -> int | None:
+def _record_the_plane(doomed, *, focus: str, active, windows,
+                      capture: bool = True) -> int | None:
     """Capture and record *doomed*. The number of chats recorded, or ``None``.
 
     Split out of :func:`cmd_quit` so that "what a quit writes down" is one function a test
@@ -8362,6 +8524,14 @@ def _record_the_plane(doomed, *, focus: str, active, windows) -> int | None:
     ``None`` for a manifest that did not land, which is the one thing that stops a quit.
     Everything else degrades per chat and is visible in what comes back: a capture that
     failed leaves the transcript field empty, so the reopen simply has nothing to offer.
+
+    **`capture=False` is #845's running plane, and it is exactly two differences.** A record
+    taken while everything is still running does not `capture-pane` — that is one subprocess
+    per chat per write at a hundred times a quit's rate, for the one restore item §4f says
+    is *offered and never replayed* — and it does not prune, because a sweep on that
+    timetable would collect the capture of a chat between a close and its reopen. What it
+    still does is NAME the capture a quit already left on disk, so a running plane's record
+    landing on top of a quit's does not silently withdraw the offer.
     """
     frames: list = []
     entries: dict[str, list] = {}
@@ -8382,7 +8552,15 @@ def _record_the_plane(doomed, *, focus: str, active, windows) -> int | None:
         transcript = ""
         dest = reopen_state.transcript_path(c.chat)
         pane_id = state.harness_pane(c.chat) or ""
-        if dest is not None and _PANE_ID_RE.fullmatch(pane_id) and c.chat in windows.get(
+        if not capture:
+            # The file rather than a capture, and `is_file()` rather than the manifest's own
+            # previous entry: the name is derived from the chat id either way
+            # (`reopen.TRANSCRIPT_SUFFIX`), so asking the directory is asking the same
+            # question one step closer to the answer — and it stays right when the previous
+            # manifest is one charter could not read.
+            if dest is not None and dest.is_file():
+                transcript = dest.name
+        elif dest is not None and _PANE_ID_RE.fullmatch(pane_id) and c.chat in windows.get(
                 server, {}):
             if _capture_transcript(server, pane_id, dest):
                 transcript = dest.name
@@ -8397,11 +8575,41 @@ def _record_the_plane(doomed, *, focus: str, active, windows) -> int | None:
         frames.append(reopen_state.Frame(workspace=ws, chats=tuple(entries[ws])))
     if not reopen_state.write(frames, focus=focus):
         return None
-    # Keyed on what was RECORDED and not on what was stopped: a transcript is a file in the
-    # frame root, and the only collector it has is this call. Keeping one for a chat no
-    # manifest names would leave it there for good.
-    reopen_state.prune_transcripts({c.chat for f in frames for c in f.chats})
+    if capture:
+        # Keyed on what was RECORDED and not on what was stopped: a transcript is a file in
+        # the frame root, and the only collector it has is this call. Keeping one for a chat
+        # no manifest names would leave it there for good.
+        reopen_state.prune_transcripts({c.chat for f in frames for c in f.chats})
     return sum(len(f.chats) for f in frames)
+
+
+def record_the_plane_now(chat: str) -> bool:
+    """Write down the plane as it stands. ``True`` when the record landed.
+
+    **`cmd_quit`'s own reading, without the stopping** — `leave.plan` over the frame root
+    and one `list-windows` per server, so "what a chat is" and "which of them are live" have
+    one answer on this plane rather than one for the quit and one for the recorder.
+
+    *chat* is the chat this process's terminal is standing in, and it becomes the manifest's
+    `focus` — the workspace a reopen attaches to. Read through `state.own_workspace`, which
+    is the membership question (#733) and the same one `cmd_quit` asks of the chat the
+    palette was opened in. ``""`` is a real answer for a launcher that has not claimed an id
+    yet, and `_attach_after_reopen` already falls back from it to the chat that was on
+    screen.
+
+    **A plane with nothing live is not recorded**, and that is a refusal rather than an
+    empty write. It is the state a plane is in for the instant between a quit's manifest and
+    the launcher noticing its attach ended, and replacing a quit's record with an empty one
+    there would destroy exactly the thing this feature exists to keep.
+    """
+    servers = _plane_servers()
+    live, windows, active = _plane_live(servers)
+    focus = state.own_workspace(chat) or ""
+    doomed = leave.stopping(leave.plan(live=live, focus=focus))
+    if not doomed:
+        return False
+    return _record_the_plane(doomed, focus=focus, active=active, windows=windows,
+                             capture=False) is not None
 
 
 def _stop_chats(doomed, *, windows) -> int:
@@ -8586,6 +8794,26 @@ NOTHING_RECORDED = (
 
 
 def cmd_reopen(args) -> int:
+    """`charter reopen`, recording the plane it puts back for as long as it holds the
+    terminal.
+
+    The body is :func:`_reopen_plane`; this is `cmd_launch`'s own wrapper, and it is needed
+    here for a sharper reason than symmetry. A reopen attaches (`_attach_after_reopen`), so
+    this process IS the frame process for the plane it just built — and `_consume` has by
+    then deleted the record that drove it. Without a recorder here, the one plane that most
+    obviously deserves one would have nothing behind it until the next quit.
+
+    Every chat it builds passes `attach=False` into `cmd_launch`, so none of THOSE starts a
+    recorder (`_records_the_plane`), and the automatic restore reaching this from inside a
+    launch finds one already running (`record.recording`).
+    """
+    if not config.FRAME.get("record", True):
+        return _reopen_plane(args)
+    with record.recording(record_the_plane_now):
+        return _reopen_plane(args)
+
+
+def _reopen_plane(args) -> int:
     """`charter reopen` — put back the plane the last quit recorded.
 
     **What comes back, per chat: the workspace, the persona, the harness and the
@@ -8667,22 +8895,48 @@ def cmd_reopen(args) -> int:
                  "at the first. Run it from an ordinary shell. Nothing was reopened, and "
                  "the record is left in place.")
         return 1
+    quiet = getattr(args, "quiet", False)
     back: list[Reopening] = []
     for f in m.frames:
         for c in f.chats:
-            r = _reopen_one(c)
+            r = _reopen_one(c, quiet=quiet)
             if r is not None:
                 back.append(r)
     if not back:
         util.err("charter reopen: none of the recorded chats could be started — the "
                  "record is left in place so this can be tried again.")
         return 1
-    util.ok(f"charter: reopened {len(back)} of {len(m.all_chats())} chats")
-    _consume(m, {r.chat.chat for r in back})
+    total = len(m.all_chats())
+    # **The refusal above is said either way, and that is deliberate.** `quiet` shortens a
+    # report of what HAPPENED; it does not make a restore that did nothing silent, which is
+    # #752's defect and the reason `_restore_the_plane` can fall through to a launch and
+    # still have told the operator something.
+    if quiet:
+        util.ok(RESTORED_ALL.format(n=len(back)) if len(back) == total
+                else RESTORED_SOME.format(n=len(back), total=total))
+    else:
+        util.ok(f"charter: reopened {len(back)} of {total} chats")
+    _consume(m, {r.chat.chat for r in back}, quiet=quiet)
     return _attach_after_reopen(m, back)
 
 
-def _consume(m, done) -> None:
+def _report(quiet: bool, say, message: str) -> None:
+    """Say *message* through *say*, unless this is the automatic restore.
+
+    **One place the suppression happens, rather than an `if not quiet` at each of the six
+    sentences.** Six branches would be six things the deletion sweep asks a test for, all
+    answering the same question; this is one, and what it costs is that a caller has to
+    build a message it may not print — which is a formatted string, on a path that has just
+    spawned a tmux session.
+
+    It suppresses the per-CHAT report and nothing else. `cmd_reopen`'s own refusals are said
+    either way: a restore that did nothing has to say so wherever it was asked from (#752).
+    """
+    if not quiet:
+        say(message)
+
+
+def _consume(m, done, *, quiet: bool = False) -> None:
     """Take the chats in *done* out of the manifest, and drop it when nothing is left.
 
     **Consumed rather than deleted, because a partial reopen has two halves and only one of
@@ -8704,11 +8958,12 @@ def _consume(m, done) -> None:
         reopen_state.forget()
         return
     if reopen_state.write(left, focus=m.focus, at=m.at):
-        util.warn(f"charter reopen: {sum(len(f.chats) for f in left)} chat(s) still "
-                  "recorded — `charter reopen` again to retry just those")
+        _report(quiet, util.warn,
+                f"charter reopen: {sum(len(f.chats) for f in left)} chat(s) still "
+                "recorded — `charter reopen` again to retry just those")
 
 
-def _reopen_one(c) -> "Reopening | None":
+def _reopen_one(c, *, quiet: bool = False) -> "Reopening | None":
     """Put one recorded chat back. The launch's own record, or ``None`` when it did not run.
 
     **The harness is resolved off the registry by its own `name`**, which is what
@@ -8735,30 +8990,34 @@ def _reopen_one(c) -> "Reopening | None":
         fallback = (config.HARNESS or {}).get("default")
         h = next((x for x in harness.all() if x.cli_name == fallback), None)
         if h is None:
-            util.warn(f"charter reopen: {c.chat} recorded harness "
-                      f"{contain.readable(c.harness) or 'nothing'}, which this charter "
-                      f"cannot launch, and this plane declares no `[harness] default` — "
-                      f"not reopened")
+            _report(quiet, util.warn,
+                    f"charter reopen: {c.chat} recorded harness "
+                    f"{contain.readable(c.harness) or 'nothing'}, which this charter "
+                    f"cannot launch, and this plane declares no `[harness] default` — "
+                    f"not reopened")
             return None
-        util.warn(f"charter reopen: {c.chat} recorded harness "
-                  f"{contain.readable(c.harness) or 'nothing'} — reopening it under "
-                  f"{h.cli_name}, this plane's default")
+        _report(quiet, util.warn,
+                f"charter reopen: {c.chat} recorded harness "
+                f"{contain.readable(c.harness) or 'nothing'} — reopening it under "
+                f"{h.cli_name}, this plane's default")
     rest: list[str] = []
     if c.resume and leave.resumable_harness(c.harness):
         rest = ["--resume", c.resume]
     where = c.cwd if c.cwd and os.path.isdir(c.cwd) else str(config.ROOT)
     if where != c.cwd:
-        util.warn(f"charter reopen: {c.chat}'s directory "
-                  f"{contain.readable(c.cwd) or 'was never recorded'} — reopening in "
-                  f"{where}")
+        _report(quiet, util.warn,
+                f"charter reopen: {c.chat}'s directory "
+                f"{contain.readable(c.cwd) or 'was never recorded'} — reopening in "
+                f"{where}")
     r = Reopening(c)
     argv_args = _reopen_args(c, harness_name=h.cli_name, rest=rest, reopening=r)
     here = os.getcwd()
     try:
         os.chdir(where)
     except OSError:
-        util.warn(f"charter reopen: cannot enter {contain.readable(where)} — {c.chat} not "
-                  "reopened")
+        _report(quiet, util.warn,
+                f"charter reopen: cannot enter {contain.readable(where)} — {c.chat} not "
+                "reopened")
         return None
     try:
         rc = cmd_launch(argv_args)
@@ -8768,11 +9027,13 @@ def _reopen_one(c) -> "Reopening | None":
         except OSError:
             pass
     if rc != 0 or not r.fid:
-        util.warn(f"charter reopen: {c.chat} did not come back (launcher returned {rc})")
+        _report(quiet, util.warn,
+                f"charter reopen: {c.chat} did not come back (launcher returned {rc})")
         return None
-    util.info(f"  {c.chat} → {r.fid} · {leave.RESUMES if rest else 'empty'}"
-              + (" · workspace is missing" if c.workspace
-                 and not workspace.exists(c.workspace) else ""))
+    _report(quiet, util.info,
+            f"  {c.chat} → {r.fid} · {leave.RESUMES if rest else 'empty'}"
+            + (" · workspace is missing" if c.workspace
+               and not workspace.exists(c.workspace) else ""))
     return r
 
 
@@ -8815,6 +9076,11 @@ def _attach_after_reopen(m, back) -> int:
         wanted = next((r for r in back if r.chat.workspace == m.focus), None)
     if wanted is None:
         wanted = next((r for r in back if r.chat.active), back[0])
+    # The chat this reopen is about to hand the operator, which is where this process's own
+    # record says the terminal is standing (#845). It has to be said here rather than in
+    # `_reopen_one`: every chat a reopen builds passes through that function, and the last
+    # one to run is not the one the operator ends up on.
+    record.focus_on(wanted.fid)
     session = state.workspace_prefix(wanted.chat.workspace)
     pane_id = state.harness_pane(wanted.fid) or ""
     if _PANE_ID_RE.fullmatch(pane_id):
@@ -8949,8 +9215,20 @@ def _start_leaving(fid: str, verb: str) -> None:
         util.self_relaunch_argv(f"frame-{verb}", "--chat", fid), fid=fid)
 
 
-def _say_it_was_quit(fid: str) -> None:
-    """Tell the operator their plane was recorded, on the shell they are back in.
+#: What the launcher tells an operator it has just handed a shell back to.
+#:
+#: **It says "is recorded" and not "was quit", and #845 is what made the difference
+#: load-bearing.** While a quit was the only writer, a manifest naming this chat WAS a quit
+#: by construction. Now the frame process records the plane as it changes, so the same
+#: reading is true of every chat that ever ran — and the sentence would have announced a
+#: quit on every ordinary detach. What is still true, and is the whole of what the operator
+#: can act on, is that the plane is on disk and one command puts it back.
+RECORDED_PLANE = ("charter: this plane is recorded — {n} chat(s) recorded, {back} with a "
+                  "conversation to resume.\n  put it back with: charter reopen")
+
+
+def _say_the_plane_is_recorded(fid: str, *, over: bool = True) -> None:
+    """Tell the operator their plane is recorded, on the shell they are back in.
 
     **The gap this closes was found by asking where the quit's own sentence goes, and the
     answer was nowhere.** `charter: quit` is started detached with `stdout` and `stderr` on
@@ -8963,19 +9241,26 @@ def _say_it_was_quit(fid: str) -> None:
 
     `cmd_launch` is the process that hands them that shell, so it is the one that can say
     it. Gated on the MANIFEST naming this chat, which is what makes the sentence true rather
-    than likely: a launcher whose harness merely exited, or whose operator detached, reaches
-    the same lines and says nothing.
+    than likely.
+
+    **And on *over*, which #845 added because the manifest stopped being able to answer
+    it.** While a quit was the only writer, a record naming this chat meant the plane had
+    been stopped; now the frame process records it as it changes, so the record names every
+    chat that is RUNNING too — and without this the launcher would tell an operator who
+    detached from a live harness that their plane was over, one line above its own
+    "detached — the harness is still running". *over* is the caller's own `fid not in
+    live_after`, the same reading that decides which of those two lines it prints.
 
     Never raises and never guesses: a manifest charter cannot read is one it says nothing
     about, exactly as `reopen.read` answers `None` for it.
     """
+    if not over:
+        return
     m = reopen_state.read()
     if m is None or not any(c.chat == fid for c in m.all_chats()):
         return
-    n = len(m.all_chats())
-    back = len([c for c in m.all_chats() if c.resume])
-    util.info(f"charter: this plane was quit — {n} chat(s) recorded, {back} with a "
-              f"conversation to resume.\n  put it back with: charter reopen")
+    util.info(RECORDED_PLANE.format(n=len(m.all_chats()),
+                                    back=len([c for c in m.all_chats() if c.resume])))
 
 
 #: What the chat bar's `+` says when this frame is a window in a tmux the operator already

--- a/charter/commands_frame.py
+++ b/charter/commands_frame.py
@@ -8626,6 +8626,14 @@ def record_the_plane_now(chat: str) -> bool:
     the launcher noticing its attach ended, and replacing a quit's record with an empty one
     there would destroy exactly the thing this feature exists to keep.
     """
+    # **Asked of the disk before it is asked of tmux.** A plane with no chat directories has
+    # nothing to record whatever a server says, and this runs on a poll: `_plane_live` is a
+    # `list-windows` per server, and spending one to be told the plane is empty is the
+    # cheapest call to not make. It also keeps a recorder that outlives its frame — a launch
+    # whose every chat was reaped — from going on asking a tmux server about a plane that
+    # is not there.
+    if not leave.plane_chats():
+        return False
     servers = _plane_servers()
     live, windows, active = _plane_live(servers)
     focus = state.own_workspace(chat) or ""

--- a/charter/frame/record.py
+++ b/charter/frame/record.py
@@ -62,12 +62,38 @@ QUIET = 2.0
 #: a second would be four extra `stat`-sized reads per chat per second for no earlier write.
 POLL = 0.5
 
+#: How long :meth:`Recorder.stop` waits for the loop to come back before giving up on it.
+#:
+#: Two seconds, and it is a fact about the WRITE rather than about :data:`POLL`: a tick that
+#: is already under way is inside `_plane_live`, whose `list-windows` carries a five-second
+#: timeout of its own, so no arithmetic over the poll interval says anything useful about
+#: how long the loop might legitimately take to return. What this number is for is the other
+#: end — a write stuck on a wedged filesystem must not stand between an operator and their
+#: shell, and the cost of giving up early is a daemon thread that dies with the process.
+#:
+#: It was `max(poll * 4, 1.0)`, and the deletion sweep reported BOTH halves as survivors:
+#: neither the product nor the floor decides anything any test can see, because neither is
+#: derived from anything. A number nothing can pin is a number that should not be computed.
+JOIN = 2.0
 
-def fingerprint() -> tuple[tuple[str, str], ...]:
-    """Every chat on this plane and the version it is at, sorted.
+
+def fingerprint() -> frozenset[tuple[str, str]]:
+    """Every chat on this plane and the version it is at, as a SET.
 
     **`state.version` and nothing else**, so "has this chat changed" has one answer rather
     than one for the panels and one for the recorder.
+
+    **A frozenset rather than a sorted tuple, and the deletion sweep is what settled it.**
+    This value is only ever compared for equality (`Debounce.saw`), so what it has to be is
+    a function of the FACTS and not of the order `os.scandir` happened to hand them over in.
+    It was `sorted(...)`, and the sweep reported `sorted` → `list` as a survivor. Measured
+    on this machine (APFS) rather than argued: readdir order is a function of the name set —
+    identical across a `rmdir`/`mkdir` reclaim of the same ordinal (the case
+    `frame/reopen.py` says happens *very often*) and across a chat added and removed between
+    two readings — so `sorted` was defending against something that cannot arrive, which is
+    a survivor wearing a guard. POSIX still promises nothing about that order, so the answer
+    is not to delete the sort and depend on the measurement: it is to stop asking. A set has
+    no order to be wrong about, and it says what this value is.
 
     Held to `chats.ID_RE` and `is_dir()` rather than to `chats.is_chat`, and that is a
     deliberate widening: `is_chat` reads a second file per chat (`state._launcher_pid`) to
@@ -87,8 +113,8 @@ def fingerprint() -> tuple[tuple[str, str], ...]:
         names = [e.name for e in os.scandir(state._root())
                  if e.is_dir() and chats.ID_RE.fullmatch(e.name)]
     except OSError:
-        return ()
-    return tuple((n, state.version(n)) for n in sorted(names))
+        return frozenset()
+    return frozenset((n, state.version(n)) for n in names)
 
 
 #: What :class:`Debounce` has seen before it has seen anything. Its own object rather
@@ -212,12 +238,13 @@ class Recorder:
 
         Joined rather than abandoned: the caller is about to reap the very directories the
         loop reads (`cmd_launch`'s closing `state.reap`), and a thread still inside `tick`
-        would be recording a plane that is being deleted. Bounded, because a write stuck on
-        a wedged filesystem must not stand between an operator and their shell.
+        would be recording a plane that is being deleted. Bounded by :data:`JOIN`, because a
+        write stuck on a wedged filesystem must not stand between an operator and their
+        shell.
         """
         self._stop.set()
         if self._thread is not None:
-            self._thread.join(timeout=max(self.poll * 4, 1.0))
+            self._thread.join(timeout=JOIN)
 
     def alive(self) -> bool:
         """Whether the watch is still running — asked of the thread rather than of a flag,

--- a/charter/frame/record.py
+++ b/charter/frame/record.py
@@ -1,0 +1,287 @@
+"""Recording the plane as it changes — the half of `frame/reopen.py` that is not a quit.
+
+**Record, never save.** `charter save` commits and pushes a tree; this writes a local file.
+The two are unrelated and a message that said "save" would be ambiguous about which one did
+not happen, so this module uses the verb `reopen.write` and 0.55.0's news entry already
+use: *"quitting charter records the plane"*.
+
+**When it writes: debounced on the bumps that already exist.** `state.bump` is charter's own
+"something changed", moved by every writer in the frame — the launcher, the hooks, a
+detached gather, a keypress that changed the shape. Reusing it means there is no second
+notion of change to keep in step with the first. Two rejected alternatives, and both were
+rejected for the same measured reason:
+
+* **On every bump.** `cmd_launch` bumps immediately after `new_chat_id` and before
+  `new-window` runs, so a record taken there names a chat that has no window and no harness
+  — a plane that never existed. The quiet period is what buys back the consistency a quit
+  got for free by stopping the world first.
+* **On a timer.** Same defect (a tick can land in that same window) plus work spent on a
+  plane that did nothing, which is most of the time.
+
+**Who writes: the frame process, alone** — the launcher that is the operator's terminal for
+the life of the frame (`commands_frame.cmd_launch`'s `attach`), and `charter reopen`'s own
+attach. Panels are separate processes: six of them notice one bump, so recording where the
+bump was NOTICED is six processes racing one manifest. A designated panel is worse, because
+it stops recording the moment that panel dies, which is exactly when the record matters.
+
+**And being that writer costs a watch this process did not have.** Only panels watch bumps
+today (`panel._watch`), so the frame process gains a polling thread it never carried. That
+cost is paid rather than avoided by moving the writer, and there is no cheaper mechanism to
+pay it with: a bump is a file written by ANOTHER process, and the standard library has no
+file-change notification to subscribe to — which is why `panel._watch` polls as well.
+:data:`POLL` is deliberately slower than `panel.TICK`: a panel is drawing for a human, this
+is deciding whether to write a file that is already :data:`QUIET` seconds behind.
+
+Nothing here raises. This runs on a daemon thread inside the process holding the operator's
+terminal, so an exception on the loop would either kill the thread silently or print into a
+frame that is about to switch to the alternate screen — `frame/state.py`'s own promise, for
+the same reason.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import os
+import threading
+import time
+
+from . import chats, state
+
+#: How long the plane must go without a bump before it is written down. Two seconds is
+#: chosen against the thing it exists to exclude rather than by feel: the window between
+#: `state.bump(fid)` in `cmd_launch` and the chat's window actually existing is the tmux
+#: round trips in between — `new-session`/`new-window`, the option writes, the panel splits
+#: — which is tens of milliseconds on a warm server and was measured under 400ms on a cold
+#: one. Two seconds clears that by a wide margin and still costs an operator at most two
+#: seconds of a plane that changed and was not yet on disk.
+QUIET = 2.0
+
+#: How often the frame process reads the bumps. Deliberately slower than `panel.TICK`
+#: (0.2s): a panel is redrawing for someone who is looking at it, and this is deciding
+#: whether to write a file whose answer is :data:`QUIET` seconds old by design. Five times
+#: a second would be four extra `stat`-sized reads per chat per second for no earlier write.
+POLL = 0.5
+
+
+def fingerprint() -> tuple[tuple[str, str], ...]:
+    """Every chat on this plane and the version it is at, sorted.
+
+    **`state.version` and nothing else**, so "has this chat changed" has one answer rather
+    than one for the panels and one for the recorder.
+
+    Held to `chats.ID_RE` and `is_dir()` rather than to `chats.is_chat`, and that is a
+    deliberate widening: `is_chat` reads a second file per chat (`state._launcher_pid`) to
+    tell a chat from the `{workspace}-{pid}` frames that predate them, and this is a
+    CHANGE DETECTOR rather than a list of things to act on. A directory that turns out not
+    to be a chat costs one write of a plane that reads the same either way; a second file
+    read per chat per poll is paid forever. What the filters do buy is the property the
+    caller depends on: the manifest and the transcripts live in this same directory and are
+    not directories themselves, so writing the record cannot move the fingerprint and
+    provoke another write.
+
+    Empty for a plane with no frame root at all — a machine that has never launched one.
+    Never raises: this is a poll loop, and `state.version` already answers ``"0"`` rather
+    than raising for every way a version can fail to be read.
+    """
+    try:
+        names = [e.name for e in os.scandir(state._root())
+                 if e.is_dir() and chats.ID_RE.fullmatch(e.name)]
+    except OSError:
+        return ()
+    return tuple((n, state.version(n)) for n in sorted(names))
+
+
+#: What :class:`Debounce` has seen before it has seen anything. Its own object rather
+#: than ``None`` because ``None`` is a fingerprint a reader could legitimately hand in, and
+#: the first reading of a plane has to count as a change: a plane that came back from
+#: `charter reopen` and then sat still has had no bump since, and `_consume` deleted the
+#: manifest that put it there — without this it would be recorded nowhere until something
+#: happened to move it.
+_NOTHING = object()
+
+
+class Debounce:
+    """One write per quiet period, driven by what was seen rather than by a clock.
+
+    Pure: no clock, no thread, no filesystem. The time is an argument, so the decision can
+    be asserted at exact instants instead of by sleeping — and so the loop below is left
+    with nothing in it but sleeping and calling.
+    """
+
+    def __init__(self, *, quiet: float = QUIET) -> None:
+        self.quiet = quiet
+        self.seen = _NOTHING
+        #: Whether what was last seen still owes a write. A flag rather than a comparison
+        #: of "seen" against "written": those two would have to be told apart by identity
+        #: (a plane that changed and changed back is genuinely a change, and an equal tuple
+        #: is a different object), and an identity test here is a mutation nothing can kill
+        #: — swapping it for equality behaves identically on every reading `saw` can
+        #: produce, because `saw` only ever replaces `seen` with something unequal.
+        self.pending = False
+        self.at = 0.0
+
+    def saw(self, fp, *, now: float) -> None:
+        """Record one reading. A reading equal to the last one is not a change, and
+        deliberately does not move the deadline: a plane that is quiet must eventually be
+        written, not held off forever by being read."""
+        if fp != self.seen:
+            self.seen = fp
+            self.at = now
+            self.pending = True
+
+    def due(self, *, now: float) -> bool:
+        """Whether what was last seen is worth writing yet."""
+        return self.pending and now - self.at >= self.quiet
+
+    def wrote(self) -> None:
+        """The reading that was due has been acted on."""
+        self.pending = False
+
+
+class Recorder:
+    """The frame process's own watch on the bumps, and the one thing that writes.
+
+    *write* is handed the chat this terminal is standing in and answers whether the record
+    landed — `commands_frame` supplies it, so this module never imports the thing that
+    knows what a plane is. *read* and the clock are injected for the same reason the
+    debounce takes its time as an argument: the loop is then two lines and every decision
+    in it is assertable without a thread.
+    """
+
+    def __init__(self, write, *, quiet: float = QUIET, poll: float = POLL,
+                 read=fingerprint, clock=time.monotonic) -> None:
+        self._write = write
+        self._read = read
+        self._clock = clock
+        self.poll = poll
+        self.debounce = Debounce(quiet=quiet)
+        #: The chat this process's terminal is on, which becomes the manifest's `focus` —
+        #: the workspace a reopen attaches to. Mutable and set from outside (`focus_on`)
+        #: for `commands_frame.Reopening.fid`'s reason: the id is allocated well after this
+        #: starts, and inferring it from the plane would be reading back a fact the
+        #: launcher has in hand. ``""`` until it is known, which `reopen`'s own reader
+        #: already treats as "no workspace recorded" and falls back from.
+        self.chat = ""
+        self._stop = threading.Event()
+        self._thread: threading.Thread | None = None
+
+    def tick(self, *, now: float | None = None) -> bool:
+        """Read the plane once and write it if it is due. Whether it wrote.
+
+        **Never raises**, in either direction. A reading that failed is a plane charter
+        could not see, which is not a plane that changed — so it is skipped rather than
+        recorded as empty. A write that raised is over as far as this loop is concerned:
+        it is marked acted-on, so a filesystem that refuses does not turn a two-second
+        debounce into a hot loop.
+        """
+        when = self._clock() if now is None else now
+        try:
+            fp = self._read()
+        except Exception:  # noqa: BLE001 - a poll loop in the operator's terminal
+            return False
+        self.debounce.saw(fp, now=when)
+        if not self.debounce.due(now=when):
+            return False
+        self.debounce.wrote()
+        try:
+            return bool(self._write(self.chat))
+        except Exception:  # noqa: BLE001 - same promise, on the writing half
+            return False
+
+    def _loop(self) -> None:
+        # `Event.wait` and not `time.sleep`, so a stop is answered inside the wait it
+        # interrupts rather than one whole POLL later — which is what makes the join in
+        # :meth:`stop` bounded by a tick rather than by the poll interval.
+        #
+        # It WAITS BEFORE IT READS, which is the ordering that matters: the launcher starts
+        # this before it has built anything, and a first reading taken instantly would be
+        # of a plane mid-launch. The debounce would hold that reading anyway; waiting first
+        # means the loop never even asks about a plane nobody has finished making.
+        while not self._stop.wait(self.poll):
+            self.tick()
+
+    def start(self) -> None:
+        """Begin watching. A daemon thread, so a launcher that exits without stopping it
+        cannot hang the process on the way out."""
+        self._thread = threading.Thread(target=self._loop, name="charter-record",
+                                        daemon=True)
+        self._thread.start()
+
+    def stop(self) -> None:
+        """Stop watching, and wait for the loop to notice.
+
+        Joined rather than abandoned: the caller is about to reap the very directories the
+        loop reads (`cmd_launch`'s closing `state.reap`), and a thread still inside `tick`
+        would be recording a plane that is being deleted. Bounded, because a write stuck on
+        a wedged filesystem must not stand between an operator and their shell.
+        """
+        self._stop.set()
+        if self._thread is not None:
+            self._thread.join(timeout=max(self.poll * 4, 1.0))
+
+    def alive(self) -> bool:
+        """Whether the watch is still running — asked of the thread rather than of a flag,
+        so :meth:`stop` failing to join would be visible instead of asserted away."""
+        return self._thread is not None and self._thread.is_alive()
+
+
+#: The one recorder this process may have, and the reason it is a module-level singleton
+#: rather than a value passed down: the automatic restore reaches `cmd_reopen` from inside
+#: `cmd_launch`, and both of those attach — so the same process would otherwise start two
+#: loops racing one manifest, which is the exact failure keeping panels out of this avoids,
+#: reached from inside instead of from six processes.
+_RUNNING: Recorder | None = None
+
+
+def running() -> Recorder | None:
+    """This process's recorder, or ``None``."""
+    return _RUNNING
+
+
+def start(write, **kw) -> Recorder | None:
+    """Start recording, or ``None`` when this process is already doing it.
+
+    The answer is what tells a caller whether it owns the :func:`stop` — a nested caller
+    gets ``None`` and leaves the outer one to end it, which is what makes a restore inside
+    a launch safe.
+    """
+    global _RUNNING
+    if _RUNNING is not None:
+        return None
+    r = Recorder(write, **kw)
+    _RUNNING = r
+    r.start()
+    return r
+
+
+def stop() -> None:
+    """Stop this process's recorder. Safe to call when there is none."""
+    global _RUNNING
+    r, _RUNNING = _RUNNING, None
+    if r is not None:
+        r.stop()
+
+
+@contextlib.contextmanager
+def recording(write, **kw):
+    """Record the plane for the duration. A no-op when this process already is.
+
+    The nesting is not hypothetical: bare `charter` restores through `cmd_reopen`, which
+    attaches and therefore wants a recorder of its own, from inside a `cmd_launch` that has
+    already started one. Only the caller that actually started it stops it — otherwise the
+    inner one would end the outer one's watch on its way out and the frame would be
+    unrecorded from then on.
+    """
+    started = start(write, **kw)
+    try:
+        yield started
+    finally:
+        if started is not None:
+            stop()
+
+
+def focus_on(chat: str) -> None:
+    """Tell the recorder which chat this terminal is on. A no-op when nothing is
+    recording, so a caller never has to ask first."""
+    if _RUNNING is not None:
+        _RUNNING.chat = chat

--- a/charter/frame/reopen.py
+++ b/charter/frame/reopen.py
@@ -38,6 +38,7 @@ from __future__ import annotations
 
 import json
 import os
+import tempfile
 import time
 from pathlib import Path
 from typing import NamedTuple
@@ -208,6 +209,21 @@ def write(frames, *, focus: str, at: int | None = None) -> bool:
     `Path.write_text`, because `os.replace` carries the SOURCE's mode onto the target
     (#582) and this is a state path.
 
+    **The temp file's NAME is `tempfile.mkstemp`'s and not this module's, and #845 is why.**
+    ``os.replace`` is atomic; the file it renames is not. While there was one temp name,
+    two writers wrote into the same bytes and the first to rename put the SECOND writer's
+    content in place — reporting, to the first, that its own record had landed. That was
+    already reachable (a quit races another quit; `_forget_transcript` races either), and
+    #845 makes it ordinary: the frame process now records on a debounce, from a thread, in
+    the same process as `cmd_reopen`'s own `_consume`. `mkstemp` is unique across processes
+    and threads by construction, which is a property to borrow rather than to re-derive out
+    of a pid and a counter — and it creates at 0600, which is the mode a state path wants
+    and the one `os.replace` will carry.
+
+    **Removed when the rename does not happen**, because a name nothing can predict is a
+    name nothing can collect: `prune_transcripts` is the only sweep the frame root has and
+    it touches nothing but `*.transcript`, so a temp left behind would stay for good.
+
     ``False`` for every way it can fail to land — no frame root, a filesystem that refuses
     the write, a value `json` cannot serialise. One answer, because the caller does the same
     thing with each: tell the operator the plane was not recorded, and let them decide
@@ -225,11 +241,20 @@ def write(frames, *, focus: str, at: int | None = None) -> bool:
         "frames": [{"workspace": f.workspace,
                     "chats": [c._asdict() for c in f.chats]} for f in frames],
     }
-    tmp = root / f"{MANIFEST}.tmp"
+    try:
+        fd, name = tempfile.mkstemp(dir=root, prefix=f"{MANIFEST}.", suffix=".tmp")
+        os.close(fd)
+    except OSError:
+        return False
+    tmp = Path(name)
     try:
         config.write_for(tmp, json.dumps(payload, indent=2, sort_keys=True) + "\n")
         os.replace(tmp, root / MANIFEST)
     except (OSError, TypeError, ValueError):
+        try:
+            tmp.unlink(missing_ok=True)
+        except OSError:
+            pass
         return False
     return True
 

--- a/charter/instance.py
+++ b/charter/instance.py
@@ -1712,6 +1712,28 @@ FRAME_FIELDS = {
     "warn": ("yellow", "warn"),
     "bad": ("red", "bad"),
     "hotkey": ("F2", "hotkey"),
+    #: Whether the frame process writes the plane down as it changes (#845), so that a
+    #: machine that went down has a record to be put back from. On, because the alternative
+    #: is that everything between the last quit and a crash is gone — and the record is one
+    #: small file written on a debounce, which is the cheapest half of this pair.
+    #:
+    #: One word, so `docs/frame.md`'s hyphen rule (`history-limit`, not `history_limit`)
+    #: does not arise. Never `save`: `charter save` commits and pushes a tree, and a key
+    #: called `save` under `[frame]` would make every message about either one ambiguous.
+    #: `reopen.write` and 0.55.0's own news entry already say *record*.
+    "record": (True, "record"),
+    #: Whether bare `charter` puts the recorded plane back rather than opening one chat
+    #: (#845). **Its own key rather than a second reading of `record`, because the two are
+    #: separable and the asymmetry is real**: recording costs a little I/O and changes
+    #: nothing an operator sees, while restoring changes what happens when they type
+    #: `charter`. Somebody may reasonably want the plane recorded — so `charter reopen` has
+    #: something to act on when they ASK — without `charter` alone resurrecting yesterday's
+    #: six chats. One key makes that position unreachable.
+    #:
+    #: On, because a plane recorded and never offered back is a feature nobody would find:
+    #: `charter reopen` is a command an operator has to already know about, and #845 is a
+    #: request for the plane to come back without being asked.
+    "restore": (True, "restore"),
     "history_limit": (50000, "history-limit"),
     "min_cols": (100, "min-cols"),
     "min_rows": (20, "min-rows"),

--- a/docs/frame.md
+++ b/docs/frame.md
@@ -813,6 +813,11 @@ builds a frame there as a window on your own server and that launcher stays awak
 life of each frame — so reopening several chats would stop at the first. It says so and
 leaves the record alone.
 
+**It refuses a plane that is already running, too.** The record describes the plane as it is
+now (see below), so reopening a live one would put a second copy of every chat beside the
+first, with a new id each so nothing on screen tells them apart. Attach to what is there
+(`tmux -L charter attach`) or quit it first. The record is left alone either way.
+
 ### The plane is recorded as it changes, and `charter` puts it back
 
 A quit is no longer the only moment the plane is written down. The process holding your

--- a/docs/frame.md
+++ b/docs/frame.md
@@ -839,13 +839,18 @@ so every per-chat rule above holds. What differs is what it says:
 ```
 
 one line, because you typed `charter` and wanted a terminal. If part of the plane could not
-come back, the line says how much and leaves exactly those chats recorded, so `charter
-reopen` is both the explanation and the retry:
+come back, the same line names the rest:
 
 ```
-✓ charter: restored 3 of the 4 chats this plane last recorded — the rest are still
-  recorded; `charter reopen` says which could not come back, and retries them
+✓ charter: restored 3 of the 4 chats this plane last recorded — beta.1 did not come back
 ```
+
+It does not offer `charter reopen` as a retry, and that is a limit worth knowing rather
+than a wording choice: the chats that could not be started *are* left in the record — but
+the process that just restored your plane is also recording it, so a couple of seconds
+later the record is the plane that is running and those leftovers are gone. Open what is
+missing yourself (`charter -w <workspace>`), or quit and use `charter reopen` while nothing
+is running, which is the state that command is for.
 
 **Two keys, both on**, because recording and restoring are separable: recording costs a
 little I/O and changes nothing you see, restoring changes what `charter` does. A plane can

--- a/docs/frame.md
+++ b/docs/frame.md
@@ -813,6 +813,56 @@ builds a frame there as a window on your own server and that launcher stays awak
 life of each frame — so reopening several chats would stop at the first. It says so and
 leaves the record alone.
 
+### The plane is recorded as it changes, and `charter` puts it back
+
+A quit is no longer the only moment the plane is written down. The process holding your
+terminal — the launcher that attached, or `charter reopen` itself — watches the same version
+bumps every panel already polls, and writes the record about two seconds after the plane
+stops changing. So a machine that goes down, a terminal that is killed, or a laptop that
+never comes back leaves a record of the chats you had, not a record of the last time you
+quit.
+
+It writes exactly what a quit writes: which chats existed, in which workspace, with which
+harness, persona and directory, and which one was on screen. It does **not** capture
+scrollback — that is one `capture-pane` per chat and it is what a quit is for — but it does
+name a capture a quit already left behind, so a record taken while you are working never
+withdraws an offer a quit made.
+
+**Bare `charter` restores it, and only when there is nothing to join.** If any chat is
+running anywhere on this plane, `charter` behaves exactly as it always did: it focuses the
+workspace you are in, or opens a chat. The restore happens on the launch that finds nothing
+running at all — the one after a restart — and it is the same `charter reopen` underneath,
+so every per-chat rule above holds. What differs is what it says:
+
+```
+✓ charter: restored the 4 chat(s) this plane last recorded
+```
+
+one line, because you typed `charter` and wanted a terminal. If part of the plane could not
+come back, the line says how much and leaves exactly those chats recorded, so `charter
+reopen` is both the explanation and the retry:
+
+```
+✓ charter: restored 3 of the 4 chats this plane last recorded — the rest are still
+  recorded; `charter reopen` says which could not come back, and retries them
+```
+
+**Two keys, both on**, because recording and restoring are separable: recording costs a
+little I/O and changes nothing you see, restoring changes what `charter` does. A plane can
+keep the record and still leave putting it back to you.
+
+```toml
+[frame]
+record  = true   # write the plane down as it changes
+restore = true   # bare `charter` puts it back when nothing is running
+```
+
+**`charter --fresh` opts one run out of both halves.** It does not restore, *and* it does
+not record over the record it skipped — so an experiment, a one-off chat, or a plane you
+want to walk away from costs you nothing you had. `charter claude --fresh` says the same
+thing about a named harness. The record is still there for `charter reopen` when you want
+it.
+
 **Resume is Claude Code only, and the warning says so per chat.** Charter records a harness's
 own session id from Claude Code's status-line hook, which is the only harness that supplies
 one — so it is the only harness whose conversation charter can ask for back. A chat that
@@ -1176,6 +1226,8 @@ density = "full"
 mouse = false
 chrome = "off"
 hotkey = "F2"
+record = true
+restore = true
 history-limit = 50000
 min-cols = 100
 min-rows = 20
@@ -2141,7 +2193,7 @@ whole number of cells on the repo table).
 Precedence, most explicit first: `[[frame.component]]`, then an explicit `slots`, then
 `density`, then the shipped default.
 
-`slots`/`density`/`mouse`/`chrome`/`hotkey` are spelled the same on both sides. `history-limit`,
+`slots`/`density`/`mouse`/`chrome`/`hotkey`/`record`/`restore` are spelled the same on both sides. `history-limit`,
 `min-cols` and `min-rows` are the three that are not: charter.toml spells them with a
 hyphen: the
 resolved settings charter's own code reads back use an underscore

--- a/docs/news/unreleased-charter-records-the-plane-as-it-changes.md
+++ b/docs/news/unreleased-charter-records-the-plane-as-it-changes.md
@@ -1,0 +1,131 @@
+---
+version: unreleased
+headline: the plane is recorded as it changes, not only when you quit — and bare `charter` puts it back
+---
+
+*"We need auto-save. Now it only saves state when exiting charter from the F2 menu, and only
+restores when running `reopen`. Make this configurable — and by default always save state
+and always restore automatically when running just `charter`."*
+
+The plane was written down at exactly one moment: `F2 → charter: quit`. Everything between
+that moment and a crash, a killed terminal or a laptop that never comes back was gone, and
+the way back was a command (`charter reopen`) you had to already know about.
+
+It is written down as it changes now, and bare `charter` puts it back.
+
+```
+$ charter                      # after a restart, nothing running
+✓ charter: restored the 4 chat(s) this plane last recorded
+```
+
+## The word is *record*, and that is not a style choice
+
+`charter save` commits and pushes a tree. This writes one local file. If both were called
+"save", every message about either would be ambiguous about which one did not happen — and
+the vocabulary already existed: `reopen.write` is what writes it, and 0.55.0's own entry
+says *"quitting charter records the plane"*.
+
+## When it writes: debounced on the bumps that were already there
+
+`state.bump` is charter's own "something changed" — every writer in the frame moves it and
+every panel already polls it. Reusing it means there is no second notion of change to keep
+in step with the first.
+
+**Not on every bump.** `cmd_launch` bumps immediately after it claims a chat id and before
+tmux has made the window, so a record taken there names a chat that has no window and no
+harness — a plane that never existed. **Not on a timer** either: a tick can land in that same
+window, and it spends work on a plane that did nothing, which is most of the time. The
+record is taken when the plane has been still for two seconds, which is the consistency a
+quit got for free by stopping the world first.
+
+## Who writes: the frame process, and it cost a watch it did not have
+
+Panels are separate processes. Six of them notice one bump, so "record where the bump was
+noticed" is six processes racing one file — and a designated panel is worse, because it
+stops recording the moment that panel dies, which is exactly when the record matters.
+
+So the writer is the process holding your terminal: the launcher that attached, and
+`charter reopen`'s own attach. **That process did not watch bumps before this** — only
+panels did (`frame/panel.py`) — so it gains a poll it never carried, one `stat`-sized read
+per chat twice a second on a thread. That cost is paid rather than avoided by moving the
+writer somewhere cheaper, and there is nothing cheaper available: a bump is a file written
+by another process and the standard library has no file-change notification to subscribe to,
+which is why the panels poll too.
+
+## How it writes: atomically, and now with a temp file of its own
+
+`reopen.write` already wrote a temp file and renamed it, so a crash mid-write leaves the
+previous record whole rather than a truncated one. At a hundred times the write rate that
+matters more, and it exposed a second half that was missing: **`os.replace` is atomic, the
+file it renames is not.** Two writers sharing one temp NAME wrote into the same bytes, and
+the first to rename put the *second* writer's content in place while reporting to the first
+that its own record had landed. The temp file is `tempfile.mkstemp`'s now — unique across
+processes and threads by construction — and it is removed when the rename does not happen,
+because a name nothing can predict is a name nothing can collect.
+
+## What it records: what a quit records, and not one field more
+
+Which chats existed, in which workspace, with which harness, persona and directory, and
+which one was on screen. **Not panel view state** — a wrong selected row or scroll offset
+fails silently and looks like a working frame, and every field added is a field that can be
+stale or unrestorable.
+
+It does not capture scrollback either: that is one `capture-pane` per chat per write, for
+the one restore item that is *offered and never replayed*. What it does do is name a capture
+a quit already left on disk, so a record taken while you are working never withdraws an
+offer a quit made.
+
+## What the restore says: one line, and never silence
+
+`charter reopen` is a deliberate act, so its per-chat report is read and is unchanged. The
+automatic restore happens because you typed `charter` and wanted a terminal, so it is one
+line. When part of the plane cannot come back, that line says how much and where the rest of
+the answer is — the chats still owed stay in the record, so `charter reopen` is both the
+explanation and the retry:
+
+```
+✓ charter: restored 3 of the 4 chats this plane last recorded — the rest are still
+  recorded; `charter reopen` says which could not come back, and retries them
+```
+
+Silence was never an option — that is a frame quietly drawing less than it should — and
+neither was refusing the whole restore because one chat could not start, which makes one
+dead workspace cost the other five.
+
+**It fires only when there is nothing to join.** With the record now current rather than a
+relic of the last quit, a second terminal typing `charter` on a running plane would
+otherwise reopen every chat it can already see, and a reopened chat gets a fresh ordinal, so
+nothing on screen would tell the duplicates from the originals. If anything is running
+anywhere on this plane, `charter` focuses or opens exactly as it always did.
+
+## Two keys, not one
+
+```toml
+[frame]
+record  = true
+restore = true
+```
+
+They are separable and the asymmetry is real: recording costs a little I/O and changes
+nothing you see, restoring changes what happens when you type `charter`. Somebody may
+reasonably want the plane recorded — so `charter reopen` has something to act on when they
+ask — without `charter` alone resurrecting yesterday's six chats. One key makes that
+position unreachable. Both ship on.
+
+## `charter --fresh` does not participate, in both directions
+
+Once restore is automatic, a plane you wanted to abandon comes back every time, and the only
+escape would be deleting a file you have to know about first. `--fresh` is that escape: no
+restore, **and no recording over the record it skipped**. Skipping only the restore is not a
+smaller version of this — it is destructive, because the same run would overwrite the
+skipped record two seconds later and nothing would say so until you asked for the plane back
+and got the wrong one. `charter claude --fresh` says the same thing about a named harness.
+
+## One sentence changed its words
+
+The line the launcher prints when it hands your shell back said *"this plane was quit"*. It
+was gated on the record naming the chat that had just ended, and while a quit was the only
+writer that reading WAS a quit. It is not any more, so the sentence says what is still true
+and still actionable — the plane is recorded, and one command puts it back — and it is now
+also gated on the chat actually being over, so a detach from a live harness is not told its
+plane is finished one line above "detached — the harness is still running".

--- a/docs/news/unreleased-charter-records-the-plane-as-it-changes.md
+++ b/docs/news/unreleased-charter-records-the-plane-as-it-changes.md
@@ -79,14 +79,19 @@ offer a quit made.
 
 `charter reopen` is a deliberate act, so its per-chat report is read and is unchanged. The
 automatic restore happens because you typed `charter` and wanted a terminal, so it is one
-line. When part of the plane cannot come back, that line says how much and where the rest of
-the answer is — the chats still owed stay in the record, so `charter reopen` is both the
-explanation and the retry:
+line — and when part of the plane cannot come back, the rest is named on that same line:
 
 ```
-✓ charter: restored 3 of the 4 chats this plane last recorded — the rest are still
-  recorded; `charter reopen` says which could not come back, and retries them
+✓ charter: restored 3 of the 4 chats this plane last recorded — beta.1 did not come back
 ```
+
+**It deliberately does not offer `charter reopen` as a retry.** `_consume` does leave
+exactly the chats still owed in the record, exactly as before — but this process is now
+recording as well, so about two seconds later the record is the plane that is running and
+the leftovers are gone. An operator who has just been attached to the frame this restore
+built cannot type anything in that window, so a line pointing there would point at
+something that is no longer there by the time it is read. The names are what the line can
+carry truthfully.
 
 Silence was never an option — that is a frame quietly drawing less than it should — and
 neither was refusing the whole restore because one chat could not start, which makes one
@@ -120,6 +125,17 @@ restore, **and no recording over the record it skipped**. Skipping only the rest
 smaller version of this — it is destructive, because the same run would overwrite the
 skipped record two seconds later and nothing would say so until you asked for the plane back
 and got the wrong one. `charter claude --fresh` says the same thing about a named harness.
+
+## One limit this creates, stated rather than discovered
+
+**`charter reopen` typed while the plane is running will now double it.** The record used to
+exist only after a quit, so there was never a live plane for it to describe; it is current
+now, and that command has no liveness gate of its own — bare `charter` has one, which is why
+the automatic restore cannot do this. Quit first, or attach (`tmux -L charter attach`),
+which is what you wanted in that situation anyway. A gate on `charter reopen` itself is a
+follow-up: it means a `list-windows` on charter's socket from that command's entry path, and
+every existing reopen test would read whatever tmux the developer running the suite happens
+to have — which is the shape `tests/_planeguard.py` exists to refuse.
 
 ## One sentence changed its words
 

--- a/docs/news/unreleased-charter-records-the-plane-as-it-changes.md
+++ b/docs/news/unreleased-charter-records-the-plane-as-it-changes.md
@@ -126,16 +126,26 @@ smaller version of this — it is destructive, because the same run would overwr
 skipped record two seconds later and nothing would say so until you asked for the plane back
 and got the wrong one. `charter claude --fresh` says the same thing about a named harness.
 
-## One limit this creates, stated rather than discovered
+## `charter reopen` now refuses a plane that is already running
 
-**`charter reopen` typed while the plane is running will now double it.** The record used to
-exist only after a quit, so there was never a live plane for it to describe; it is current
-now, and that command has no liveness gate of its own — bare `charter` has one, which is why
-the automatic restore cannot do this. Quit first, or attach (`tmux -L charter attach`),
-which is what you wanted in that situation anyway. A gate on `charter reopen` itself is a
-follow-up: it means a `list-windows` on charter's socket from that command's entry path, and
-every existing reopen test would read whatever tmux the developer running the suite happens
-to have — which is the shape `tests/_planeguard.py` exists to refuse.
+This is a footgun the feature creates, closed where it is created. The record used to exist
+only after a quit, so `charter reopen` never had a live plane to describe. Now it does — so
+typing it out of habit after closing a terminal (which only *detaches*) would put a second
+copy of every running chat on the plane, each with a fresh ordinal so nothing on screen
+tells the copies apart, and for Claude Code both copies resuming one conversation.
+
+```
+✗ charter reopen: this plane is already running — reopening it would open a second copy
+  of every chat, and a reopened chat gets a new id, so nothing on screen would tell the
+  copies apart. Attach to what is there (`tmux -L charter attach`), or quit it first
+  (`F2 → charter: quit`). Nothing was reopened, and the record is left in place.
+```
+
+It is the same rule bare `charter`'s restore already follows, read a second time rather than
+a second rule — and it asks the disk before it asks tmux, because a live chat always has a
+directory (`state.new_chat_id` claims its ordinal with the `mkdir`). A server that will not
+answer reads as *nothing live*, which is the opposite of what a quit assumes and is right
+for the opposite reason: a reopen is wanted precisely when there is no server at all.
 
 ## One sentence changed its words
 

--- a/tests/test_a_chat_records_where_it_was_started.py
+++ b/tests/test_a_chat_records_where_it_was_started.py
@@ -181,9 +181,11 @@ class TheLauncherSTailIsWhereAReopenDiffers(PersonaIso, unittest.TestCase):
     which is exactly what the mutations were about.
     """
 
-    def _launch(self, *, reopening=None, live_workspace=False, rest=()):
+    def _launch(self, *, reopening=None, live_workspace=False, rest=(), fresh=False,
+                still_live=True):
         """Run `cmd_launch` to its return. Answers what it asked, and records the calls."""
         calls = {"attached": False, "focused": False, "said": []}
+        asked: list[int] = []
 
         def _interact(argv, **kw):
             calls["attached"] = True
@@ -194,7 +196,7 @@ class TheLauncherSTailIsWhereAReopenDiffers(PersonaIso, unittest.TestCase):
             return None            # never actually focus; the call is the observation
 
         args = SimpleNamespace(harness="claude", rest=list(rest), no_frame=False,
-                               workspace="alpha", pick=False)
+                               workspace="alpha", pick=False, fresh=fresh)
         if reopening is not None:
             args.reopening = reopening
         sessions = {"alpha"} if live_workspace else set()
@@ -207,7 +209,15 @@ class TheLauncherSTailIsWhereAReopenDiffers(PersonaIso, unittest.TestCase):
             chat it had just built (`state.clear_claim` has already run by then, so nothing
             else is holding it). That is correct behaviour against a server with nothing on
             it, and it is not the server this test means.
+
+            *still_live* is what tells the two asks apart, and a quit is why it exists: the
+            launcher asks once on the way IN and once on the way OUT, and a plane that was
+            quit while this client was attached answers the second one with nothing. Without
+            it, no case here can reach the launcher's own "this chat is over" tail.
             """
+            asked.append(1)
+            if not still_live and len(asked) > 1:
+                return set()
             try:
                 return {d.name for d in state._root().iterdir() if d.is_dir()}
             except OSError:
@@ -307,9 +317,19 @@ class TheLauncherSTailIsWhereAReopenDiffers(PersonaIso, unittest.TestCase):
         self.assertNotIn("detached", buf.getvalue())
 
     def test_a_launch_whose_plane_was_quit_names_the_command_that_undoes_it(self):
-        # `if _wants_attach(args): _say_it_was_quit(fid)`. The chat this launch is about has
+        # `if _wants_attach(args): _say_the_plane_is_recorded(fid, over=…)`. The chat this launch is about has
         # to BE in the manifest, which for an ordinary launch means the ordinal it is handed
         # is one a quit recorded — the recycled-ordinal case, which is the common one.
+        #
+        # **`fresh=True`, and #845 is why the premise had to be said out loud.** Bare
+        # `charter` on a plane with nothing live now RESTORES the record instead of opening
+        # a chat, so a launch that reaches this tail on a recorded plane is exactly a launch
+        # that opted out — which is what `--fresh` is. Without the flag this case tested the
+        # restore, and the notice it is about never ran.
+        #
+        # **`still_live=False` for the other half of the same change.** The record now names
+        # running chats too, so the notice is gated on this chat being over — which is what
+        # a quit makes true and an ordinary detach does not.
         import io
         from contextlib import redirect_stderr
         reopen.write([reopen.Frame(workspace="alpha", chats=(
@@ -319,7 +339,7 @@ class TheLauncherSTailIsWhereAReopenDiffers(PersonaIso, unittest.TestCase):
         buf = io.StringIO()
 
         with redirect_stderr(buf):
-            self._launch()
+            self._launch(fresh=True, still_live=False)
 
         self.assertIn("charter reopen", buf.getvalue())
 

--- a/tests/test_a_quit_records_the_plane_before_it_kills.py
+++ b/tests/test_a_quit_records_the_plane_before_it_kills.py
@@ -384,7 +384,7 @@ class TheQuitsOwnSentenceIsSaidByTheLauncher(PersonaIso, unittest.TestCase):
         from contextlib import redirect_stderr
         buf = io.StringIO()
         with redirect_stderr(buf):
-            commands_frame._say_it_was_quit(fid)
+            commands_frame._say_the_plane_is_recorded(fid)
         return buf.getvalue()
 
     def test_a_launcher_whose_chat_was_quit_names_the_command_that_undoes_it(self):

--- a/tests/test_charter_records_the_plane_as_it_changes.py
+++ b/tests/test_charter_records_the_plane_as_it_changes.py
@@ -552,7 +552,16 @@ class WhoRecordsAndWhoDoesNot(unittest.TestCase):
     The gate is asked as a predicate rather than discovered inside the launcher, because
     every one of these five is a way of NOT being the operator's terminal, and a guard that
     passes only because a different guard caught the case is one this repository deletes.
+
+    **`config.FRAME` is stated rather than inherited**, which is this suite's own recurring
+    defect (#459): these cases are not `PersonaIso`, so the ambient value is whatever plane
+    the suite happens to be running inside, and a machine that had written `record = false`
+    would turn every "it records" case here red for a reason that is about a config file.
     """
+
+    def setUp(self) -> None:
+        self.enterContext(mock.patch.dict(config.FRAME,
+                                          {"record": True, "restore": True}))
 
     def test_a_launch_that_is_the_terminal_records(self):
         with mock.patch("sys.stdout.isatty", return_value=True):
@@ -600,7 +609,14 @@ class WhoRecordsAndWhoDoesNot(unittest.TestCase):
 
 
 class WhenBareCharterPutsThePlaneBack(unittest.TestCase):
-    """`commands_frame._restores_the_plane` — and the one case it must never fire in."""
+    """`commands_frame._restores_the_plane` — and the one case it must never fire in.
+
+    `config.FRAME` stated rather than inherited, for the class above's reason.
+    """
+
+    def setUp(self) -> None:
+        self.enterContext(mock.patch.dict(config.FRAME,
+                                          {"record": True, "restore": True}))
 
     def test_a_bare_launch_that_is_the_terminal_restores(self):
         self.assertTrue(commands_frame._restores_the_plane(_launch_args()))

--- a/tests/test_charter_records_the_plane_as_it_changes.py
+++ b/tests/test_charter_records_the_plane_as_it_changes.py
@@ -490,6 +490,14 @@ class WhatARunningPlaneRecordsIsWhatAQuitRecords(PersonaIso, unittest.TestCase):
 
         self.assertEqual(reopen.read().all_chats()[0].transcript, "")
 
+    def test_a_plane_with_no_chats_at_all_asks_no_server_anything(self):
+        """This runs on a poll. A `list-windows` spent to be told the plane is empty is the
+        cheapest call not to make — and a recorder that outlived its frame would otherwise
+        go on asking a tmux server about a plane that is not there."""
+        with mock.patch.object(commands_frame, "_chat_seats") as seats:
+            self.assertFalse(commands_frame.record_the_plane_now("alpha.1"))
+        seats.assert_not_called()
+
     def test_a_plane_with_nothing_live_is_not_recorded_over(self):
         """The last thing a plane that has just been quit needs is its record replaced by
         an empty one. Nothing live is nothing to record, and the previous record stands."""

--- a/tests/test_charter_records_the_plane_as_it_changes.py
+++ b/tests/test_charter_records_the_plane_as_it_changes.py
@@ -754,8 +754,8 @@ class WhatAnAutomaticRestoreSays(PersonaIso, unittest.TestCase):
         self.assertIn("charter: restored the 2 chat(s) this plane last recorded", out)
         self.assertEqual(len(out.strip().splitlines()), 1)
 
-    def test_a_plane_that_came_back_short_says_how_short_and_where_to_look(self):
-        """Not silence, and not a wall: the count, and the command that names which."""
+    def test_a_plane_that_came_back_short_names_the_rest_on_the_same_line(self):
+        """Not silence, and not a wall: the count and the names, on one line."""
         self._record(self._chat(chat="alpha.1", workspace="alpha"),
                      self._chat(chat="beta.1", workspace="beta"))
         self.fail_for = {"beta"}
@@ -763,14 +763,24 @@ class WhatAnAutomaticRestoreSays(PersonaIso, unittest.TestCase):
         rc, out = self._reopen(quiet=True)
 
         self.assertEqual(rc, 0)
-        self.assertIn("charter: restored 1 of the 2 chats this plane last recorded — the "
-                      "rest are still recorded; `charter reopen` says which could not come "
-                      "back, and retries them", out)
+        self.assertIn("charter: restored 1 of the 2 chats this plane last recorded — "
+                      "beta.1 did not come back", out)
+        self.assertEqual(len(out.strip().splitlines()), 1)
 
-    def test_the_chats_that_did_not_come_back_are_still_recorded_to_retry(self):
-        """What makes "detail on demand" a real offer rather than a form of words:
-        `_consume` leaves exactly the chats still owed, so the command the line names both
-        explains and retries."""
+    def test_a_long_list_of_missing_chats_is_still_one_short_line(self):
+        """A compact line stays compact on a plane that lost six workspaces."""
+        self._record(self._chat(chat="alpha.1", workspace="alpha"),
+                     *[self._chat(chat=f"w{i}.1", workspace=f"w{i}") for i in range(5)])
+        self.fail_for = {f"w{i}" for i in range(5)}
+
+        _rc, out = self._reopen(quiet=True)
+
+        self.assertIn("w0.1, w1.1, w2.1 and 2 more did not come back", out)
+
+    def test_the_chats_that_did_not_come_back_are_still_recorded(self):
+        """`_consume`'s own contract, unchanged: what is left behind is the retry. What the
+        line no longer does is POINT at it — this process is recording too, so the record is
+        the running plane again a couple of seconds later."""
         self._record(self._chat(chat="alpha.1", workspace="alpha"),
                      self._chat(chat="beta.1", workspace="beta"))
         self.fail_for = {"beta"}

--- a/tests/test_charter_records_the_plane_as_it_changes.py
+++ b/tests/test_charter_records_the_plane_as_it_changes.py
@@ -1,0 +1,1055 @@
+"""#845: the plane is recorded as it changes, and put back when you type `charter`.
+
+**The word is RECORD.** `charter save` commits and pushes a tree; `reopen.write` writes a
+file. 0.55.0's own news entry says *"quitting charter records the plane"*, so that is the
+vocabulary this uses — a refusal that said "save" would be ambiguous about which of the two
+did not happen.
+
+Four claims, and each one is a decision that could have gone the other way.
+
+**1. The write is debounced on the bumps that already exist.** `state.bump` is charter's
+own "something changed" signal and every writer in the frame already moves it, so there is
+no second notion of change to keep in step. Writing on every bump would record planes that
+never existed — `cmd_launch` bumps after `new_chat_id` and before the window is made, so a
+record taken there names a chat with no window — and a periodic timer would do the same
+while also spending work on a plane that did nothing. `Debounce` is that arithmetic on its
+own, with no clock and no thread under it.
+
+**2. The frame process is the sole writer, and it has to POLL to be one.** Panels are
+separate processes and six of them notice one bump, so "record where the bump was noticed"
+is six processes racing one file. A designated panel is worse — it stops recording when
+that panel dies, which is when the record matters most. **The cost this pays is real and is
+stated rather than hidden: the frame process does not watch bumps today, only panels do
+(`panel._watch`), so this adds a watch to it.** There is no cheaper mechanism available: a
+bump is a file written by another process and the standard library has no file-change
+notification, which is why `panel._watch` polls too.
+
+**3. What it records is what the manifest records today**, and the transcript field is the
+one that needs saying: a continuous record does not `capture-pane` (that is one subprocess
+per chat per write), so it names the capture a QUIT left on disk and never invents one.
+
+**4. `--fresh` does not participate**, in both directions. Skipping the restore alone would
+leave the recorder overwriting the record it declined to act on, on a two-second timer, and
+the loss would be invisible until the operator asked for the plane back.
+
+**`PersonaIso` on every case that touches a path, and every case asserts the state
+directory it is about to write is a throwaway one.** This issue is about writing plane
+state, so the hazard `tests/_planeguard.py` exists for is at its sharpest here.
+"""
+
+from __future__ import annotations
+
+import io
+import subprocess
+import threading
+import unittest
+from contextlib import redirect_stderr
+from types import SimpleNamespace
+from unittest import mock
+
+from charter import cli, commands_frame, config, instance
+from charter.frame import record, reopen, state
+
+from tests._isolation import PersonaIso
+
+
+def _completed(rc=0, out=""):
+    return subprocess.CompletedProcess(["tmux"], rc, stdout=out, stderr="")
+
+
+class TheDebounceIsOneWritePerQuietPeriod(unittest.TestCase):
+    """`record.Debounce` — the whole of "when it writes", with no clock and no thread.
+
+    Pure arithmetic over (what was seen, when it changed, what was written), so the
+    decision can be asserted at exact times rather than by sleeping.
+    """
+
+    def test_a_change_is_not_written_until_the_plane_has_been_quiet(self):
+        d = record.Debounce(quiet=2.0)
+        d.saw(("a", "1"), now=10.0)
+        self.assertFalse(d.due(now=11.9))
+        self.assertTrue(d.due(now=12.0))
+
+    def test_a_second_change_inside_the_window_moves_the_deadline(self):
+        """The half that makes this a debounce rather than a delay. A launch bumps several
+        times in a row; the record is taken once, after the last of them."""
+        d = record.Debounce(quiet=2.0)
+        d.saw(("a", "1"), now=10.0)
+        d.saw(("a", "2"), now=11.0)
+        self.assertFalse(d.due(now=12.0))
+        self.assertTrue(d.due(now=13.0))
+
+    def test_a_plane_that_has_not_changed_is_not_written_again(self):
+        d = record.Debounce(quiet=2.0)
+        d.saw(("a", "1"), now=10.0)
+        self.assertTrue(d.due(now=12.0))
+        d.wrote()
+        self.assertFalse(d.due(now=99.0))
+
+    def test_the_first_reading_of_a_plane_is_itself_a_change(self):
+        """A plane that came back from `charter reopen` and then sat still has had no bump
+        since — and `_consume` deleted the manifest that put it there. Without this it
+        would be recorded nowhere at all until something happened to move it."""
+        d = record.Debounce(quiet=2.0)
+        d.saw((("a", "1"),), now=0.0)
+        self.assertTrue(d.due(now=2.0))
+
+    def test_a_plane_that_goes_empty_is_a_change_like_any_other(self):
+        """The chats went away — that is a fact about the plane, not an absence of one."""
+        d = record.Debounce(quiet=2.0)
+        d.saw((("a", "1"),), now=0.0)
+        d.wrote()
+        d.saw((), now=5.0)
+        self.assertTrue(d.due(now=7.0))
+
+
+class TheFingerprintIsTheBumpsThatAlreadyExist(PersonaIso, unittest.TestCase):
+    """`record.fingerprint` — every chat on the plane and the version it is at.
+
+    Read through `state.version`, which is what a panel polls, so there is one answer to
+    "has this chat changed" rather than two that can drift.
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.assertIn("edm-test-", str(config.STATE_DIR))
+
+    def test_a_bump_changes_it(self):
+        state.frame_dir("alpha.1", create=True)
+        state.bump("alpha.1")
+        before = record.fingerprint()
+        state.bump("alpha.1")
+        self.assertNotEqual(record.fingerprint(), before)
+
+    def test_a_new_chat_changes_it(self):
+        state.frame_dir("alpha.1", create=True)
+        state.bump("alpha.1")
+        before = record.fingerprint()
+        state.frame_dir("alpha.2", create=True)
+        state.bump("alpha.2")
+        self.assertNotEqual(record.fingerprint(), before)
+
+    def test_a_chat_that_went_away_changes_it(self):
+        state.frame_dir("alpha.1", create=True)
+        state.bump("alpha.1")
+        state.frame_dir("alpha.2", create=True)
+        state.bump("alpha.2")
+        before = record.fingerprint()
+        state.reap(set(), server="charter")
+        self.assertNotEqual(record.fingerprint(), before)
+
+    def test_the_manifest_beside_the_chats_is_not_one_of_them(self):
+        """The frame root holds the record itself and the transcripts, and neither is a
+        chat — `leave.plane_chats`' own rule, and the reason writing the record cannot
+        make the fingerprint change and provoke another write."""
+        config.private_mkdir(state._root())
+        config.write_for(state._root() / "reopen.json", "{}\n")
+        config.write_for(state._root() / "alpha.1.transcript", "hi\n")
+        self.assertEqual(record.fingerprint(), ())
+
+    def test_a_plane_with_no_frame_root_at_all_answers_empty(self):
+        """A machine that has never launched a frame. A reader on a poll loop may not
+        raise for it — `state.version`'s own promise, one directory out."""
+        self.assertEqual(record.fingerprint(), ())
+
+
+class TheRecorderIsOneWriterPerProcess(unittest.TestCase):
+    """`record.Recorder` — the loop, and the singleton that stops it being two loops.
+
+    No filesystem: the reading and the writing are both injected, because what is under
+    test is when the loop calls out and with what, not what the call does.
+    """
+
+    def setUp(self) -> None:
+        self.addCleanup(record.stop)
+        self.wrote: list[str] = []
+
+    def _writer(self, ok: bool = True):
+        def write(chat: str) -> bool:
+            self.wrote.append(chat)
+            return ok
+        return write
+
+    def test_a_tick_writes_nothing_until_the_plane_has_been_quiet(self):
+        r = record.Recorder(self._writer(), read=lambda: (("a", "1"),), quiet=2.0)
+        r.tick(now=0.0)
+        self.assertEqual(self.wrote, [])
+        r.tick(now=2.0)
+        self.assertEqual(self.wrote, [""])
+
+    def test_the_write_is_told_which_chat_the_terminal_is_on(self):
+        """The `focus` a reopen attaches to comes from this. It is the launcher's OWN chat
+        rather than a session name off tmux: session names are shared by every plane on the
+        machine (§3.3), so reading the focus off one would be another plane answering for
+        this one."""
+        r = record.Recorder(self._writer(), read=lambda: (("a", "1"),), quiet=0.0)
+        r.chat = "alpha.2"
+        r.tick(now=0.0)
+        self.assertEqual(self.wrote, ["alpha.2"])
+
+    def test_a_plane_that_did_not_change_is_written_once(self):
+        r = record.Recorder(self._writer(), read=lambda: (("a", "1"),), quiet=0.0)
+        for now in (0.0, 1.0, 2.0, 3.0):
+            r.tick(now=now)
+        self.assertEqual(self.wrote, [""])
+
+    def test_a_write_that_did_not_land_is_not_retried_every_tick(self):
+        """A full filesystem must not turn a two-second debounce into a hot loop. The
+        reading was acted on; that it failed is `reopen.write`'s answer, not a reason to
+        ask it again about the same plane."""
+        r = record.Recorder(self._writer(ok=False), read=lambda: (("a", "1"),), quiet=0.0)
+        r.tick(now=0.0)
+        r.tick(now=1.0)
+        self.assertEqual(self.wrote, [""])
+
+    def test_a_reader_that_raises_does_not_take_the_loop_down(self):
+        """This runs on a thread inside the process holding the operator's terminal, so an
+        exception here is either a silently dead recorder or a traceback drawn over a
+        frame. `frame/state.py`'s promise, one module out."""
+        def boom():
+            raise OSError("gone")
+        r = record.Recorder(self._writer(), read=boom, quiet=0.0)
+        r.tick(now=0.0)
+        self.assertEqual(self.wrote, [])
+
+    def test_a_writer_that_raises_does_not_take_the_loop_down(self):
+        def boom(_chat):
+            raise OSError("gone")
+        r = record.Recorder(boom, read=lambda: (("a", "1"),), quiet=0.0)
+        r.tick(now=0.0)
+
+    def test_a_started_recorder_writes_and_a_stopped_one_has_really_stopped(self):
+        """The thread is asked, not a flag: a `stop` that set a bit and left the loop
+        running would be a recorder still writing into a plane the launcher is reaping."""
+        landed = threading.Event()
+
+        def write(_chat: str) -> bool:
+            landed.set()
+            return True
+
+        r = record.start(write, quiet=0.0, poll=0.001)
+        self.assertIsNotNone(r)
+        self.assertTrue(landed.wait(timeout=5), "the recorder never wrote")
+        record.stop()
+        self.assertFalse(r.alive())
+        self.assertIsNone(record.running())
+
+    def test_a_second_start_in_one_process_does_not_make_a_second_writer(self):
+        """The automatic restore reaches `cmd_reopen` from inside `cmd_launch`, and both
+        of them attach — so without this the one process would hold two loops racing one
+        manifest, which is the very thing keeping panels out of this buys."""
+        first = record.start(self._writer(), quiet=0.0, poll=0.001)
+        self.assertIsNotNone(first)
+        self.assertIsNone(record.start(self._writer(), quiet=0.0, poll=0.001))
+        self.assertIs(record.running(), first)
+
+    def test_a_recorder_that_never_started_stops_without_a_fuss(self):
+        """`record.stop` is the `finally` of every caller, so it has to be safe for a watch
+        that never began — a launch that refused before it got that far."""
+        r = record.Recorder(self._writer())
+        r.stop()
+        self.assertFalse(r.alive())
+
+    def test_focus_on_moves_the_chat_without_starting_anything(self):
+        record.focus_on("alpha.9")
+        self.assertIsNone(record.running())
+        r = record.start(self._writer(), quiet=0.0, poll=0.001)
+        record.focus_on("alpha.9")
+        self.assertEqual(r.chat, "alpha.9")
+
+
+class RecordingAndRestoringAreTwoKeys(unittest.TestCase):
+    """`[frame] record` and `[frame] restore`, both shipped on.
+
+    **Two keys and not one, because the two are separable and the asymmetry is real.**
+    Recording costs a little I/O and changes nothing an operator sees; restoring changes
+    what happens when they type `charter`. Somebody may reasonably want the plane recorded
+    — so `charter reopen` has something to act on when they ask for it — without `charter`
+    alone bringing back yesterday's six chats. One key makes that position unreachable.
+
+    Asked of `instance.frame_of` rather than of `config.FRAME`, which on a developer's
+    machine is the plane the suite is running inside (this suite's own recurring defect).
+    """
+
+    def test_both_are_on_for_a_plane_that_says_nothing(self):
+        got = instance.frame_of({})
+        self.assertIs(got["record"], True)
+        self.assertIs(got["restore"], True)
+
+    def test_recording_can_be_turned_off_on_its_own(self):
+        got = instance.frame_of({"frame": {"record": False}})
+        self.assertIs(got["record"], False)
+        self.assertIs(got["restore"], True)
+
+    def test_restoring_can_be_turned_off_on_its_own(self):
+        """The position one key cannot express: record it, and let me ask for it back."""
+        got = instance.frame_of({"frame": {"restore": False}})
+        self.assertIs(got["restore"], False)
+        self.assertIs(got["record"], True)
+
+    def test_a_value_that_is_not_a_boolean_is_the_shipped_answer(self):
+        """`charter.toml` is committed and arrives from somebody else's machine, so a key
+        charter cannot read degrades rather than raising — `frame_of`'s own contract."""
+        for value in ("yes", 1, [], {"on": True}):
+            with self.subTest(value=value):
+                got = instance.frame_of({"frame": {"record": value, "restore": value}})
+                self.assertIs(got["record"], True)
+                self.assertIs(got["restore"], True)
+
+    def test_the_toml_spelling_is_the_word_itself(self):
+        """One word each, so `docs/frame.md`'s hyphen rule (`history-limit`, never
+        `history_limit`) does not arise for either of them."""
+        self.assertEqual(instance.FRAME_FIELDS["record"][1], "record")
+        self.assertEqual(instance.FRAME_FIELDS["restore"][1], "restore")
+
+
+def _frame(ws: str, fid: str, *, resume: str = "") -> "reopen.Frame":
+    """One workspace's worth of manifest, spelled once so a case says what it is about."""
+    return reopen.Frame(workspace=ws, chats=(reopen.Chat(
+        chat=fid, workspace=ws, persona="", harness="claude-code", cwd="",
+        resume=resume, transcript="", active=True),))
+
+
+class TheRecordIsWrittenAtomically(PersonaIso, unittest.TestCase):
+    """`reopen.write` — temp plus rename, so a crash mid-write leaves the PREVIOUS record.
+
+    This already mattered when a quit was the only writer. At a hundred times the write
+    rate it matters more, and it brings a second writer with it: the frame process is now
+    recording while a quit — or a second attached terminal — may also be writing.
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.assertIn("edm-test-", str(config.STATE_DIR))
+
+    def test_two_writers_do_not_interleave_into_one_temp_file(self):
+        """`os.replace` is atomic; the file it renames is not. Two writers sharing one temp
+        NAME write into the same bytes — and the first to rename puts the SECOND writer's
+        content in place while reporting that its own record landed, which is a manifest
+        that describes a plane nobody asked to record."""
+        real = config.write_for
+        sibling: list[bool] = []
+
+        def racing(path, text, **kw):
+            real(path, text, **kw)
+            if not sibling:            # the other writer, once, mid-write
+                sibling.append(True)
+                reopen.write([_frame("beta", "beta.1")], focus="beta")
+
+        with mock.patch.object(config, "write_for", racing):
+            landed = reopen.write([_frame("alpha", "alpha.1")], focus="alpha")
+
+        self.assertTrue(landed)
+        self.assertEqual(reopen.read().focus, "alpha")
+
+    def test_a_rename_that_fails_leaves_the_previous_record_whole(self):
+        reopen.write([_frame("alpha", "alpha.1", resume="conv-1")], focus="alpha")
+
+        with mock.patch("os.replace", side_effect=OSError("no")):
+            self.assertFalse(reopen.write([_frame("beta", "beta.1")], focus="beta"))
+
+        self.assertEqual([c.resume for c in reopen.read().all_chats()], ["conv-1"])
+
+    def test_a_temp_file_that_cannot_be_made_is_a_record_that_did_not_land(self):
+        """A full filesystem answers here rather than at the write, and the caller does the
+        same thing with either: tell the operator the plane was not recorded."""
+        reopen.write([_frame("alpha", "alpha.1", resume="conv-1")], focus="alpha")
+
+        with mock.patch("tempfile.mkstemp", side_effect=OSError("no space")):
+            self.assertFalse(reopen.write([_frame("beta", "beta.1")], focus="beta"))
+
+        self.assertEqual([c.resume for c in reopen.read().all_chats()], ["conv-1"])
+
+    def test_a_temp_file_that_cannot_be_removed_is_still_only_a_false(self):
+        """The filesystem that refused the rename can refuse the tidy-up too, and this
+        function's whole contract is that it answers rather than raises."""
+        with mock.patch("os.replace", side_effect=OSError("no")), \
+                mock.patch("pathlib.Path.unlink", side_effect=OSError("no")):
+            self.assertFalse(reopen.write([_frame("alpha", "alpha.1")], focus="alpha"))
+
+    def test_a_rename_that_fails_leaves_no_half_written_file_behind(self):
+        """A temp name of this writer's own would otherwise accumulate one file per crash
+        in a directory whose only collector (`reopen.prune_transcripts`) touches nothing but
+        `*.transcript`."""
+        with mock.patch("os.replace", side_effect=OSError("no")):
+            reopen.write([_frame("alpha", "alpha.1")], focus="alpha")
+
+        self.assertEqual(sorted(p.name for p in state._root().iterdir()), [])
+
+
+def _seats(windows, active):
+    """`commands_frame._chat_seats`' answer, built from what a case means to say — the
+    same helper `tests/test_a_quit_records_the_plane_before_it_kills.py` uses, so the two
+    suites cannot come to disagree about the shape of a tmux listing."""
+    return [(chat, window, chat in active) for chat, window in windows.items()]
+
+
+def _plant(fid: str, *, ws: str, harness: str = "claude-code", pane: str = "%1",
+           sid: str = "", cwd: str = "") -> None:
+    """Make *fid* look like a chat charter launched — through the production writers, so a
+    fixture that stopped agreeing with the launcher fails here rather than against itself."""
+    state.frame_dir(fid, create=True)
+    state.record_server(fid, commands_frame.SOCKET)
+    state.record_workspace(fid, ws)
+    state.record_harness_pane(fid, pane)
+    state.record_identity(fid, {"CHARTER_HARNESS": harness, "CHARTER_WORKSPACE": "",
+                                "CHARTER_PERSONA": ""})
+    if sid:
+        state.record_harness_session(fid, sid)
+    if cwd:
+        state.record_cwd(fid, cwd)
+
+
+class WhatARunningPlaneRecordsIsWhatAQuitRecords(PersonaIso, unittest.TestCase):
+    """`commands_frame.record_the_plane_now` — the same manifest, taken without stopping.
+
+    **The same reader as the quit** (`leave.plan`), so "what a chat is" has one answer.
+    What differs is the two things a running plane cannot do: it does not `capture-pane`
+    (one subprocess per chat per write, at a hundred times the rate), and it does not prune
+    — a record taken while everything is still running has no business being the collector
+    for files a quit left behind.
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.assertIn("edm-test-", str(config.STATE_DIR))
+
+    def test_it_records_the_chats_the_plane_has(self):
+        _plant("alpha.1", ws="alpha", sid="conv-1", cwd=str(config.ROOT))
+        _plant("beta.1", ws="beta", harness="opencode")
+
+        with mock.patch.object(commands_frame, "_chat_seats") as seats:
+            seats.return_value = _seats({"alpha.1": "@0", "beta.1": "@1"}, {"beta.1"})
+            self.assertTrue(commands_frame.record_the_plane_now("alpha.1"))
+
+        m = reopen.read()
+        self.assertEqual([f.workspace for f in m.frames], ["alpha", "beta"])
+        first = m.all_chats()[0]
+        self.assertEqual(first.chat, "alpha.1")
+        self.assertEqual(first.workspace, "alpha")
+        self.assertEqual(first.harness, "claude-code")
+        self.assertEqual(first.cwd, str(config.ROOT))
+        self.assertEqual(first.resume, "conv-1")
+        self.assertFalse(first.active)
+        self.assertTrue(m.all_chats()[1].active)
+
+    def test_the_focus_is_the_workspace_this_terminal_is_standing_in(self):
+        _plant("alpha.1", ws="alpha")
+        _plant("beta.1", ws="beta")
+
+        with mock.patch.object(commands_frame, "_chat_seats") as seats:
+            seats.return_value = _seats({"alpha.1": "@0", "beta.1": "@1"}, set())
+            commands_frame.record_the_plane_now("beta.1")
+
+        self.assertEqual(reopen.read().focus, "beta")
+
+    def test_a_terminal_that_has_not_claimed_a_chat_yet_records_no_focus(self):
+        """`""` is a real answer, not a hole: the launcher starts recording before it
+        allocates an id, and `_attach_after_reopen` already falls back from a focus it
+        cannot place to the chat that was on screen."""
+        _plant("alpha.1", ws="alpha")
+
+        with mock.patch.object(commands_frame, "_chat_seats") as seats:
+            seats.return_value = _seats({"alpha.1": "@0"}, set())
+            self.assertTrue(commands_frame.record_the_plane_now(""))
+
+        self.assertEqual(reopen.read().focus, "")
+
+    def test_it_never_captures_a_pane(self):
+        """A `capture-pane` per chat per write is the cost that makes a continuous record
+        unaffordable, and a scrollback is the one restore item §4f says is OFFERED rather
+        than replayed — so nothing is lost by leaving it to the quit."""
+        _plant("alpha.1", ws="alpha")
+
+        with mock.patch.object(commands_frame, "_chat_seats") as seats, \
+                mock.patch.object(commands_frame, "_capture_transcript") as cap:
+            seats.return_value = _seats({"alpha.1": "@0"}, set())
+            commands_frame.record_the_plane_now("alpha.1")
+
+        cap.assert_not_called()
+
+    def test_it_names_the_capture_a_quit_already_left_on_disk(self):
+        """Not capturing is not the same as forgetting. A quit that captured and then had
+        its manifest overwritten by this would lose the offer — so the field names the file
+        that is there, which is the same name the capture would have written."""
+        _plant("alpha.1", ws="alpha")
+        config.write_for(reopen.transcript_path("alpha.1"), "what was on screen\n")
+
+        with mock.patch.object(commands_frame, "_chat_seats") as seats:
+            seats.return_value = _seats({"alpha.1": "@0"}, set())
+            commands_frame.record_the_plane_now("alpha.1")
+
+        self.assertEqual(reopen.read().all_chats()[0].transcript, "alpha.1.transcript")
+
+    def test_a_chat_with_no_capture_offers_none(self):
+        _plant("alpha.1", ws="alpha")
+
+        with mock.patch.object(commands_frame, "_chat_seats") as seats:
+            seats.return_value = _seats({"alpha.1": "@0"}, set())
+            commands_frame.record_the_plane_now("alpha.1")
+
+        self.assertEqual(reopen.read().all_chats()[0].transcript, "")
+
+    def test_a_plane_with_nothing_live_is_not_recorded_over(self):
+        """The last thing a plane that has just been quit needs is its record replaced by
+        an empty one. Nothing live is nothing to record, and the previous record stands."""
+        _plant("alpha.1", ws="alpha")
+        reopen.write([reopen.Frame(workspace="alpha", chats=(reopen.Chat(
+            chat="alpha.1", workspace="alpha", persona="", harness="claude-code",
+            cwd="", resume="conv-1", transcript="", active=True),))], focus="alpha")
+
+        with mock.patch.object(commands_frame, "_chat_seats") as seats:
+            seats.return_value = []
+            self.assertFalse(commands_frame.record_the_plane_now("alpha.1"))
+
+        self.assertEqual([c.resume for c in reopen.read().all_chats()], ["conv-1"])
+
+    def test_a_record_that_did_not_land_says_so(self):
+        """The recorder's own loop reads this: a write that failed is not retried on every
+        tick, so the answer has to be honest rather than optimistic."""
+        _plant("alpha.1", ws="alpha")
+
+        with mock.patch.object(commands_frame, "_chat_seats") as seats, \
+                mock.patch.object(reopen, "write", return_value=False):
+            seats.return_value = _seats({"alpha.1": "@0"}, set())
+            self.assertFalse(commands_frame.record_the_plane_now("alpha.1"))
+
+    def test_it_does_not_collect_a_transcript_no_live_chat_names(self):
+        """`reopen.prune_transcripts` is the quit's, and it has to be: a running plane's
+        record is taken while chats come and go, and a sweep on that timetable would delete
+        the capture of a chat that is between a close and its reopen."""
+        _plant("alpha.1", ws="alpha")
+        stale = reopen.transcript_path("alpha.9")
+        config.write_for(stale, "an older chat's screen\n")
+
+        with mock.patch.object(commands_frame, "_chat_seats") as seats:
+            seats.return_value = _seats({"alpha.1": "@0"}, set())
+            commands_frame.record_the_plane_now("alpha.1")
+
+        self.assertTrue(stale.is_file())
+
+
+def _launch_args(**kw):
+    """The namespace `cmd_launch` reads, with every field it consults named rather than
+    left to a `getattr` default — `_reopen_args`' own rule."""
+    base = dict(harness="claude", rest=[], no_frame=False, workspace="alpha", pick=False,
+                fresh=False)
+    base.update(kw)
+    return SimpleNamespace(**base)
+
+
+class WhoRecordsAndWhoDoesNot(unittest.TestCase):
+    """`commands_frame._records_the_plane` — the frame process, and nothing else.
+
+    The gate is asked as a predicate rather than discovered inside the launcher, because
+    every one of these five is a way of NOT being the operator's terminal, and a guard that
+    passes only because a different guard caught the case is one this repository deletes.
+    """
+
+    def test_a_launch_that_is_the_terminal_records(self):
+        with mock.patch("sys.stdout.isatty", return_value=True):
+            self.assertTrue(commands_frame._records_the_plane(_launch_args()))
+
+    def test_a_launch_that_will_never_attach_does_not(self):
+        """`_open_workspace` launches from a `frame-switch` running detached with all three
+        streams on `/dev/null`, and a reopen's own per-chat launches pass `attach=False`.
+        Neither is anybody's terminal, and both would be a second writer."""
+        with mock.patch("sys.stdout.isatty", return_value=True):
+            self.assertFalse(
+                commands_frame._records_the_plane(_launch_args(attach=False)))
+
+    def test_a_probe_does_not(self):
+        """`--probe` is read-only and answers before the launcher touches anything —
+        `cmd_launch`'s own first line."""
+        with mock.patch("sys.stdout.isatty", return_value=True):
+            self.assertFalse(commands_frame._records_the_plane(_launch_args(probe=True)))
+
+    def test_a_harness_run_bare_does_not(self):
+        """`--no-frame` is an `os.execvp`: there is no frame to record and, a moment later,
+        no charter left in this process to record it."""
+        with mock.patch("sys.stdout.isatty", return_value=True):
+            self.assertFalse(
+                commands_frame._records_the_plane(_launch_args(no_frame=True)))
+
+    def test_a_pipeline_does_not(self):
+        """`charter 2>&1 | head` is a probe for "is charter installed" and `cmd_launch`
+        answers it with `bypass` — an exec. Recording there would write a manifest for a
+        plane this process is about to stop being part of."""
+        with mock.patch("sys.stdout.isatty", return_value=False):
+            self.assertFalse(commands_frame._records_the_plane(_launch_args()))
+
+    def test_a_plane_that_turned_recording_off_does_not(self):
+        with mock.patch("sys.stdout.isatty", return_value=True), \
+                mock.patch.dict(config.FRAME, {"record": False}):
+            self.assertFalse(commands_frame._records_the_plane(_launch_args()))
+
+    def test_fresh_does_not_record_over_the_record_it_skipped(self):
+        """The half of `--fresh` that is easy to leave out and impossible to notice
+        missing: a run that declines to restore and then records anyway destroys the record
+        it declined, two seconds later, with nothing said."""
+        with mock.patch("sys.stdout.isatty", return_value=True):
+            self.assertFalse(commands_frame._records_the_plane(_launch_args(fresh=True)))
+
+
+class WhenBareCharterPutsThePlaneBack(unittest.TestCase):
+    """`commands_frame._restores_the_plane` — and the one case it must never fire in."""
+
+    def test_a_bare_launch_that_is_the_terminal_restores(self):
+        self.assertTrue(commands_frame._restores_the_plane(_launch_args()))
+
+    def test_a_launch_carrying_a_command_does_not(self):
+        """`charter claude --resume <id>` and `charter frame -- <cmd>` asked for a
+        particular thing. Answering with six other chats is not a restore, it is an
+        override."""
+        self.assertFalse(
+            commands_frame._restores_the_plane(_launch_args(rest=["--resume", "x"])))
+
+    def test_a_launch_that_will_never_attach_does_not(self):
+        self.assertFalse(commands_frame._restores_the_plane(_launch_args(attach=False)))
+
+    def test_a_plane_that_turned_restoring_off_does_not(self):
+        with mock.patch.dict(config.FRAME, {"restore": False}):
+            self.assertFalse(commands_frame._restores_the_plane(_launch_args()))
+
+    def test_fresh_does_not(self):
+        self.assertFalse(commands_frame._restores_the_plane(_launch_args(fresh=True)))
+
+    def test_recording_being_off_does_not_stop_a_restore(self):
+        """Two keys, and this is the pair that proves they are two: a plane that stopped
+        recording still has whatever its last quit wrote, and asking `charter` to put that
+        back is a coherent thing to want."""
+        with mock.patch.dict(config.FRAME, {"record": False}):
+            self.assertTrue(commands_frame._restores_the_plane(_launch_args()))
+
+
+class TheLauncherTakesTheDecision(PersonaIso, unittest.TestCase):
+    """`cmd_launch` reaching `cmd_reopen`, and the live plane it must not reach it from.
+
+    Driven to the decision and stopped immediately after it: `state.new_chat_id` answers
+    ``None``, which is `cmd_launch`'s own "could not open a chat" — the first exit past the
+    branch that starts nothing and writes nothing.
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.assertIn("edm-test-", str(config.STATE_DIR))
+        reopen.write([_frame("alpha", "alpha.1")], focus="alpha")
+
+    def _launch(self, *, chats_live=(), reopen_rc=0, **kw):
+        with mock.patch.multiple(commands_frame,
+                                 _live_sessions=mock.DEFAULT,
+                                 _live_chats=mock.DEFAULT,
+                                 _choose_workspace=mock.DEFAULT,
+                                 _workspace_to_focus=mock.DEFAULT,
+                                 cmd_reopen=mock.DEFAULT) as m, \
+                mock.patch("charter.frame.state.new_chat_id", return_value=None), \
+                mock.patch("charter.commands_frame.shutil.which",
+                           side_effect=lambda n, *a, **k: f"/usr/bin/{n}"), \
+                mock.patch("charter.frame.tmuxctl.version", return_value=(3, 7)), \
+                mock.patch("charter.frame.tmuxctl.operator_server", return_value=None), \
+                mock.patch("sys.stdout.isatty", return_value=True):
+            m["_live_sessions"].return_value = set()
+            m["_live_chats"].return_value = set(chats_live)
+            m["_choose_workspace"].return_value = ("alpha", None, False)
+            m["_workspace_to_focus"].return_value = None
+            m["cmd_reopen"].return_value = reopen_rc
+            rc = commands_frame.cmd_launch(_launch_args(**kw))
+        return rc, m["cmd_reopen"]
+
+    def test_bare_charter_on_a_dead_plane_puts_the_record_back(self):
+        rc, reopened = self._launch()
+        self.assertEqual(rc, 0)
+        reopened.assert_called_once()
+
+    def test_the_restore_is_the_quiet_one(self):
+        """An operator who typed `charter reopen` is reading. An operator who typed
+        `charter` wanted a terminal, so the same wall of per-chat lines there is noise at
+        the worst moment — one line, and the detail on demand."""
+        _rc, reopened = self._launch()
+        self.assertIs(getattr(reopened.call_args[0][0], "quiet", False), True)
+
+    def test_a_plane_with_chats_still_running_is_never_restored_over(self):
+        """The defect this gate exists for. With recording on, the record is CURRENT rather
+        than a relic of the last quit — so a second terminal typing `charter` while the
+        plane runs would reopen every chat it can already see, and nothing on screen would
+        tell the duplicates from the originals."""
+        rc, reopened = self._launch(chats_live=("alpha.1",))
+        self.assertEqual(rc, 1)
+        reopened.assert_not_called()
+
+    def test_a_plane_with_nothing_recorded_opens_a_chat_as_it_always_did(self):
+        reopen.forget()
+        rc, reopened = self._launch()
+        self.assertEqual(rc, 1)
+        reopened.assert_not_called()
+
+    def test_a_restore_that_started_nothing_falls_through_to_a_launch(self):
+        """Refusing to open anything because the record could not be acted on would leave
+        an operator who asked for a terminal without one."""
+        rc, reopened = self._launch(reopen_rc=1)
+        reopened.assert_called_once()
+        self.assertEqual(rc, 1)
+
+
+class WhatAnAutomaticRestoreSays(PersonaIso, unittest.TestCase):
+    """One compact line, detail on demand — and never silence.
+
+    **The two halves of #752 and #823 pulling in opposite directions, settled here.**
+    Silence is #752's defect exactly: a frame that quietly draws less than it should, with
+    nothing to act on. A wall of per-chat lines is what `charter reopen` prints, and it is
+    right there — that command is a deliberate act and the operator is reading. This one
+    happens because somebody typed `charter` and wanted a terminal.
+
+    **Each sentence is spelled out by hand**, not compared against the constant that
+    produces it: a round trip through the constant moves the test with the reword and stays
+    green, which is what `tests/test_what_a_quit_says_is_spelled_where_it_is_asserted.py`
+    exists to stop. The duplication IS the assertion.
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.assertIn("edm-test-", str(config.STATE_DIR))
+        self.fail_for: set[str] = set()
+
+    def _launcher(self, args):
+        if args.workspace in self.fail_for:
+            return 1
+        args.reopening.fid = f"{args.workspace}.9"
+        return 0
+
+    def _record(self, *chats_):
+        by_ws: dict = {}
+        for c in chats_:
+            by_ws.setdefault(c.workspace, []).append(c)
+        reopen.write([reopen.Frame(workspace=w, chats=tuple(cs))
+                      for w, cs in by_ws.items()], focus="alpha")
+
+    def _chat(self, **kw):
+        base = dict(chat="alpha.1", workspace="alpha", persona="", harness="claude-code",
+                    cwd=str(config.ROOT), resume="", transcript="", active=True)
+        base.update(kw)
+        return reopen.Chat(**base)
+
+    def _reopen(self, **kw):
+        said = io.StringIO()
+        with mock.patch.object(commands_frame, "cmd_launch", side_effect=self._launcher), \
+                mock.patch.object(commands_frame.sys.stdout, "isatty",
+                                  return_value=True), \
+                mock.patch.object(commands_frame.tmuxctl, "version",
+                                  return_value=(3, 7)), \
+                mock.patch.object(commands_frame.tmuxctl, "operator_server",
+                                  return_value=None), \
+                mock.patch.object(commands_frame, "_attach_after_reopen",
+                                  return_value=0), \
+                redirect_stderr(said):
+            rc = commands_frame.cmd_reopen(SimpleNamespace(**kw))
+        return rc, said.getvalue()
+
+    def test_a_whole_plane_that_came_back_is_one_line(self):
+        self._record(self._chat(chat="alpha.1"), self._chat(chat="alpha.2"))
+
+        rc, out = self._reopen(quiet=True)
+
+        self.assertEqual(rc, 0)
+        self.assertIn("charter: restored the 2 chat(s) this plane last recorded", out)
+        self.assertEqual(len(out.strip().splitlines()), 1)
+
+    def test_a_plane_that_came_back_short_says_how_short_and_where_to_look(self):
+        """Not silence, and not a wall: the count, and the command that names which."""
+        self._record(self._chat(chat="alpha.1", workspace="alpha"),
+                     self._chat(chat="beta.1", workspace="beta"))
+        self.fail_for = {"beta"}
+
+        rc, out = self._reopen(quiet=True)
+
+        self.assertEqual(rc, 0)
+        self.assertIn("charter: restored 1 of the 2 chats this plane last recorded — the "
+                      "rest are still recorded; `charter reopen` says which could not come "
+                      "back, and retries them", out)
+
+    def test_the_chats_that_did_not_come_back_are_still_recorded_to_retry(self):
+        """What makes "detail on demand" a real offer rather than a form of words:
+        `_consume` leaves exactly the chats still owed, so the command the line names both
+        explains and retries."""
+        self._record(self._chat(chat="alpha.1", workspace="alpha"),
+                     self._chat(chat="beta.1", workspace="beta"))
+        self.fail_for = {"beta"}
+
+        self._reopen(quiet=True)
+
+        self.assertEqual([c.chat for c in reopen.read().all_chats()], ["beta.1"])
+
+    def test_charter_reopen_itself_still_says_it_chat_by_chat(self):
+        """The quiet line is the AUTOMATIC restore's, and `charter reopen` is unchanged: an
+        operator who asked for it by name is reading the answer."""
+        self._record(self._chat(chat="alpha.1", workspace="alpha"),
+                     self._chat(chat="beta.1", workspace="beta"))
+        self.fail_for = {"beta"}
+
+        rc, out = self._reopen()
+
+        self.assertEqual(rc, 0)
+        self.assertIn("charter: reopened 1 of 2 chats", out)
+        self.assertIn("beta.1 did not come back", out)
+        self.assertIn("`charter reopen` again to retry just those", out)
+
+
+class TheRecorderIsToldWhereTheTerminalIsStanding(PersonaIso, unittest.TestCase):
+    """`record.focus_on` — the manifest's `focus`, which is the workspace a reopen attaches
+    to.
+
+    **The launcher's OWN chat, and not a session name read back off tmux.** Session names
+    are shared by every plane on the machine (§3.3: `default` is a name every plane has), so
+    reading the focus off `list-clients` would let another plane answer for this one — the
+    exact inversion `_plane_session` exists to prevent. What this costs is stated rather than
+    hidden: a client that has since been moved to another workspace by a workspace tab
+    leaves the focus naming the workspace this terminal launched into, and
+    `_attach_after_reopen` falls back from a focus it cannot place to the chat that was on
+    screen.
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.assertIn("edm-test-", str(config.STATE_DIR))
+        self.addCleanup(record.stop)
+
+    def test_a_focused_launch_names_the_chat_it_joined(self):
+        record.start(lambda _chat: True, quiet=99.0, poll=99.0)
+        with mock.patch.object(commands_frame.tmuxctl, "interact",
+                               return_value=_completed(0)):
+            commands_frame._focus_workspace("$3", "shared.1", ws="shared", picked=False)
+        self.assertEqual(record.running().chat, "shared.1")
+
+    def test_a_reopen_names_the_chat_it_put_the_operator_back_on(self):
+        record.start(lambda _chat: True, quiet=99.0, poll=99.0)
+        back = [commands_frame.Reopening(reopen.Chat(
+            chat="alpha.1", workspace="alpha", persona="", harness="claude-code", cwd="",
+            resume="", transcript="", active=True))]
+        back[0].fid = "alpha.4"
+        m = reopen.Manifest(at=0, focus="alpha", frames=())
+        with mock.patch.object(commands_frame.tmuxctl, "run",
+                               return_value=_completed(0)), \
+                mock.patch.object(commands_frame.tmuxctl, "interact",
+                                  return_value=_completed(0)):
+            commands_frame._attach_after_reopen(m, back)
+        self.assertEqual(record.running().chat, "alpha.4")
+
+
+class ReopenRecordsThePlaneItPutsBack(PersonaIso, unittest.TestCase):
+    """`charter reopen` attaches, so it is the frame process for the plane it just built.
+
+    Without this the one case that most needs a record has none: `_consume` deletes the
+    record that drove the reopen, so a plane restored and then lost to a crash would have
+    nothing behind it at all.
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.assertIn("edm-test-", str(config.STATE_DIR))
+        self.addCleanup(record.stop)
+
+    def test_the_reopen_is_recording_while_it_holds_the_terminal(self):
+        reopen.write([_frame("alpha", "alpha.1")], focus="alpha")
+        seen: list = []
+
+        def _launcher(args):
+            args.reopening.fid = "alpha.9"
+            return 0
+
+        with mock.patch.object(commands_frame, "cmd_launch", side_effect=_launcher), \
+                mock.patch.object(commands_frame.sys.stdout, "isatty",
+                                  return_value=True), \
+                mock.patch.object(commands_frame.tmuxctl, "version",
+                                  return_value=(3, 7)), \
+                mock.patch.object(commands_frame.tmuxctl, "operator_server",
+                                  return_value=None), \
+                mock.patch.object(commands_frame, "_attach_after_reopen",
+                                  side_effect=lambda *_a: seen.append(record.running()) or 0):
+            self.assertEqual(commands_frame.cmd_reopen(SimpleNamespace()), 0)
+
+        self.assertIsNotNone(seen[0], "the reopen held the terminal and recorded nothing")
+
+    def test_a_plane_that_turned_recording_off_reopens_without_one(self):
+        reopen.write([_frame("alpha", "alpha.1")], focus="alpha")
+        seen: list = []
+
+        def _launcher(args):
+            args.reopening.fid = "alpha.9"
+            return 0
+
+        with mock.patch.dict(config.FRAME, {"record": False}), \
+                mock.patch.object(commands_frame, "cmd_launch", side_effect=_launcher), \
+                mock.patch.object(commands_frame.sys.stdout, "isatty",
+                                  return_value=True), \
+                mock.patch.object(commands_frame.tmuxctl, "version",
+                                  return_value=(3, 7)), \
+                mock.patch.object(commands_frame.tmuxctl, "operator_server",
+                                  return_value=None), \
+                mock.patch.object(commands_frame, "_attach_after_reopen",
+                                  side_effect=lambda *_a: seen.append(record.running()) or 0):
+            commands_frame.cmd_reopen(SimpleNamespace())
+
+        self.assertIsNone(seen[0])
+
+
+class FreshIsARunThatDoesNotParticipate(PersonaIso, unittest.TestCase):
+    """`charter --fresh` and `charter <harness> --fresh` — one flag, charter's own.
+
+    **It exists because restore is automatic.** Without it, a plane an operator wanted to
+    abandon comes back every time they type `charter`, and the only escape is deleting a
+    file they must first know exists. What the flag means is *this run does not
+    participate*: no restore, **and no recording over the record it skipped**. That second
+    half is not a nicety — the alternative destroys the skipped record on a two-second
+    timer, so nothing the operator does makes the loss visible until it is too late.
+    """
+
+    def _plane_defaults_to(self, harness: str) -> None:
+        (self.tmp / "charter.toml").write_text(
+            f'schema = 1\n\n[harness]\ndefault = "{harness}"\n')
+        config.use(self.tmp)
+
+    def test_bare_charter_fresh_becomes_the_planes_harness_carrying_the_flag(self):
+        self._plane_defaults_to("claude")
+        with mock.patch.object(cli.sys.stdout, "isatty", return_value=True):
+            argv, rc = cli._bare_launch(["--fresh"])
+        self.assertIsNone(rc)
+        self.assertEqual(argv, ["claude", "--fresh"])
+
+    def test_a_word_that_is_not_charters_own_flag_is_still_a_subcommand(self):
+        """The rewrite widens by exactly one token and no further: anything else in `argv`
+        is a command the operator typed, and `_bare_launch` must not touch it."""
+        self._plane_defaults_to("claude")
+        with mock.patch.object(cli.sys.stdout, "isatty", return_value=True):
+            self.assertEqual(cli._bare_launch(["doctor"]), (["doctor"], None))
+            self.assertEqual(cli._bare_launch(["--fresh", "doctor"]),
+                             (["--fresh", "doctor"], None))
+
+    def test_a_plane_that_names_no_harness_is_still_a_usage_error(self):
+        """The rewrite is gated on a declared `[harness] default` exactly as bare `charter`
+        is: charter does not guess a harness for somebody who never named one, and adding a
+        flag does not make it start guessing."""
+        (self.tmp / "charter.toml").write_text("schema = 1\n")
+        config.use(self.tmp)
+        with mock.patch.object(cli.sys.stdout, "isatty", return_value=True):
+            self.assertEqual(cli._bare_launch(["--fresh"]), (["--fresh"], None))
+
+    def test_the_flag_reaches_the_launcher_rather_than_the_harness(self):
+        parser = cli.build_parser()
+        argv, rest = cli._split_frame_argv(["claude", "--fresh"])
+        args = parser.parse_args(argv)
+        self.assertIs(args.fresh, True)
+        self.assertEqual(rest, [])
+
+    def test_past_the_leading_run_it_is_the_harnesss_own_word(self):
+        """`_OWN_FLAGS`' rule, unchanged: once the harness's own argv has started, a token
+        that happens to spell one of charter's flags is the harness's."""
+        argv, rest = cli._split_frame_argv(["claude", "--resume", "x", "--fresh"])
+        self.assertEqual(argv, ["claude"])
+        self.assertEqual(rest, ["--resume", "x", "--fresh"])
+
+
+class TheLauncherStopsAnnouncingAQuitThatDidNotHappen(PersonaIso, unittest.TestCase):
+    """`_say_the_plane_is_recorded` — the neighbour this feature makes false if left alone.
+
+    The line `cmd_launch` prints on the way out was gated on one thing: the record naming
+    the chat this launch was about. While a quit was the only writer that reading WAS a
+    quit, by construction. Now the frame process records the plane as it changes, so it is
+    true of every chat that ever ran — the sentence had to stop claiming a quit, and it had
+    to stop firing for a chat that is still running.
+
+    **Spelled out by hand**, not compared against the constant that produces it.
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.assertIn("edm-test-", str(config.STATE_DIR))
+        reopen.write([_frame("alpha", "alpha.1", resume="conv-1")], focus="alpha")
+
+    def _said(self, fid: str, **kw) -> str:
+        buf = io.StringIO()
+        with redirect_stderr(buf):
+            commands_frame._say_the_plane_is_recorded(fid, **kw)
+        return buf.getvalue()
+
+    def test_it_says_the_plane_is_recorded_rather_than_that_it_was_quit(self):
+        said = self._said("alpha.1", over=True)
+        self.assertIn("charter: this plane is recorded — 1 chat(s) recorded, 1 with a "
+                      "conversation to resume.\n  put it back with: charter reopen", said)
+        self.assertNotIn("was quit", said)
+
+    def test_a_chat_that_is_still_running_is_told_nothing(self):
+        """The launcher's own next line is "detached — the harness is still running", and
+        an offer to put the plane back directly above it describes a different plane."""
+        self.assertEqual(self._said("alpha.1", over=False), "")
+
+    def test_a_chat_the_record_does_not_name_is_still_told_nothing(self):
+        self.assertEqual(self._said("beta.9", over=True), "")
+
+
+class ALaunchRecordsForAsLongAsItHoldsTheTerminal(PersonaIso, unittest.TestCase):
+    """`cmd_launch`'s wrapper — the watch starts with the launch and is gone with it.
+
+    A whole launch with tmux faked, because the two facts under test are at opposite ends of
+    it: the watch has to be running before anything is built, and the chat it names is one
+    only the allocation knows.
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.assertIn("edm-test-", str(config.STATE_DIR))
+        self.addCleanup(record.stop)
+        self.seen: list = []
+
+    def _launch(self):
+        def _live_chats(_socket):
+            try:
+                return {d.name for d in state._root().iterdir() if d.is_dir()}
+            except OSError:
+                return set()
+
+        def _spawn(fid, ws):
+            # The one place inside the launch that runs after the allocation and before
+            # tmux, so it is where "which chat is the watch on" can be read.
+            self.seen.append((record.running(), fid))
+
+        args = SimpleNamespace(harness="claude", rest=[], no_frame=False,
+                               workspace="alpha", pick=False, fresh=False)
+        with mock.patch.object(commands_frame.tmuxctl, "version", return_value=(3, 7)), \
+                mock.patch.object(commands_frame.tmuxctl, "operator_server",
+                                  return_value=None), \
+                mock.patch.object(commands_frame.shutil, "which", return_value="/bin/true"), \
+                mock.patch.object(commands_frame.sys.stdout, "isatty", return_value=True), \
+                mock.patch("sys.stdin.isatty", return_value=False), \
+                mock.patch.object(commands_frame, "_live_sessions", return_value=set()), \
+                mock.patch.object(commands_frame, "_live_chats", side_effect=_live_chats), \
+                mock.patch.object(commands_frame, "_spawn_gather", side_effect=_spawn), \
+                mock.patch.object(commands_frame, "_workspace_to_focus",
+                                  return_value=None), \
+                mock.patch.object(commands_frame, "_draw_panels", return_value={}), \
+                mock.patch.object(commands_frame, "_arm_panel_respawn"), \
+                mock.patch.object(commands_frame, "_query_pane_dead_status",
+                                  return_value=None), \
+                mock.patch.object(commands_frame, "_chat_being_left", return_value=""), \
+                mock.patch.object(commands_frame, "_drop_panels"), \
+                mock.patch.object(commands_frame.tmuxctl, "run",
+                                  return_value=_completed(0)), \
+                mock.patch.object(commands_frame.tmuxctl, "interact",
+                                  return_value=_completed(0)):
+            return commands_frame.cmd_launch(args)
+
+    def test_the_launch_is_recording_before_it_builds_anything(self):
+        self._launch()
+        self.assertTrue(self.seen)
+        self.assertIsNotNone(self.seen[0][0], "the launch built a frame and recorded none")
+
+    def test_the_record_names_the_chat_this_launch_opened(self):
+        self._launch()
+        watch, fid = self.seen[0]
+        self.assertEqual(watch.chat, fid)
+
+    def test_the_watch_is_gone_when_the_launch_is(self):
+        """It has to be: the last thing a launch does is `state.reap`, which removes the
+        directories the watch reads."""
+        self._launch()
+        self.assertIsNone(record.running())
+        self.assertFalse(self.seen[0][0].alive())

--- a/tests/test_charter_records_the_plane_as_it_changes.py
+++ b/tests/test_charter_records_the_plane_as_it_changes.py
@@ -40,6 +40,8 @@ state, so the hazard `tests/_planeguard.py` exists for is at its sharpest here.
 from __future__ import annotations
 
 import io
+import json
+import os
 import subprocess
 import threading
 import unittest
@@ -48,7 +50,7 @@ from types import SimpleNamespace
 from unittest import mock
 
 from charter import cli, commands_frame, config, instance
-from charter.frame import record, reopen, state
+from charter.frame import leave, record, reopen, state
 
 from tests._isolation import PersonaIso
 
@@ -145,12 +147,12 @@ class TheFingerprintIsTheBumpsThatAlreadyExist(PersonaIso, unittest.TestCase):
         config.private_mkdir(state._root())
         config.write_for(state._root() / "reopen.json", "{}\n")
         config.write_for(state._root() / "alpha.1.transcript", "hi\n")
-        self.assertEqual(record.fingerprint(), ())
+        self.assertEqual(record.fingerprint(), frozenset())
 
     def test_a_plane_with_no_frame_root_at_all_answers_empty(self):
         """A machine that has never launched a frame. A reader on a poll loop may not
         raise for it — `state.version`'s own promise, one directory out."""
-        self.assertEqual(record.fingerprint(), ())
+        self.assertEqual(record.fingerprint(), frozenset())
 
 
 class TheRecorderIsOneWriterPerProcess(unittest.TestCase):
@@ -660,7 +662,9 @@ class TheLauncherTakesTheDecision(PersonaIso, unittest.TestCase):
         reopen.write([_frame("alpha", "alpha.1")], focus="alpha")
 
     def _launch(self, *, chats_live=(), reopen_rc=0, **kw):
-        with mock.patch.multiple(commands_frame,
+        said = io.StringIO()
+        self.said = said
+        with redirect_stderr(said), mock.patch.multiple(commands_frame,
                                  _live_sessions=mock.DEFAULT,
                                  _live_chats=mock.DEFAULT,
                                  _choose_workspace=mock.DEFAULT,
@@ -709,10 +713,15 @@ class TheLauncherTakesTheDecision(PersonaIso, unittest.TestCase):
 
     def test_a_restore_that_started_nothing_falls_through_to_a_launch(self):
         """Refusing to open anything because the record could not be acted on would leave
-        an operator who asked for a terminal without one."""
+        an operator who asked for a terminal without one — and it says so on the way past,
+        because a launch that quietly did something else is #752's own defect."""
         rc, reopened = self._launch(reopen_rc=1)
         reopened.assert_called_once()
         self.assertEqual(rc, 1)
+        self.assertIn(
+            "charter: nothing this plane recorded could be started — opening a chat "
+            "instead. The record is left in place; `charter reopen` says why.",
+            self.said.getvalue())
 
 
 class WhatAnAutomaticRestoreSays(PersonaIso, unittest.TestCase):
@@ -1081,6 +1090,15 @@ class ALaunchRecordsForAsLongAsItHoldsTheTerminal(PersonaIso, unittest.TestCase)
         watch, fid = self.seen[0]
         self.assertEqual(watch.chat, fid)
 
+    def test_a_launch_the_gate_refuses_records_nothing(self):
+        """`cmd_launch` asks `_records_the_plane` and acts on the answer. Without the ask,
+        every launch there is — a probe, a pipeline, a workspace tab's detached one —
+        becomes a writer, which is the whole thing keeping panels out of this avoids."""
+        with mock.patch.dict(config.FRAME, {"record": False}):
+            self._launch()
+        self.assertTrue(self.seen)
+        self.assertIsNone(self.seen[0][0])
+
     def test_the_watch_is_gone_when_the_launch_is(self):
         """It has to be: the last thing a launch does is `state.reap`, which removes the
         directories the watch reads."""
@@ -1160,3 +1178,256 @@ class AReopenOntoARunningPlaneIsRefused(PersonaIso, unittest.TestCase):
         with mock.patch.object(commands_frame, "_chat_seats") as seats:
             self.assertFalse(commands_frame._plane_is_running())
         seats.assert_not_called()
+
+
+def _doomed(**kw):
+    """One `leave.Doomed` with every field defaulted, so a case states only what it means."""
+    base = dict(chat="alpha.1", workspace="alpha", persona="", harness="claude-code",
+                cwd="", resume="", server=commands_frame.SOCKET, live=True, active=False,
+                exit_code=None, closed=False, homeless=False, cwd_gone=False)
+    base.update(kw)
+    return leave.Doomed(**base)
+
+
+class WhatTheSweepAskedFor(PersonaIso, unittest.TestCase):
+    """The guards the deletion sweep could not tell from dead code, pinned one by one.
+
+    Each case here exists because deleting one line left the suite green. They are grouped
+    rather than scattered so the next reader can see what the sweep charged this change with
+    and what each answer was.
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.assertIn("edm-test-", str(config.STATE_DIR))
+
+    def test_the_fingerprint_of_an_unchanged_plane_does_not_depend_on_scandir(self):
+        """A SET, so the order `os.scandir` hands entries over in cannot be read as a
+        change and answered with a write.
+
+        **This holds by construction rather than by a guard, and that is the finding**: the
+        sweep reported `sorted` → `list` as a survivor, and measuring readdir on this
+        machine said why — order is a function of the name set, identical across a reclaim
+        of the same ordinal and across churn, so the sort was defending against something
+        that cannot arrive. POSIX promises nothing about that order, so the answer was to
+        stop depending on it rather than to pin a sort. This case is what says so."""
+        state.frame_dir("alpha.1", create=True)
+        state.bump("alpha.1")
+        state.frame_dir("alpha.2", create=True)
+        state.bump("alpha.2")
+        first = record.fingerprint()
+
+        real = os.scandir
+        with mock.patch("os.scandir", lambda p: list(reversed(list(real(p))))):
+            self.assertEqual(record.fingerprint(), first)
+
+    def test_exactly_three_missing_chats_are_all_named(self):
+        """`<=`, not `<`. At the boundary the shorter comparison names two of three and
+        then counts "and 0 more", which is a sentence about nothing."""
+        self.assertEqual(commands_frame._named_briefly(["a.1", "b.1", "c.1"]),
+                         "a.1, b.1, c.1")
+        self.assertEqual(commands_frame._named_briefly(["a.1", "b.1", "c.1", "d.1"]),
+                         "a.1, b.1, c.1 and 1 more")
+
+    def test_a_chat_whose_id_cannot_name_a_transcript_offers_none(self):
+        """`dest is not None`. `reopen.transcript_path` answers ``None`` for an id that is
+        not one, and this function's whole contract is that it degrades per chat — so
+        asking that ``None`` whether it is a file would be the record taking the plane down
+        over a name it was written to survive."""
+        kept = commands_frame._record_the_plane(
+            [_doomed(chat="../evil", workspace="alpha")],
+            focus="alpha", active=set(), windows={}, capture=False)
+
+        self.assertEqual(kept, 1)
+        self.assertEqual(reopen.read().frames, (),
+                         "and the reader drops the entry, which is the other half")
+
+    def test_a_quit_still_collects_the_transcripts_its_record_stops_naming(self):
+        """The `if capture:` around `prune_transcripts` — the half that must NOT be dropped
+        with the half it guards. A transcript is a file in the frame root and a quit's own
+        record is its only collector."""
+        state.frame_dir("alpha.1", create=True)
+        config.write_for(reopen.transcript_path("alpha.1"), "kept\n")
+        stale = reopen.transcript_path("alpha.9")
+        config.write_for(stale, "collected\n")
+
+        with mock.patch.object(commands_frame, "_capture_transcript", return_value=False):
+            commands_frame._record_the_plane([_doomed(chat="alpha.1")], focus="alpha",
+                                             active=set(), windows={})
+
+        self.assertFalse(stale.exists(), "a quit is the collector, and it did not collect")
+        self.assertTrue(reopen.transcript_path("alpha.1").is_file())
+
+    def test_a_terminal_with_no_chat_writes_an_empty_focus_and_not_a_null(self):
+        """`or ""`. `reopen.read` coerces a non-string focus back to `""`, so the parsed
+        answer cannot tell the two apart — the file can, and the file is what a charter of
+        another version reads."""
+        _plant("alpha.1", ws="alpha")
+
+        with mock.patch.object(commands_frame, "_chat_seats") as seats:
+            seats.return_value = _seats({"alpha.1": "@0"}, set())
+            commands_frame.record_the_plane_now("")
+
+        self.assertEqual(json.loads(reopen.path().read_text())["focus"], "")
+
+
+class ThePlaneThatSaysNothingRecordsAndRestores(PersonaIso, unittest.TestCase):
+    """The shipped answer, asserted at the READ sites and not only at the config boundary.
+
+    **Three survivors said the default was assumed rather than pinned.** `[frame] record`
+    and `[frame] restore` both default true — a decision, not an accident — and a suite that
+    only ever sets them explicitly would leave a fresh plane doing whatever the fallback
+    happened to be, forever, with nothing to notice.
+
+    Two directions, two keys, and the absence of the key is one of them: `config.FRAME` is a
+    module attribute, and a caller that assigns a whole mapping over it is not resolving
+    anything (`tests/test_frame_border_surface._frame` builds `{"components": [...]}` and
+    patches it in). A bare subscript there is a `KeyError` out of the launcher's entry path.
+
+    `PersonaIso` with no `charter.toml` written, so `config.FRAME` really is the plane that
+    declared nothing rather than the plane the suite is running inside.
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.assertIn("edm-test-", str(config.STATE_DIR))
+        self.assertFalse((config.ROOT / "charter.toml").exists(),
+                         "the premise: this plane declares nothing at all")
+
+    def test_a_plane_that_declares_nothing_records(self):
+        with mock.patch("sys.stdout.isatty", return_value=True):
+            self.assertTrue(commands_frame._records_the_plane(_launch_args()))
+
+    def test_a_plane_that_declares_nothing_restores(self):
+        self.assertTrue(commands_frame._restores_the_plane(_launch_args()))
+
+    def test_a_config_mapping_that_carries_neither_key_still_records(self):
+        """The absent key, which is not the same fact as the declared default: a resolved
+        config always carries both, and a hand-built mapping assigned over `config.FRAME`
+        carries whatever its author needed."""
+        with mock.patch.object(config, "FRAME", {"components": []}), \
+                mock.patch("sys.stdout.isatty", return_value=True):
+            self.assertTrue(commands_frame._records_the_plane(_launch_args()))
+
+    def test_a_config_mapping_that_carries_neither_key_still_restores(self):
+        with mock.patch.object(config, "FRAME", {"components": []}):
+            self.assertTrue(commands_frame._restores_the_plane(_launch_args()))
+
+    def test_a_config_mapping_that_carries_neither_key_still_records_a_reopen(self):
+        """`cmd_reopen`'s own read of the same key, which is a third site and a third
+        chance to get the default wrong."""
+        reopen.write([_frame("alpha", "alpha.1")], focus="alpha")
+        seen: list = []
+
+        def _launcher(args):
+            args.reopening.fid = "alpha.9"
+            return 0
+
+        with mock.patch.object(config, "FRAME", {"components": []}), \
+                mock.patch.object(commands_frame, "cmd_launch", side_effect=_launcher), \
+                mock.patch.object(commands_frame, "_plane_is_running",
+                                  return_value=False), \
+                mock.patch.object(commands_frame.sys.stdout, "isatty",
+                                  return_value=True), \
+                mock.patch.object(commands_frame.tmuxctl, "version",
+                                  return_value=(3, 7)), \
+                mock.patch.object(commands_frame.tmuxctl, "operator_server",
+                                  return_value=None), \
+                mock.patch.object(commands_frame, "_attach_after_reopen",
+                                  side_effect=lambda *_a: seen.append(record.running()) or 0):
+            self.assertEqual(commands_frame.cmd_reopen(SimpleNamespace()), 0)
+        self.addCleanup(record.stop)
+
+        self.assertIsNotNone(seen[0], "a plane that said nothing reopened without a record")
+
+
+class TheQuietPeriodIsWhatABumpAtAllocationCosts(PersonaIso, unittest.TestCase):
+    """`record.QUIET` — the whole consistency argument for recording on bumps.
+
+    A quit gets a consistent picture for free: it stops the world first. Recording as the
+    plane changes gives that up, and the quiet period is what buys it back — so the claim
+    that has to be true is not "the arithmetic debounces" (`Debounce`'s own cases) but
+    **"the record is never the plane mid-launch"**.
+
+    The state that makes it concrete is `cmd_launch`'s own: `state.new_chat_id` claims the
+    directory and `state.bump` moves the version BEFORE tmux has made the window, so a
+    reading taken at that instant names a chat with no window and no harness — a plane that
+    never existed. This drives a recorder through exactly that sequence.
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.assertIn("edm-test-", str(config.STATE_DIR))
+        self.windowed = False
+
+    def _seats(self, _socket):
+        return _seats({"alpha.1": "@0"}, set()) if self.windowed else []
+
+    def test_a_chat_that_is_allocated_but_not_yet_windowed_is_not_recorded(self):
+        """The bump lands at allocation; the window arrives later. A record taken on the
+        bump alone would name a chat tmux has never heard of."""
+        _plant("alpha.1", ws="alpha")
+        state.bump("alpha.1")
+        r = record.Recorder(commands_frame.record_the_plane_now, quiet=2.0,
+                            clock=lambda: 0.0)
+
+        with mock.patch.object(commands_frame, "_chat_seats", side_effect=self._seats):
+            r.tick(now=0.0)                      # the allocation's own bump
+            r.tick(now=1.9)                      # still inside the quiet period
+
+        self.assertIsNone(reopen.read(), "the plane was recorded before it existed")
+
+    def test_once_the_window_is_there_the_quiet_period_records_it(self):
+        """The other direction, so the case above is a delay and not a refusal."""
+        _plant("alpha.1", ws="alpha")
+        state.bump("alpha.1")
+        r = record.Recorder(commands_frame.record_the_plane_now, quiet=2.0,
+                            clock=lambda: 0.0)
+
+        with mock.patch.object(commands_frame, "_chat_seats", side_effect=self._seats):
+            r.tick(now=0.0)
+            self.windowed = True
+            r.tick(now=2.0)
+
+        self.assertEqual([c.chat for c in reopen.read().all_chats()], ["alpha.1"])
+
+    def test_the_quiet_period_outlasts_the_window_it_exists_to_skip(self):
+        """The number, stated against the thing it excludes rather than by feel. `POLL` is
+        how often the frame process looks; `QUIET` has to be longer than a launch's own
+        allocate-to-window gap, or the debounce is decoration."""
+        self.assertGreater(record.QUIET, record.POLL)
+        self.assertGreaterEqual(record.QUIET, 2.0)
+
+
+class AStopGivesUpRatherThanHanging(unittest.TestCase):
+    """`record.JOIN` — the bound on the join, pinned by the one state that can see it.
+
+    The number itself is not derivable from anything (it replaced a `max(poll * 4, 1.0)`
+    the sweep reported as a survivor in BOTH directions, because neither half was), but its
+    EXISTENCE is: a write stuck on a wedged filesystem must not stand between an operator
+    and their shell, and without a timeout the join is that wait, unbounded.
+    """
+
+    def test_a_write_that_never_returns_does_not_hold_the_launcher(self):
+        held = threading.Event()
+        released = threading.Event()
+
+        def write(_chat: str) -> bool:
+            held.set()
+            # Bounded, and the bound is DATA rather than a round number: it has to outlast
+            # `record.JOIN` for the case to mean anything, and it has to end at all so a
+            # failing run cannot leak the thread. It is the fake's, not production's — the
+            # mutation this pins (`join()` with no timeout) is caught by this returning,
+            # not by the suite hanging, which the sweep can only report as unmeasured.
+            released.wait(record.JOIN + 3)
+            return True
+
+        r = record.Recorder(write, read=lambda: (("a", "1"),), quiet=0.0, poll=0.001)
+        r.start()
+        try:
+            self.assertTrue(held.wait(timeout=5), "the recorder never reached the write")
+            r.stop()                    # returns because the join is bounded
+            self.assertTrue(r.alive(), "the thread is still stuck, and stop said so")
+        finally:
+            released.set()
+            record.stop()

--- a/tests/test_charter_records_the_plane_as_it_changes.py
+++ b/tests/test_charter_records_the_plane_as_it_changes.py
@@ -1087,3 +1087,76 @@ class ALaunchRecordsForAsLongAsItHoldsTheTerminal(PersonaIso, unittest.TestCase)
         self._launch()
         self.assertIsNone(record.running())
         self.assertFalse(self.seen[0][0].alive())
+
+
+class AReopenOntoARunningPlaneIsRefused(PersonaIso, unittest.TestCase):
+    """The footgun this feature creates, closed where it is created.
+
+    The record used to exist only after a quit, so `charter reopen` never had a live plane
+    to describe. It is written as the plane CHANGES now — so `charter reopen` typed out of
+    habit, after closing a terminal (which only detaches), would put a second copy of every
+    running chat on the plane, with a fresh ordinal each so nothing on screen tells the
+    copies apart, and for Claude Code both copies resuming one conversation.
+
+    **The sentence is spelled out by hand**, and the refusal is asserted by what it did NOT
+    do rather than only by what it said.
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.assertIn("edm-test-", str(config.STATE_DIR))
+        reopen.write([_frame("alpha", "alpha.1")], focus="alpha")
+
+    def _reopen(self, *, seats):
+        def _launcher(args):
+            args.reopening.fid = "alpha.9"
+            return 0
+
+        said = io.StringIO()
+        with mock.patch.object(commands_frame, "cmd_launch",
+                               side_effect=_launcher) as launch, \
+                mock.patch.object(commands_frame, "_chat_seats", return_value=seats), \
+                mock.patch.object(commands_frame.sys.stdout, "isatty",
+                                  return_value=True), \
+                mock.patch.object(commands_frame.tmuxctl, "version",
+                                  return_value=(3, 7)), \
+                mock.patch.object(commands_frame.tmuxctl, "operator_server",
+                                  return_value=None), \
+                mock.patch.object(commands_frame, "_attach_after_reopen",
+                                  return_value=0), \
+                redirect_stderr(said):
+            rc = commands_frame.cmd_reopen(SimpleNamespace())
+        return rc, said.getvalue(), launch
+
+    def test_a_plane_with_a_chat_running_is_refused_and_nothing_is_started(self):
+        _plant("alpha.1", ws="alpha")
+
+        rc, out, launch = self._reopen(seats=_seats({"alpha.1": "@0"}, set()))
+
+        self.assertEqual(rc, 1)
+        launch.assert_not_called()
+        self.assertIn(
+            "charter reopen: this plane is already running — reopening it would open a "
+            "second copy of every chat, and a reopened chat gets a new id, so nothing on "
+            "screen would tell the copies apart. Attach to what is there (`tmux -L charter "
+            "attach`), or quit it first (`F2 → charter: quit`). Nothing was reopened, and "
+            "the record is left in place.", out)
+        self.assertIsNotNone(reopen.read(), "and the record is left to act on")
+
+    def test_a_server_that_will_not_answer_does_not_block_the_reopen(self):
+        """The opposite of `leave.plan`'s direction, and right for the opposite reason: a
+        reopen is wanted precisely when there is no server at all, so "could not ask" must
+        not refuse the command in the one situation it exists for."""
+        _plant("alpha.1", ws="alpha")
+
+        rc, _out, launch = self._reopen(seats=None)
+
+        self.assertEqual(rc, 0)
+        launch.assert_called()
+
+    def test_a_plane_with_no_chat_directories_asks_no_server_anything(self):
+        """A live chat always has a directory — `state.new_chat_id` claims its ordinal with
+        the `mkdir` — so no directories is a complete answer, not a guess."""
+        with mock.patch.object(commands_frame, "_chat_seats") as seats:
+            self.assertFalse(commands_frame._plane_is_running())
+        seats.assert_not_called()

--- a/tests/test_the_branch_not_taken_is_still_a_promise.py
+++ b/tests/test_the_branch_not_taken_is_still_a_promise.py
@@ -988,7 +988,7 @@ class AChatIdCharterCannotResolveWritesAndReadsNothing(PersonaIso):
 
 
 class TheLaunchHintCountsOnlyWhatCanResume(PersonaIso):
-    """`_say_it_was_quit` — the line `cmd_launch` prints when the chat it just opened is
+    """`_say_the_plane_is_recorded` — the line `cmd_launch` prints when the chat it just opened is
     named in a manifest nobody has reopened. Every existing case records one chat with an
     id, so `n` and `back` were the same number and the comprehension's filter decided
     nothing."""
@@ -1002,7 +1002,7 @@ class TheLaunchHintCountsOnlyWhatCanResume(PersonaIso):
         reopen.write([_frame("alpha", *chats_)], focus="alpha")
         said: list[str] = []
         with mock.patch.object(util, "info", side_effect=said.append):
-            commands_frame._say_it_was_quit(chats_[0].chat)
+            commands_frame._say_the_plane_is_recorded(chats_[0].chat)
         return said
 
     def test_the_second_number_is_how_many_have_a_conversation(self):
@@ -1016,7 +1016,7 @@ class TheLaunchHintCountsOnlyWhatCanResume(PersonaIso):
     def test_a_chat_the_manifest_does_not_name_is_said_nothing_about(self):
         reopen.write([_frame("alpha", _chat(chat="alpha.1"))], focus="alpha")
         with mock.patch.object(util, "info") as said:
-            commands_frame._say_it_was_quit("beta.9")
+            commands_frame._say_the_plane_is_recorded("beta.9")
 
         said.assert_not_called()
 


### PR DESCRIPTION
Closes #845.

Today the plane is recorded at exactly one moment — `charter frame-quit` calls `reopen.write` — and restored only by `charter reopen`. Everything between that moment and a crash is gone, and the way back is a command you have to already know about.

It is recorded as it changes now, and bare `charter` puts it back.

```
$ charter                      # after a restart, nothing running
✓ charter: restored the 4 chat(s) this plane last recorded
```

## The design, as settled

**The word is `record`.** `charter save` commits and pushes a tree; this writes one local file. `reopen.write` and 0.55.0's news entry already say *record*, so nothing new was invented and no message about either is ambiguous.

**When it writes — debounced on the version bumps that already exist.** `state.bump` is charter's own "something changed"; every writer in the frame moves it and every panel already polls it. Not on every bump (`cmd_launch` bumps after it claims a chat id and *before* tmux makes the window — a record taken there names a plane that never existed) and not on a timer (same defect, plus work spent on a plane that did nothing). The quiet period is what buys back the consistency a quit got for free by stopping the world first. It lives in `charter/frame/record.py` as `Debounce` — pure arithmetic over (what was seen, when it changed, whether it still owes a write), with the clock as an argument.

**Who writes — the frame process, as sole writer.** Panels are separate processes: six notice one bump, so recording where a bump is *noticed* is six writers racing one file, and a designated panel stops recording the moment it dies, which is when the record matters most.

> **The cost the brief asked to be told about, measured: the frame process did NOT watch bumps. Only panels did** (`frame/panel.py`'s `_watch`). It gains one — a daemon thread reading `state.version` per chat twice a second, the same read a panel already makes five times a second. That cost is paid rather than avoided by moving the writer, and there is nothing cheaper available: a bump is a file written by *another* process and the standard library has no file-change notification to subscribe to, which is exactly why the panels poll too.

**How it writes — atomically, and that turned up a real defect.** `reopen.write` already renamed a temp file into place. But `os.replace` is atomic and *the file it renames is not*: two writers sharing one temp NAME wrote into the same bytes, and the first to rename put the **second** writer's content in place while reporting to the first that its own record had landed. Already reachable (a quit racing a quit, `_forget_transcript` racing either); ordinary now that a thread records on a debounce in the same process as `cmd_reopen`'s `_consume`. The temp file is `tempfile.mkstemp`'s now, and is removed when the rename does not happen.

**What it records — what the manifest records today.** Which chats existed, in which workspace, with which harness, persona and directory, and which was on screen. No panel view state. It does not `capture-pane` (one subprocess per chat per write, for the one restore item that is *offered and never replayed*) but it does name a capture a quit already left on disk, so a running plane's record never withdraws an offer a quit made.

**What restore says — one compact line, and never silence.**

```
✓ charter: restored 3 of the 4 chats this plane last recorded — beta.1 did not come back
```

Refusing the whole restore because one chat could not start would make one dead workspace cost the other five; saying nothing is a frame quietly drawing less than it should. `charter reopen` typed by hand is unchanged — that is a deliberate act and its per-chat report is read.

**Two config keys, both defaulting true** — `[frame] record` and `[frame] restore`. Separable, because recording costs a little I/O and changes nothing you see while restoring changes what `charter` does; one key makes "record it, but let me ask for it back" unreachable.

**`charter --fresh` does not participate** — no restore, *and* no recording over the record it skipped. The alternative destroys the skipped record on a two-second timer, so the loss is invisible until it is too late.

## Two things measured that the brief did not settle

**1. "Detail on demand" could not be `charter reopen`, so the line does not offer it.** `_consume` does leave exactly the chats still owed in the record — but the process that just restored the plane is *also recording it*, so about `record.QUIET` seconds later the record is the running plane and the leftovers are gone. An operator who has just been attached to the frame the restore built cannot type anything in that window. So the compact line **names the chats that did not come back** (up to three, then a count) rather than pointing at a retry that is not there by the time the line is read.

**2. `charter reopen` had to learn to refuse a plane that is already running.** The record used to exist only after a quit, so that command never had a live plane to describe. It does now — and typing it out of habit after closing a terminal (which only *detaches*) would put a second copy of every running chat on the plane, each with a fresh ordinal so nothing on screen tells the copies apart, and for Claude Code both copies resuming one conversation. That is the same rule bare `charter`'s restore already follows, read a second time rather than a second rule, and it asks the disk before it asks tmux (a live chat always has a directory — `new_chat_id` claims its ordinal with the `mkdir`). A server that will not answer reads as *nothing live*, the opposite of what a quit assumes and right for the opposite reason: a reopen is wanted precisely when there is no server at all.

The restore on bare `charter` is gated the same way — **only when nothing is live anywhere on this plane** — for the same reason.

## One neighbour changed with it

`cmd_launch`'s closing line said *"this plane was quit"*, gated on the record naming the chat that had just ended. That reading **was** a quit only while a quit was the only writer. It now says what is still true and still actionable — the plane is recorded, one command puts it back — and it is gated on the chat actually being over, so a detach from a live harness is not told its plane is finished one line above "detached — the harness is still running".

`tests/test_a_chat_records_where_it_was_started.py` is updated to state its premise (`fresh=True`, `still_live=False`) rather than to accommodate the change: without them it was exercising the restore, not the notice it is about.

## The deletion sweep's thirteen, one classification each

First round: `no verdict: 13 survivors so far, 81 of 82 measured, 1 out of time`.
After this section's work: **`no survivors`** — `0 unpinned, 0 in masked cluster(s), 0 out of time, 77 pinned`, 3 of 3 shards reporting.

**Deleted — unreachable, not untested (3):**

| survivor | evidence |
|---|---|
| `cli.py` `argv and not all(…)` | `all()` over an empty iterable is `True`, so the conjunct cannot decide anything the clause behind it does not already say. |
| `record.py` `max(self.poll * 4, 1.0)` (both halves) | It is `Recorder.stop`'s **join timeout**, not the debounce. A tick already under way is inside a `list-windows` with its own five-second budget, so no arithmetic over the poll interval says anything about it. Now one named `JOIN = 2.0` — and the *bound* is pinned by a write that never returns. |
| `record.py` `sorted(names)` | **Measured, not argued.** On this machine readdir order is a function of the name set: identical across a `rmdir`/`mkdir` reclaim of the same ordinal (the case `frame/reopen.py` says happens *very often*) and across a chat added and removed between two readings. So the sort defended against something that cannot arrive. POSIX still promises nothing there, so the answer was not to delete the sort and lean on the measurement — the fingerprint is a `frozenset` now and has no order to be wrong about. |

**Kept and pinned — reachability established first (10):**

`config.FRAME.get(key, True)` ×3 looked dead, because `frame_of` starts from `FRAME_DEFAULTS`. It is not: `config.FRAME` is a module attribute and `tests/test_frame_border_surface._frame` assigns a **partial** mapping over it, where a bare subscript is a `KeyError` out of the launcher's entry path — `_bare_launch`'s own recorded reason for `config.HARNESS or {}`, one setting over. Both keys default true *by design*, so the **absence of the key is pinned, in both directions, at all three read sites**, alongside a plane with no `charter.toml` at all.

`dest is not None and dest.is_file()` is reachable through `_record_the_plane`'s own signature — without it, a chat id that cannot name a transcript is an `AttributeError` out of a writer whose contract is to degrade per chat.

The rest are ordinary test gaps, now closed: the `_records_the_plane` gate, the `if capture:` that keeps `prune_transcripts` a quit's job, `len(kept) <= MISSING_NAMED` at its boundary, `state.own_workspace(chat) or ""` (asserted against the **file**, since the reader coerces a `null` back to `""`), and the `NOT_RESTORED` sentence hand-spelled at the surface it reaches.

And `QUIET` now has the claim it exists for, rather than only its arithmetic: **a chat allocated and bumped but not yet windowed is not recorded**, and is once its window is there.

**`1 out of time` is pinned, not non-terminating.** It is `instance.py`'s `"restore"` toml key. Applying the exact mutation (`"restore"` → `"sftupsf"`) fails the suite in normal time — the shard was cancelled, not hung.

Every one of the thirteen was verified by applying the mutation and watching the named test fail. (One methodology note worth passing on: an equal-length mutation applied and reverted inside one second leaves a **stale `.pyc`** — same mtime, same size — so a hand-run mutation check must clear `__pycache__` or it silently measures the unmutated tree.)

## Verification

- `python3 -m unittest discover -s tests` (CI's own loader): **Ran 10726 tests … OK (skipped=9)**, on the final head, rebased onto `main` with #847 merged.
- 96 tests in `tests/test_charter_records_the_plane_as_it_changes.py`; every path-touching case asserts `edm-test-` is in `config.STATE_DIR` before it writes, and no case reaches a real tmux socket.
- Every operator-facing sentence is hand-spelled at the assertion, not compared against the constant that produces it.
- `dependencies = []` holds — stdlib only (`threading`, `tempfile`, `contextlib`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Us4MbwkSCJCxwt1CjAd1sf
