### PR TITLE
`--skip-existing` carries the argument it makes, and the build proves the rest (#835)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -274,6 +274,55 @@ jobs:
         run: pipx run build
       - name: Validate metadata renders on PyPI
         run: pipx run twine check dist/*
+      # NO `if:` ON THIS STEP. It is the whole of the claim `publish` makes about what a
+      # dispatch retry can do to a version PyPI already holds, and a skipped step is a
+      # green step — the same rule, and the same reason, as `guard`.
+      - name: Refuse an artefact set skip-existing cannot reason about
+        id: artefact-set
+        run: |
+          # WHAT THIS IS FOR, AND WHY IT IS HERE RATHER THAN IN `publish` (#835).
+          #
+          # `publish` passes `skip-existing` on the retry trigger, and the sentence that
+          # makes that safe is written where the input is set. Its load-bearing half is
+          # *what a dispatch can upload*: `--skip-existing` does not skip a VERSION, it
+          # skips the individual files PyPI already holds BY NAME and uploads the rest. So
+          # a retry against a published version is a no-op only while every file this
+          # repository can build for that version is already up there — which is true
+          # because the artefact set is determined by the project NAME and the VERSION and
+          # by nothing else. That is arithmetic living in the build configuration, not in
+          # this workflow, and a second wheel tag, a platform wheel or an `--python-tag`
+          # would end it silently: nothing would fail, a file would simply appear under a
+          # version already published. This step is that arithmetic, asserted.
+          #
+          # In `build` because `publish` cannot ask: it holds `contents: none` and never
+          # checks the repository out, so it has no `pyproject.toml` to derive the names
+          # from. `build` is also the right END of the release: this refusal lands before
+          # anything is uploaded, so a build config that outgrew the invariant costs a red
+          # run rather than a file glued onto a published version.
+          #
+          # `set -eu` for the reason `announce` spells out — Actions already runs `run:`
+          # under `bash -e`, and a property this file leans on should be one this file
+          # states.
+          set -eu
+          # Both names derived here, never written down: PEP 625/427 build the filename
+          # from the NORMALISED project name, so `charter-cp` is `charter_cp` on disk and a
+          # check spelling either by hand would be a second answer to a question
+          # `pyproject.toml` already answers.
+          expected=$(python -c 'import re,tomllib;p=tomllib.load(open("pyproject.toml","rb"))["project"];n=re.sub(r"[-_.]+","_",p["name"]).lower();v=p["version"];print("\n".join(sorted([f"{n}-{v}-py3-none-any.whl",f"{n}-{v}.tar.gz"])))')
+          # `-A`, so a DOTFILE in dist/ is a refusal. That is stricter than the upload,
+          # which globs `dist/*` and so would not offer one to PyPI — deliberately: a
+          # hidden file appearing here means the build changed (`uv build` writes a
+          # `.gitignore` into its output directory; `python -m build`, which this job
+          # runs, does not), and a release gate should stop for that rather than reason
+          # about whose glob rules decide. It costs a red run before anything is
+          # uploaded, which is the cheap end.
+          built=$(ls -A dist | LC_ALL=C sort)
+          if [ "$built" != "$expected" ]; then
+            echo "::error::this build did not emit the artefact set release.yml's retry path assumes. Expected exactly the two files the project name and version determine, and got something else — see the diff below. A dispatch retry uploads every built file PyPI does not already hold BY NAME, so an artefact set that depends on more than name-and-version means a run against an already-published version can ADD a file to it, which is not what `skip-existing` is there for (#835). If the new set is deliberate, decide what a retry should now mean before changing this step — the reasoning is beside `skip-existing` in the publish job."
+            printf 'expected:\n%s\n\nbuilt:\n%s\n' "$expected" "$built"
+            exit 1
+          fi
+          printf 'dist holds exactly what the name and version determine:\n%s\n' "$built"
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: dist
@@ -320,9 +369,30 @@ jobs:
           # fault, and the run cannot check it by comparing bytes either. `docs/news/`
           # ships inside the sdist, so the #665 recovery — fix the entry, re-dispatch —
           # rebuilds a different sdist by construction, and `--ref main` picks up whatever
-          # else merged besides. PyPI keeps what it has. That is what makes a version one
-          # immutable thing, and it is the right outcome: this run's business is the
-          # Release, not the artifacts.
+          # else merged besides. PyPI never lets a file be REPLACED, so the bytes this run
+          # rebuilds cannot displace the ones it holds, and that is the right outcome:
+          # this run's business is the Release, not the artifacts.
+          #
+          # THAT SENTENCE IS ABOUT REPLACEMENT AND SAYS NOTHING ABOUT ADDITION (#835). It
+          # used to read "PyPI keeps what it has, that is what makes a version one
+          # immutable thing", which is a claim `--skip-existing` does not make: the flag
+          # does not skip a VERSION, it skips the individual files PyPI already holds BY
+          # NAME and uploads the rest. Nor does `guard` close the gap — it reads an HTTP
+          # status off the version endpoint, so a `200` proves the version is there and
+          # not which files are under it, and finishing an upload that got the sdist up
+          # and died before the wheel is precisely what this retry is for.
+          #
+          # What actually bounds a dispatch is that every file this repository can build
+          # for a version is determined by the project NAME and that VERSION and by
+          # nothing else — so the set it uploads is either already there or the missing
+          # half of the same two files. That arithmetic lives in the build configuration,
+          # not here: a second wheel tag, a platform wheel or an `--python-tag` would end
+          # it with nothing failing and a file simply appearing under a published version.
+          # `build` therefore refuses an artefact set that is not exactly those two names
+          # (`id: artefact-set`, with the reasoning on the step), so changing what the
+          # build emits is a decision somebody makes in the open rather than a sentence
+          # here quietly ceasing to be true. `tests/test_a_half_finished_release_can_be_
+          # finished.py` holds both halves.
           #
           # NOT `true`, and the asymmetry is the whole of the decision. On the tag path a
           # version PyPI already holds has one realistic cause: a tag deleted and re-pushed

--- a/docs/news/unreleased-a-published-version-cannot-quietly-gain-a-file.md
+++ b/docs/news/unreleased-a-published-version-cannot-quietly-gain-a-file.md
@@ -1,0 +1,85 @@
+---
+version: unreleased
+headline: A release refuses a build whose artefact set a retry could add to a version PyPI already published
+---
+
+`release.yml` passes `--skip-existing` to the PyPI upload, on the `workflow_dispatch`
+trigger and only there (#673). The sentence beside it read:
+
+> PyPI keeps what it has. That is what makes a version one immutable thing.
+
+That is a claim `--skip-existing` does not make. **The flag does not skip a version.** It
+skips the individual files PyPI already holds *by name* and uploads the rest — so a
+dispatch against a published version is a no-op only while every file the build can emit
+for that version is already up there.
+
+## What was actually holding it up
+
+Nothing in the publishing workflow. `guard` asks
+`pypi.org/pypi/charter-cp/<version>/json` and reads the HTTP status: a `200` says the
+version exists, and says nothing about which files are under it. (An upload that got the
+sdist up and died before the wheel leaves exactly that state — and finishing it is what
+the retry is *for*.)
+
+What held was arithmetic in `pyproject.toml`. Hatchling emits
+
+```
+charter_cp-<version>.tar.gz
+charter_cp-<version>-py3-none-any.whl
+```
+
+and nothing else, both determined by the project name and the version alone. So the set a
+retry offers is either already published or the missing half of the same two files.
+
+Add a second wheel tag, a platform wheel or an `--python-tag` and that stops being true
+**silently**: nothing fails, and a file appears under a version that is already out. Same
+shape as #681 — a claim true of every run it was written for, with nothing making it true.
+
+## What happens now
+
+`build` refuses an artefact set that is not exactly the two names the project name and
+version determine, and says why the consequence lands two jobs later:
+
+```
+::error::this build did not emit the artefact set release.yml's retry path assumes.
+Expected exactly the two files the project name and version determine, and got something
+else … A dispatch retry uploads every built file PyPI does not already hold BY NAME, so an
+artefact set that depends on more than name-and-version means a run against an
+already-published version can ADD a file to it …
+
+expected:
+charter_cp-0.55.0-py3-none-any.whl
+charter_cp-0.55.0.tar.gz
+
+built:
+charter_cp-0.55.0-cp312-cp312-manylinux_2_17_x86_64.whl
+charter_cp-0.55.0-py3-none-any.whl
+charter_cp-0.55.0.tar.gz
+```
+
+Both names are derived from `pyproject.toml` — including the PEP 625 normalisation that
+makes `charter-cp` into `charter_cp` on disk — so the check has no opinion about the
+version, which is the release's own input.
+
+**In `build`, not beside the upload.** `publish` holds `contents: none` and never checks
+the repository out, so it has no `pyproject.toml` to derive the names from. `build` is
+also the safe end: the refusal costs a red run *before* anything irreversible, where the
+same refusal one job later would arrive with half a release shipped.
+
+## What a release refuses that it did not refuse before
+
+Exactly one thing: a build whose `dist/` holds anything other than those two files.
+Today's build emits precisely them, so no release that would have succeeded now fails.
+The step carries no `if:` — a skipped step is a green step, which is #558 — and it runs
+before `upload-artifact`, so the set `publish` receives is the set that was measured.
+
+The claim is asserted from both ends. `tests/test_a_half_finished_release_can_be_finished.py`
+executes the step's own script over a fake `dist/` (a third artefact, a missing wheel, a
+version that disagrees with the packaged one, a project name needing normalisation), and
+reads `pyproject.toml` for the two configuration changes that would end the invariant — a
+different build backend, or a wheel target pinned to a tag. That second half is a *prompt*
+rather than a proof, the same distinction `.github/publish-closure.json` already draws:
+what hatchling emits is settled by hatchling, and nothing offline reads that. It is why
+the proof runs over the files that actually came out.
+
+Nothing to adopt.

--- a/tests/test_a_half_finished_release_can_be_finished.py
+++ b/tests/test_a_half_finished_release_can_be_finished.py
@@ -45,9 +45,16 @@ different bytes by construction**: `docs/news/` ships inside the sdist, so the #
 recovery (fix the entry, re-dispatch) changes it, and `--ref main` picks up whatever else
 merged besides. A byte comparison would refuse the exact retry it exists to enable.
 
-PyPI keeps what it already holds either way. That is what makes a published version one
-immutable thing, and it is the right outcome: a retry's business is the Release, not the
+PyPI never lets a file be REPLACED either way, so the rebuilt bytes cannot displace the
+published ones, and that is the right outcome: a retry's business is the Release, not the
 artifacts.
+
+That sentence is about replacement, and for a while it was read as saying a published
+version cannot change at all. It does not (#835). `--skip-existing` skips the files PyPI
+already holds *by name* and uploads the rest, so what bounds a retry is not PyPI's refusal
+but the artefact set being determined by the project name and the version — an arithmetic
+that lives in `pyproject.toml`, which the publishing workflow never reads. `build` now
+asserts it, and `WhatARetryCanUploadIsBoundedByTheSetTheBuildEmits` below is that half.
 
 So the discriminator is which trigger asked — the only honest one available — and a
 trigger nobody has taught this rule gets the strict path. That is asserted below rather
@@ -59,12 +66,14 @@ from __future__ import annotations
 
 import os
 import re
+import shlex
 import subprocess
+import sys
 import tempfile
 import unittest
 from pathlib import Path
 
-from tests.test_workflows import Unparsed, _release, needs
+from tests.test_workflows import Unparsed, _release, _step, needs
 
 #: The action whose `skip-existing` this module is about. Matched by what the step *is*
 #: rather than by an `id:`, so the assertions below cannot be satisfied by a second step
@@ -272,6 +281,275 @@ class TheReaderRendersOnlyWhatItUnderstands(unittest.TestCase):
             with self.subTest(value=value):
                 with self.assertRaises(Unparsed):
                     skip_existing_on(self._step(value), "push")
+
+
+def _artefact_check() -> str:
+    """`build`'s script for the artefact set, refused if it is not there.
+
+    By `id:` rather than by what the step *is*, unlike `upload_step` above, because there
+    is nothing else to match on: it is a `run:` block, and matching it on its own text
+    would mean this reader agreeing with the script about the script.
+    """
+    return _step(_release()["jobs"]["build"], "artefact-set")["run"]
+
+
+def _run_artefact_check(built, packaged: str = "0.55.0",
+                        project: str = "charter-cp") -> tuple[int, str]:
+    """Run that step over a `dist/` holding exactly *built*, in a tree whose pyproject
+    says *project* / *packaged*.
+
+    A `python` shim for the same reason `_execute` has one — the step parses TOML, which
+    is 3.11+, and the runner's default `python` is a version nobody chose. Nothing else is
+    stubbed: this step reaches no network and asks nobody anything, which is most of why
+    it belongs in `build` rather than beside the upload.
+    """
+    with tempfile.TemporaryDirectory() as raw:
+        tmp = Path(os.path.realpath(raw))
+        (tmp / "pyproject.toml").write_text(
+            f'[project]\nname = "{project}"\nversion = "{packaged}"\n')
+        (tmp / "dist").mkdir()
+        for name in built:
+            (tmp / "dist" / name).write_bytes(b"")
+        (tmp / "bin").mkdir()
+        shim = tmp / "bin" / "python"
+        shim.write_text(f'#!/bin/sh\nexec {shlex.quote(sys.executable)} "$@"\n')
+        shim.chmod(0o755)
+        done = subprocess.run(["bash", "-e", "-c", _artefact_check()], cwd=tmp,
+                              env={"PATH": f"{tmp / 'bin'}:/usr/bin:/bin"},
+                              capture_output=True, text=True)
+        return done.returncode, done.stdout + done.stderr
+
+
+def _emitted(version: str = "0.55.0", project: str = "charter_cp") -> list[str]:
+    """The artefact set hatchling emits for this package — the two names the retry path's
+    whole safety rests on being all of them."""
+    return [f"{project}-{version}-py3-none-any.whl", f"{project}-{version}.tar.gz"]
+
+
+class WhatARetryCanUploadIsBoundedByTheSetTheBuildEmits(unittest.TestCase):
+    """The half of #673 that was true by arithmetic nobody had written down (#835).
+
+    `skip-existing` reads like "tolerate a version PyPI already has". It is not what the
+    flag does. **It skips the individual files PyPI already holds BY NAME and uploads the
+    rest** — so a dispatch against a published version is a no-op only while every file
+    the build can emit for that version is one PyPI already has. Otherwise the run adds a
+    file to a version that is already out, and nothing anywhere reports it.
+
+    Two things that look like they close that gap and do not:
+
+    * **`guard` does not.** It asks `pypi.org/pypi/<project>/<version>/json` and reads the
+      HTTP status. A `200` says the version exists; it says nothing about which files are
+      under it. An upload that got the sdist up and died before the wheel leaves exactly
+      that state, and finishing it is what the retry is *for*.
+    * **The action does not.** `--skip-existing` is per file, by construction: twine
+      uploads one distribution at a time and this flag is how a `400`/`409` on one of them
+      stops being fatal.
+
+    What actually holds is that hatchling emits `<name>-<version>.tar.gz` and
+    `<name>-<version>-py3-none-any.whl` and nothing else, both fully determined by the
+    project name and the version — so the set a retry offers is either already up there or
+    is the missing half of the same two files. That is a fact about `pyproject.toml`, in a
+    file the publishing workflow does not read, and it would stop being true silently:
+    add a second wheel tag, a platform wheel or an `--python-tag` and a published version
+    quietly gains a file on the next dispatch.
+
+    So it is asserted, in `build`, where the files exist and before any of them is
+    uploaded — the same move #681 made one file along, where the claim was "the tree a
+    dispatch publishes agrees with the version beside it" and the answer was to ask rather
+    than to write the assumption down.
+
+    **In `build` and not in `publish`, and that is not a preference.** `publish` holds
+    `contents: none` and never checks the repository out — it downloads the artifact and
+    uploads it — so it has no `pyproject.toml` to derive the two names from. `build` is
+    also the safe end: a refusal there costs a red run before anything irreversible, where
+    the same refusal beside the upload would arrive with half a release already shipped.
+    """
+
+    def setUp(self):
+        self.release = _release()
+        self.build = self.release["jobs"]["build"]
+
+    # ------------------------------------------------------------------ the premise
+
+    def test_a_trigger_still_tolerates_a_version_pypi_already_holds(self):
+        """If `skip-existing` ever comes off every trigger, PyPI refuses an upload into a
+        published version on every path and this class guards a door already locked. That
+        would be fine; it would also leave the reasoning above reading as current."""
+        upload = upload_step(self.release["jobs"]["publish"])
+        self.assertTrue(
+            any(skip_existing_on(upload, t) for t in self.release["on"]),
+            "no trigger passes `skip-existing` any more, so nothing can add a file to a "
+            "published version. This class's subject has changed shape — re-read the "
+            "module rather than deleting the assertions.")
+
+    # ------------------------------------------------------------------ the shape
+
+    def test_the_bound_is_measured_in_the_job_whose_output_publish_uploads(self):
+        """`publish` uploads the artifact `build` produced, so a check anywhere else is a
+        check of something other than the bytes PyPI is offered."""
+        self.assertIn("build", needs(self.release["jobs"]["publish"]),
+                      "`publish` no longer takes its distributions from `build`, so this "
+                      "step is measuring a set nobody uploads")
+        _artefact_check()      # raises by name if the step is gone from `build`
+
+    def test_the_bound_is_taken_before_the_artifact_publish_downloads_is_uploaded(self):
+        """Order, not merely presence. `upload-artifact` is what leaves `build`; a check
+        after it would pass or fail over a set that had already been handed on."""
+        steps = self.build["steps"]
+        checked = [i for i, s in enumerate(steps) if s.get("id") == "artefact-set"]
+        handed = [i for i, s in enumerate(steps)
+                  if str(s.get("uses", "")).startswith("actions/upload-artifact@")]
+        self.assertEqual(len(checked), 1, "one step bounds the artefact set")
+        self.assertEqual(len(handed), 1, "one step hands it to `publish`")
+        self.assertLess(checked[0], handed[0],
+                        "the artefact set is handed to `publish` before anything has "
+                        "asked what is in it")
+
+    def test_the_bound_cannot_be_skipped(self):
+        """#558's rule, applied to the step that carries #835's claim: a conditional step
+        reports success without running, which is indistinguishable here from a build
+        whose artefact set was checked and found correct."""
+        step = _step(self.build, "artefact-set")
+        self.assertNotIn(
+            "if", step,
+            "a condition on the step that bounds what a retry can upload. A skipped step "
+            "is a green step, so this is a way for the bound to report success unrun")
+
+    # ------------------------------------------------------------------ the behaviour
+
+    def test_the_two_files_name_and_version_determine_are_accepted(self):
+        """The direction that has to keep working: today's build must still release. A
+        step that refused everything would pass every other case in this class."""
+        code, said = _run_artefact_check(_emitted())
+        self.assertEqual(code, 0, said)
+
+    def test_the_order_the_files_are_found_in_does_not_decide_the_answer(self):
+        """`ls` orders by locale and the check compares a sorted listing, so this is the
+        difference between asserting about a SET and asserting about a directory read."""
+        code, said = _run_artefact_check(list(reversed(_emitted())))
+        self.assertEqual(code, 0, said)
+
+    def test_a_third_artefact_is_refused_and_named(self):
+        """#835 itself: the platform wheel that would otherwise be added to a version
+        already on PyPI by the next `workflow_dispatch`, with nothing failing."""
+        extra = "charter_cp-0.55.0-cp312-cp312-manylinux_2_17_x86_64.whl"
+        code, said = _run_artefact_check(_emitted() + [extra])
+        self.assertNotEqual(code, 0, f"a third artefact was accepted:\n{said}")
+        self.assertIn(extra, said, "the refusal does not name the file it is about")
+
+    def test_the_refusal_says_why_an_extra_file_matters_on_this_path(self):
+        """An exit code says a build changed; it does not say that the consequence lands
+        two jobs later, on a trigger, against a version already published. Whoever added
+        the wheel is the person who needs that sentence."""
+        code, said = _run_artefact_check(_emitted() + ["charter_cp-0.55.0-py2-none-any.whl"])
+        self.assertNotEqual(code, 0, said)
+        self.assertIn("ADD a file to it", said)
+        self.assertIn("skip-existing", said)
+
+    def test_an_artefact_that_did_not_get_built_is_refused_too(self):
+        """The other direction, and it is not symmetry for its own sake. A build that
+        emitted only the sdist would satisfy "nothing unexpected is here" while shipping a
+        release with no wheel — and would leave the wheel as a file a later dispatch could
+        still add."""
+        for missing, kept in (("the wheel", [_emitted()[1]]),
+                              ("the sdist", [_emitted()[0]]),
+                              ("both", [])):
+            with self.subTest(missing=missing):
+                code, said = _run_artefact_check(kept)
+                self.assertNotEqual(code, 0, f"a build missing {missing} was accepted:\n"
+                                             f"{said}")
+
+    def test_a_hidden_file_in_dist_is_refused_rather_than_reasoned_about(self):
+        """Stricter than the upload, on purpose, and measured so it stays a decision.
+
+        The action globs `dist/*`, which does not match a dotfile, so a hidden file would
+        never reach PyPI — and this refuses it anyway. A dotfile in `dist/` means the
+        build changed (`uv build` writes a `.gitignore` into its output directory; the
+        `python -m build` this job runs does not), and the alternative is a release gate
+        whose correctness depends on whose glob rules decide. It costs a red run before
+        anything is uploaded.
+        """
+        code, said = _run_artefact_check(_emitted() + [".gitignore"])
+        self.assertNotEqual(code, 0, f"a dotfile in dist/ was accepted:\n{said}")
+
+    def test_a_dist_that_is_not_there_at_all_is_a_refusal_and_not_a_pass(self):
+        """`ls` fails and the pipeline's status is `sort`'s, so `set -e` does not fire and
+        `built` comes out empty — which has to read as "not the expected set" rather than
+        as nothing to check. Fails closed, and this is the case that says so."""
+        with tempfile.TemporaryDirectory() as raw:
+            tmp = Path(os.path.realpath(raw))
+            (tmp / "pyproject.toml").write_text(
+                '[project]\nname = "charter-cp"\nversion = "0.55.0"\n')
+            (tmp / "bin").mkdir()
+            shim = tmp / "bin" / "python"
+            shim.write_text(f'#!/bin/sh\nexec {shlex.quote(sys.executable)} "$@"\n')
+            shim.chmod(0o755)
+            done = subprocess.run(["bash", "-e", "-c", _artefact_check()], cwd=tmp,
+                                  env={"PATH": f"{tmp / 'bin'}:/usr/bin:/bin"},
+                                  capture_output=True, text=True)
+        self.assertNotEqual(done.returncode, 0,
+                            f"no dist/ at all was accepted:\n{done.stdout}{done.stderr}")
+
+    def test_the_names_are_read_from_pyproject_rather_than_written_down(self):
+        """A step with the current version baked into it would pass every case above and
+        refuse the next release. The version is the release's own input, so it is the one
+        thing this check may not have an opinion about."""
+        code, said = _run_artefact_check(_emitted(version="9.9.9"), packaged="9.9.9")
+        self.assertEqual(code, 0, said)
+        code, said = _run_artefact_check(_emitted(version="0.55.0"), packaged="9.9.9")
+        self.assertNotEqual(code, 0, f"a dist built for another version was accepted:\n"
+                                     f"{said}")
+
+    def test_the_project_name_is_normalised_the_way_a_built_filename_is(self):
+        """`charter-cp` is `charter_cp` on disk: PEP 625 and PEP 427 both name the file
+        from the NORMALISED project name. A check spelling `p["name"]` straight through
+        would refuse every real build of this package, and one spelling the underscore by
+        hand would be a second answer to a question `pyproject.toml` already answers."""
+        code, said = _run_artefact_check(_emitted(project="charter_cp"),
+                                         project="charter-cp")
+        self.assertEqual(code, 0, said)
+        for spelling in ("Charter.CP", "charter__cp"):
+            with self.subTest(name=spelling):
+                code, said = _run_artefact_check(_emitted(project="charter_cp"),
+                                                 project=spelling)
+                self.assertEqual(code, 0, f"{spelling!r} normalises to charter_cp and the "
+                                          f"check did not read it that way:\n{said}")
+
+    def test_the_set_it_expects_is_the_set_this_repository_asks_for(self):
+        """The only assertion here that reaches past the workflow into `pyproject.toml`,
+        and it is a PROMPT rather than a proof — the same distinction `.github/publish-
+        closure.json` draws about the pins it records.
+
+        The proof runs in `build`, over the files that actually came out. This reads the
+        configuration that produces them, so the two changes #835 names in the abstract —
+        a backend whose filenames follow other rules, a wheel target pinned to a tag that
+        is not `py3-none-any` — arrive in a pull request rather than waiting for a release
+        to go red. It cannot be complete, because "what hatchling emits" is settled by
+        hatchling, and nothing offline reads that. Which is why it is not the thing being
+        relied on.
+        """
+        import tomllib
+        root = Path(__file__).resolve().parent.parent
+        with (root / "pyproject.toml").open("rb") as fh:
+            pkg = tomllib.load(fh)
+        self.assertEqual(
+            pkg["build-system"]["build-backend"], "hatchling.build",
+            "the backend changed, and a backend names its artefacts by its own rules — so "
+            "`build`'s artefact-set step is now encoding somebody else's convention (#835)")
+        wheel = ((pkg.get("tool", {}).get("hatch", {}).get("build", {})
+                  .get("targets", {}).get("wheel", {})) or {})
+        self.assertNotIn(
+            "tag", wheel,
+            "the wheel target pins a `tag`, so the built filename no longer follows from "
+            "the project name and the version alone. That is exactly the change that lets "
+            "a `workflow_dispatch` retry add a file to a version PyPI already holds — "
+            "decide what a retry should mean before widening `build`'s artefact-set step "
+            "to accept it (#835).")
+        code, said = _run_artefact_check(_emitted(version=pkg["project"]["version"]),
+                                         packaged=pkg["project"]["version"],
+                                         project=pkg["project"]["name"])
+        self.assertEqual(code, 0, f"the step refuses the set this repository's own name "
+                                  f"and version determine:\n{said}")
 
 
 def _announce_script(job: dict | None = None) -> str:

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -1541,13 +1541,19 @@ def _release() -> dict:
 
 
 def _step(job: dict, step_id: str) -> dict:
-    """The step this job runs under a given `id:`, refused if it is not there."""
+    """The step this job runs under a given `id:`, refused if it is not there.
+
+    Every step reached this way stands between a release and something irreversible —
+    `version-check` is the cross-check #558 exists for, `artefact-set` is the bound #835
+    put on what a retry may upload — so "not found" is refused rather than answered with a
+    default. A reader that shrugged would report a green measurement of a step that is no
+    longer in the file.
+    """
     found = [s for s in job["steps"] if isinstance(s, dict) and s.get("id") == step_id]
     if len(found) != 1:
         raise AssertionError(
-            f"expected exactly one step with `id: {step_id}`, found {len(found)}. That "
-            f"step is the version cross-check #558 exists for; if it moved, move these "
-            f"tests with it rather than deleting them.")
+            f"expected exactly one step with `id: {step_id}`, found {len(found)}. If it "
+            f"moved, move the tests that read it with it rather than deleting them.")
     return found[0]
 
 


### PR DESCRIPTION
Closes #835.

## The premise still holds, and is sharper than filed

`release.yml` was last touched on 2026-08-30 (`c6e8eb5`, #681); the issue was filed
2026-09-02. Nothing has moved.

Two corrections to the issue, both making the case stronger:

**`--skip-existing` really is per-file — verified from twine's source, not inferred.**
`twine/commands/upload.py` loops `for package in packages_to_upload:` and asks
`repository.package_is_uploaded(package)` for each one. The flag skips *files*, never a
version.

**`guard` does not cross-check both artefact names.** The issue says it does. It does
not — it runs

```
curl -sS -o /dev/null -w '%{http_code}' … https://pypi.org/pypi/$project/$pkg/json
```

and branches on the status. `-o /dev/null` throws the body away, so a `200` proves the
version exists and says nothing about which files are under it. The arithmetic was
thinner than the issue credited it with: an upload that got the sdist up and died before
the wheel leaves a `200` behind, and finishing it is exactly what the retry is *for*.

## What changed

**A step in `build`** (`id: artefact-set`) refuses a `dist/` that is not exactly the two
files the project name and version determine. Both names are derived from
`pyproject.toml`, including the PEP 625 normalisation that makes `charter-cp` into
`charter_cp` on disk — so the check has no opinion about the version, which is the
release's own input.

**In `build` rather than beside the upload**, and not by preference: `publish` holds
`contents: none` and never checks the repository out, so it has no `pyproject.toml` to
derive the names from. `build` is also the safe end — the refusal costs a red run before
anything irreversible, where the same refusal one job later would arrive with half a
release shipped.

**The header sentence is corrected.** "PyPI keeps what it has. That is what makes a
version one immutable thing" now says what is true (PyPI refuses *replacement*), states
that it says nothing about *addition*, names what actually bounds a dispatch, and points
at the step that enforces it.

## What a release would newly refuse

Exactly one thing: a build whose `dist/` holds anything other than
`charter_cp-<version>.tar.gz` and `charter_cp-<version>-py3-none-any.whl`.

**Measured, not reasoned.** A real `uv build` of this tree emits precisely those two, and
the step's own script run over that real `dist/` exits 0:

```
=== exit 0 ===
dist holds exactly what the name and version determine:
charter_cp-0.55.0-py3-none-any.whl
charter_cp-0.55.0.tar.gz
```

The 0.55.0 wheel actually on PyPI corroborates it: `Tag: py3-none-any`, `Generator:
hatchling 1.32.0`. **No release that would have succeeded now fails.**

One deliberate strictness: `ls -A`, so a dotfile in `dist/` is a refusal even though the
upload globs `dist/*` and would not offer one to PyPI. A hidden file there means the
build changed (`uv build` writes a `.gitignore` into its output directory; the
`python -m build` this job runs does not), and a release gate should stop for that rather
than reason about whose glob rules decide. It is commented and tested as a decision.

## Nothing was triggered, and no pin moved

No test tags, no `workflow_dispatch` runs. Every `uses:` is untouched, so
`.github/publish-closure.json` is unchanged and stays current. Behaviour is proved by
reading the file as YAML and by executing the step's script over a fake `dist/` — the
mechanism `tests/test_a_half_finished_release_can_be_finished.py` already uses for
`guard` and `announce`, extended rather than duplicated.

## Tests

`tests/test_a_half_finished_release_can_be_finished.py` gains
`WhatARetryCanUploadIsBoundedByTheSetTheBuildEmits`:

- *the premise* — some trigger still passes `skip-existing`, else this guards a locked door
- *the shape* — the step is in the job whose output `publish` uploads, runs before
  `upload-artifact`, and carries no `if:` (a skipped step is a green step, which is #558)
- *the behaviour* — the script is executed over a fake `dist/`: the two files (accepted,
  in either order), a third artefact (refused and named), a missing wheel/sdist/both, a
  dotfile, no `dist/` at all, a version disagreeing with the packaged one, and three
  project-name spellings that must normalise to `charter_cp`
- *the configuration* — `pyproject.toml` read for the two changes that would end the
  invariant (a different backend, a wheel target pinning a `tag`). Explicitly a **prompt,
  not a proof**, the same distinction `.github/publish-closure.json` already draws: what
  hatchling emits is settled by hatchling, which is why the proof runs over the files
  that actually came out.

`_step`'s failure message in `tests/test_workflows.py` no longer says every step it finds
is the #558 cross-check, since it now serves two.

## Verification

- New tests red on today's code before the workflow change: `Ran 28 tests` /
  `FAILED (failures=13)`
- Green after: `Ran 28 tests` / `OK`
- Full suite, CI's own loader (`python -m unittest discover -s tests`):
  `Ran 10740 tests in 559.722s` / `OK (skipped=9)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Us4MbwkSCJCxwt1CjAd1sf
