### PR TITLE
doctor answers for the directory it is running in, not the plane it resolved (#851)

### DIFF
--- a/charter/commands.py
+++ b/charter/commands.py
@@ -1040,8 +1040,17 @@ def _hooks_snippet() -> str:
     return json.dumps({"hooks": {"PreToolUse": [_GUARD_HOOK]}}, indent=2)
 
 
-def _plugin_dispatches_guard() -> str | None:
+def _plugin_dispatches_guard(root: Path) -> str | None:
     """The enabled plugin whose own ``hooks.json`` dispatches `charter hook pretooluse`.
+
+    *root* is the directory whose ``enabledPlugins`` decides it, and it is passed rather
+    than inherited because doctor's default is no longer the plane (#851): every row there
+    now answers for the directory the SESSION is rooted in, which is where the host reads
+    settings from. This caller is not asking about a session — it is about to write
+    ``root/.claude/settings.json``, so the enablement that matters is the one recorded in
+    that same file. Without the argument, `charter reinit` typed from a subdirectory would
+    miss the plugin enabled in the plane's settings and write a second declaration into it
+    — the doubling this function exists to prevent, arrived at from a new direction.
 
     Deliberately NOT "is a charter plugin enabled". `doctor._plugin_declaring_guard`
     records why, and 0.43.1 got it wrong by reading `enabledPlugins` instead: **installed,
@@ -1054,7 +1063,7 @@ def _plugin_dispatches_guard() -> str | None:
     """
     from . import doctor
 
-    return doctor._plugin_declaring_guard()
+    return doctor._plugin_declaring_guard(root)
 
 
 def _ensure_guard_hook(root: Path) -> tuple[str, Path | None]:
@@ -1075,7 +1084,7 @@ def _ensure_guard_hook(root: Path) -> tuple[str, Path | None]:
     # `charter hook pretooluse` runs twice for every Bash call — the same doubling Codex
     # got from two installers, arrived at here by one writer and one checker disagreeing
     # about what "wired" means in the same file.
-    if _plugin_dispatches_guard():
+    if _plugin_dispatches_guard(root):
         return "present", p
     if not p.exists():
         try:

--- a/charter/doctor.py
+++ b/charter/doctor.py
@@ -639,22 +639,101 @@ def check_plane_root() -> Result:
 
 
 
-def _settings_files() -> list[Path]:
+def session_root() -> Path:
+    """The directory the HOST resolves this session's project settings against (#851).
+
+    **Not the plane, and that is the whole point.** `config.ROOT` comes from
+    `root.find_root`, which walks UP from the working directory until it finds a
+    `charter.toml` — so it lands on the plane from anywhere inside it, which is exactly
+    right for identity. Claude Code does not walk up: project settings, agents, skills and
+    commands are read from the session's own directory and nowhere above it (only
+    `CLAUDE.md` walks). A chat launched at `workspaces/<ws>/` — where the `+` button and
+    every workspace tab put one — therefore reads none of the plane's `.claude/`, while
+    `doctor` read all of it and reported the plugin enabled and the guard wired over a
+    session that had neither.
+
+    ``os.getcwd()`` is the evidence available, and it is the right evidence rather than a
+    stand-in: doctor runs *inside* the session it is reporting on, so the directory this
+    process is standing in is the directory the host resolved settings against.
+    ``$CLAUDE_PROJECT_DIR`` is exported to hook commands only — measured, not assumed: it
+    is absent from a session's own shell, so a `charter doctor` the agent or the operator
+    types would read nothing from it.
+
+    Deliberately NOT `root.tree_of`. That function answers "am I in a linked worktree of
+    the plane's repo" and answers ``None`` for ``workspaces/<ws>/<repo>`` **on purpose**
+    (its own docstring says so, and `nested_plane_in` exists because widening it would be
+    wrong). The question here is neither of those: it is "which directory is this session
+    rooted in", which no plane-relative derivation can answer.
+
+    Falls back to the plane if the cwd cannot be read at all — a process whose working
+    directory was deleted out from under it. A preflight row must render something.
+    """
+    from . import config as _config
+    try:
+        # Already canonical: the kernel resolves symlinks on the way out of `getcwd`, so
+        # this compares cleanly against a resolved plane without a second syscall that
+        # could itself raise.
+        return Path(os.getcwd())
+    except OSError:
+        return _canonical(Path(_config.ROOT))
+
+
+def _canonical(p: Path) -> Path:
+    """*p* with symlinks resolved, or *p* itself when it cannot be.
+
+    **One call site, deliberately.** The first draft resolved both sides of the comparison
+    in :func:`session_is_the_plane`, and the deletion sweep charged both — each was
+    individually deletable with the suite still green, because they masked each other and
+    because a Linux runner's ``/tmp`` needs no normalising either way. Only one of them was
+    ever load-bearing: `os.getcwd` hands back the physical path already, so the SESSION
+    side has nothing to normalise, while `config.derive` stores ROOT exactly as it was
+    handed in — a plane reached through a symlink (macOS's ``/var`` → ``/private/var``, a
+    symlinked checkout, `config.use` in a test) keeps that spelling.
+
+    So the plane is the side that needs it, and this is where it happens. Resolving a path
+    can raise `OSError` (an unreadable ancestor) or `RuntimeError` (a symlink loop), and a
+    preflight row must render something rather than traceback.
+    """
+    try:
+        return p.resolve()
+    except (OSError, RuntimeError):
+        return p
+
+
+def session_is_the_plane() -> bool:
+    """Is this session rooted at the plane, so that the plane's ``.claude/`` is in force?
+
+    The plane is canonicalised before comparing and the session is not, because only the
+    plane can be spelled two ways — see :func:`_canonical`. Without it a plane whose path
+    runs through a symlink answers "not the plane" for a session standing in the very
+    directory it resolved, and every row below would report a divergence that is not there.
+    """
+    from . import config as _config
+    return session_root() == _canonical(Path(_config.ROOT))
+
+
+def _settings_files(root: Path | None = None) -> list[Path]:
     """The settings the HOST actually resolves, in the order it reads them.
 
     One list, used both for a directly-declared hook and for `enabledPlugins`, so the two
     halves of "is it wired" can never disagree about which files are in force.
+
+    *root* defaults to :func:`session_root` — the directory this session is rooted in, not
+    the plane (#851). A caller that is asking about a **specific** file rather than about
+    this session names its own root: `commands._ensure_guard_hook` is about to write the
+    PLANE's `settings.json` and must read the plane's `enabledPlugins`, whatever directory
+    the operator happened to be standing in when they typed `charter reinit`.
     """
-    from . import config as _config
-    return [Path(_config.ROOT) / ".claude" / "settings.json",
-            Path(_config.ROOT) / ".claude" / "settings.local.json",
+    here = Path(root) if root is not None else session_root()
+    return [here / ".claude" / "settings.json",
+            here / ".claude" / "settings.local.json",
             Path.home() / ".claude" / "settings.json"]
 
 
-def _enabled_plugin_ids() -> set[str]:
+def _enabled_plugin_ids(root: Path | None = None) -> set[str]:
     """Plugin ids the host has ENABLED. Installed is not enabled (#177)."""
     out: set[str] = set()
-    for p in _settings_files():
+    for p in _settings_files(root):
         try:
             doc = json.loads(p.read_text())
         except (OSError, ValueError, UnicodeDecodeError):
@@ -667,7 +746,7 @@ def _enabled_plugin_ids() -> set[str]:
     return out
 
 
-def _plugin_declaring_guard() -> str | None:
+def _plugin_declaring_guard(root: Path | None = None) -> str | None:
     """An ENABLED Claude Code plugin whose own ``hooks.json`` dispatches the guard.
 
     ``CLAUDE_PLUGIN_ROOT`` is set only for the plugin's OWN processes, so a `charter doctor`
@@ -693,8 +772,14 @@ def _plugin_declaring_guard() -> str | None:
     Read from ``installed_plugins.json`` rather than globbed out of the plugin cache: the
     cache keeps every version ever fetched, so a stale copy would answer for a plugin since
     removed. The manifest is what the host actually installed.
+
+    *root* is the directory whose ``enabledPlugins`` to believe, defaulting to
+    :func:`session_root`. ``enabledPlugins`` is a settings key like any other, so it is
+    scoped to the directory the host read it from — a plugin enabled in the plane's
+    ``settings.json`` is not enabled for a chat rooted at ``workspaces/<ws>/`` (#851). A
+    caller writing a specific file names that file's directory instead.
     """
-    enabled = _enabled_plugin_ids()
+    enabled = _enabled_plugin_ids(root)
     if not enabled:
         return None
     manifest = Path.home() / ".claude" / "plugins" / "installed_plugins.json"
@@ -716,6 +801,54 @@ def _plugin_declaring_guard() -> str | None:
             except (OSError, UnicodeDecodeError):
                 continue
     return None
+
+
+def check_session_root() -> Result:
+    """Which directory answered for the settings rows — and whether it is the plane (#851).
+
+    Every row below that reads `.claude/settings.json` reads :func:`session_root`'s, and
+    when that is not the plane the operator will go and look at the plane's file, find the
+    guard declared in it, and conclude doctor is broken. So the divergence is stated once,
+    up front, in the vocabulary charter already uses for it: **the plane is identity, the
+    directory you are standing in is artifacts** (`config.in_tree`, `docs/control-plane.md`
+    → *What follows the plane, and what follows the tree*).
+
+    **A fact, never a verdict — OK even when the two differ.** A chat rooted in a workspace
+    is the designed workflow: the `+` button and every workspace tab put one there, and a
+    row that warns on the normal case is a row operators learn to skip — the failure
+    `check_memory_indexes` and `check_harness` each record in their own docstrings.
+    Whatever is actually *missing* because of the divergence warns on its own row, where it
+    can name its own remedy; this one supplies the reason those rows read the way they do
+    (ADR 0013).
+
+    **Trust is deliberately not asked here, and that is a real gap rather than an
+    oversight.** Claude Code gates hook execution and the status line on the directory
+    being trusted, globally, whatever declared them — so "the plugin is enabled here" and
+    "charter's hooks actually run here" are two different questions, and an untrusted
+    directory answers yes to the first and no to the second. That belongs to
+    `check_guard_seen`, which already answers dispatch from evidence (a guard that ran)
+    rather than from configuration, and which says in its own docstring why no amount of
+    reading configuration can see it. Naming a directory as trusted by reading
+    ``~/.claude.json`` would be one more proxy in the family this row is fixing.
+    """
+    from . import config as _config
+
+    name = "session root"
+    here = session_root()
+    if not _config.HAS_CONTROL_PLANE:
+        return Result(name, OK, detail=f"{here} — no control plane found")
+    if session_is_the_plane():
+        return Result(name, OK, detail=f"{here} — the plane")
+    return Result(
+        name, OK,
+        detail=(f"{here} — not the plane ({_config.ROOT})\n"
+                f"        ↳ the host reads project settings, agents, skills and commands "
+                f"from the session's own directory and does not walk up, so the plane's "
+                f".claude/ is not in force here — the rows below read {here}/.claude/ and "
+                f"~/.claude/\n"
+                f"        ↳ the plane is still this session's identity: personas, the "
+                f"vault, memory and workspaces resolve to {_config.ROOT} from anywhere "
+                f"inside it"))
 
 
 def check_guard_wired() -> Result:
@@ -802,6 +935,26 @@ def check_guard_wired() -> Result:
                  "was right — but it was the declaration this session actually had.")
     if declared:
         return Result(name, OK, detail=f"wired ({declared[0]})")
+    # The remedy has to name a file THIS session reads. `charter reinit` writes the PLANE's
+    # `.claude/settings.json`, and for a chat rooted at `workspaces/<ws>/` the host never
+    # reads that file — so the old hint would have been followed, believed, and left the
+    # session exactly as unguarded (#851). That is this row's own defect one level down: a
+    # remedy that looks like a fix and is not.
+    if not session_is_the_plane():
+        from . import config as _config
+
+        here = session_root()
+        return Result(
+            name, WARN,
+            detail=f"pretooluse is not wired — branch moves in the plane root are NOT "
+                   f"refused, and nothing declares it in {here}",
+            hint=(f"This session is rooted at {here}, not the plane ({_config.ROOT}), and "
+                  f"the host does not walk up — so the plane's .claude/settings.json never "
+                  f"reaches here, wired or not. `charter reinit` writes THAT file, so it "
+                  f"would not change this session. Declare `charter hook pretooluse` under "
+                  f"hooks.PreToolUse in {here}/.claude/settings.json, or in "
+                  f"~/.claude/settings.json which every session reads — or install the "
+                  f"Claude Code plugin."))
     return Result(name, WARN,
                   detail="pretooluse is not wired — branch moves in the plane root are "
                          "NOT refused",
@@ -1117,9 +1270,23 @@ def check_nested_plane() -> Result:
 
 
 def _ask_rules() -> list | None:
-    """`permissions.ask` from the plane's settings — ``None`` when it cannot be read."""
-    from . import config as _config
-    p = Path(_config.ROOT) / ".claude" / "settings.json"
+    """`permissions.ask` from the settings THIS SESSION reads — ``None`` when unreadable.
+
+    The session's project settings, not the plane's (#855, the same defect as #851 one
+    check over). `permissions` is a host settings key like any other, so the host resolves
+    it from the session's own directory and does not walk up. Reading the plane's file
+    instead was wrong in both directions for a chat rooted at ``workspaces/<ws>/``: it
+    reported the plane's `ask` rules as shadowing a persona's declared tools when they never
+    reach that session, and it could not see a rule in the session's own settings that
+    genuinely does. This row exists to say *why* pre-approved tools started prompting
+    (ADR 0014), so an answer read out of a file the host never opened sends the reader
+    hunting in the wrong place.
+
+    Still the project settings file alone, as before — widening to `settings.local.json` and
+    `~/.claude/settings.json`, which also carry `permissions`, is a second change and is not
+    this one.
+    """
+    p = session_root() / ".claude" / "settings.json"
     if not p.exists():
         return []
     try:
@@ -2490,7 +2657,8 @@ def _checks():
         results.append(check_forge_cli(forge))
         results.append(check_forge_auth(forge))
     results += [check_ssh(), check_control_plane_config(), check_control_plane_schema(),
-                check_plane_root(), check_harness(), check_frame(), check_guard_wired(), check_guard_seen(), check_nested_plane(),
+                check_plane_root(), check_session_root(),
+                check_harness(), check_frame(), check_guard_wired(), check_guard_seen(), check_nested_plane(),
                 check_workspace_clones(), check_changes(),
                 check_inventory(), check_vaults(),
                 check_vault_registry_divergence(), check_version_lock(),
@@ -2529,7 +2697,7 @@ def _checks():
 _FIXED_CHECK_NAMES = (
     "python3", "git", "git identity",
     # ← the forge cli/auth pair is spliced in here, see `check_names`
-    "git auth", "charter.toml", "schema", "plane root", "harness", "frame",
+    "git auth", "charter.toml", "schema", "plane root", "session root", "harness", "frame",
     "plane-root guard", "guard seen", "nested plane", "workspace clones", "changes",
     "inventory", "vaults", "vault registry", "version lock", "memory indexes",
     "personas", "persona grant", "front door", "news", "ask rules", "shadowed docs",

--- a/docs/news/unreleased-doctor-answers-for-the-directory-it-is-running-in.md
+++ b/docs/news/unreleased-doctor-answers-for-the-directory-it-is-running-in.md
@@ -1,0 +1,108 @@
+---
+version: unreleased
+headline: '`charter doctor` reports the directory the session is rooted in, and says when that is not the plane'
+---
+
+*"I ran `charter doctor` in a chat that was clearly unguarded. It told me the plugin was
+enabled and the guard was wired."*
+
+## What was measured
+
+A throwaway plane wired the way `charter init` leaves one — `enabledPlugins`, a
+`statusLine`, and a `hooks.PreToolUse` entry running `charter hook pretooluse` in
+`.claude/settings.json` — and a chat rooted at `workspaces/fleet/`, which is where the `+`
+button and every workspace tab put one. That directory has no `.claude/` at all.
+
+On the tree before this change:
+
+```
+cwd        : /…/plane/workspaces/fleet
+config.ROOT: /…/plane
+settings   : ['/…/plane/.claude/settings.json',
+              '/…/plane/.claude/settings.local.json',
+              '/…/home/.claude/settings.json']
+guard row  : ok | wired (/…/plane/.claude/settings.json)
+```
+
+A tick, naming a file that session never reads.
+
+## Why it read the wrong file
+
+`doctor._settings_files` asked about `config.ROOT/.claude/settings.json`, and `config.ROOT`
+comes from `root.find_root`, which **walks up** from the working directory until it finds a
+`charter.toml`. That is exactly right for identity — the plane is who you are, from anywhere
+inside it.
+
+The host does not walk up. Claude Code reads project settings, agents, skills and commands
+from the session's own directory and nowhere above it; only `CLAUDE.md` walks. So the two
+answers differ for every chat that is not rooted at the plane, and doctor reported the one
+the operator was not in.
+
+**That is the shape of the defect, not the shape of one plane.** Doctor is what an operator
+runs *because something felt wrong in that chat*, and a checker that reports on a different
+directory than the one it is running in is wrong wherever it lands — a workspace, a clone, a
+worktree, or anywhere you `cd`'d before launching.
+
+## What happens now
+
+A new `session root` row, and every row that reads settings answers for that directory:
+
+```
+  ✓  session root     /…/plane/workspaces/fleet — not the plane (/…/plane)
+        ↳ the host reads project settings, agents, skills and commands from the session's
+          own directory and does not walk up, so the plane's .claude/ is not in force here
+          — the rows below read /…/plane/workspaces/fleet/.claude/ and ~/.claude/
+        ↳ the plane is still this session's identity: personas, the vault, memory and
+          workspaces resolve to /…/plane from anywhere inside it
+  !  plane-root guard  pretooluse is not wired — branch moves in the plane root are NOT
+                       refused, and nothing declares it in /…/plane/workspaces/fleet
+```
+
+The row is **OK, never a warning**. A chat rooted in a workspace is the designed workflow;
+a row that warns on the normal case is one operators learn to skip. What is actually missing
+warns on its own row, where it can name its own remedy — and this row is the sentence that
+stops that warning reading as a bug in doctor.
+
+Charter says which is which rather than silently preferring either, in the vocabulary it
+already uses for the split (`docs/control-plane.md` → *What follows the plane, and what
+follows the tree*): **the plane is identity, the directory you are standing in is
+artifacts.**
+
+## The `ask rules` row had it too
+
+`_ask_rules` read `permissions.ask` from the plane's `settings.json` by its own path, so
+#851's fix did not reach it. `permissions` is a host settings key like any other and is
+scoped to the directory the host read it from, so for a chat rooted at `workspaces/<ws>/`
+the row was wrong in both directions: it reported the plane's `ask` rules as shadowing a
+persona's declared tools when they never reach that session, and it could not see a rule in
+the session's own settings that genuinely does. That row exists to name *why* pre-approved
+tools started prompting (ADR 0014), so a wrong answer sends the reader hunting in a file the
+host never opened. It now reads the same root every other settings row does.
+
+## The remedy had the same defect one level down
+
+`charter reinit` writes the **plane's** `.claude/settings.json`. Offered to a session rooted
+elsewhere, that hint would have been followed, believed, and left the session exactly as
+unguarded. So the guard row now names a file this session actually reads — the session
+root's own `.claude/settings.json`, or `~/.claude/settings.json`, which every session reads
+whatever it is rooted in.
+
+## What this does not check, and what a green row does not mean
+
+**Trust.** Claude Code gates hook execution and the status line on the directory being
+trusted, globally, whatever declared them — so *"the plugin is enabled here"* and *"charter's
+hooks actually run here"* stay two different questions, and an untrusted directory answers
+yes to the first and no to the second. Reading `~/.claude.json` for a `hasTrustDialogAccepted`
+flag would be one more proxy of exactly the kind this fix removes, and charter has not
+measured that file's semantics — a directory with no entry has not been *refused*, it has
+merely never been opened, and a checker that read absence as refusal would warn on planes
+that are fine.
+
+So, plainly: **a green `plane-root guard` row means "a file this session reads declares the
+guard". It does not mean the guard will fire.** Those are two rows on purpose — `guard seen`
+is the one that answers firing, and it answers from evidence that a guard actually ran. What
+neither row asks is whether this directory is trusted, and an untrusted directory is one
+where a declaration reads as present and nothing dispatches. `workspaces/<ws>/` inherits the
+plane's trust because it is inside the plane's git repo; a clone or a linked worktree has a
+git root of its own and needs its own acceptance, so that is where the gap bites. Filed
+separately rather than guessed at here.

--- a/tests/test_doctor_answers_for_the_session_root.py
+++ b/tests/test_doctor_answers_for_the_session_root.py
@@ -1,0 +1,341 @@
+"""`doctor` reports the directory it is RUNNING in, not the plane it resolved (#851).
+
+Fourth variant of the family #168, #177 and #261 belong to. Each one is a checker reading
+a proxy instead of the fact: *packaged* read as protection, *installed* read as wired,
+*enabled* read as loaded. This one is **elsewhere read as here**.
+
+`_settings_files` asked about `config.ROOT/.claude/settings.json`, and `config.ROOT` is
+resolved by walking UP from the working directory — so it lands on the plane from anywhere
+inside it. Claude Code does not walk up: a session's project settings, agents, skills and
+commands come from the session's own directory and nowhere above it. Only `CLAUDE.md`
+walks.
+
+So a chat launched at `workspaces/<ws>/` — where the `+` button and every workspace tab put
+it — has no plugin, no `PreToolUse` guard and no status line, and `charter doctor` read the
+plane's file and called all of it fine. **A checker that reports on a different directory
+than the one it is running in is wrong regardless of what it finds there**, and doctor is
+the one command an operator runs *because something felt wrong in that chat*.
+
+The fix is not to prefer either directory silently. The plane is still identity — personas,
+the vault, memory and workspaces resolve to it from anywhere (`config.in_tree`,
+`docs/control-plane.md`) — and the session's own root is what the host reads settings from.
+Doctor now says which is which, and the rows that read settings answer for the session.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from charter import config, doctor
+from tests._isolation import PersonaIso
+
+OK, WARN = doctor.OK, doctor.WARN
+
+#: Hand-spelled, never imported from the module under test. A test that compares a report
+#: against the constant that spells it asserts nothing — it passes just as happily over an
+#: empty string. `_GUARD_HOOK` lives in `commands` and is deliberately not reused here.
+_PRETOOLUSE = '{"hooks": {"PreToolUse": [{"matcher": "Bash", "hooks": [' \
+              '{"type": "command", "command": "charter hook pretooluse"}]}]}}'
+
+
+class SessionRootCase(PersonaIso):
+    """A plane wired the way `charter init` leaves one, and a workspace directory under it
+    that nothing has scaffolded — the exact shape the report describes."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        (config.ROOT / "charter.toml").write_text("schema = 1\n")
+        self.enterContext(mock.patch.object(config, "HAS_CONTROL_PLANE", True))
+        # A HOME with no user-level settings, so nothing here can pass on the developer's
+        # own machine config and prove nothing on CI.
+        self.home = self.tmp / "home"
+        (self.home / ".claude").mkdir(parents=True, exist_ok=True)
+        self.enterContext(mock.patch.dict(os.environ, {"HOME": str(self.home)}))
+        os.environ.pop("CLAUDE_PLUGIN_ROOT", None)
+        self.workspace = config.ROOT / "workspaces" / "fleet"
+        self.workspace.mkdir(parents=True, exist_ok=True)
+        # Resolved, because `os.getcwd()` is: the kernel hands back the physical path, and
+        # macOS's temp directory is reached through a symlink (`/var` → `/private/var`).
+        # Comparing a report built from `getcwd` against an unresolved fixture path fails
+        # on the developer's machine and passes on CI, which is worse than either.
+        self.workspace = self.workspace.resolve()
+        # Registered AFTER `PersonaIso`'s own cleanup, so it runs BEFORE it (LIFO): the
+        # tmp tree cannot be removed out from under the process's own cwd.
+        self.addCleanup(os.chdir, os.getcwd())
+
+    def rooted_at(self, where: Path) -> None:
+        """Launch this "session" at *where* — the directory the host resolves settings
+        against. `os.getcwd()` is the only evidence a running `charter doctor` has of it:
+        `$CLAUDE_PROJECT_DIR` is exported to hook commands, not to the session's shell."""
+        os.chdir(where)
+
+    def wire_the_plane(self) -> Path:
+        p = config.ROOT / ".claude" / "settings.json"
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(_PRETOOLUSE)
+        return p
+
+    def wire(self, where: Path) -> Path:
+        p = where / ".claude" / "settings.json"
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(_PRETOOLUSE)
+        return p
+
+
+class TestTheFalseGreen(SessionRootCase):
+    """The report, reproduced: the plane is wired, the session is not, doctor said fine."""
+
+    def test_the_planes_wiring_does_not_count_for_a_session_rooted_below_it(self):
+        self.wire_the_plane()
+        self.rooted_at(self.workspace)
+        self.assertEqual(doctor.check_guard_wired().status, WARN)
+
+    def test_the_settings_it_reads_are_the_ones_the_host_would_read(self):
+        self.rooted_at(self.workspace)
+        read = [str(p) for p in doctor._settings_files()]
+        self.assertEqual(read[:2],
+                         [str(self.workspace / ".claude" / "settings.json"),
+                          str(self.workspace / ".claude" / "settings.local.json")])
+
+    def test_a_plugin_enabled_only_in_the_planes_settings_does_not_reach_the_session(self):
+        """`enabledPlugins` is a settings key like any other, so it is scoped to the
+        directory the host read it from. The report's chat had no plugin for exactly this
+        reason, and doctor named one."""
+        p = config.ROOT / ".claude" / "settings.json"
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(json.dumps({"enabledPlugins": {"charter@charter": True}}))
+        self.rooted_at(self.workspace)
+        self.assertEqual(doctor._enabled_plugin_ids(), set())
+
+
+class TestItSaysWhichDirectoryAnsweredForIt(SessionRootCase):
+    def test_it_names_the_session_root_and_says_it_is_not_the_plane(self):
+        self.rooted_at(self.workspace)
+        detail = doctor.check_session_root().detail
+        self.assertIn(str(self.workspace), detail)
+        self.assertIn("not the plane", detail)
+
+    def test_it_says_the_host_does_not_walk_up(self):
+        """The whole mechanism, in the row. Without it "not the plane" reads as trivia —
+        every workspace directory is not the plane — instead of as the reason the plane's
+        `.claude/` is not in force."""
+        self.rooted_at(self.workspace)
+        self.assertIn("does not walk up", doctor.check_session_root().detail)
+
+    def test_it_keeps_the_plane_as_identity(self):
+        """Plane is identity, tree is artifacts. Charter's own vocabulary, said here so an
+        operator does not read this row as "you are on the wrong plane" and go looking for
+        their personas."""
+        self.rooted_at(self.workspace)
+        self.assertIn("identity", doctor.check_session_root().detail)
+
+    def test_a_session_rooted_at_the_plane_says_so(self):
+        self.rooted_at(config.ROOT)
+        r = doctor.check_session_root()
+        self.assertEqual(r.status, OK)
+        self.assertIn("the plane", r.detail)
+        self.assertNotIn("not the plane", r.detail)
+
+    def test_it_is_a_fact_and_never_a_verdict(self):
+        """A chat rooted in a workspace clone is the DESIGNED workflow — the `+` button
+        puts it there. A row that warns every session for the normal case is one operators
+        learn to skip, which is the failure `check_memory_indexes` and `check_harness` both
+        record. The unwired guard is what warns; this row supplies the reason."""
+        self.rooted_at(self.workspace)
+        self.assertEqual(doctor.check_session_root().status, OK)
+
+    def test_doctor_runs_it(self):
+        self.assertIn("session root", doctor.check_names())
+
+
+class TestTheGuardRowDoesNotSendYouSomewhereItDoesNotReach(SessionRootCase):
+    def test_it_does_not_offer_reinit_as_the_fix_for_a_session_rooted_elsewhere(self):
+        """`charter reinit` wires the PLANE's `.claude/settings.json`. That file is not the
+        one this session reads, so following the hint would leave the session exactly as
+        unguarded and the operator convinced they had fixed it — this issue again, one
+        level down, in the remedy rather than in the reading."""
+        self.rooted_at(self.workspace)
+        hint = doctor.check_guard_wired().hint
+        self.assertIn(str(self.workspace), hint)
+        self.assertIn("~/.claude/settings.json", hint)
+
+    def test_the_hint_stays_as_it_was_when_the_session_is_rooted_at_the_plane(self):
+        self.rooted_at(config.ROOT)
+        self.assertIn("charter reinit", doctor.check_guard_wired().hint)
+
+    def test_wiring_the_session_root_is_what_counts(self):
+        self.wire(self.workspace)
+        self.rooted_at(self.workspace)
+        r = doctor.check_guard_wired()
+        self.assertEqual(r.status, OK)
+        self.assertIn(str(self.workspace / ".claude" / "settings.json"), r.detail)
+
+    def test_user_settings_still_reach_every_session(self):
+        """Trust is inherited up to the git root and `~/.claude/settings.json` is read by
+        every session, so this is the one declaration that covers a chat rooted anywhere
+        inside the plane's repo. The hint above names it for that reason."""
+        (self.home / ".claude" / "settings.json").write_text(_PRETOOLUSE)
+        self.rooted_at(self.workspace)
+        self.assertEqual(doctor.check_guard_wired().status, OK)
+
+
+class TestTheHostileCases(SessionRootCase):
+    """Every catch pinned by a test that makes the call under it throw. `nested_plane_in`
+    states the rule these follow: a promise asserted only by paths that never fail is a
+    promise nothing measured — and a preflight row must render something whatever it finds,
+    because a check that raises is a check the reader never sees."""
+
+    def test_a_deleted_working_directory_falls_back_to_the_plane(self):
+        """`os.getcwd()` raises when the directory the process is standing in has been
+        removed under it. Doctor still has to print a row — and it must not print the
+        divergence one, which would blame a plane for a failed syscall."""
+        with mock.patch("os.getcwd", side_effect=OSError("cwd is gone")):
+            self.assertTrue(doctor.session_root().samefile(config.ROOT))
+            self.assertTrue(doctor.session_is_the_plane(),
+                            "a getcwd that failed is not a session rooted elsewhere")
+
+    def test_an_unresolvable_path_compares_unresolved_rather_than_raising(self):
+        """A symlink loop makes `Path.resolve` raise `RuntimeError`, and an inaccessible
+        ancestor makes it raise `OSError`. Neither is a reason for `charter doctor` to
+        traceback."""
+        self.rooted_at(config.ROOT)
+        with mock.patch.object(Path, "resolve", side_effect=RuntimeError("symlink loop")):
+            self.assertIsInstance(doctor.session_is_the_plane(), bool)
+
+    def test_with_no_plane_anywhere_the_row_says_so_instead_of_reporting_a_divergence(self):
+        """`charter doctor` outside a control plane is supported — `check_guard_wired` says
+        so in its own first branch, and `find_root_or_cwd` exists so import-time path
+        building survives there. `config.ROOT` is then the starting directory rather than a
+        plane, so without this branch the row compares a directory against a non-plane and
+        announces a divergence between two things neither of which is a plane.
+
+        **Asserted on what only this branch can say.** The first version of this test
+        checked that the detail names the directory — which the fall-through detail also
+        does, so deleting the branch left it green and the deletion sweep charged the line
+        as unpinned. `no control plane` is reachable from here and from nowhere else."""
+        self.rooted_at(self.workspace)
+        with mock.patch.object(config, "HAS_CONTROL_PLANE", False):
+            r = doctor.check_session_root()
+        self.assertEqual(r.status, OK)
+        self.assertIn(str(self.workspace), r.detail)
+        self.assertIn("no control plane", r.detail)
+        self.assertNotIn("not the plane", r.detail)
+
+
+class TestTwoSpellingsOfOneDirectoryAreOneDirectory(SessionRootCase):
+    """The comparison is the whole fix, and a path comparison is only right if the two
+    sides are spelled the same way.
+
+    A fixture whose paths need no normalising leaves that untested exactly where it breaks.
+    #837 hit the mirror image of this — a masked pair of `resolve()` calls CI caught and
+    macOS did not, *hidden locally because macOS `/tmp` is a symlink and every fixture path
+    needed normalising for free*. So the symlink here is built on purpose rather than
+    inherited from the platform, and the test means the same thing on both.
+
+    The failure it prevents is worse than the one #851 is about: doctor announcing "this
+    session is rooted elsewhere" for a session rooted exactly where it should be, and every
+    settings row below it reporting a divergence that does not exist.
+    """
+
+    def _linked_plane(self) -> tuple[Path, Path]:
+        real = self.tmp / "real-plane"
+        real.mkdir()
+        (real / "charter.toml").write_text("schema = 1\n")
+        link = self.tmp / "linked-plane"
+        link.symlink_to(real)
+        return real, link
+
+    def test_a_plane_spelled_through_a_symlink_is_still_this_sessions_plane(self):
+        """`config.derive` stores ROOT exactly as it was handed in — `config.use`, a
+        symlinked checkout, and macOS's own `/var` → `/private/var` all produce one. The
+        session side needs nothing: `os.getcwd` hands back the physical path already."""
+        real, link = self._linked_plane()
+        with mock.patch.object(config, "ROOT", link):
+            self.rooted_at(real)
+            self.assertTrue(doctor.session_is_the_plane())
+
+    def test_the_row_does_not_announce_a_divergence_that_is_not_there(self):
+        real, link = self._linked_plane()
+        with mock.patch.object(config, "ROOT", link):
+            self.rooted_at(real)
+            detail = doctor.check_session_root().detail
+        self.assertIn("the plane", detail)
+        self.assertNotIn("not the plane", detail)
+
+    def test_the_planes_own_wiring_still_counts_when_it_is_reached_that_way(self):
+        """The consequence, not the predicate. An unnormalised comparison would report the
+        guard unwired at the plane's own root — the false alarm this fix must not create
+        while removing a false green."""
+        real, link = self._linked_plane()
+        self.wire(real)
+        with mock.patch.object(config, "ROOT", link):
+            self.rooted_at(real)
+            self.assertEqual(doctor.check_guard_wired().status, OK)
+
+
+class TestTheAskRulesRowAnswersForTheSessionToo(SessionRootCase):
+    """#855, folded in: the same defect one check over, and the same one-line shape of fix.
+
+    `permissions.ask` is a host settings key, so it is scoped to the directory the host read
+    it from. The row exists to name *why* a persona's declared tools started prompting
+    (ADR 0014) — an answer read out of a file the session never opens sends the reader to
+    the wrong file, in both directions.
+    """
+
+    def _persona_declaring(self, *tools: str) -> None:
+        from charter import persona
+        self.make_persona("ops", role="Ops", vault="none", tools=", ".join(tools))
+        persona.set_active("ops")
+
+    def _ask(self, where: Path, *rules: str) -> None:
+        p = where / ".claude" / "settings.json"
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(json.dumps({"permissions": {"ask": list(rules)}}))
+
+    def test_a_rule_in_the_planes_settings_does_not_shadow_a_session_rooted_below_it(self):
+        self._persona_declaring("kubectl")
+        self._ask(Path(config.ROOT), "Bash(kubectl *)")
+        self.rooted_at(self.workspace)
+        r = doctor.check_ask_rules()
+        self.assertEqual(r.status, OK)
+        self.assertNotIn("kubectl", f"{r.detail} {r.hint}")
+
+    def test_a_rule_in_the_sessions_own_settings_does(self):
+        self._persona_declaring("kubectl")
+        self._ask(self.workspace, "Bash(kubectl *)")
+        self.rooted_at(self.workspace)
+        r = doctor.check_ask_rules()
+        self.assertEqual(r.status, WARN)
+        self.assertIn("kubectl", f"{r.detail} {r.hint}")
+
+
+class TestTheWriterStillAsksAboutTheFileItWrites(SessionRootCase):
+    def test_the_plugin_lookup_can_be_asked_about_a_named_root(self):
+        """`commands._ensure_guard_hook` writes the PLANE's settings file and skips it when
+        an enabled plugin already dispatches the guard. That question is about the plane's
+        own `enabledPlugins`, wherever the operator happened to be standing when they typed
+        `charter reinit` — so the writer names its root rather than inheriting doctor's."""
+        plug = self.tmp / "plug"
+        (plug / "hooks").mkdir(parents=True)
+        (plug / "hooks" / "hooks.json").write_text(json.dumps({"hooks": {"PreToolUse": [
+            {"hooks": [{"type": "command", "command": "charter hook pretooluse"}]}]}}))
+        man = self.home / ".claude" / "plugins" / "installed_plugins.json"
+        man.parent.mkdir(parents=True, exist_ok=True)
+        man.write_text(json.dumps({"version": 2, "plugins": {
+            "charter@charter": [{"scope": "user", "installPath": str(plug)}]}}))
+        p = config.ROOT / ".claude" / "settings.json"
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(json.dumps({"enabledPlugins": {"charter@charter": True}}))
+        self.rooted_at(self.workspace)
+        self.assertIsNone(doctor._plugin_declaring_guard(),
+                          "the session's own root sees no plugin")
+        self.assertEqual(doctor._plugin_declaring_guard(Path(config.ROOT)),
+                         "charter@charter")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_doctor_guard_wired.py
+++ b/tests/test_doctor_guard_wired.py
@@ -39,6 +39,17 @@ class GuardWiredCase(PersonaIso):
         self._real_home = os.environ.get("HOME")
         os.environ["HOME"] = str(self.home)
         self.addCleanup(self._restore_home)
+        # This session is rooted AT the plane — the case every test below is about, and
+        # since #851 something the fixture has to say out loud. `check_guard_wired` reads
+        # the settings the host would read for the running session, which is the working
+        # directory and never an ancestor of it; without this chdir these tests would
+        # write into `config.ROOT` and then read the developer's own checkout, passing or
+        # failing on whatever is wired there. Registered after `PersonaIso`'s cleanup so
+        # it runs before it (LIFO) and the tmp tree is never removed under our own cwd.
+        self.addCleanup(os.chdir, os.getcwd())
+        os.chdir(config.ROOT)
+        self.assertTrue(doctor.session_is_the_plane(),
+                        "these tests are about a session rooted at the plane")
 
     def _restore_home(self):
         if self._real_home is None:

--- a/tests/test_guard_ask.py
+++ b/tests/test_guard_ask.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 import io
 import json
+import os
 import unittest
 from contextlib import redirect_stderr, redirect_stdout
 from pathlib import Path
@@ -31,6 +32,17 @@ from tests._isolation import PersonaIso
 
 
 class GuardCase(PersonaIso):
+    def setUp(self) -> None:
+        super().setUp()
+        # Rooted at the plane, which is what these tests are about: `cmd_guard_ask` writes
+        # `config.ROOT/.claude/settings.json`, and since #855 `check_ask_rules` reads the
+        # settings the SESSION reads — the directory it is standing in, never an ancestor.
+        # The two agree here, which is the ordinary case; without the chdir the writer and
+        # the reader would be looking at different files and every assertion below would be
+        # about the developer's own checkout.
+        self.addCleanup(os.chdir, os.getcwd())
+        os.chdir(config.ROOT)
+
     def settings(self) -> Path:
         return Path(config.ROOT) / ".claude" / "settings.json"
 

--- a/tests/test_guard_enabled_is_not_loaded.py
+++ b/tests/test_guard_enabled_is_not_loaded.py
@@ -40,6 +40,14 @@ class GuardCase(PersonaIso):
         # early without one. Asserted here rather than worked around, so the fixture says
         # out loud that these rows are about a real plane.
         self.enterContext(mock.patch.object(config, "HAS_CONTROL_PLANE", True))
+        # Rooted at the plane, so `config.ROOT/.claude/settings.json` is the file the host
+        # would actually read for this "session" (#851). Without it these tests write one
+        # settings file and `check_guard_wired` reads another — the developer's own — which
+        # is how a fixture goes on passing while asserting nothing.
+        self.addCleanup(os.chdir, os.getcwd())
+        os.chdir(config.ROOT)
+        self.assertTrue(doctor.session_is_the_plane(),
+                        "these tests are about a session rooted at the plane")
 
     def plugin_enabled(self):
         """The plugin is enabled in settings — declared, and loaded only at session start."""

--- a/tests/test_guard_seen.py
+++ b/tests/test_guard_seen.py
@@ -19,6 +19,7 @@ date and the name; the reader draws the line (ADR 0013).
 from __future__ import annotations
 
 import json
+import os
 import unittest
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -28,6 +29,16 @@ from tests._isolation import PersonaIso, run_hook
 
 
 class SeenCase(PersonaIso):
+    def setUp(self) -> None:
+        super().setUp()
+        # Rooted at the plane. `check_guard_seen` asks whether a settings file still
+        # declares the guard, and since #851 that question is answered by the directory
+        # the session is rooted in rather than by the plane it resolved — so a fixture
+        # that only redirects `config.ROOT` would have this row reading the developer's
+        # own checkout, and these rows turning on whatever is wired there.
+        self.addCleanup(os.chdir, os.getcwd())
+        os.chdir(config.ROOT)
+
     def used_plane(self) -> None:
         """A plane a human has worked in — the gate on saying anything at all."""
         self.make_persona("ops", role="Ops", vault="none")


### PR DESCRIPTION
Fixes #851.

## The false green, reproduced

A throwaway plane wired the way `charter init` leaves one, and a chat rooted at
`workspaces/fleet/` — where the `+` button and every workspace tab put one. That directory
has no `.claude/` at all. On `main`:

```
cwd        : /…/plane/workspaces/fleet
config.ROOT: /…/plane
settings   : ['/…/plane/.claude/settings.json',
              '/…/plane/.claude/settings.local.json',
              '/…/home/.claude/settings.json']
guard row  : ok | wired (/…/plane/.claude/settings.json)
```

A tick, naming a file that session never opens.

## Root cause

`doctor._settings_files` asked about `config.ROOT/.claude/settings.json`, and `config.ROOT`
comes from `root.find_root`, which **walks up** from the working directory until it finds a
`charter.toml`. That is right for identity and wrong for settings: the host reads project
settings, agents, skills and commands from the session's own directory and does not walk up
— only `CLAUDE.md` walks. Verified rather than assumed, on this machine.

Fourth variant of the family #168, #177 and #261 belong to. *Packaged* read as protection,
*installed* read as wired, *enabled* read as loaded — and now **elsewhere read as here**.

## What changed

* `doctor.session_root()` — the directory the host resolved this session's settings against,
  which is `os.getcwd()`. Measured: `$CLAUDE_PROJECT_DIR` is exported to hook commands only
  and is absent from a session's own shell, so it is not available to a `charter doctor` the
  operator or the agent types. Deliberately **not** `root.tree_of`, which answers `None` for
  `workspaces/<ws>/<repo>` on purpose.
* `_settings_files`, `_enabled_plugin_ids` and `_plugin_declaring_guard` default to that
  root, so `plane-root guard`, `guard seen` and the plugin lookup all answer for the
  directory doctor is running in.
* A new **`session root`** row says when that is not the plane, in the vocabulary charter
  already draws (`docs/control-plane.md` → *What follows the plane, and what follows the
  tree*):

```
  ✓  session root     /…/plane/workspaces/fleet — not the plane (/…/plane)
        ↳ the host reads project settings, agents, skills and commands from the session's
          own directory and does not walk up, so the plane's .claude/ is not in force here
          — the rows below read /…/plane/workspaces/fleet/.claude/ and ~/.claude/
        ↳ the plane is still this session's identity: personas, the vault, memory and
          workspaces resolve to /…/plane from anywhere inside it
  !  plane-root guard  pretooluse is not wired — branch moves in the plane root are NOT
                       refused, and nothing declares it in /…/plane/workspaces/fleet
```

  **OK, never a warning.** A chat rooted in a workspace is the designed workflow, and a row
  that warns on the normal case is one operators learn to skip — the failure
  `check_memory_indexes` and `check_harness` each record. What is actually missing warns on
  its own row; this row is what stops that warning reading as a bug in doctor.
* The guard row's **remedy** had the same defect one level down. `charter reinit` writes the
  *plane's* `.claude/settings.json`; offered to a session rooted elsewhere it would have
  been followed, believed, and left the session exactly as unguarded. It now names a file
  this session actually reads — the session root's own, or `~/.claude/settings.json`, which
  every session reads whatever it is rooted in.
* `commands._plugin_dispatches_guard(root)` takes the root it is about to write. Doctor's
  default is no longer the plane, and this caller is not asking about a session — without
  the argument, `charter reinit` typed from a subdirectory would miss a plugin enabled in
  the plane's settings and write the second declaration that function exists to prevent.

## Trust is deliberately out of scope

Claude Code gates hook execution and the status line on the directory being **trusted**,
globally, whatever declared them — so *"the plugin is enabled here"* and *"charter's hooks
actually run here"* stay two different questions. Checked against `~/.claude.json` on this
machine: trust is inherited up to the git root (`workspaces/<ws>/` has no entry of its own
and rides the plane's), while a clone under `workspaces/<ws>/<repo>` has its own git root
and its own `hasTrustDialogAccepted` entry.

Reading that flag would be one more proxy of exactly the kind this PR removes, and dispatch
already has a row that answers it from evidence: `guard seen`, which exists because *no
amount of reading configuration can see it*. This fix does not make trust worse — `main`
reports the same tick over an untrusted directory today, from a different file — and it does
not claim more than it knows: `wired (<path>)` is a statement about a declaration, and the
row that speaks about dispatch is the one beside it. Noted in the news entry so it is a
known gap rather than a silent one.

## Neighbours, checked rather than assumed

Changing which directory `_settings_files` reaches makes any test that writes into
`config.ROOT` while standing somewhere else assert nothing. Three fixtures were in that
state and are now rooted at the plane explicitly (`test_doctor_guard_wired`,
`test_guard_enabled_is_not_loaded`, `test_guard_seen`), two of them asserting
`doctor.session_is_the_plane()` in `setUp` so the fixture states the case it is about. Left
unfixed they read the developer's own checkout — passing or failing on whatever is wired
there.

## Verification

Full suite, run the way CI runs it, in a clean worktree at `origin/main` + this commit:

```
python3 -m unittest discover -s tests
Ran 10647 tests in 569.558s
OK (skipped=9)
```

Red-green, checked rather than assumed: the new test file run against `origin/main`'s
`doctor.py` and `commands.py` with the test kept — `FAILED (failures=7, errors=5)`; with the
fix — `OK`. The three hostile-case pins (`getcwd` raising, `resolve` raising, no plane at
all) were each checked against a mutated copy that removes the fallback they cover, and each
one reddens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Us4MbwkSCJCxwt1CjAd1sf
