### PR TITLE
`charter init` re-derives config where the marker lands (#858)

### DIFF
--- a/charter/commands.py
+++ b/charter/commands.py
@@ -2245,6 +2245,36 @@ def cmd_init(args) -> int:
     else:
         toml_path.write_text(_render_charter_toml(forge_kind, owner, host))
         created.append(_root.MARKER)
+        # THE ANSWER JUST CHANGED, SO RE-DERIVE IT HERE (#858).
+        #
+        # `charter.config` resolves the plane once, at import, through
+        # `root.find_root_or_cwd` — which is right for every command except this one.
+        # `init` is the command whose own first act turns the answer over: the line above
+        # is what `root.find_root` looks for, so from here on this directory IS a plane
+        # and `config.HAS_CONTROL_PLANE` still said it was not, along with everything
+        # `derive` reads out of the file (`GROUP` is the `--owner` this very run wrote).
+        #
+        # Nothing visibly broke on it, because every helper below takes *root* as an
+        # argument and is handed the right directory — `_ensure_front_door` says so in its
+        # own docstring. That made it a trap rather than a fault: the first code path to
+        # ask "am I in a plane?" is correct everywhere except inside `init`, and #857 was
+        # that path — a harness context file gated on `HAS_CONTROL_PLANE` came out empty
+        # from a fresh `init`, and the gate was reverted rather than shipped.
+        #
+        # `config.use(root)` and NOT a fresh resolution, which is the tempting spelling and
+        # would be wrong: `root._outermost` hops outward through an enclosing plane's
+        # `workspaces/`, so a plane scaffolded inside one — `workspaces/<ws>/charter`, what
+        # charter's own dogfooding produces — would re-derive to the plane ABOVE it and
+        # `init` would spend the rest of its run reporting on a plane it did not create.
+        # `init` acts on the root it chose; the re-derivation follows that root.
+        #
+        # Once, here, rather than making `HAS_CONTROL_PLANE` a call at its ~25 read sites.
+        # The value changes at exactly one point in charter's life and this is it; a call
+        # everywhere would pay a stat per read to model an event with one cause, and would
+        # let the answer move mid-command for reasons nobody chose. `root._outermost`'s
+        # "loop until the answer stops moving" is not a precedent for that — it iterates
+        # inside ONE resolution and then the answer is fixed, which is what this is too.
+        config.use(root)
         if not owner:
             util.warn(f"No --owner given — {_root.MARKER}'s [[forge]] block has no "
                       f"owner/group set. Add one before `charter discover`.")

--- a/docs/news/unreleased-the-plane-init-creates-is-one-init-can-see.md
+++ b/docs/news/unreleased-the-plane-init-creates-is-one-init-can-see.md
@@ -1,0 +1,84 @@
+---
+version: unreleased
+headline: '`charter init` re-derives config where the marker lands, so the plane it just built is one it can see'
+---
+
+`charter.config` resolves the control plane **once**, at import, through
+`root.find_root_or_cwd`. That is right for every command except the one whose own first act
+changes the answer: `cmd_init` wrote `charter.toml` and then ran to completion with
+`config.HAS_CONTROL_PLANE` still `False`, in a directory that was by then a plane (#858).
+
+Nineteen other derived settings were stale with it. `GROUP` is the plainest: `--owner` is
+written into `charter.toml` by that very command, and the parsed copy beside it never saw
+it.
+
+## Why nothing was visibly broken
+
+Every helper `init` calls takes *root* as an argument and is handed the right directory —
+`_create_baseline_dirs(root)`, `_wire_harnesses(root)`, and `_ensure_front_door`, whose own
+docstring says it writes "through explicit paths under *root* rather than
+`config.PERSONAS_DIR`". So the stale globals were never *read* on the path that mattered.
+That made it a trap rather than a fault: correct until somebody adds a code path that asks
+"am I in a plane?".
+
+Somebody did. Gating `hooks.context_block` on `HAS_CONTROL_PLANE` (#852/#857) broke a fresh
+`charter init` — the gate asked during `init`, the answer was `False`, and the generated
+opencode context file came out empty. That gate was reverted rather than shipped, and this
+is why it can be written now.
+
+## What init does differently
+
+One statement, where the marker lands:
+
+```python
+toml_path.write_text(_render_charter_toml(forge_kind, owner, host))
+created.append(_root.MARKER)
+config.use(root)
+```
+
+Everything `init` runs afterwards — baseline directories, `.gitignore`, the status line,
+every harness's wiring, the front door, the guard hook, the first-clone offer — now sees a
+config that agrees with the directory it is standing in.
+
+**`config.use(root)` and not a fresh resolution**, which is the tempting spelling and is
+wrong. `root._outermost` hops outward through an enclosing plane's `workspaces/`, so a
+plane scaffolded inside one — `workspaces/<ws>/charter`, which is what charter's own
+dogfooding produces — would re-derive to the plane *above* it, and `init` would spend the
+rest of its run reporting on a plane it did not create. `init` acts on the root it chose;
+the re-derivation follows that root.
+
+**Once, here, rather than making `HAS_CONTROL_PLANE` a call.** The larger change was
+considered and refused: the value changes at exactly one point in charter's life and this
+is it, so a call at each of its ~25 read sites would pay a stat per read to model an event
+with one cause — and would let the answer move mid-command for reasons nobody chose.
+`root._outermost`'s "loop until the answer stops moving" is not a precedent for that: it
+iterates inside **one** resolution and then the answer is fixed, which is what this is too.
+
+## What is asserted
+
+`tests/test_the_plane_init_creates_is_one_init_can_see.py`. The claim pinned is not
+"`HAS_CONTROL_PLANE` is True afterwards" — that is one name, and the next reader will reach
+for a different one — but that **nothing derived from the root is left stale**: every name
+in `config.DERIVED` equals what `config.derive` produces for the directory `init` wrote
+into. A setting added to `derive` tomorrow is covered the day it is added.
+
+Two cases beyond that: a harness being wired is told there is a plane (the #857 symptom,
+asserted through the registry rather than through one harness), and a plane scaffolded
+inside another plane's `workspaces/` is the one `init` built rather than the one above it
+— the case that tells `config.use(root)` and a re-resolution apart.
+
+## One thing this moved in the suite
+
+Four `init` fixtures isolated themselves with `mock.patch.object(config, "ROOT", root)`.
+That looked like isolation and was a coincidence — the command's helpers take *root* as an
+argument, so the other twenty settings were simply never read while still pointing at the
+developer's real plane. It does not survive a command that re-derives: measured on
+`tests/test_init.py`, the patcher put `ROOT` back and left **nineteen** names in a temp
+directory `addCleanup` had already deleted, for every test that ran afterwards — the worse
+half of #402's shape, `config` reporting the real plane's root beside a `PERSONAS_DIR` that
+no longer exists.
+
+They now use `tests._isolation.point_config_at`, which snapshots and restores the same set
+`config.use` writes.
+
+Nothing to adopt.

--- a/tests/_isolation.py
+++ b/tests/_isolation.py
@@ -249,6 +249,30 @@ def make_plane(case, body: str = "schema = 1\n") -> Path:
     return case.tmp
 
 
+def point_config_at(case, root: Path) -> Path:
+    """Point every derived setting at *root* for one case, restoring all of them after.
+
+    What ``mock.patch.object(config, "ROOT", root)`` was standing in for in the four `init`
+    fixtures, and it was standing in badly. Patching the one name looked like isolation and
+    was a coincidence: `cmd_init`'s helpers all take *root* as an argument, so the other
+    twenty-odd settings were simply never read — while still pointing at the developer's
+    real plane throughout.
+
+    It stopped being survivable when `cmd_init` began re-deriving where the marker lands
+    (#858). `config.use` updates every `DERIVED` name; a patcher scoped to ``ROOT`` then
+    puts ``ROOT`` back and leaves the other nineteen in a temp directory that `addCleanup`
+    has already deleted — measured, on `tests/test_init.py`, and the WORSE half of #402's
+    shape: `config` reporting the real plane's root beside a `PERSONAS_DIR` that no longer
+    exists, for every test that runs afterwards.
+
+    So the snapshot is taken over the same set `config.use` writes, which is the set
+    `config.derive` produces — a setting added there is covered here the day it is added.
+    `PersonaIso`-based cases need none of this; they already snapshot in `setUp`.
+    """
+    case.addCleanup(config.restore, config.use(root))
+    return root
+
+
 def isolate_state_dir(case) -> Path:
     """Point ``config.STATE_DIR`` at a throwaway dir for one test case, restoring after.
 

--- a/tests/test_harness_registry.py
+++ b/tests/test_harness_registry.py
@@ -15,9 +15,9 @@ from pathlib import Path
 from types import SimpleNamespace
 from unittest import mock
 
-from charter import commands, config
+from charter import commands
 from charter.harness import base, registry
-from tests import _envguard
+from tests import _envguard, _isolation
 
 
 class Registry(unittest.TestCase):
@@ -60,8 +60,10 @@ class InitIsHarnessAgnostic(unittest.TestCase):
 
         root = Path(tempfile.mkdtemp(prefix="charter-fake-h-")).resolve()
         self.addCleanup(lambda: __import__("shutil").rmtree(root, True))
-        with mock.patch.dict(registry.KINDS, {"fake": FakeHarness}), \
-                mock.patch.object(config, "ROOT", root):
+        # Every derived setting, not just `ROOT` — see `_isolation.point_config_at`:
+        # `cmd_init` re-derives where the marker lands (#858).
+        _isolation.point_config_at(self, root)
+        with mock.patch.dict(registry.KINDS, {"fake": FakeHarness}):
             commands.cmd_init(SimpleNamespace(forge="github", owner="acme", host=None))
         self.assertTrue((root / ".fake-wiring").is_file(),
                         "cmd_init wired only the harnesses it names by hand")

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -9,10 +9,9 @@ import tempfile
 import unittest
 from pathlib import Path
 from types import SimpleNamespace
-from unittest import mock
 
-from charter import commands, config, instance
-from tests import _envguard
+from charter import commands, instance
+from tests import _envguard, _isolation
 
 
 class InitIso(unittest.TestCase):
@@ -23,13 +22,16 @@ class InitIso(unittest.TestCase):
         _envguard.unset_all()
 
         self.root = Path(tempfile.mkdtemp(prefix="charter-init-")).resolve()
+        # Every derived setting, not just `ROOT`. `cmd_init` re-derives where the marker
+        # lands (#858), so a patcher scoped to one name would put that one back and leave
+        # the other nineteen pointing into this temp directory for the rest of the run.
+        _isolation.point_config_at(self, self.root)
 
     def _init(self, **kw):
         args = SimpleNamespace(forge=kw.get("forge", "gitlab"),
                                owner=kw.get("owner", "acme"),
                                host=kw.get("host", None))
-        with mock.patch.object(config, "ROOT", self.root):
-            return commands.cmd_init(args)
+        return commands.cmd_init(args)
 
 
 class TestFreshDirectory(InitIso):

--- a/tests/test_init_front_door.py
+++ b/tests/test_init_front_door.py
@@ -16,10 +16,9 @@ import tempfile
 import unittest
 from pathlib import Path
 from types import SimpleNamespace
-from unittest import mock
 
-from charter import commands, config, instance
-from tests import _envguard
+from charter import commands, instance
+from tests import _envguard, _isolation
 
 
 class InitFrontDoorIso(unittest.TestCase):
@@ -30,14 +29,16 @@ class InitFrontDoorIso(unittest.TestCase):
         _envguard.unset_all()
 
         self.root = Path(tempfile.mkdtemp(prefix="charter-fd-")).resolve()
+        # Every derived setting, not just `ROOT` — see `_isolation.point_config_at`:
+        # `cmd_init` re-derives where the marker lands (#858).
+        _isolation.point_config_at(self, self.root)
 
     def _init(self, **kw):
         args = SimpleNamespace(forge=kw.get("forge", "github"),
                                owner=kw.get("owner", "acme"),
                                host=None,
                                front_door=kw.get("front_door", "steward"))
-        with mock.patch.object(config, "ROOT", self.root):
-            return commands.cmd_init(args)
+        return commands.cmd_init(args)
 
     def charter_of(self, name: str) -> str:
         return (self.root / "personas" / name / "persona.md").read_text()

--- a/tests/test_init_harness_wiring.py
+++ b/tests/test_init_harness_wiring.py
@@ -15,9 +15,9 @@ from pathlib import Path
 from types import SimpleNamespace
 from unittest import mock
 
-from charter import commands, config
+from charter import commands
 from charter.harness import opencode
-from tests import _envguard
+from tests import _envguard, _isolation
 
 
 class InitWiresBothHarnesses(unittest.TestCase):
@@ -33,9 +33,10 @@ class InitWiresBothHarnesses(unittest.TestCase):
         home = self.root / "xdg"
         home.mkdir(parents=True, exist_ok=True)
         self.enterContext(mock.patch.dict(os.environ, {"XDG_CONFIG_HOME": str(home)}))
-        args = SimpleNamespace(forge="github", owner="acme", host=None)
-        with mock.patch.object(config, "ROOT", self.root):
-            commands.cmd_init(args)
+        # Every derived setting, not just `ROOT` — see `_isolation.point_config_at`:
+        # `cmd_init` re-derives where the marker lands (#858).
+        _isolation.point_config_at(self, self.root)
+        commands.cmd_init(SimpleNamespace(forge="github", owner="acme", host=None))
 
     def test_the_opencode_plugin_is_installed_not_dropped_in_the_plane(self):
         """`init` installs opencode's plugin where opencode reads it for every project.
@@ -57,8 +58,7 @@ class InitWiresBothHarnesses(unittest.TestCase):
         settings["env"]["OTEL_METRICS_EXPORTER"] = "otlp"
         settings["env"]["CHARTER_HARNESS"] = "hand-edited"
         p.write_text(json.dumps(settings))
-        with mock.patch.object(config, "ROOT", self.root):
-            commands.cmd_reinit(SimpleNamespace())
+        commands.cmd_reinit(SimpleNamespace())
         again = json.loads(p.read_text())
         self.assertEqual(again["env"]["OTEL_METRICS_EXPORTER"], "otlp")
         self.assertEqual(again["env"]["CHARTER_HARNESS"], "hand-edited")

--- a/tests/test_the_plane_init_creates_is_one_init_can_see.py
+++ b/tests/test_the_plane_init_creates_is_one_init_can_see.py
@@ -1,0 +1,210 @@
+"""`charter init` writes the marker that makes a directory a plane — and then has to be
+able to see it.
+
+`charter.config` resolves the plane ONCE, at import, through `root.find_root_or_cwd`. That
+is right for every command except one: `init` is the command whose own first act changes
+the answer. It wrote `charter.toml` and carried on with `config.HAS_CONTROL_PLANE` still
+`False`, in a directory that was by then a plane (#858).
+
+## Why nothing was visibly broken
+
+`cmd_init`'s helpers all take *root* as an argument and are handed the right directory
+explicitly — `_create_baseline_dirs(root)`, `_wire_harnesses(root)`, `_ensure_front_door`,
+which says in its own docstring that it writes "through explicit paths under *root* rather
+than `config.PERSONAS_DIR`". So the stale globals were never *read* on the path that
+mattered, and the defect was one code change away from surfacing rather than a live fault.
+
+It surfaced under exactly such a change. Gating `hooks.context_block` on
+`HAS_CONTROL_PLANE` (#852/#857) broke a fresh `charter init`: the gate asked "am I in a
+plane?" during `init`, the answer was `False` in a plane charter had just built, and the
+generated opencode context file came out empty. That gate was reverted rather than shipped,
+and this module is why it can be written now.
+
+## What is asserted, and what is deliberately not
+
+The claim is not "`HAS_CONTROL_PLANE` is True afterwards" — that is one name, and the next
+reader will reach for a different one. It is that **nothing derived from the root is left
+stale**: after `init`, every name in `config.DERIVED` equals what `config.derive` produces
+for the directory `init` actually wrote into. A setting added to `derive` tomorrow is
+covered by that the day it is added, the same way `DERIVED` itself is computed rather than
+listed.
+
+The other half is *how*. Re-resolving — `find_root_or_cwd()` again — is the tempting
+spelling and is wrong: `root._outermost` hops outward through an enclosing plane's
+`workspaces/`, so a plane scaffolded inside another plane's workspace would re-derive to
+the OUTER one and `init` would spend the rest of its run reporting on a plane it did not
+create. `init` acts on the root it chose, so the re-derivation is `config.use(root)`, and
+`TheAnswerIsTakenAtTheRootInitChose` is the case that tells the two apart.
+"""
+
+from __future__ import annotations
+
+import io
+import shutil
+import tempfile
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
+
+from charter import commands, config, root as _root
+from charter.harness import base, registry
+from tests import _envguard, _isolation
+
+
+class InitSeesItsOwnPlane(unittest.TestCase):
+    """A throwaway root, with every derived setting pointing into it and restored after.
+
+    `config.use` rather than `mock.patch.object(config, "ROOT", …)`, which is what the
+    other `init` fixtures did: patching the one name looked like isolation while the rest
+    of `config` still pointed at the developer's real plane, and it cannot survive a
+    command that re-derives — the patcher would put `ROOT` back and leave the other twenty
+    names in the temp directory for every test that ran afterwards.
+    """
+
+    def setUp(self) -> None:
+        # `cmd_init` reports what it wrote on stdout/stderr. Captured, so a run of this
+        # module is a row of dots rather than seven scaffolding reports.
+        self.enterContext(redirect_stdout(io.StringIO()))
+        self.enterContext(redirect_stderr(io.StringIO()))
+        # Outside a frame, with no session id and no pinned workspace: stated here rather
+        # than inherited from the shell the suite was launched from (#519, #521, #528).
+        _envguard.unset_all()
+        self.root = Path(tempfile.mkdtemp(prefix="edm-test-init-sees-")).resolve()
+        self.addCleanup(shutil.rmtree, self.root, True)
+        _isolation.point_config_at(self, self.root)
+
+    def init(self, **kw) -> int:
+        return commands.cmd_init(SimpleNamespace(
+            forge=kw.get("forge", "github"), owner=kw.get("owner", "acme"),
+            host=kw.get("host", None)))
+
+
+class TheMarkerLandingChangesThisProcessesAnswer(InitSeesItsOwnPlane):
+    def test_the_directory_init_just_made_a_plane_reads_as_a_plane(self):
+        """The one-line version of #858, and the one a future `HAS_CONTROL_PLANE` gate
+        depends on."""
+        self.assertFalse(config.HAS_CONTROL_PLANE, "the fixture starts outside a plane")
+        self.init()
+        self.assertTrue((self.root / _root.MARKER).is_file(), "init wrote no marker")
+        self.assertTrue(
+            config.HAS_CONTROL_PLANE,
+            "`charter init` built a control plane and this process still reports there is "
+            "none. Any code that asks 'am I in a plane?' is correct everywhere except "
+            "inside `init`, and the failure is invisible until somebody runs it (#858)")
+
+    def test_nothing_derived_from_the_root_is_left_stale(self):
+        """The general claim, so the next setting is covered without anybody remembering
+        this file exists. `HAS_CONTROL_PLANE` is the name #858 was found through; `GROUP`
+        is a second one that was already wrong (`--owner` is written into `charter.toml`
+        by this very command and the parsed copy never saw it), and there is no reason to
+        think the third would be noticed either."""
+        self.init(owner="acme")
+        fresh = config.derive(self.root, start=self.root)
+        stale = {k: (getattr(config, k), fresh[k]) for k in config.DERIVED
+                 if getattr(config, k) != fresh[k]}
+        self.assertEqual(
+            stale, {},
+            "`init` left settings disagreeing with the plane it had just created — "
+            "`{name: (what config says, what the plane says)}`. Re-derive where the "
+            "marker lands (#858)")
+
+    def test_the_owner_this_run_declared_is_the_group_this_run_reads(self):
+        """`GROUP` named, because the general case above would pass over it if `derive`
+        ever stopped reading `[[forge]] owner` — and because it is the plainest evidence
+        that the staleness was never only about one boolean."""
+        self.init(owner="diazoxide")
+        self.assertEqual(config.GROUP, "diazoxide")
+
+    def test_running_it_twice_leaves_the_same_agreement(self):
+        """`init` is additive and idempotent, and the second run takes the branch where
+        the marker is already there. A re-derivation written only into the "I wrote it"
+        branch has to leave the second run correct as well — it does, because the first
+        run already made it true, and this is the case that says so rather than assuming
+        it."""
+        self.init()
+        self.init()
+        self.assertTrue(config.HAS_CONTROL_PLANE)
+        self.assertEqual({k: getattr(config, k) for k in config.DERIVED},
+                         config.derive(self.root, start=self.root))
+
+
+class TheWiringThatRunsAfterTheMarkerSeesAPlane(InitSeesItsOwnPlane):
+    """The reported symptom, isolated from the harness it was found in.
+
+    #857 gated a harness's generated context file on `HAS_CONTROL_PLANE`. `_wire_harnesses`
+    runs inside `cmd_init`, *after* the marker is written, so the gate saw `False` and the
+    file came out empty. Asserted through the registry rather than through opencode: the
+    property is "everything `init` runs after the marker sees a plane", and pinning it to
+    one harness would leave the next one to rediscover it.
+    """
+
+    def test_a_harness_being_wired_is_told_there_is_a_plane(self):
+        seen = {}
+
+        class Watcher(base.Harness):
+            name = "watcher"
+
+            def wire(self, root):
+                seen["plane"] = config.HAS_CONTROL_PLANE
+                seen["root"] = config.ROOT
+                return [("created", ".watcher")]
+
+        with mock.patch.dict(registry.KINDS, {"watcher": Watcher}):
+            self.init()
+        self.assertEqual(seen.get("root"), self.root,
+                         "the harness was wired against a root that is not the one init "
+                         "wrote the marker into")
+        self.assertIs(
+            seen.get("plane"), True,
+            "a harness wired by `charter init` is told it is outside a control plane, in "
+            "the plane `init` created two statements earlier. That is #858, and it is how "
+            "a gated context file shipped empty from a fresh init (#857)")
+
+
+class TheAnswerIsTakenAtTheRootInitChose(InitSeesItsOwnPlane):
+    """Not re-resolved — and the difference is a whole plane.
+
+    `root.find_root` hops outward through an enclosing plane's `workspaces/` and keeps
+    hopping "until the answer stops moving" (`root._outermost`), because the plane holding
+    the vault is the one every other command means. `init` means something else: the
+    directory it was told to build in. Re-deriving by resolution rather than from that
+    directory would leave `init` reporting on, and deriving state paths for, a plane it did
+    not create — silently, and only for the nested case, which is the one charter's own
+    dogfooding produces (`workspaces/<ws>/charter`).
+    """
+
+    def test_a_plane_scaffolded_inside_another_planes_workspace_is_the_one_init_built(self):
+        outer = Path(tempfile.mkdtemp(prefix="edm-test-outer-")).resolve()
+        self.addCleanup(shutil.rmtree, outer, True)
+        (outer / _root.MARKER).write_text("schema = 1\n")
+        inner = outer / "workspaces" / "dev" / "plane"
+        inner.mkdir(parents=True)
+
+        # The premise: standing at `inner`, resolution answers `outer`. If that ever stops
+        # being true this case is testing nothing, so it is measured rather than assumed.
+        self.assertEqual(_root.find_root(inner), outer,
+                         "resolution no longer hops outward, so the two spellings of the "
+                         "re-derivation can no longer be told apart here")
+
+        # Point config at `inner` the way a shell standing there would have to be pointed
+        # ($CHARTER_ROOT), since resolution on its own answers `outer` — which is the whole
+        # premise above.
+        _isolation.point_config_at(self, inner)
+        commands.cmd_init(SimpleNamespace(forge="github", owner="acme", host=None))
+
+        self.assertEqual(
+            config.ROOT, inner,
+            "after `init`, config points at the ENCLOSING plane rather than the one init "
+            "just built. The re-derivation re-ran resolution instead of deriving from the "
+            "root init chose, so every state path init reports now belongs to a plane it "
+            "did not create")
+        self.assertTrue(config.HAS_CONTROL_PLANE)
+        self.assertEqual(config.NESTED_ORIGIN, inner,
+                         "and the nesting itself goes unrecorded, so nothing downstream "
+                         "can say charter is standing in a plane inside a plane")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_the_plane_init_creates_is_one_init_can_see.py
+++ b/tests/test_the_plane_init_creates_is_one_init_can_see.py
@@ -182,17 +182,22 @@ class TheAnswerIsTakenAtTheRootInitChose(InitSeesItsOwnPlane):
         inner = outer / "workspaces" / "dev" / "plane"
         inner.mkdir(parents=True)
 
-        # The premise: standing at `inner`, resolution answers `outer`. If that ever stops
-        # being true this case is testing nothing, so it is measured rather than assumed.
-        self.assertEqual(_root.find_root(inner), outer,
-                         "resolution no longer hops outward, so the two spellings of the "
-                         "re-derivation can no longer be told apart here")
-
-        # Point config at `inner` the way a shell standing there would have to be pointed
-        # ($CHARTER_ROOT), since resolution on its own answers `outer` — which is the whole
-        # premise above.
+        # Point config at `inner` the way a shell standing there has to be pointed
+        # ($CHARTER_ROOT, which wins outright in `find_root`), since resolution on its own
+        # answers `outer`.
         _isolation.point_config_at(self, inner)
         commands.cmd_init(SimpleNamespace(forge="github", owner="acme", host=None))
+
+        # THE PREMISE, asserted after `init` rather than before it, because that is where
+        # it is load-bearing. Before, `inner` has no marker and resolution answers `outer`
+        # for the uninteresting reason. After, `inner` carries its own `charter.toml` and
+        # resolution STILL answers `outer` — that is `_outermost`'s hop, and it is the only
+        # thing that makes `config.use(root)` and a re-resolution distinguishable here.
+        self.assertEqual(
+            _root.find_root(inner), outer,
+            "resolution no longer hops outward past a plane inside another plane's "
+            "workspaces/, so this case can no longer tell the two spellings of the "
+            "re-derivation apart — re-read the class before trusting it")
 
         self.assertEqual(
             config.ROOT, inner,


### PR DESCRIPTION
Closes #858.

## The premise holds

`charter/config.py` and `charter/root.py` were last touched on 2026-08-31 (`67d9121`);
the issue was filed today. Reproduced before changing anything: six assertions red on
`origin/main`, including `config.HAS_CONTROL_PLANE is False` in a directory `cmd_init`
had just made a plane.

It is also **wider than filed**. `HAS_CONTROL_PLANE` is one of **nineteen** stale derived
settings. `GROUP` is the plainest: `--owner` is written into `charter.toml` by that very
command, and the parsed copy beside it never saw it.

## The design question, answered

**Re-derive once, where the marker lands.** One statement in `cmd_init`:

```python
toml_path.write_text(_render_charter_toml(forge_kind, owner, host))
created.append(_root.MARKER)
config.use(root)
```

Everything `init` runs afterwards — baseline directories, `.gitignore`, the status line,
every harness's wiring, the front door, the guard hook, the first-clone offer — now sees
a config that agrees with the directory it is standing in.

**Not the larger change**, and for a reason rather than for size. `HAS_CONTROL_PLANE`
changes at exactly one point in charter's life and this is it. A call at each of its ~25
read sites would pay a stat per read to model an event with one cause — and would let the
answer move *mid-command* for reasons nobody chose, trading one known staleness for an
unbounded set of inconsistencies. `root._outermost`'s "loop until the answer stops
moving" is not a precedent for lazy evaluation: it iterates inside **one** resolution and
then the answer is fixed, which is what this is too. (It would also collide with three
agents live on `hooks.py`, `doctor.py` and `harness/*`.)

**`config.use(root)` and not a fresh resolution**, which is the tempting spelling and is
wrong. `root._outermost` hops outward through an enclosing plane's `workspaces/`, so a
plane scaffolded inside one — `workspaces/<ws>/charter`, which is what charter's own
dogfooding produces — would re-derive to the plane *above* it, and `init` would spend the
rest of its run reporting on a plane it did not create. `TheAnswerIsTakenAtTheRootInitChose`
is the case that tells the two spellings apart.

## What an `init` does differently

Nothing it writes. Every file it produces is byte-identical — the helpers already took
`root` as an argument, which is why nothing was visibly broken. What changes is what the
rest of the run *sees*: `HAS_CONTROL_PLANE` is `True`, `GROUP` is the owner just
declared, and every root-derived path points into the new plane rather than at whatever
`find_root_or_cwd` answered before the marker existed.

Concretely, the next `HAS_CONTROL_PLANE` gate somebody adds — #857's, which was reverted
rather than shipped because a fresh `init` produced an empty opencode context file — can
now be written.

## Tests

`tests/test_the_plane_init_creates_is_one_init_can_see.py`. The claim pinned is **not**
"`HAS_CONTROL_PLANE` is True afterwards" — that is one name, and the next reader will
reach for a different one — but that *nothing derived from the root is left stale*: every
name in `config.DERIVED` equals what `config.derive` produces for the directory `init`
wrote into. A setting added to `derive` tomorrow is covered the day it is added, the same
way `DERIVED` is computed rather than listed.

Plus: `GROUP` named directly; idempotence across two runs; the #857 symptom asserted
through the harness registry rather than through one harness; and the nested-plane case
above.

## One thing this moved in the suite, and it is not cosmetic

Four `init` fixtures isolated with `mock.patch.object(config, "ROOT", root)`. That looked
like isolation and was a coincidence — the command's helpers take `root`, so the other
twenty settings were simply never read while still pointing at the developer's real plane.

It does not survive a command that re-derives. **Measured** on `tests/test_init.py`: the
patcher put `ROOT` back and left **nineteen** names in a temp directory `addCleanup` had
already deleted — the worse half of #402's shape, `config` reporting the real plane's
root beside a `PERSONAS_DIR` that no longer exists, for every test that ran afterwards.

They now use `tests._isolation.point_config_at`, which snapshots and restores the same
set `config.use` writes. Re-measured after the change: **zero leaked names** from any of
the seven modules that drive `cmd_init`.

## Verification

- New tests red on `origin/main`: `Ran 6 tests` / `FAILED (failures=6)`
- Green after the one-line fix: `Ran 6 tests` / `OK`
- Every `cmd_init`-driving module, leak-checked name by name against `config.DERIVED`:
  all `ok=True leaked=none`
- Full suite, CI's own loader (`python -m unittest discover -s tests`), on this exact
  commit: `Ran 10732 tests in 556.876s` / `OK (skipped=9)`
- `tools/sweep.py --plan`: 30 added lines in `charter/commands.py`, **0 mutations** — 29
  are comment and the one statement is not a shape any operator mutates. No survivors to
  classify; the pin is the red/green above.

No `charter init` was run anywhere inside the checkout; every case scaffolds into an
`edm-test-`/`charter-init-` prefixed temp directory with `config` pointed at it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Us4MbwkSCJCxwt1CjAd1sf
