### PR TITLE
A chat in a workspace directory gets charter's layer there (#850)

### DIFF
--- a/charter/commands_frame.py
+++ b/charter/commands_frame.py
@@ -4879,6 +4879,24 @@ def _launch(args) -> int:
     ws, rc, picked = _choose_workspace(args)
     if rc is not None:
         return rc
+    # **The isolation boundary exists before a chat is put inside it** (#850).
+    # `_choose_workspace` CREATES only on the picker's create branch; a launch that
+    # resolved silently — `charter claude`, `charter claude -w api`, every reopen — had a
+    # workspace name and possibly no directory to go with it, and the chat below then
+    # recorded that name beside whatever cwd the operator happened to be standing in.
+    # `_launch_root` answers the same question for the two callers that chdir first; this
+    # is it for the launch that does not, and both go through `ensure` so there is one
+    # creator rather than two.
+    #
+    # **Best effort, and it must be**: this runs before the frame exists, so a `util.err`
+    # here would be printed into a terminal that is about to switch to tmux's alternate
+    # screen (see the `tmuxctl.FLOOR` note above for the same measurement). A workspace
+    # charter could not create is exactly the state `_launch_root` already degrades to,
+    # and `doctor`'s `workspace layer` row is where it is reported.
+    try:
+        workspace.ensure(ws)
+    except (ValueError, OSError):
+        pass
     # Inside a tmux the operator already has, the frame is a WINDOW in THEIR server —
     # same layout, no second tmux, no second prefix key (ADR 0018 and the design spec
     # both settle this; `docs/frame.md` describes what it costs). Read from `$TMUX`,
@@ -7154,17 +7172,35 @@ def _launch_root(ws: str):
     to stand in the right place first — and the right place is what `charter --workspace
     <ws>` typed in it would have used.
 
-    **The plane's own root when that workspace has no directory yet**, which is a real
-    state rather than a defensive one: `switch.workspaces` folds
-    `config.DEFAULT_WORKSPACE` into its list whether or not its directory exists —
-    `workspace.ensure` makes it on demand — so a plane that has never made one still
-    offers a tab and a `+` for it. `config.ROOT` is where charter would have created it.
+    **`workspace.ensure`, not "the plane root if the directory is missing"** (#850). The
+    fallback was real rather than defensive — `switch.workspaces` folds
+    `config.DEFAULT_WORKSPACE` into its list whether or not its directory exists, so a
+    plane that has never made one still offers a tab and a `+` for it — and it created a
+    disagreement at the moment of launch that nothing downstream could resolve: the chat
+    recorded `workspace = <name>` and `cwd = <plane root>`, so every reader that asks
+    "which workspace am I in" got one answer and every reader that asks "where am I"
+    got the other. It also put a chat's cwd at the plane root, which ADR 0008 says is not
+    a work tree, and #850's own boundary — charter's layer, materialised per workspace —
+    cannot exist for a directory that does not.
+
+    `workspace.ensure` is the validating creator `_choose_workspace` already uses, and it
+    scaffolds: `workspaces/<ws>/` comes back holding its structure marker and the harness
+    layer, so the chat about to be started there gets charter at all.
+
+    **Still degrades, never raises.** This is on a launch path reached from a tab press
+    with no operator waiting on it, and `ensure` raises `ValueError` for a name that
+    cannot be a workspace (`$CHARTER_WORKSPACE=..` reaches `state.workspace_for`'s last
+    rung untouched — see `workspace.exists`) and `OSError` for a `workspaces/` charter
+    cannot write. The plane root is where charter would have created it, which is the
+    same answer this always gave, now given only when creating is impossible.
 
     Shared by :func:`_open_workspace` and :func:`cmd_new_chat` for
     :func:`_same_harness_as`' reason: it was the same two lines twice.
     """
-    where = workspace.workspace_dir(ws)
-    return where if where.is_dir() else config.ROOT
+    try:
+        return workspace.ensure(ws)
+    except (ValueError, OSError):
+        return config.ROOT
 
 
 def _open_workspace(fid: str, ws: str, *, socket: str,

--- a/charter/commands_workspace.py
+++ b/charter/commands_workspace.py
@@ -1205,14 +1205,18 @@ def cmd_workspace_reinit(args) -> int:
         # current can still hold a `.claude/settings.json` generated before the plane's
         # own settings moved — and it is the one this command silently repaired while
         # printing "nothing to do" until it was said out loud.
-        for rel, was in before.get("layer") or ():
-            if was == "foreign":
+        for rel, did in before.get("layer") or ():
+            if did == "foreign":
                 util.warn(f"'{n}': {rel} was not written by charter — left completely "
                           f"untouched. Remove it if you want charter's own again.")
+            elif did == "blocked":
+                util.err(f"'{n}': {rel} could not be written — something is in the way at "
+                         f"that path. charter never deletes or renames existing content.")
             else:
                 healed += 1
-                util.ok(f"Reinitialized '{n}' → {'wrote' if was == 'missing' else 'refreshed'} "
-                        f"{rel} (charter's harness layer).")
+                util.ok(f"Reinitialized '{n}' → "
+                        f"{'wrote' if did == 'created' else 'refreshed'} {rel} "
+                        f"(charter's harness layer).")
         if before["ok"]:
             continue
         healed += 1

--- a/charter/commands_workspace.py
+++ b/charter/commands_workspace.py
@@ -1205,7 +1205,17 @@ def cmd_workspace_reinit(args) -> int:
         # current can still hold a `.claude/settings.json` generated before the plane's
         # own settings moved — and it is the one this command silently repaired while
         # printing "nothing to do" until it was said out loud.
-        for rel, did in before.get("layer") or ():
+        #
+        # Subscripted, not `.get("layer") or ()`. The fallback was defending against a
+        # shape charter itself builds one function away: `workspace.reinit` sets `layer`
+        # unconditionally, before its own first return, so no call can hand this loop a
+        # dict without it. The deletion sweep found the `or ()` as a survivor and there
+        # was no test to write — a fixture would have had to stub `reinit` into returning
+        # something `reinit` cannot return. `h.workspace_files() or {}` one module over
+        # keeps its fallback for the opposite reason and that is the distinction: that
+        # one guards a THIRD PARTY's answer, and a harness charter did not write can
+        # return anything at all.
+        for rel, did in before["layer"]:
             if did == "foreign":
                 util.warn(f"'{n}': {rel} was not written by charter — left completely "
                           f"untouched. Remove it if you want charter's own again.")

--- a/charter/commands_workspace.py
+++ b/charter/commands_workspace.py
@@ -1200,6 +1200,19 @@ def cmd_workspace_reinit(args) -> int:
     healed = 0
     for n in names:
         before = workspace.reinit(n)
+        # The HARNESS LAYER, reported as its own line rather than folded into the
+        # structure one (#850). It is a separate fact — a workspace whose layout is
+        # current can still hold a `.claude/settings.json` generated before the plane's
+        # own settings moved — and it is the one this command silently repaired while
+        # printing "nothing to do" until it was said out loud.
+        for rel, was in before.get("layer") or ():
+            if was == "foreign":
+                util.warn(f"'{n}': {rel} was not written by charter — left completely "
+                          f"untouched. Remove it if you want charter's own again.")
+            else:
+                healed += 1
+                util.ok(f"Reinitialized '{n}' → {'wrote' if was == 'missing' else 'refreshed'} "
+                        f"{rel} (charter's harness layer).")
         if before["ok"]:
             continue
         healed += 1

--- a/charter/doctor.py
+++ b/charter/doctor.py
@@ -1582,6 +1582,86 @@ def check_workspace_clones() -> Result:
                         "— never a live query, this runs at SessionStart."))
 
 
+def check_workspace_harness() -> Result:
+    """Does every workspace still carry charter's layer, and is it the current one? (#850)
+
+    A chat launched in `workspaces/<ws>/` gets its settings from that directory and
+    nowhere else — Claude Code does not walk up for them — so the generated
+    `.claude/settings.json` there is the whole of whether that chat has a status line, a
+    plugin and a `$CHARTER_HARNESS`. It is generated from the plane's own settings, so it
+    goes stale the moment the plane's do, and nothing else notices.
+
+    **Regenerate and compare** (`workspace.harness_layer`), which is
+    `persona lint --only stale`'s test rather than a second notion of staleness — see that
+    function for why a stored diff answers the wrong question.
+
+    **Reads, never writes.** This runs from the SessionStart hook, and a check that healed
+    what it found would report every workspace current by having just made it so.
+
+    **The two harnesses that cannot isolate are NAMED, not omitted.** Their config is
+    machine-global, so a per-workspace answer has nowhere to live; printing one row for
+    Claude Code and nothing for them reads as three ticks, which is the failure
+    `base.Deficit` exists to prevent. They sit in the detail rather than in the hint,
+    because they are a standing property of those harnesses and not something to go and
+    fix — `charter harness list` is where the full sentence lives.
+
+    WARN, never FAIL: a workspace without the layer is a chat that will be poorer than it
+    should be, not a broken machine — and `charter workspace reinit` is one command.
+    """
+    from . import config as _config
+    from . import workspace as _workspace
+
+    name = "workspace layer"
+    if not _config.HAS_CONTROL_PLANE:
+        return Result(name, OK, detail="no control plane found")
+
+    gaps = ", ".join(h for h, _d in _workspace.harness_deficits())
+    # A finished clause rather than a bare list of names, for `Deficit.detail`'s own
+    # reason: the *why* is the harness's, and two names with no verb beside them read as
+    # a failure.
+    aside = (f"  ({gaps}: config is machine-global, so a workspace cannot diverge — "
+             f"charter harness list)" if gaps else "")
+
+    findings: list[str] = []
+    foreign = False
+    total = 0
+    try:
+        for ws in _workspace.list_workspaces():
+            rows = _workspace.harness_layer(ws)
+            total += len(rows)
+            for rel, status in rows:
+                if status == "ok":
+                    continue
+                if status == "foreign":
+                    foreign = True
+                findings.append(f"{ws}/{rel} ({status})")
+    except (OSError, ValueError) as e:
+        # Narrow, per `check_memory_indexes`: a broad catch here once swallowed a
+        # NameError and reported OK, and a check that silently does nothing is worse than
+        # no check.
+        return Result(name, WARN, detail=f"not checked ({e})", hint=_NOT_CHECKED_HINT)
+
+    if not findings:
+        if not total:
+            return Result(name, OK,
+                          detail=f"nothing to mirror — the plane declares no plugin, "
+                                 f"status line or env of its own{aside}")
+        return Result(name, OK,
+                      detail=f"{total} generated file(s) across all workspaces, "
+                             f"all current{aside}")
+    # No leading arrow — `Result.render` writes one. `check_workspace_clones` carries its
+    # own and therefore prints two; that is a wart rather than the convention (76 of the
+    # 77 hints in this file start with the command), and not one to copy.
+    hint = f"charter workspace reinit --all{aside}"
+    if foreign:
+        hint += ("   A 'foreign' file is one charter did not write: it is left completely "
+                 "untouched and never repaired. Remove it to have charter generate its "
+                 "own again.")
+    return Result(name, WARN,
+                  detail=", ".join(findings[:4]) + (", …" if len(findings) > 4 else ""),
+                  hint=hint)
+
+
 #: The optional prompt before every cross-repo landing, named by :func:`check_changes` and
 #: **never written by charter**.
 #:
@@ -2693,7 +2773,7 @@ def _checks():
     results += [check_ssh(), check_control_plane_config(), check_control_plane_schema(),
                 check_plane_root(), check_session_root(),
                 check_harness(), check_frame(), check_guard_wired(), check_guard_seen(), check_nested_plane(),
-                check_workspace_clones(), check_changes(),
+                check_workspace_clones(), check_workspace_harness(), check_changes(),
                 check_inventory(), check_vaults(),
                 check_vault_registry_divergence(), check_version_lock(),
                 check_memory_indexes(), check_personas(), check_persona_grant(),
@@ -2732,7 +2812,8 @@ _FIXED_CHECK_NAMES = (
     "python3", "git", "git identity",
     # ← the forge cli/auth pair is spliced in here, see `check_names`
     "git auth", "charter.toml", "schema", "plane root", "session root", "harness", "frame",
-    "plane-root guard", "guard seen", "nested plane", "workspace clones", "changes",
+    "plane-root guard", "guard seen", "nested plane", "workspace clones",
+    "workspace layer", "changes",
     "inventory", "vaults", "vault registry", "version lock", "memory indexes",
     "personas", "persona grant", "front door", "news", "ask rules", "shadowed docs",
     "credential paths", "mcp", "plugin", "plugin files",

--- a/charter/harness/base.py
+++ b/charter/harness/base.py
@@ -37,6 +37,18 @@ class Deficit(NamedTuple):
     remedy: str = ""
 
 
+#: The :attr:`Deficit.key` a harness uses to say it cannot hold per-workspace
+#: configuration at all — its config is machine-global, so two workspaces on one machine
+#: cannot be made to differ.
+#:
+#: A named constant rather than a string each side spells, because the two sides are far
+#: apart: the harness declares it, and `workspace.harness_layer` reads it to decide
+#: whether to ask that harness for files. A misspelling on either side would report a
+#: workspace as carrying a layer it has never had — the "looks wired and is not" shape
+#: #177 and #433 already cost this repo twice.
+WORKSPACE_SCOPE = "workspace-scope"
+
+
 class Harness:
     """One agent runtime charter can run inside."""
 
@@ -126,6 +138,40 @@ class Harness:
         name.
         """
         return []
+
+    def workspace_files(self) -> dict[str, str]:
+        """What this harness needs inside a directory charter OWNS — ``{relpath: text}``.
+
+        The fifth member, and the argument for it is that :meth:`wire` answers a different
+        question about a different file. `wire` writes into somebody else's tree — the
+        plane root, whose `.claude/settings.json` is user-owned and git-tracked — so its
+        contract is *if absent, never repair*, and its answer is a write. A workspace
+        directory is charter's own (`workspace.ensure` makes it, `.charter-structure`
+        stamps it), so its files are **generated**: they must be regenerable when the
+        plane moves, and they must be READABLE without writing, because `doctor` reports
+        their staleness from the SessionStart hook and a check that writes is not a check.
+        A `dry_run` flag on `wire` would have bought the second of those and neither of
+        the first two, and it would have put a branch inside every harness's writer for a
+        root only one of them can use.
+
+        So this returns the CONTENT and nothing else. Materialising it — the ownership
+        marker, the digest, refusing a file charter did not write — is one generic loop in
+        `charter/workspace.py` rather than a copy per harness, which is the same reason
+        :meth:`ask_rule` returns a rule instead of writing one.
+
+        **Empty means "nothing to put here", and a harness that empties it because it
+        CANNOT must also declare :data:`WORKSPACE_SCOPE`.** Those are opposite facts that
+        an empty dict alone spells identically — `registry.deficits`' own complaint — and
+        the caller renders them differently: nothing, versus a named ceiling. The base
+        default is empty because charter has no idea what an unmet harness needs, and
+        `TestEveryRegisteredHarnessEitherCarriesFilesOrNamesTheCeiling` is what fails on
+        the day one answers neither.
+
+        Paths are RELATIVE and must stay inside the directory: they are joined onto a
+        workspace root, and `..` in one would put charter's writes outside the boundary
+        this whole mechanism exists to draw.
+        """
+        return {}
 
     def upgrade(self, root: Path) -> tuple[str, str]:
         """Move THIS harness's installed charter artifact to the running CLI's version.

--- a/charter/harness/claude_code.py
+++ b/charter/harness/claude_code.py
@@ -7,12 +7,38 @@ function answers by sniffing for Claude-Code-shaped variables.
 
 from __future__ import annotations
 
+import json
 import os
 from pathlib import Path
 
 from .base import Harness
 
 NAME = "claude-code"
+
+#: The keys charter mirrors from the plane's own `.claude/settings.json` into a workspace
+#: directory, and the reason there are three rather than one.
+#:
+#: Claude Code reads project settings from the session's working directory and **does not
+#: walk up**, so a chat whose cwd is `workspaces/<ws>/` reads no settings at all. Agents,
+#: skills and CLAUDE.md *do* walk up and stop at a git boundary — which a workspace
+#: directory is not, being a plain directory inside the plane's own repo — so those
+#: already arrive and are deliberately NOT copied here (#850). A second copy of `skills/`
+#: would shadow the plugin's own non-deterministically; Claude Code says so itself, by
+#: name: *"is already taken by X, which takes precedence"*.
+#:
+#: `enabledPlugins` alone is not enough, which is the correction this list records.
+#: `statusLine` has no plugin surface at all, and `env` is where `$CHARTER_HARNESS` comes
+#: from on a harness with no per-shell hook. A workspace given only the plugin loads
+#: charter's skills and hooks and still renders no status line and cannot say which
+#: harness it is.
+#:
+#: Nothing else. `permissions` is the plane's decision about the plane's own root, and
+#: copying a grant sideways into a directory nobody granted it in puts a permission in
+#: force where no one clicked for it.
+WORKSPACE_KEYS = ("enabledPlugins", "statusLine", "env")
+
+#: Where the mirrored document goes, relative to the workspace directory.
+WORKSPACE_SETTINGS = ".claude/settings.json"
 
 
 class ClaudeCodeHarness(Harness):
@@ -53,6 +79,39 @@ class ClaudeCodeHarness(Harness):
 
         status, _path = commands.ensure_env_var(root, "CHARTER_HARNESS", self.name)
         return [(status, ".claude/settings.json (env)")]
+
+    def workspace_files(self) -> dict[str, str]:
+        """The plane's own three settings keys, as one document for a workspace to hold.
+
+        **A 1:1 sync, and v1 has no overrides on purpose.** The whole of the requirement
+        is that a chat standing in `workspaces/<ws>/` gets the layer a chat standing in
+        the plane root gets; a `workspace.json` key that makes one workspace differ is a
+        second feature, and building the divergence before anybody has asked for a
+        specific one would ship a mechanism nothing exercises — ADR 0007's objection.
+
+        **Read from the plane's committed file rather than composed from charter's own
+        constants**, and that is what makes it a sync rather than a second generator.
+        `commands._STATUSLINE` is one of the two things that would have to be spelled
+        here, and a plane whose operator changed their status line by hand would then get
+        charter's default mirrored into every workspace — silently reverting a deliberate
+        choice, in a new place, which is the one thing `_ensure_statusline` exists not to
+        do.
+
+        Empty for a plane with no settings of its own, and empty for one whose settings
+        are not parseable: `_load_settings` returns ``None`` for the second, and charter
+        does not guess over a file somebody is holding. Empty here means the workspace
+        gets no file and no marker at all, which is the honest rendering of "there is
+        nothing to mirror" — writing an empty `{}` would look like a layer.
+        """
+        from .. import commands, config
+
+        settings, _p = commands._load_settings(config.ROOT)
+        if not settings:
+            return {}
+        doc = {k: settings[k] for k in WORKSPACE_KEYS if k in settings}
+        if not doc:
+            return {}
+        return {WORKSPACE_SETTINGS: json.dumps(doc, indent=2) + "\n"}
 
     def upgrade(self, root: Path) -> tuple[str, str]:
         """Named, never run — the restraint `cmd_version_sync` already keeps.

--- a/charter/harness/codex.py
+++ b/charter/harness/codex.py
@@ -26,7 +26,7 @@ import os
 import tomllib
 from pathlib import Path
 
-from .base import Deficit, Harness
+from .base import WORKSPACE_SCOPE, Deficit, Harness
 
 NAME = "codex"
 
@@ -138,6 +138,16 @@ class CodexHarness(Harness):
                 "`$CHARTER_SESSION_ID` reaches a shell; the workspace lock falls back to "
                 "the terminal-pane key. Hooks are unaffected — their payload carries "
                 "`session_id` directly."),
+        # The sharpest of the three, and the one that is a fact about Codex rather than
+        # about a widget: it has NO project-level config at all. A `.codex/config.toml`
+        # or `codex.toml` beside a project is ignored — measured by planting a deliberate
+        # type error in each and watching the config load anyway (ADR 0015 records the
+        # same measurement for the hooks). So there is nowhere for a per-workspace answer
+        # to live, and charter says so rather than printing a tick beside Claude Code's.
+        Deficit(WORKSPACE_SCOPE,
+                "no project-level config exists at all — a `.codex/config.toml` beside a "
+                "project is ignored, so `~/.codex/config.toml` is the only answer and "
+                "every workspace on this machine necessarily shares it."),
     )
 
     cli_name = "codex"

--- a/charter/harness/opencode.py
+++ b/charter/harness/opencode.py
@@ -28,7 +28,7 @@ import re
 from pathlib import Path
 
 from .. import __version__
-from .base import Deficit, Harness
+from .base import WORKSPACE_SCOPE, Deficit, Harness
 
 NAME = "opencode"
 
@@ -689,6 +689,18 @@ class OpenCodeHarness(Harness):
                 "or throw, so charter's own tool-time asks (the routing and "
                 "overlapping-dispatch nudges) allow and are not shown. Denials are "
                 "unaffected — they throw, and every guard that refuses still refuses."),
+        # NOT the same shape as the three above, and worth saying so: those are surfaces
+        # opencode lacks. This one is a surface it has *too widely*. Charter's layer is
+        # already live in every workspace directory here — which is why #850 is a
+        # Claude-Code-only defect — and the price of that reach is that two workspaces on
+        # one machine cannot be made to differ. Charter reports the ceiling rather than
+        # printing a tick beside Claude Code's, because "already everywhere" and
+        # "isolated per workspace" are different answers and only one of them was asked
+        # for.
+        Deficit(WORKSPACE_SCOPE,
+                "config is machine-global (`~/.config/opencode/`), so charter's layer is "
+                "already live in every workspace directory and cannot be made to DIFFER "
+                "between two of them — a workspace is not an isolation boundary here."),
     )
 
     cli_name = "opencode"

--- a/charter/workspace.py
+++ b/charter/workspace.py
@@ -1579,7 +1579,15 @@ def needs_reinit(name: str) -> bool:
 def reinit(name: str) -> dict:
     """Idempotently bring a workspace up to the current structure — create any missing
     baseline files and stamp the version marker. Additive: never destroys existing
-    content. Returns the pre-reinit status (what was missing / the old version)."""
+    content. Returns the pre-reinit status (what was missing / the old version), plus
+    ``layer`` — the harness-layer rows this call actually wrote.
+
+    **``layer`` is always set, on every path**, and `cmd_workspace_reinit` subscripts it
+    rather than carrying a fallback. An early return added above the line that sets it
+    would be a `KeyError` in the repair command, which is the loud failure; the fallback
+    it replaced made the same mistake print "up to date" over a workspace whose layer had
+    just been rewritten.
+    """
     before = structure_status(name)
     # The harness layer, written HERE rather than left to `scaffold`'s own call, because
     # the repair has to report what it DID and only the writer knows that: a `.claude`

--- a/charter/workspace.py
+++ b/charter/workspace.py
@@ -24,6 +24,7 @@ Secrets are deliberately *not* part of this — vaults are cross-workspace.
 
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 import re
@@ -1039,7 +1040,8 @@ def scaffold_memory(name: str) -> Path:
 
 def scaffold(name: str) -> None:
     """Create a workspace's baseline structure: memory/ (per-file DB + index), refs/, the
-    workspace.md charter, and the structure-version marker. Idempotent + additive."""
+    workspace.md charter, the harness layer, and the structure-version marker. Idempotent
+    + additive."""
     scaffold_memory(name)
     refs = refs_dir(name)
     refs.mkdir(parents=True, exist_ok=True)
@@ -1048,7 +1050,226 @@ def scaffold(name: str) -> None:
         rr.write_text(f"# {name} — task references\n\nDrop docs, links, and snippets for "
                       f"this task here (local, gitignored).\n")
     scaffold_charter(name)  # workspace.md — the living vision/context/glossary charter
+    wire_harnesses(name)    # the harness layer — see `harness_layer`
     _structure_marker(name).write_text(str(STRUCTURE_VERSION) + "\n")  # stamp the layout version
+
+
+# --------------------------------------------------------------------------- #
+# the harness layer — what a chat standing in `workspaces/<ws>/` needs to get   #
+# charter at all (#850).                                                        #
+#                                                                               #
+# Claude Code reads project settings from the session's working directory and    #
+# does not walk up, so a chat launched there loaded no plugin, ran no status     #
+# line and had no `$CHARTER_HARNESS` — while its agents and skills DID arrive,   #
+# because those walk up and a workspace directory is not a git boundary. Half a  #
+# layer, and the half that was missing is the half that runs.                    #
+#                                                                               #
+# ADR 0015 deleted a per-tree design of this shape and the caution is real, so   #
+# the difference is worth stating: what it deleted wrote the same GLOBAL answer  #
+# into every checkout, for a harness that reads one global file anyway. This     #
+# writes config that is MEANT to differ per workspace, into a directory charter  #
+# itself creates. What is re-incurred from that design is the staleness          #
+# bookkeeping below — and not its `.git/info/exclude` entry per checkout, which  #
+# is the cost that never arrives here: `/workspaces/*/*` is already in the       #
+# plane's `.gitignore` (`_ensure_gitignore`) and the managed LIVE block          #
+# un-ignores four named paths, none of them `.claude/`. Nothing generated here   #
+# can reach a commit.                                                            #
+#                                                                               #
+# Nothing is written into a CLONE — `workspaces/<ws>/<repo>/` is a repo charter  #
+# does not own, and `git add -A` there would stage it. The stated limit that     #
+# follows: in a clone you cannot delegate to a persona.                          #
+# --------------------------------------------------------------------------- #
+
+#: The charter-owned sidecar recording what charter last generated in a workspace, as
+#: ``{relative path: sha256 of the text charter wrote}``.
+#:
+#: **A sidecar and not a key inside the vendor's JSON**, which is the same reason
+#: symlinking `.claude/` was wrong: that file's schema belongs to Claude Code, an unknown
+#: key in it is charter making a claim on somebody else's document, and a validator that
+#: rejects unknown keys would make charter's bookkeeping a startup failure. `persona
+#: sync-agents` can put its marker INSIDE the file it generates because Markdown has a
+#: comment syntax; JSON has none, which is precisely why this exists as a file.
+#:
+#: `.charter-structure` is the precedent for a charter-owned marker file in a workspace,
+#: and this sits beside it for the same reason: one directory, one place to look.
+GENERATED_MARKER = ".charter-generated"
+
+
+def content_digest(text: str) -> str:
+    """The hash the marker records for one generated file.
+
+    Named and public because the writer and the ownership test must not be two spellings
+    of "the same content" — a marker written one way and read another reports every file
+    charter wrote as somebody else's, which is the direction that costs work.
+    """
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def is_workspace_dir(path) -> bool:
+    """Is *path* one of THIS plane's workspace directories?
+
+    The boundary the whole mechanism draws, asked in one place. A clone under a workspace
+    (`workspaces/<ws>/<repo>/`) answers **no** — it is somebody else's repo — and so does
+    the plane root, whose `.claude/settings.json` is user-owned, git-tracked and governed
+    by the never-repair restraint `commands._ensure_statusline` records.
+
+    :func:`valid_name` is asked first for :func:`exists`' reason: ``WORKSPACES_DIR / ".."``
+    is the plane root, so a parent-directory comparison alone answers *yes* for a name
+    that is not a workspace and can never be one.
+    """
+    p = Path(path)
+    if not valid_name(p.name):
+        return False
+    try:
+        return p.parent == config.WORKSPACES_DIR
+    except OSError:
+        return False
+
+
+def harness_deficits() -> list[tuple[str, object]]:
+    """``(harness name, Deficit)`` for every registered harness that cannot isolate.
+
+    Their config is machine-global, so per-workspace divergence is not buildable for them
+    at all. Reported rather than skipped in silence: `base.Deficit` exists for exactly
+    this — *"a capability that is simply missing reads as a broken integration"* — and a
+    report showing one row for the harness that can and nothing for the two that cannot
+    would be read as three ticks.
+    """
+    from .harness import base as _base
+    from .harness import registry as _registry
+
+    out: list[tuple[str, object]] = []
+    for h in _registry.all():
+        gap = next((d for d in h.deficits if d.key == _base.WORKSPACE_SCOPE), None)
+        if gap is not None:
+            out.append((h.name, gap))
+    return out
+
+
+def _layer_files(name: str) -> dict[str, str]:
+    """``{relative path: text}`` every registered harness needs inside workspace *name*.
+
+    Nothing here names a harness — the registry is iterated, so a harness added to
+    ``KINDS`` is covered the day it is registered, which is the reason
+    `harness/registry.py` records for its own existence. A harness that cannot hold
+    per-workspace config returns nothing AND declares :data:`base.WORKSPACE_SCOPE`;
+    :func:`harness_deficits` is what turns the second half into a sentence.
+
+    A relative path that would escape the workspace is dropped rather than written. The
+    harness contract says paths stay inside; a contract nothing enforces is a comment,
+    and this is the one place every harness's answer passes through.
+    """
+    from .harness import registry as _registry
+
+    wd = workspace_dir(name)
+    out: dict[str, str] = {}
+    for h in _registry.all():
+        for rel, text in (h.workspace_files() or {}).items():
+            target = (wd / rel).resolve()
+            if target == wd.resolve() or wd.resolve() not in target.parents:
+                continue
+            out[rel] = text
+    return out
+
+
+def _read_marker(name: str) -> dict:
+    try:
+        doc = json.loads((workspace_dir(name) / GENERATED_MARKER).read_text())
+    except (OSError, json.JSONDecodeError, UnicodeDecodeError):
+        return {}
+    return doc if isinstance(doc, dict) else {}
+
+
+def harness_layer(name: str) -> list[tuple[str, str]]:
+    """``(relative path, status)`` for every file the harness layer wants — READ ONLY.
+
+    ``"ok"`` · ``"missing"`` · ``"stale"`` · ``"foreign"`` · ``"unreadable"``.
+
+    **Regenerate and compare**, which is `persona lint --only stale`'s test verbatim
+    (`commands_persona._agent_sync_issues`) rather than a second notion of staleness. A
+    stored diff would answer the wrong question: the generator's own output drifts — the
+    plane's status line changes, a plugin is enabled — so what "current" means is whatever
+    the generator says *today*, and the only way to know that is to run it.
+
+    **Read only, because `doctor` calls this from the SessionStart hook.** A check that
+    writes is not a check: it would report every workspace healthy by having just healed
+    it, which is the "looks wired" shape this repo keeps paying for.
+
+    ``foreign`` is the operator's file — content charter cannot vouch for against the
+    marker. Charter never repairs it and never overwrites it, the restraint ADR 0015
+    settles for an unstamped shim: charter cannot tell a file it wrote before the marker
+    existed from one somebody rewrote, and guessing wrong in that direction destroys work.
+    """
+    wd = workspace_dir(name)
+    marker = _read_marker(name)
+    rows: list[tuple[str, str]] = []
+    for rel, want in sorted(_layer_files(name).items()):
+        p = wd / rel
+        if not p.exists():
+            rows.append((rel, "missing"))
+            continue
+        try:
+            have = p.read_text()
+        except (OSError, UnicodeDecodeError):
+            rows.append((rel, "unreadable"))
+            continue
+        if have == want:
+            rows.append((rel, "ok"))
+        elif marker.get(rel) == content_digest(have):
+            rows.append((rel, "stale"))
+        else:
+            rows.append((rel, "foreign"))
+    return rows
+
+
+def wire_harnesses(name: str) -> list[tuple[str, str]]:
+    """Materialise the harness layer into workspace *name*. ``(relative path, status)``.
+
+    ``"created"`` · ``"refreshed"`` · ``"present"`` · ``"foreign"`` · ``"blocked"``.
+
+    **Refresh, not create-once.** `ensure_shim`'s restraint was right about the operator's
+    files and wrong about charter's own: a plugin generated by 0.40.0 survived every
+    upgrade afterwards while `doctor` reported the tree wired (ADR 0015). A file whose
+    digest is in the marker is charter's, and charter brings its own files up to date.
+    A file whose digest is not is the operator's, and is left exactly as found.
+
+    Called from :func:`scaffold`, so a launch gets it: `commands_frame._launch_root` runs
+    `ensure` before the chat's cwd is read. `charter workspace reinit` is the repair.
+    """
+    wd = workspace_dir(name)
+    marker = _read_marker(name)
+    want_all = _layer_files(name)
+    rows: list[tuple[str, str]] = []
+    wrote = False
+    for rel, status in harness_layer(name):
+        if status in ("foreign", "unreadable"):
+            # The operator's file, and the marker entry for it stays exactly as it was:
+            # charter has not written this path, so it has nothing new to vouch for.
+            rows.append((rel, "foreign"))
+            continue
+        if status == "ok":
+            rows.append((rel, "present"))
+            continue
+        want = want_all[rel]
+        p = wd / rel
+        try:
+            p.parent.mkdir(parents=True, exist_ok=True)
+            p.write_text(want)
+        except OSError:
+            rows.append((rel, "blocked"))
+            continue
+        marker[rel] = content_digest(want)
+        wrote = True
+        rows.append((rel, "created" if status == "missing" else "refreshed"))
+    if wrote:
+        # Only when something was actually generated. Rewriting the marker on every
+        # `ensure` would make a workspace's mtimes move for a call that changed nothing,
+        # which is the noise `_ensure_statusline` avoids one file over.
+        try:
+            (wd / GENERATED_MARKER).write_text(json.dumps(marker, indent=2) + "\n")
+        except OSError:
+            pass
+    return rows
 
 
 def remember(name: str, text: str, title: str | None = None) -> Path:
@@ -1281,8 +1502,9 @@ def read_vision(name: str) -> str:
 # workspace picks up the three new un-ignore lines. Without it a plane that went LIVE
 # before this version keeps a block that never mentions `changes`, and the records simply
 # never travel — the same silent half-failure `todos/` had.
-STRUCTURE_VERSION = 3  # v2: memory is a per-file DB (MEMORY.md index), not a lone notes.md
+STRUCTURE_VERSION = 4  # v2: memory is a per-file DB (MEMORY.md index), not a lone notes.md
                        # v3: the managed .gitignore block shares `changes/` (not its log)
+                       # v4: the workspace carries charter's harness layer (#850)
 _STRUCTURE_MARKER = ".charter-structure"
 _LEGACY_STRUCTURE_MARKER = ".edm-structure"   # pre-rename; migrated in place on read
 
@@ -1347,6 +1569,12 @@ def reinit(name: str) -> dict:
     baseline files and stamp the version marker. Additive: never destroys existing
     content. Returns the pre-reinit status (what was missing / the old version)."""
     before = structure_status(name)
+    # The harness layer, READ before `scaffold` writes it — a repair that reports what it
+    # found has to look first. It is not folded into `ok`: `structure_status` answers
+    # "is this workspace's LAYOUT current", a question `needs_reinit` and the status line
+    # both key off, and a layer that has gone stale because the plane's settings moved is
+    # not a workspace built by an older charter. Two facts, two keys.
+    before["layer"] = [(rel, st) for rel, st in harness_layer(name) if st != "ok"]
     scaffold(name)  # creates memory/refs/workspace.md if missing + stamps the marker
     # Structure is not only what lives inside the workspace directory: which of its paths
     # are SHARED is part of the layout too, and that lives in the managed .gitignore block.

--- a/charter/workspace.py
+++ b/charter/workspace.py
@@ -1569,12 +1569,17 @@ def reinit(name: str) -> dict:
     baseline files and stamp the version marker. Additive: never destroys existing
     content. Returns the pre-reinit status (what was missing / the old version)."""
     before = structure_status(name)
-    # The harness layer, READ before `scaffold` writes it — a repair that reports what it
-    # found has to look first. It is not folded into `ok`: `structure_status` answers
-    # "is this workspace's LAYOUT current", a question `needs_reinit` and the status line
-    # both key off, and a layer that has gone stale because the plane's settings moved is
-    # not a workspace built by an older charter. Two facts, two keys.
-    before["layer"] = [(rel, st) for rel, st in harness_layer(name) if st != "ok"]
+    # The harness layer, written HERE rather than left to `scaffold`'s own call, because
+    # the repair has to report what it DID and only the writer knows that: a `.claude`
+    # that cannot be made comes back `blocked`, and reading the pre-state instead would
+    # have printed "wrote it" over a write that never happened. `scaffold` below re-runs
+    # it and gets `present` for everything, which is what idempotent means.
+    #
+    # Not folded into `ok`: `structure_status` answers "is this workspace's LAYOUT
+    # current", which `needs_reinit` and the status line both key off, and a layer that
+    # went stale because the plane's settings moved is not a workspace built by an older
+    # charter. Two facts, two keys.
+    before["layer"] = [(rel, st) for rel, st in wire_harnesses(name) if st != "present"]
     scaffold(name)  # creates memory/refs/workspace.md if missing + stamps the marker
     # Structure is not only what lives inside the workspace directory: which of its paths
     # are SHARED is part of the layout too, and that lives in the managed .gitignore block.

--- a/charter/workspace.py
+++ b/charter/workspace.py
@@ -1166,7 +1166,17 @@ def _layer_files(name: str) -> dict[str, str]:
     for h in _registry.all():
         for rel, text in (h.workspace_files() or {}).items():
             target = (wd / rel).resolve()
-            if target == wd.resolve() or wd.resolve() not in target.parents:
+            # ONE clause, not two. `target == wd.resolve()` was here to drop a `rel`
+            # naming the workspace directory itself, and it can never be the clause
+            # that decides: a path is never in its own `.parents`, so whenever the
+            # equality holds the containment test has already fired. The deletion
+            # sweep found it as a survivor and it was masked, not unpinned.
+            #
+            # The `.resolve()` that remains is load-bearing and is pinned by
+            # `AWorkspaceRootReachedThroughASymlink`: `config.use` hands its root
+            # through unresolved, so under a symlinked plane `wd` is not among the
+            # resolved `target`'s parents and every file would be dropped.
+            if wd.resolve() not in target.parents:
                 continue
             out[rel] = text
     return out

--- a/charter/workspace.py
+++ b/charter/workspace.py
@@ -1120,10 +1120,12 @@ def is_workspace_dir(path) -> bool:
     p = Path(path)
     if not valid_name(p.name):
         return False
-    try:
-        return p.parent == config.WORKSPACES_DIR
-    except OSError:
-        return False
+    # NO `try` around the comparison. `PurePath.__eq__` is a string compare on the
+    # normalised parts — it never touches the filesystem, so it cannot raise `OSError`,
+    # and a catch there is a branch nothing can reach. Measured against a NUL byte, a lone
+    # surrogate, 4000 slashes and the empty string: every one answers `False` rather than
+    # raising. The deletion sweep found the narrowed catch as a survivor and was right.
+    return p.parent == config.WORKSPACES_DIR
 
 
 def harness_deficits() -> list[tuple[str, object]]:

--- a/docs/harnesses.md
+++ b/docs/harnesses.md
@@ -38,8 +38,8 @@ offer**, and `charter doctor` prints the gap rather than leaving you to find it:
 | | how it is installed | how it updates | what it cannot carry | what to do about it |
 | --- | --- | --- | --- | --- |
 | Claude Code | the plugin (`claude plugin install charter@charter`) | `claude plugin update charter@charter` | — | — |
-| opencode | `charter init` — one plugin under opencode's config dir, read by every project | charter moves it — its own file, compared byte for byte (`read_bytes`) with the one charter generates; anything else in that plugin directory is named too, and nothing charter did not write is ever overwritten | no status bar; no per-turn prompt hook; no ask at tool time; **no isolation from other plugins** | `charter statusline --watch`; mid-session notes ride tool output already; charter's own tool-time asks allow and are not shown — denials are unaffected; a second plugin in that directory shares charter's globals and can disable its guards, so `doctor` names it — charter reports the realm, it cannot contain it |
-| Codex | the same plugin (`codex plugin`), plus `charter harness install codex` to name the harness | `codex plugin marketplace upgrade charter && codex plugin add charter@charter` | no status bar; no command-pattern permissions | `charter statusline --watch`; `guard ask` rules stay in charter's own hook |
+| opencode | `charter init` — one plugin under opencode's config dir, read by every project | charter moves it — its own file, compared byte for byte (`read_bytes`) with the one charter generates; anything else in that plugin directory is named too, and nothing charter did not write is ever overwritten | no status bar; no per-turn prompt hook; no ask at tool time; no per-workspace config; **no isolation from other plugins** | `charter statusline --watch`; mid-session notes ride tool output already; charter's own tool-time asks allow and are not shown — denials are unaffected; a second plugin in that directory shares charter's globals and can disable its guards, so `doctor` names it — charter reports the realm, it cannot contain it |
+| Codex | the same plugin (`codex plugin`), plus `charter harness install codex` to name the harness | `codex plugin marketplace upgrade charter && codex plugin add charter@charter` | no status bar; no command-pattern permissions; no project-level config at all, so no per-workspace config | `charter statusline --watch`; `guard ask` rules stay in charter's own hook |
 
 You never have to remember that third column — `charter update` asks the harness you are in
 and names its command (or, for opencode, just moves it). It is written down because a
@@ -53,9 +53,27 @@ exist costs more to chase than an honest gap.
 
 ## Wiring, and when it happens
 
-`charter init` writes each harness's wiring into the plane, and `charter clone` /
-`charter worktree add` arm every tree as it is created, because a session starts in a clone
-and not in the plane root. Nothing to install per harness, with one exception.
+`charter init` writes each harness's wiring into the plane. Nothing to install per harness,
+with one exception (Codex, below).
+
+**Plus one generated file per workspace, and only for Claude Code.** Claude Code reads
+project settings from the session's working directory and does not walk up, so a chat
+launched in `workspaces/<ws>/` — which is where the `+` and every workspace tab put it —
+would otherwise get no plugin, no status line and no `$CHARTER_HARNESS`. Charter mirrors
+the plane's `enabledPlugins`, `statusLine` and `env` into
+`workspaces/<ws>/.claude/settings.json` at launch, records what it wrote in a
+`.charter-generated` sidecar, and never touches a file whose hash it cannot vouch for.
+`charter doctor`'s `workspace layer` row reports staleness; `charter workspace reinit` is
+the repair.
+
+opencode and Codex get nothing here and say why: their config is machine-global, so
+charter's layer is already live in every workspace and two workspaces on one machine
+cannot be made to differ. That ceiling is in `charter harness list` beside the others.
+
+Nothing is written into a **clone** — `workspaces/<ws>/<repo>/` is a repo charter does not
+own, and `git add -A` there would stage it. So a session inside a clone gets charter from
+the plugin, and **cannot delegate to a persona**: the plugin ships no `agents/`, and a
+clone's own git root stops the walk-up that would have found the plane's.
 
 ## `charter statusline --watch`
 

--- a/docs/news/unreleased-a-chat-in-a-workspace-gets-charters-layer.md
+++ b/docs/news/unreleased-a-chat-in-a-workspace-gets-charters-layer.md
@@ -1,0 +1,103 @@
+---
+version: unreleased
+headline: a chat launched in `workspaces/<ws>/` gets charter's layer there — the status line, the plugin and `$CHARTER_HARNESS` — and the two harnesses that cannot hold one say so instead of showing a tick
+---
+
+*"in workspace user should be 100% isolated."*
+
+A chat whose cwd is `workspaces/<ws>/` — which is where the `+` and every workspace tab
+put it — got **none of charter's settings**. Measured on this plane:
+
+```
+plane root      .claude/settings.json  { env, statusLine, enabledPlugins }
+workspaces/*/   nothing — not one had a .claude
+```
+
+Claude Code reads project settings from the session's working directory and **does not walk
+up**. Agents, skills and CLAUDE.md *do* walk up and stop at a git boundary, and a workspace
+directory is not one — it is a plain directory inside the plane's own repo — so those
+already arrived. What did not was everything that comes from a settings file: no plugin, no
+status line, no `$CHARTER_HARNESS`. On this plane `fleet.1` and `opencode-integration.1`
+had been running that way all along.
+
+## What is written now
+
+One generated file per workspace, `workspaces/<ws>/.claude/settings.json`, holding the
+plane's own `enabledPlugins`, `statusLine` and `env` and nothing else. A 1:1 sync of the
+three keys; `workspace.json` overrides come when somebody wants a specific one.
+
+**All three, and the reason is that the plugin alone is not the layer.** Enabling
+`charter@charter` there brings the hooks and the skills. `statusLine` has no plugin surface
+at all, and `env` is where `$CHARTER_HARNESS` comes from on a harness with no per-shell
+hook — so a workspace given only the plugin still renders no status line and still cannot
+say which harness it is.
+
+**Nothing else, deliberately.** No `skills/`, no `agents/`, no `CLAUDE.md`. Skills arrive
+with the plugin and agents already walk up; a second copy of either would shadow the
+plugin's own non-deterministically, and Claude Code says so in its own words — *"is already
+taken by X, which takes precedence"*.
+
+**Nothing at all inside a clone.** `workspaces/<ws>/<repo>/` is a repo charter does not
+own, and `git add -A` there would stage whatever charter left behind. The limit that
+follows is stated rather than discovered: **in a clone you cannot delegate to a persona.**
+
+## Written when, and owned how
+
+Lazily, at launch — `charter workspace reinit` is the repair, and `--all` after this
+upgrade. `charter doctor` grows a **`workspace layer`** row that regenerates the document
+and compares, the same test `persona lint --only stale` makes of a generated sub-agent
+rather than a second notion of staleness: what "current" means is whatever the generator
+says today, and the only way to know that is to run it.
+
+Ownership is a `.charter-generated` sidecar beside `.charter-structure`, holding a hash of
+what charter last wrote — **not a key inside the vendor's JSON**, for the same reason
+symlinking `.claude/` was wrong. `persona sync-agents` can put its marker inside the file
+it generates because Markdown has a comment syntax; JSON has none. A file whose hash
+matches is charter's and gets refreshed when the plane's settings move. A file whose hash
+does not is the operator's: left completely untouched, never repaired, and named in the
+`doctor` row.
+
+## The workspace exists before a chat is put in it
+
+`_launch_root` used to hand back the plane root when the workspace had no directory yet.
+That was a real state rather than a defensive one — a plane draws a tab for its default
+workspace whether or not it has been made — and it created a disagreement at the moment of
+launch that nothing downstream could resolve: the chat recorded `workspace = <name>`
+beside `cwd = <plane root>`. It now calls `workspace.ensure`, which is what `charter
+--workspace <ws>` typed in the plane would have done, and it still degrades to the plane
+root for a name that cannot be a workspace or a `workspaces/` charter cannot write.
+
+## opencode and Codex are named, not skipped
+
+Their config is machine-global. opencode reads `~/.config/opencode/` for every project;
+Codex has **no project-level config at all** — a `.codex/config.toml` beside a project is
+ignored, measured by planting a deliberate type error in one and watching the config load
+anyway. So charter's layer is already live in a workspace on both, and there is nowhere for
+two workspaces on one machine to differ.
+
+That is a ceiling, and each now declares it as a `Deficit` — visible in `charter harness
+list` and in the `workspace layer` row. Reporting one row for the harness that can and
+nothing for the two that cannot would have read as three ticks.
+
+## Why this is not what ADR 0015 deleted
+
+ADR 0015 removed a per-tree design of exactly this shape, and the caution is real: *"255
+lines and a test file"*. What it removed wrote the same **global** answer into every clone
+and worktree for a harness that reads one global file anyway — *"all correct, and all
+answering a question that does not need asking"*. This writes config that is **meant** to
+differ per workspace, into a directory charter itself creates.
+
+Two of that design's costs come back and one does not. The staleness bookkeeping is here,
+and is paid for by the `doctor` row above. The `.git/info/exclude` entry per checkout is
+not: `/workspaces/*/*` is already in the plane's `.gitignore` and the managed LIVE block
+un-ignores four named paths, none of them `.claude/`. Nothing generated here can reach a
+commit.
+
+## To adopt
+
+```
+charter workspace reinit --all
+```
+
+The workspace structure version moved to 4, so every workspace made by an earlier charter
+flags itself in the status line and in `charter workspace list` until this runs.

--- a/docs/workspaces.md
+++ b/docs/workspaces.md
@@ -10,6 +10,7 @@ made while working on them, and a written account of what the task is for.
       workspace.json    the committed manifest: which repos, which branches
       memory/           durable notes, one file per fact, with a MEMORY.md index
       todos/            what this task still means to do
+      .claude/          charter's harness layer, generated (see below)
 
 `default` always exists. `charter workspace create <name> --use` starts another.
 
@@ -21,6 +22,34 @@ something in it does (`charter clone -w default`, `charter workspace use default
 `—` for its repos, because a table that draws a "you are here" mark has to have a row for
 where you are — and because the `F2` picker inside a frame offers exactly the same names.
 The name is `[workspace] default` if your `charter.toml` sets one.
+
+## A chat standing here gets charter
+
+Claude Code reads project settings from the session's working directory and **does not walk
+up** for them. A chat launched in `workspaces/<name>/` — which is where the `+` and every
+workspace tab put it — would therefore get no plugin, no status line and no
+`$CHARTER_HARNESS`, while its agents and skills arrived anyway, because those *do* walk up
+and this directory is not a git boundary.
+
+So charter generates one file here, at launch: `.claude/settings.json`, holding the plane's
+own `enabledPlugins`, `statusLine` and `env` and nothing else. Skills come with the plugin
+and agents already walk up; a second copy of either would shadow the plugin's.
+
+It is **charter's file, and only while it stays charter's**. A `.charter-generated` sidecar
+records a hash of what charter wrote. A file that still matches is refreshed when the
+plane's settings move; one that does not is yours — left completely untouched, never
+repaired, and named by `charter doctor`'s `workspace layer` row. `charter workspace reinit`
+(or `--all`) is the repair.
+
+**Nothing is written into a clone.** `workspaces/<name>/<repo>/` is a repo charter does not
+own, and `git add -A` there would stage whatever charter left behind. The limit that
+follows: a session inside a clone gets charter from the plugin, and **cannot delegate to a
+persona** — the plugin ships no `agents/`, and the clone's own git root stops the walk-up.
+
+Only Claude Code binds config to a project root. opencode and Codex read machine-global
+config, so charter's layer is already live in every workspace on those — and, by the same
+fact, cannot be made to differ between two of them. `charter harness list` names that
+ceiling.
 
 ## Which workspace am I in
 

--- a/tests/test_a_chat_records_where_it_was_started.py
+++ b/tests/test_a_chat_records_where_it_was_started.py
@@ -165,20 +165,17 @@ class _Answered:
         self.returncode = returncode
 
 
-class TheLauncherSTailIsWhereAReopenDiffers(PersonaIso, unittest.TestCase):
-    """`cmd_launch` driven all the way to its return, on both paths.
+class _DrivesTheLauncher:
+    """`cmd_launch`, run to its return with every tmux call answered — the fixture.
 
-    **Written because the deletion sweep asked for it.** Three branches in that tail are the
-    whole of what `Reopening` changes, and every one of them was unpinned: open-or-focus,
-    the `attach`, and the sentence `cmd_launch` says on the operator's behalf when their
-    plane was quit. `TheReopenPathSuppressesFourThingsInTheLauncher` asserts the PREDICATE
-    those branch on and says in its own docstring that the tail "cannot be reached without a
-    real tmux session and a real `attach`". The sweep disagreed, and it was right: the tail
-    is reachable with every tmux call answered and `attach` stubbed, which is what this does.
+    A mixin rather than a base case, so a second class can drive the launcher without
+    inheriting the first one's assertions: `unittest` collects methods from base classes,
+    and a driver that was also a `TestCase` would run every test on it again under each
+    name that borrowed it.
 
     Nothing here starts a server. `tmuxctl.run` answers `%0` to everything and
     `tmuxctl.interact` is the attach — so what is under test is charter's own branching,
-    which is exactly what the mutations were about.
+    which is exactly what the mutations that asked for this fixture were about.
     """
 
     def _launch(self, *, reopening=None, live_workspace=False, rest=(), fresh=False,
@@ -255,6 +252,21 @@ class TheLauncherSTailIsWhereAReopenDiffers(PersonaIso, unittest.TestCase):
         rec = reopen.Chat(chat=chat, workspace=workspace, persona="", harness="claude-code",
                           cwd="", resume="", transcript="", active=False)
         return commands_frame.Reopening(rec)
+
+
+class TheLauncherSTailIsWhereAReopenDiffers(_DrivesTheLauncher, PersonaIso,
+                                            unittest.TestCase):
+    """`cmd_launch` driven all the way to its return, on both paths.
+
+    **Written because the deletion sweep asked for it.** Three branches in that tail are the
+    whole of what `Reopening` changes, and every one of them was unpinned: open-or-focus,
+    the `attach`, and the sentence `cmd_launch` says on the operator's behalf when their
+    plane was quit. `TheReopenPathSuppressesFourThingsInTheLauncher` asserts the PREDICATE
+    those branch on and says in its own docstring that the tail "cannot be reached without a
+    real tmux session and a real `attach`". The sweep disagreed, and it was right: the tail
+    is reachable with every tmux call answered and `attach` stubbed, which is what
+    `_DrivesTheLauncher` does.
+    """
 
     def test_an_ordinary_launch_attaches_and_asks_about_open_or_focus(self):
         calls = self._launch()
@@ -359,6 +371,51 @@ class TheLauncherSTailIsWhereAReopenDiffers(PersonaIso, unittest.TestCase):
             self._launch(reopening=self._reopening())
 
         self.assertNotIn("charter reopen", buf.getvalue())
+
+
+class TheLauncherStillLaunchesWhenTheBoundaryCannotBeMade(_DrivesTheLauncher, PersonaIso,
+                                                          unittest.TestCase):
+    """`try: workspace.ensure(ws)` / `except (ValueError, OSError): pass` in `_launch`.
+
+    The isolation boundary is made before a chat is put inside it (#850), and the catch
+    around it is the "best effort, and it must be" the line's own comment argues for.
+    Nothing exercised it: every case reaching that line had a workspace charter could
+    create, so the sweep replaced the clause with an exception nothing raises and the
+    suite stayed green.
+
+    **What the catch buys is not a tidy traceback.** This runs before the frame exists, so
+    the failure it would otherwise become is a traceback printed into a terminal that
+    switches to tmux's alternate screen milliseconds later — the operator sees their chat
+    fail to start and nothing saying why, on the surface where `util.warn` was already
+    measured landing 86 bytes too early to be read. `_launch_root` degrades the same way
+    for the two callers that chdir first, and its clause is pinned by
+    `test_a_name_that_cannot_be_a_workspace_still_falls_back_to_the_plane`; this is the
+    launch that does not chdir, and it is the other half of the same promise.
+
+    Both members are asked because both are real and they are different failures.
+    `workspace.ensure` raises `ValueError` for a name that cannot be a workspace —
+    `$CHARTER_WORKSPACE=..` reaches it untouched — and `OSError` for a `workspaces/`
+    charter cannot write. `doctor`'s `workspace layer` row is where either is reported,
+    which is the whole reason the launcher is allowed to say nothing here.
+    """
+
+    def _launch_unable_to_ensure(self, exc):
+        """The launch, with the boundary refusing. The patch is on the module attribute
+        `_launch` reads, so the refusal arrives exactly where the operator's would."""
+        with mock.patch.object(commands_frame.workspace, "ensure", side_effect=exc):
+            return self._launch()
+
+    def test_a_workspaces_directory_that_cannot_be_written_still_starts_the_chat(self):
+        calls = self._launch_unable_to_ensure(OSError("read-only file system"))
+
+        self.assertTrue(calls["attached"], "the chat never reached the operator's terminal")
+        self.assertEqual(calls["rc"], 0)
+
+    def test_a_name_that_cannot_be_a_workspace_still_starts_the_chat(self):
+        calls = self._launch_unable_to_ensure(ValueError("invalid workspace name '..'"))
+
+        self.assertTrue(calls["attached"], "the chat never reached the operator's terminal")
+        self.assertEqual(calls["rc"], 0)
 
 
 if __name__ == "__main__":       # pragma: no cover

--- a/tests/test_a_workspace_carries_charters_layer.py
+++ b/tests/test_a_workspace_carries_charters_layer.py
@@ -578,10 +578,11 @@ class TheRowsQuietStates(WorkspaceLayer):
 
         Falling through renders the sentence below it with the number it has, and
         ``0 generated file(s) across all workspaces, all current`` is a true count wearing
-        the wrong row: it tells an operator their workspaces are mirroring the plane
-        correctly when the plane has nothing to mirror and no workspace holds a file at
-        all. The two states differ in what the next command should be — `reinit` repairs
-        the first and can do nothing about the second — so the row has to tell them apart.
+        the wrong row: it reports charter's files as in place and current when there are
+        no files, and no workspace holds one. Both states are green and they are not the
+        same fact — the second says the plane declares nothing worth mirroring, which is
+        the only one of the two an operator can do anything about, and `reinit` is not
+        what does it.
         """
         (config.ROOT / ".claude" / "settings.json").write_text(json.dumps(
             {"permissions": {"allow": ["Bash(ls:*)"]}}))

--- a/tests/test_a_workspace_carries_charters_layer.py
+++ b/tests/test_a_workspace_carries_charters_layer.py
@@ -572,6 +572,222 @@ class TheRowsQuietStates(WorkspaceLayer):
             r = doctor.check_workspace_harness()
         self.assertNotIn("machine-global", r.detail)
         self.assertNotIn("  (", r.detail, "an empty aside still printed its brackets")
+
+    def test_a_plane_with_nothing_to_mirror_says_so_rather_than_counting_zero(self):
+        """`if not total` — the branch whose deletion the suite could not see.
+
+        Falling through renders the sentence below it with the number it has, and
+        ``0 generated file(s) across all workspaces, all current`` is a true count wearing
+        the wrong row: it tells an operator their workspaces are mirroring the plane
+        correctly when the plane has nothing to mirror and no workspace holds a file at
+        all. The two states differ in what the next command should be — `reinit` repairs
+        the first and can do nothing about the second — so the row has to tell them apart.
+        """
+        (config.ROOT / ".claude" / "settings.json").write_text(json.dumps(
+            {"permissions": {"allow": ["Bash(ls:*)"]}}))
+        self.assertTrue(workspace.list_workspaces(),
+                        "no workspace at all — the count below would be zero either way")
+        r = doctor.check_workspace_harness()
+        self.assertEqual(r.status, doctor.OK)
+        self.assertIn("nothing to mirror — the plane declares no plugin, status line or "
+                      "env of its own", r.detail)
+        self.assertNotIn("generated file(s)", r.detail)
+
+
+class TheDetailNamesFourFindingsAndThenSaysSo(WorkspaceLayer):
+    """`", ".join(findings[:4]) + (", …" if len(findings) > 4 else "")` — the truncation,
+    pinned at its boundary and not only in its direction.
+
+    Two survivors sat on this one expression and the sweep read them together, because
+    either alone can be written off: a case with five findings pins the ellipsis but not
+    where the cut is — `len(findings) >= 4` renders it there too — and a case with four
+    pins the cut but not that the ellipsis ever appears. So both counts are here. FOUR is
+    the last that fits whole; FIVE is the first that is abbreviated.
+
+    **The count is the row's budget, not a detail.** This is one doctor line an operator
+    reads in a terminal, `[:4]` is what fits on it, and the two failures either side are
+    both silent: a boundary one low prints `…` over findings that were all named, and the
+    ellipsis lost means a fifth broken workspace is dropped from the row with nothing
+    saying anything was left out.
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+        # A real plane, for `DoctorSaysSo`'s reason: without one the row short-circuits on
+        # `HAS_CONTROL_PLANE` and every count below is measured against a row that never
+        # looked at a workspace.
+        _isolation.make_plane(self)
+        _plane_settings(config.ROOT)
+        workspace.ensure(self.ws)
+
+    def _detail_for(self, n: int) -> str:
+        """The row's detail with exactly *n* findings — *n* workspaces missing their file.
+
+        `self.ws` stays current on purpose: it counts towards `total` and contributes no
+        finding, so the number under test is the number of things WRONG rather than the
+        number of workspaces.
+        """
+        for i in range(n):
+            ws = f"w{i}"
+            workspace.ensure(ws)
+            (workspace.workspace_dir(ws) / ".claude" / "settings.json").unlink()
+        r = doctor.check_workspace_harness()
+        self.assertEqual(r.status, doctor.WARN)
+        self.assertEqual(r.detail.count("(missing)"), min(n, 4),
+                         f"asked for {n} findings and the row named a different number")
+        return r.detail
+
+    def test_four_findings_are_all_named_and_nothing_says_there_are_more(self):
+        detail = self._detail_for(4)
+        for i in range(4):
+            self.assertIn(f"w{i}/.claude/settings.json (missing)", detail)
+        self.assertNotIn("…", detail,
+                         "four fit — the row promised a fifth finding it does not have")
+
+    def test_a_fifth_finding_is_abbreviated_rather_than_dropped_in_silence(self):
+        detail = self._detail_for(5)
+        self.assertTrue(detail.endswith(", …"),
+                        f"a finding was dropped with nothing saying so: {detail}")
+
+
+class ARowThatCouldNotRunSaysSoRatherThanEndingTheDoctor(WorkspaceLayer):
+    """`except (OSError, ValueError)` around the whole workspace walk — both members.
+
+    Neither is theoretical, and what they cost is not this row. `check_workspace_harness`
+    runs from the SessionStart hook alongside every other check: an exception out of it is
+    not a missing row, it is every row after it never printed, on a path the operator did
+    not ask for and cannot see.
+
+    **OSError is the operating system's.** `list_workspaces` walks `workspaces/`, and a
+    directory it cannot read raises there. It is asked with a stub rather than a `chmod`
+    deliberately: `chmod` is a no-op for root, root is who a container may run this suite
+    as, and a guard whose test passes for the wrong reason on somebody's machine is the
+    exact failure this file's tripwire exists for.
+
+    **ValueError is a registered harness's.** The walk reaches every harness's
+    `workspace_files()` through `harness_layer`, and
+    `OneMisbehavingHarnessDoesNotEmptyTheLayer` already settles what charter owes a
+    third-party integration that misbehaves: one broken harness costs its own answer and
+    not everybody else's. This is that rule applied one level up — it must not cost the
+    doctor either.
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+        _isolation.make_plane(self)
+        _plane_settings(config.ROOT)
+        workspace.ensure(self.ws)
+
+    def test_a_workspaces_directory_that_cannot_be_read_is_reported_not_checked(self):
+        with mock.patch.object(workspace, "list_workspaces",
+                               side_effect=OSError("workspaces/ is unreadable")):
+            r = doctor.check_workspace_harness()
+        self.assertEqual(r.status, doctor.WARN)
+        self.assertEqual(r.detail, "not checked (workspaces/ is unreadable)")
+        self.assertEqual(r.hint, doctor._NOT_CHECKED_HINT)
+
+    def test_a_harness_that_raises_costs_its_own_answer_and_not_the_doctor(self):
+        def _boom():
+            raise ValueError("this harness cannot say")
+
+        broken = SimpleNamespace(name="broken", deficits=[], workspace_files=_boom)
+        with mock.patch.object(registry, "all", return_value=[broken]):
+            r = doctor.check_workspace_harness()
+        self.assertEqual(r.status, doctor.WARN)
+        self.assertEqual(r.detail, "not checked (this harness cannot say)")
+
+
+class APathThatWouldLeaveTheWorkspaceIsNeverWritten(WorkspaceLayer):
+    """`if wd.resolve() not in target.parents: continue` — asked with a path that escapes.
+
+    `_layer_files`' own docstring says why the clause is there — *"the harness contract
+    says paths stay inside; a contract nothing enforces is a comment, and this is the one
+    place every harness's answer passes through"* — and nothing put a path through it that
+    the contract forbids. Every registered harness names `.claude/settings.json`, which
+    is inside, so deleting the whole guard left the suite green and the sweep said so.
+
+    `AWorkspaceRootReachedThroughASymlink` pins the `.resolve()` inside the clause from
+    the other side: drop it and the guard fires for EVERY file. That is the case where the
+    clause wrongly refuses. This is the case it exists for, and the two together are why
+    it is one clause with two normalised sides rather than either alone.
+
+    **What it costs is not a stray file.** `wire_harnesses` writes what `_layer_files`
+    returns, so a `rel` climbing out of the workspace is charter generating into a
+    directory it never claimed — the plane root's own `.claude/settings.json` is one `..`
+    away, git-tracked and the operator's, and `commands._ensure_statusline`'s never-repair
+    restraint is written against exactly that write.
+    """
+
+    def test_a_relative_path_climbing_out_of_the_workspace_is_dropped(self):
+        rogue = SimpleNamespace(workspace_files=lambda: {"../escaped.json": "{}\n"})
+        real = claude_code.ClaudeCodeHarness()
+        with mock.patch.object(registry, "all", return_value=[rogue, real]):
+            files = workspace._layer_files(self.ws)
+            rows = workspace.wire_harnesses(self.ws)
+        self.assertEqual(sorted(files), [".claude/settings.json"],
+                         "a path outside the workspace was accepted into the layer")
+        self.assertEqual([rel for rel, _ in rows], [".claude/settings.json"])
+        escaped = workspace.workspace_dir(self.ws).parent / "escaped.json"
+        self.assertFalse(escaped.exists(),
+                         "charter generated a file outside the workspace it was wiring")
+
+
+class TheRowsComeBackInOneOrder(WorkspaceLayer):
+    """`sorted(_layer_files(name).items())` — path order, not registry order.
+
+    `list` passes every test this suite had, because the one harness that carries files
+    carries exactly one. The sweep found the `sorted` as a survivor for that reason, and
+    it is not cosmetic: `_layer_files` merges the whole registry into one dict, so without
+    the sort the rows arrive in whatever order harnesses happen to have been registered
+    in — which `registry.all` is free to change and no caller of this function knows.
+
+    Two readers depend on the order being the path's. `doctor.check_workspace_harness`
+    prints the first four findings and abbreviates the rest, so registry order decides
+    WHICH four an operator is shown; `cmd_workspace_reinit` prints one line per file, and
+    a repair whose report reshuffles between runs cannot be diffed against the last one.
+    """
+
+    def test_files_from_two_harnesses_are_reported_in_path_order(self):
+        late = SimpleNamespace(workspace_files=lambda: {"z-late.json": "{}\n"})
+        early = SimpleNamespace(workspace_files=lambda: {"a-early.json": "{}\n"})
+        with mock.patch.object(registry, "all", return_value=[late, early]):
+            rows = workspace.harness_layer(self.ws)
+        self.assertEqual([rel for rel, _ in rows], ["a-early.json", "z-late.json"],
+                         "the rows came back in the order the harnesses were registered")
+
+
+class AMarkerThatCannotBeWrittenCostsOnlyTheMarker(WorkspaceLayer):
+    """`except OSError: pass` around the marker write — the one catch in `wire_harnesses`
+    that is not about the operator's file.
+
+    The write above it has its own catch and its own test
+    (`test_a_path_charter_cannot_write_is_reported_and_never_forced`, which reports
+    `blocked`); this one is the sidecar, and it is silent on purpose. By the time it runs
+    the layer is already on disk and correct — the marker only records that charter wrote
+    it — so raising here would turn a workspace that was successfully wired into a failed
+    `charter workspace reinit`, and `scaffold` calls this on every launch.
+
+    A DIRECTORY at the marker's path is the fixture because it is the one refusal no
+    permission bit decides: `write_text` on a directory raises `IsADirectoryError` for
+    every user including root, where a `chmod 500` fixture silently succeeds for root and
+    measures nothing. The cost of losing the marker is real and is charged next run —
+    charter no longer recognises its own file and reads it as the operator's — which is
+    why this is `pass` and not repair.
+    """
+
+    def test_a_directory_where_the_marker_goes_does_not_cost_the_layer(self):
+        wd = workspace.workspace_dir(self.ws)
+        marker = wd / workspace.GENERATED_MARKER
+        self.settings().unlink()
+        marker.unlink()
+        marker.mkdir()
+
+        rows = workspace.wire_harnesses(self.ws)
+
+        self.assertEqual(rows, [(".claude/settings.json", "created")])
+        self.assertTrue(self.settings().is_file(),
+                        "the layer was lost to a marker that could not be written")
+        self.assertTrue(marker.is_dir(), "charter removed what was in its way")
 class WhatReinitSaysAboutTheLayer(WorkspaceLayer):
     """`cmd_workspace_reinit`'s per-file report — every outcome that reaches it.
 

--- a/tests/test_a_workspace_carries_charters_layer.py
+++ b/tests/test_a_workspace_carries_charters_layer.py
@@ -348,6 +348,58 @@ class TheGeneratorIsOnePlace(WorkspaceLayer):
                          workspace.content_digest(files[".claude/settings.json"]))
 
 
+class TheRowsQuietStates(WorkspaceLayer):
+    """The states of `check_workspace_harness` that say **nothing is wrong**.
+
+    `DoctorSaysSo` covers the three that report a problem. The sweep returned these as
+    survivors, which is the usual asymmetry: the failing paths get cases because somebody
+    was fixing a failure, and the reassuring ones are believed. A row that answers OK for
+    the wrong reason is the harder defect, because nobody looks at it again.
+
+    **This class writes a `charter.toml` and re-derives, and that is the whole reason the
+    survivors survived.** `tests/_isolation.py` says it outright — *"`PersonaIso` hands
+    every case a root; it deliberately does not put a `charter.toml`"* — so
+    `HAS_CONTROL_PLANE` is False for every case in this module and the row returns
+    ``no control plane found`` before reaching a single line below it. Dropping that guard
+    changes nothing a test can see, because no test was ever past it.
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+        (Path(config.ROOT) / "charter.toml").write_text("schema = 1\n")
+        prev = config.use(Path(config.ROOT))
+        self.addCleanup(config.restore, prev)
+        self.assertTrue(config.HAS_CONTROL_PLANE,
+                        "fixture did not give the row a plane — every case below would "
+                        "pass through the short-circuit and assert nothing")
+
+    def test_outside_a_plane_the_row_says_so_and_checks_nothing(self):
+        with mock.patch.object(config, "HAS_CONTROL_PLANE", False):
+            r = doctor.check_workspace_harness()
+        self.assertEqual(r.status, doctor.OK)
+        self.assertEqual(r.detail, "no control plane found")
+
+    def test_a_current_plane_counts_what_it_mirrors(self):
+        r = doctor.check_workspace_harness()
+        self.assertEqual(r.status, doctor.OK)
+        self.assertIn("generated file(s) across all workspaces, all current", r.detail)
+        self.assertNotIn("nothing to mirror", r.detail)
+
+    def test_the_deficit_aside_names_the_harnesses_that_cannot_diverge(self):
+        r = doctor.check_workspace_harness()
+        self.assertIn("config is machine-global, so a workspace cannot diverge — "
+                      "charter harness list", r.detail)
+
+    def test_a_plane_whose_harnesses_can_all_isolate_gets_no_aside(self):
+        """The `else` half, which no registry this repository ships can reach: opencode and
+        Codex both declare the ceiling, so `gaps` is never empty and the aside is always
+        rendered. That makes the empty string look like dead code — it is not, it is the
+        answer the day a harness gains per-workspace config, and it is the difference
+        between a clean row and one carrying a trailing parenthetical about nothing."""
+        with mock.patch.object(workspace, "harness_deficits", return_value=[]):
+            r = doctor.check_workspace_harness()
+        self.assertNotIn("machine-global", r.detail)
+        self.assertNotIn("  (", r.detail, "an empty aside still printed its brackets")
 class WhatReinitSaysAboutTheLayer(WorkspaceLayer):
     """`cmd_workspace_reinit`'s per-file report — every outcome that reaches it.
 

--- a/tests/test_a_workspace_carries_charters_layer.py
+++ b/tests/test_a_workspace_carries_charters_layer.py
@@ -237,6 +237,25 @@ class ReinitRepairs(WorkspaceLayer):
         commands_workspace.cmd_workspace_reinit(SimpleNamespace(name=self.ws, all=False))
         self.assertIn("later@market", self.settings().read_text())
 
+    def test_reinit_says_what_it_DID_rather_than_what_it_found(self):
+        """A `.claude` that is a file cannot be made into a directory, and charter never
+        deletes or renames existing content. Reading the pre-state would have printed
+        "wrote it" over a write that never happened — and a tick is what stops you
+        checking."""
+        import shutil
+
+        shutil.rmtree(workspace.workspace_dir(self.ws) / ".claude")
+        (workspace.workspace_dir(self.ws) / ".claude").write_text("not a directory\n")
+        rows = dict(workspace.reinit(self.ws)["layer"])
+        self.assertEqual(rows[".claude/settings.json"], "blocked")
+        self.assertEqual((workspace.workspace_dir(self.ws) / ".claude").read_text(),
+                         "not a directory\n")
+
+    def test_a_current_layer_is_not_announced(self):
+        """Idempotent means quiet: a second `reinit` has nothing to say about the layer."""
+        commands_workspace.cmd_workspace_reinit(SimpleNamespace(name=self.ws, all=False))
+        self.assertEqual(workspace.reinit(self.ws)["layer"], [])
+
 
 class DoctorSaysSo(WorkspaceLayer):
     def setUp(self) -> None:

--- a/tests/test_a_workspace_carries_charters_layer.py
+++ b/tests/test_a_workspace_carries_charters_layer.py
@@ -348,6 +348,92 @@ class TheGeneratorIsOnePlace(WorkspaceLayer):
                          workspace.content_digest(files[".claude/settings.json"]))
 
 
+class WhatReinitSaysAboutTheLayer(WorkspaceLayer):
+    """`cmd_workspace_reinit`'s per-file report — every outcome that reaches it.
+
+    Nothing exercised this loop, which is why the deletion sweep returned eight survivors
+    across it: both `did ==` branches, both their literals, the `"layer"` key, the `or ()`
+    and the wrote/refreshed ternary.
+
+    **`"present"` never arrives here, and that is worth writing down because it looks like
+    it does.** `write_layer` answers `"present"` for a file already exactly right, and the
+    `else` below increments `healed` and prints *refreshed* — so the two functions read
+    side by side say a current layer is reported as healed, which would make
+    `charter workspace reinit` claim work it had not done. It does not: `reinit` filters
+    those rows first (`workspace.py:1592`, ``if st != "present"``), so a third branch here
+    would be unreachable. `test_a_current_layer_reports_nothing_at_all` pins the filter
+    from this end so the next reader need not re-derive it.
+
+    The sentences are spelled out rather than compared against the code that prints them,
+    because a test built from the same f-string agrees with any wording it takes — and
+    *"was not written by charter — left completely untouched"* is the ownership promise
+    made visible. If it stops being true, the operator finds out by having their file
+    overwritten.
+    """
+
+    def _reinit(self):
+        said: list[tuple[str, str]] = []
+        with mock.patch.object(commands_workspace.util, "ok",
+                               side_effect=lambda m: said.append(("ok", m))), \
+             mock.patch.object(commands_workspace.util, "warn",
+                               side_effect=lambda m: said.append(("warn", m))), \
+             mock.patch.object(commands_workspace.util, "err",
+                               side_effect=lambda m: said.append(("err", m))), \
+             mock.patch.object(commands_workspace.util, "info", side_effect=lambda m: None):
+            commands_workspace.cmd_workspace_reinit(
+                SimpleNamespace(name=self.ws, all=False))
+        return said
+
+    def test_a_hand_edited_file_is_named_as_the_operators_and_left(self):
+        self.settings().write_text("{}")
+        said = self._reinit()
+        self.assertIn(
+            f"'{self.ws}': .claude/settings.json was not written by charter — left "
+            f"completely untouched. Remove it if you want charter's own again.",
+            [m for _, m in said])
+        self.assertEqual(self.settings().read_text(), "{}")
+
+    def test_a_current_layer_reports_nothing_at_all(self):
+        said = self._reinit()
+        self.assertNotIn("harness layer", " ".join(m for _, m in said))
+        self.assertIn("Up to date", " ".join(m for _, m in said))
+
+    def test_a_file_charter_owns_and_the_plane_moved_reads_refreshed(self):
+        # One of the THREE mirrored keys, not `permissions` — that one stays in the plane,
+        # so moving it leaves the layer correctly unchanged and this would assert nothing.
+        _plane_settings(config.ROOT, statusLine={"type": "command",
+                                                 "command": "charter statusline --wide"})
+        said = self._reinit()
+        self.assertIn(
+            f"Reinitialized '{self.ws}' → refreshed .claude/settings.json "
+            f"(charter's harness layer).", [m for _, m in said])
+
+    def test_a_missing_file_reads_wrote_rather_than_refreshed(self):
+        self.settings().unlink()
+        (workspace.workspace_dir(self.ws) / workspace.GENERATED_MARKER).unlink()
+        said = self._reinit()
+        self.assertIn(
+            f"Reinitialized '{self.ws}' → wrote .claude/settings.json "
+            f"(charter's harness layer).", [m for _, m in said])
+
+    def test_a_path_charter_cannot_write_is_reported_and_never_forced(self):
+        """`blocked`. A DIRECTORY at that path reads `foreign` instead — charter cannot
+        match it against the marker so it treats it as the operator's, which is the safe
+        direction. `blocked` is the other half: the path IS charter's to write and the
+        write itself fails."""
+        f = self.settings()
+        f.unlink()
+        d = f.parent
+        d.chmod(0o500)
+        self.addCleanup(d.chmod, 0o700)
+        said = self._reinit()
+        self.assertIn(
+            f"'{self.ws}': .claude/settings.json could not be written — something is in "
+            f"the way at that path. charter never deletes or renames existing content.",
+            [m for _, m in said])
+        self.assertFalse(f.exists(), "charter forced the write past a refusal")
+        self.assertNotIn("harness layer", " ".join(m for _, m in said),
+                         "a blocked file was also counted as healed")
 class TheMarkersNameIsPartOfTheOnDiskContract(_isolation.PersonaIso):
     """`.charter-generated` is spelled out here once, by hand.
 

--- a/tests/test_a_workspace_carries_charters_layer.py
+++ b/tests/test_a_workspace_carries_charters_layer.py
@@ -348,6 +348,65 @@ class TheGeneratorIsOnePlace(WorkspaceLayer):
                          workspace.content_digest(files[".claude/settings.json"]))
 
 
+class AMarkerCharterCannotReadIsNotAMarker(WorkspaceLayer):
+    """`_read_marker` — three ways the sidecar fails, and they must all mean the same thing.
+
+    The marker answers *did charter write this file?*, so a marker charter cannot read has
+    to answer **no**, and `harness_layer` must then call the file `foreign` and leave it.
+    Getting that backwards is the destructive direction: a wrong *yes* overwrites work.
+
+    Three failures the sweep found unpinned. **Missing** is the ordinary case and is
+    covered elsewhere. **Unparseable** and **not-a-dict** are different: a truncated write
+    leaves bytes that are not JSON, and a file whose top level is a list or a string parses
+    fine and then answers nothing to `marker.get(rel)`. Without the `isinstance` that is an
+    `AttributeError` out of a reader whose whole contract is to degrade.
+
+    The `except` is narrow on purpose — `check_memory_indexes`' recorded reason is that a
+    broad catch here once swallowed a `NameError` and reported OK.
+    """
+
+    def _marker(self):
+        return workspace.workspace_dir(self.ws) / workspace.GENERATED_MARKER
+
+    def test_bytes_that_are_not_json_read_as_no_marker(self):
+        self._marker().write_text("{ truncated")
+        self.assertEqual(workspace._read_marker(self.ws), {})
+
+    def test_bytes_that_are_not_text_read_as_no_marker(self):
+        self._marker().write_bytes(b"\xff\xfe not utf-8")
+        self.assertEqual(workspace._read_marker(self.ws), {})
+
+    def test_valid_json_that_is_not_an_object_reads_as_no_marker(self):
+        for doc in ("[]", '"a string"', "3", "null"):
+            self._marker().write_text(doc)
+            self.assertEqual(workspace._read_marker(self.ws), {}, doc)
+
+    def test_an_edited_file_whose_marker_cannot_be_read_is_foreign_and_survives(self):
+        """The consequence, not the return value. `ok` is decided by CONTENT equality, so
+        an unreadable marker changes nothing while the file still matches — the marker only
+        separates `stale` (charter's, the plane moved) from `foreign` (somebody else's).
+        Edit the file AND break the marker and charter must choose `foreign`, because the
+        wrong answer here overwrites work."""
+        self.settings().write_text("{ \"env\": {} }")
+        self._marker().write_text("[]")
+        rows = dict(workspace.harness_layer(self.ws))
+        self.assertEqual(rows[".claude/settings.json"], "foreign")
+        before = self.settings().read_text()
+        workspace.wire_harnesses(self.ws)
+        self.assertEqual(self.settings().read_text(), before,
+                         "charter overwrote a file it could not vouch for")
+
+    def test_a_file_charter_cannot_read_says_so_rather_than_guessing(self):
+        """The `unreadable` status — the FILE, not the marker. Bytes that are not text
+        cannot be compared against what charter would write, and `write_layer` treats it
+        exactly as `foreign`: left alone."""
+        self.settings().write_bytes(b"\xff\xfe not utf-8")
+        rows = dict(workspace.harness_layer(self.ws))
+        self.assertEqual(rows[".claude/settings.json"], "unreadable")
+        before = self.settings().read_bytes()
+        workspace.wire_harnesses(self.ws)
+        self.assertEqual(self.settings().read_bytes(), before,
+                         "charter overwrote bytes it could not read")
 class OneMisbehavingHarnessDoesNotEmptyTheLayer(WorkspaceLayer):
     """`h.workspace_files() or {}` — the fallback, and why it is tolerance rather than a
     guard against something that happens.

--- a/tests/test_a_workspace_carries_charters_layer.py
+++ b/tests/test_a_workspace_carries_charters_layer.py
@@ -348,6 +348,35 @@ class TheGeneratorIsOnePlace(WorkspaceLayer):
                          workspace.content_digest(files[".claude/settings.json"]))
 
 
+class TheCeilingReportedIsTheOneAboutWorkspaces(WorkspaceLayer):
+    """`harness_deficits` filters on `WORKSPACE_SCOPE`, and Codex is why.
+
+    Codex declares three deficits — `status-bar`, `session-lock` and `WORKSPACE_SCOPE` —
+    so `next(...)` without the key test returns whichever is first. The existing case
+    asserts *which harnesses* have a ceiling; nothing asserted *which ceiling*, which is
+    why the sweep found the filter as a survivor.
+
+    The consequence is a sentence rather than a crash, which is why it would have survived
+    a reader too: `check_workspace_harness` renders the match as
+    *"(codex: config is machine-global, so a workspace cannot diverge)"*. Drop the filter
+    and that explanation is attached to Codex's **status bar** — a true fact about a
+    different limitation, printed as the reason a workspace cannot hold its own config.
+    """
+
+    def test_the_deficit_returned_is_the_workspace_one_not_merely_the_first(self):
+        got = dict(workspace.harness_deficits())
+        self.assertIn("codex", got)
+        self.assertEqual(got["codex"].key, base.WORKSPACE_SCOPE)
+        self.assertNotEqual(got["codex"].key, "status-bar")
+
+    def test_a_harness_declaring_other_ceilings_only_is_not_reported_here(self):
+        """The filter's other half: a harness with deficits but none about workspaces has
+        no ceiling to name, and must not be listed as unable to diverge."""
+        only_other = SimpleNamespace(
+            name="probe", deficits=(base.Deficit("status-bar", "d", "r"),))
+        real = claude_code.ClaudeCodeHarness()
+        with mock.patch.object(registry, "all", return_value=[only_other, real]):
+            self.assertEqual(workspace.harness_deficits(), [])
 class AMarkerCharterCannotReadIsNotAMarker(WorkspaceLayer):
     """`_read_marker` — three ways the sidecar fails, and they must all mean the same thing.
 

--- a/tests/test_a_workspace_carries_charters_layer.py
+++ b/tests/test_a_workspace_carries_charters_layer.py
@@ -348,6 +348,24 @@ class TheGeneratorIsOnePlace(WorkspaceLayer):
                          workspace.content_digest(files[".claude/settings.json"]))
 
 
+class TheBoundaryAsksTheNameFirst(WorkspaceLayer):
+    """`is_workspace_dir` — the parent comparison alone is not the boundary.
+
+    Its own docstring names the case and nothing tested it, which is why the sweep found
+    the `valid_name` guard as a survivor: ``WORKSPACES_DIR / ".."`` **is the plane root**,
+    and its parent is `WORKSPACES_DIR`, so a comparison alone answers *yes* for the one
+    directory the whole mechanism exists to keep its hands off. The plane root's
+    `.claude/settings.json` is user-owned and git-tracked; generating into it is the
+    failure `commands._ensure_statusline`'s never-repair restraint is written against.
+    """
+
+    def test_the_plane_root_reached_as_dot_dot_is_not_a_workspace(self):
+        self.assertFalse(workspace.is_workspace_dir(config.WORKSPACES_DIR / ".."))
+
+    def test_a_name_that_cannot_be_a_workspace_is_refused_beside_real_ones(self):
+        self.assertTrue(workspace.is_workspace_dir(config.WORKSPACES_DIR / self.ws))
+        for bad in ("..", ".", ".hidden"):
+            self.assertFalse(workspace.is_workspace_dir(config.WORKSPACES_DIR / bad), bad)
 class TheRowsQuietStates(WorkspaceLayer):
     """The states of `check_workspace_harness` that say **nothing is wrong**.
 

--- a/tests/test_a_workspace_carries_charters_layer.py
+++ b/tests/test_a_workspace_carries_charters_layer.py
@@ -348,7 +348,91 @@ class TheGeneratorIsOnePlace(WorkspaceLayer):
                          workspace.content_digest(files[".claude/settings.json"]))
 
 
+class TheMarkersNameIsPartOfTheOnDiskContract(_isolation.PersonaIso):
+    """`.charter-generated` is spelled out here once, by hand.
+
+    Every other reference in this suite reads `workspace.GENERATED_MARKER`, which agrees
+    with any value that constant takes — the deletion sweep found the literal as a
+    `retune-string` survivor for exactly that reason, and it is the eleventh time this
+    repository has shipped that shape.
+
+    **The name is a contract, not an implementation detail.** It is the file that answers
+    *is this layer charter's or the operator's* — the rule `_AGENT_MARKER` already sets for
+    generated sub-agents: a file charter wrote is refreshed, a file without the marker is
+    never clobbered. Rename it and charter stops recognising work it did itself: it would
+    either overwrite an operator's edited `settings.json` believing it had never written
+    one, or refuse to refresh its own believing somebody had taken ownership. Neither
+    failure announces itself.
+
+    It also sits beside `.charter-structure` in a workspace, which is the precedent for a
+    charter-owned dotfile there and the reason the name is shaped the way it is.
+    """
+
+    def test_the_marker_is_named_charter_generated(self):
+        self.assertEqual(workspace.GENERATED_MARKER, ".charter-generated")
+
+    def test_it_is_a_dotfile_so_a_workspace_listing_does_not_show_it(self):
+        self.assertTrue(workspace.GENERATED_MARKER.startswith("."))
+
+class AWorkspaceRootReachedThroughASymlink(_isolation.PersonaIso):
+    """`_layer_files`' containment check normalises **both** sides, and only one of them
+    is normalised for it.
+
+    `target` is `(wd / rel).resolve()`, so a `rel` carrying `..` cannot escape. `wd` looks
+    like it needs no resolving — `config.ROOT` is resolved by `root.find_root` (`.resolve()`
+    at `root.py:60`), so every path derived from it is already canonical and
+    `wd == wd.resolve()`. On that reading the two `wd.resolve()` calls are dead and the
+    deletion sweep, which found both as survivors, would be pointing at redundancy.
+
+    **It is not redundancy, and the difference is `config.use`.** `use(root)` hands *root*
+    straight to `derive()` without resolving it (`config.py:698`) — deliberately, so a
+    caller pins the directory it named rather than one charter picked. `PersonaIso` calls
+    exactly that. So a root reached through a symlink stays unresolved, and then::
+
+        wd            = /private/tmp/…/link/workspaces/alpha
+        wd.resolve()  = /private/tmp/…/real/workspaces/alpha
+
+    With the resolve, `wd.resolve() in target.parents` holds and the file is written. Drop
+    either call and the unresolved `wd` is not among the resolved `target`'s parents, the
+    `continue` fires for **every** file, and a workspace silently receives **no layer at
+    all** — the failure mode this whole feature exists to prevent, produced by the guard
+    against a different one.
+
+    macOS makes this easy to miss rather than hard to hit: `tempfile.mkdtemp()` answers
+    under `/var/folders/…` and `/var` is itself a symlink, so a fixture that resolves its
+    temp path before handing it over normalises for free and never reaches this. #837 hit
+    the mirror image — a masked `.resolve()` pair "hidden locally because macOS `/tmp` is a
+    symlink and every fixture path needed normalising for free".
+    """
+
+    def setUp(self):
+        super().setUp()
+        # A plane with settings of its own, because `workspace_files` mirrors the plane's
+        # COMMITTED file rather than charter's constants — a plane with none answers `{}`
+        # deliberately, and a fixture without one would assert nothing.
+        real = Path(config.ROOT) / "real-plane"
+        (real / "workspaces" / "alpha").mkdir(parents=True, exist_ok=True)
+        (real / ".claude").mkdir(parents=True, exist_ok=True)
+        (real / ".claude" / "settings.json").write_text(json.dumps({
+            "env": {"CHARTER_HARNESS": "claude-code"},
+            "statusLine": {"type": "command", "command": "charter statusline"},
+            "enabledPlugins": {"charter@charter": True},
+        }))
+        (real / "charter.toml").write_text("schema = 1\n")
+        link = Path(config.ROOT) / "link-plane"
+        if not link.exists():
+            link.symlink_to("real-plane")
+        self.link, self.real = link, real
+
+    def test_the_layer_reaches_a_workspace_under_an_unresolved_root(self):
+        prev = config.use(self.link)
+        self.addCleanup(config.restore, prev)
+        wd = workspace.workspace_dir("alpha")
+        self.assertNotEqual(wd, wd.resolve(),
+                            "fixture normalised for free — this case would assert nothing")
+        self.assertTrue(workspace._layer_files("alpha"),
+                        "a workspace under a symlinked root received no layer at all")
+
+
 if __name__ == "__main__":  # pragma: no cover
     import unittest
-
-    unittest.main()

--- a/tests/test_a_workspace_carries_charters_layer.py
+++ b/tests/test_a_workspace_carries_charters_layer.py
@@ -1,0 +1,335 @@
+"""A chat launched in `workspaces/<ws>/` gets charter's layer there — #850.
+
+Claude Code reads project settings from the session's working directory and does not walk
+up, so a chat whose cwd is a workspace directory loaded charter's plugin from nowhere, ran
+no status line and had no `$CHARTER_HARNESS`. The fix is one generated file per workspace
+and a marker saying charter wrote it.
+
+Every test here writes only into a `PersonaIso` tmp plane. Nothing in this file may touch
+the developer's real `workspaces/` — see `_planeguard` for what that has cost before.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
+
+from charter import commands_workspace, config, doctor, workspace
+from charter.harness import base, claude_code, registry
+
+from tests import _isolation
+
+
+def _plane_settings(root: Path, **extra) -> Path:
+    """The plane's own `.claude/settings.json`, shaped like this repo's committed one."""
+    d = root / ".claude"
+    d.mkdir(parents=True, exist_ok=True)
+    p = d / "settings.json"
+    doc = {
+        "env": {"CHARTER_HARNESS": "claude-code"},
+        "statusLine": {"type": "command", "command": "charter statusline",
+                       "padding": 0, "refreshInterval": 10},
+        "enabledPlugins": {"charter@charter": True},
+    }
+    doc.update(extra)
+    p.write_text(json.dumps(doc, indent=2) + "\n")
+    return p
+
+
+class WorkspaceLayer(_isolation.PersonaIso):
+    def setUp(self) -> None:
+        super().setUp()
+        # The tripwire this whole file is written under. `PersonaIso` repoints every
+        # derived path at a throwaway `edm-test-…` tree; if that ever stops being true,
+        # every write below lands in somebody's real plane.
+        self.assertIn("edm-test-", str(config.STATE_DIR))
+        _plane_settings(config.ROOT, permissions={"allow": ["Bash(ls:*)"]})
+        self.ws = "api"
+        workspace.ensure(self.ws)
+
+    def settings(self, name: str | None = None) -> Path:
+        return workspace.workspace_dir(name or self.ws) / ".claude" / "settings.json"
+
+
+class WhatIsWritten(WorkspaceLayer):
+    def test_a_workspace_gets_the_planes_three_keys_and_only_those(self):
+        """`enabledPlugins`, `statusLine` and `env` — the plugin alone loses the last two."""
+        p = self.settings()
+        self.assertTrue(p.is_file(), "workspaces/api/.claude/settings.json was not written")
+        doc = json.loads(p.read_text())
+        self.assertEqual(sorted(doc), ["enabledPlugins", "env", "statusLine"])
+        self.assertEqual(doc["enabledPlugins"], {"charter@charter": True})
+        self.assertEqual(doc["env"], {"CHARTER_HARNESS": "claude-code"})
+        self.assertEqual(doc["statusLine"]["command"], "charter statusline")
+
+    def test_the_planes_other_keys_stay_in_the_plane(self):
+        """A `permissions` block is the plane's decision about the plane's own root."""
+        self.assertNotIn("permissions", json.loads(self.settings().read_text()))
+
+    def test_nothing_else_is_materialised_into_the_workspace(self):
+        """Skills arrive with the plugin; agents walk up from here because this directory
+        is inside the plane's git repo. A second copy of either would shadow the plugin's
+        non-deterministically — Claude Code's own words are "is already taken by X, which
+        takes precedence"."""
+        wd = workspace.workspace_dir(self.ws)
+        for unwanted in ("skills", "agents", ".claude/skills", ".claude/agents",
+                         "CLAUDE.md", ".claude/CLAUDE.md"):
+            self.assertFalse((wd / unwanted).exists(), f"{unwanted} should not be written")
+
+    def test_the_layer_names_exactly_one_file(self):
+        rows = workspace.harness_layer(self.ws)
+        self.assertEqual([rel for rel, _status in rows], [".claude/settings.json"])
+
+
+class NothingReachesAClone(WorkspaceLayer):
+    def test_a_clone_inside_the_workspace_is_left_alone(self):
+        """`workspaces/<ws>/<repo>/` is a repo charter does not own — `git add -A` there
+        would stage whatever charter left behind."""
+        clone = workspace.workspace_dir(self.ws) / "api-service"
+        (clone / ".git").mkdir(parents=True)
+        workspace.wire_harnesses(self.ws)
+        self.assertFalse((clone / ".claude").exists())
+        self.assertFalse((clone / workspace.GENERATED_MARKER).exists())
+
+    def test_a_clone_directory_is_not_a_workspace_directory(self):
+        clone = workspace.workspace_dir(self.ws) / "api-service"
+        clone.mkdir(parents=True)
+        self.assertTrue(workspace.is_workspace_dir(workspace.workspace_dir(self.ws)))
+        self.assertFalse(workspace.is_workspace_dir(clone))
+        self.assertFalse(workspace.is_workspace_dir(config.ROOT))
+
+
+class OwnershipIsASidecar(WorkspaceLayer):
+    def test_the_marker_records_what_charter_wrote(self):
+        """Not a key inside the vendor's JSON — the same reason symlinking `.claude/` was
+        wrong. `.charter-structure` is the precedent for a charter-owned marker here."""
+        marker = workspace.workspace_dir(self.ws) / workspace.GENERATED_MARKER
+        self.assertTrue(marker.is_file())
+        self.assertIn(".claude/settings.json", json.loads(marker.read_text()))
+
+    def test_a_hand_edited_file_is_reported_and_never_rewritten(self):
+        p = self.settings()
+        p.write_text('{"statusLine": {"type": "command", "command": "mine"}}\n')
+        rows = dict(workspace.wire_harnesses(self.ws))
+        self.assertEqual(rows[".claude/settings.json"], "foreign")
+        self.assertIn("mine", p.read_text())
+
+    def test_a_file_with_no_marker_at_all_is_foreign(self):
+        """Charter cannot tell one it wrote before the marker existed from one somebody
+        else wrote, and guessing wrong in that direction destroys work."""
+        (workspace.workspace_dir(self.ws) / workspace.GENERATED_MARKER).unlink()
+        self.settings().write_text('{"env": {"MINE": "1"}}\n')
+        rows = dict(workspace.harness_layer(self.ws))
+        self.assertEqual(rows[".claude/settings.json"], "foreign")
+
+    def test_charters_own_file_is_refreshed_rather_than_left_stale(self):
+        _plane_settings(config.ROOT, enabledPlugins={"charter@charter": True,
+                                                     "other@market": True})
+        rows = dict(workspace.wire_harnesses(self.ws))
+        self.assertEqual(rows[".claude/settings.json"], "refreshed")
+        self.assertIn("other@market", self.settings().read_text())
+
+    def test_an_unchanged_file_is_present_and_not_rewritten(self):
+        before = self.settings().stat().st_mtime_ns
+        rows = dict(workspace.wire_harnesses(self.ws))
+        self.assertEqual(rows[".claude/settings.json"], "present")
+        self.assertEqual(self.settings().stat().st_mtime_ns, before)
+
+
+class StalenessIsRegenerateAndCompare(WorkspaceLayer):
+    def test_a_workspace_reads_stale_when_the_plane_moves(self):
+        """Regenerate and compare, the way `persona lint --only stale` does — the
+        generator's own wording drifts, so a stored diff would answer the wrong question."""
+        _plane_settings(config.ROOT, statusLine={"type": "command",
+                                                 "command": "charter statusline",
+                                                 "padding": 0, "refreshInterval": 5})
+        self.assertEqual(dict(workspace.harness_layer(self.ws))[".claude/settings.json"],
+                         "stale")
+
+    def test_reading_staleness_writes_nothing(self):
+        _plane_settings(config.ROOT, env={"CHARTER_HARNESS": "claude-code", "X": "1"})
+        before = self.settings().read_text()
+        workspace.harness_layer(self.ws)
+        self.assertEqual(self.settings().read_text(), before)
+
+    def test_a_missing_file_reads_missing(self):
+        self.settings().unlink()
+        self.assertEqual(dict(workspace.harness_layer(self.ws))[".claude/settings.json"],
+                         "missing")
+
+
+class TheOtherHarnessesGetADeficit(WorkspaceLayer):
+    def test_opencode_and_codex_declare_the_workspace_scope_ceiling(self):
+        """Their config is global — Codex has no project-level config at all — so
+        per-workspace divergence is not buildable for them. Silence would read as three
+        ticks."""
+        keyed = {h.name: [d for d in h.deficits if d.key == base.WORKSPACE_SCOPE]
+                 for h in registry.all()}
+        self.assertEqual(keyed["claude-code"], [])
+        for name in ("opencode", "codex"):
+            self.assertTrue(keyed[name], f"{name} must name the ceiling, not stay silent")
+            self.assertTrue(keyed[name][0].detail)
+
+    def test_a_harness_that_cannot_isolate_writes_nothing_into_a_workspace(self):
+        gaps = dict(workspace.harness_deficits())
+        self.assertEqual(sorted(gaps), ["codex", "opencode"])
+        # And nothing of theirs landed in the workspace.
+        wd = workspace.workspace_dir(self.ws)
+        self.assertEqual(sorted(p.name for p in wd.iterdir() if p.name.startswith(".")),
+                         sorted([".charter-structure", workspace.GENERATED_MARKER,
+                                 ".claude"]))
+
+    def test_every_registered_harness_either_carries_files_or_names_the_ceiling(self):
+        """The rot this pins: a harness added later that answers neither would report a
+        clean workspace it has never been checked in."""
+        for h in registry.all():
+            files = h.workspace_files()
+            gap = [d for d in h.deficits if d.key == base.WORKSPACE_SCOPE]
+            self.assertTrue(bool(files) != bool(gap),
+                            f"{h.name} must return workspace files OR declare "
+                            f"{base.WORKSPACE_SCOPE}, exactly one")
+
+
+class ThePlaneRootIsUntouched(WorkspaceLayer):
+    def test_wire_at_the_plane_root_still_writes_only_the_env_key(self):
+        """`init`'s contract is unchanged: that file is user-owned and git-tracked, and
+        the never-repair restraint on it is the whole reason the workspace file needed a
+        marker of its own."""
+        h = claude_code.ClaudeCodeHarness()
+        rows = h.wire(config.ROOT)
+        self.assertEqual([label for _s, label in rows], [".claude/settings.json (env)"])
+        self.assertFalse((config.ROOT / workspace.GENERATED_MARKER).exists())
+        self.assertFalse((config.ROOT / ".claude" / workspace.GENERATED_MARKER).exists())
+
+    def test_the_planes_own_settings_are_not_rewritten(self):
+        before = (config.ROOT / ".claude" / "settings.json").read_text()
+        workspace.wire_harnesses(self.ws)
+        self.assertEqual((config.ROOT / ".claude" / "settings.json").read_text(), before)
+
+
+class APlaneWithNothingToMirror(_isolation.PersonaIso):
+    def test_no_plane_settings_means_no_workspace_file_and_no_marker(self):
+        self.assertIn("edm-test-", str(config.STATE_DIR))
+        workspace.ensure("solo")
+        wd = workspace.workspace_dir("solo")
+        self.assertFalse((wd / ".claude").exists())
+        self.assertEqual(workspace.harness_layer("solo"), [])
+
+    def test_a_malformed_plane_settings_file_is_never_guessed_over(self):
+        (config.ROOT / ".claude").mkdir(parents=True, exist_ok=True)
+        (config.ROOT / ".claude" / "settings.json").write_text("{not json")
+        workspace.ensure("solo")
+        self.assertFalse((workspace.workspace_dir("solo") / ".claude").exists())
+
+
+class ReinitRepairs(WorkspaceLayer):
+    def test_reinit_puts_a_deleted_layer_back(self):
+        self.settings().unlink()
+        commands_workspace.cmd_workspace_reinit(SimpleNamespace(name=self.ws, all=False))
+        self.assertTrue(self.settings().is_file())
+
+    def test_reinit_refreshes_a_stale_layer(self):
+        _plane_settings(config.ROOT, enabledPlugins={"charter@charter": True,
+                                                     "later@market": True})
+        commands_workspace.cmd_workspace_reinit(SimpleNamespace(name=self.ws, all=False))
+        self.assertIn("later@market", self.settings().read_text())
+
+
+class DoctorSaysSo(WorkspaceLayer):
+    def setUp(self) -> None:
+        super().setUp()
+        # A real plane: the check refuses to say anything outside one, and the row this
+        # class is about is the one an operator reads on a plane.
+        _isolation.make_plane(self)
+        _plane_settings(config.ROOT)
+        self.ws = "api"
+        workspace.ensure(self.ws)
+
+    def test_a_current_workspace_reads_ok(self):
+        r = doctor.check_workspace_harness()
+        self.assertEqual(r.status, doctor.OK)
+        self.assertEqual(r.name, "workspace layer")
+
+    def test_a_stale_workspace_is_named_with_the_repair_command(self):
+        _plane_settings(config.ROOT, env={"CHARTER_HARNESS": "claude-code", "Y": "2"})
+        r = doctor.check_workspace_harness()
+        self.assertEqual(r.status, doctor.WARN)
+        self.assertIn(self.ws, r.detail)
+        self.assertIn("charter workspace reinit", r.hint)
+        # `Result.render` writes the arrow. A hint carrying its own prints two, which is
+        # what `check_workspace_clones` does and what this row must not learn from it.
+        self.assertFalse(r.hint.startswith("→"), r.hint)
+
+    def test_a_missing_layer_is_named(self):
+        self.settings().unlink()
+        r = doctor.check_workspace_harness()
+        self.assertEqual(r.status, doctor.WARN)
+        self.assertIn(self.ws, r.detail)
+
+    def test_a_hand_edited_layer_says_charter_will_not_touch_it(self):
+        self.settings().write_text('{"env": {"MINE": "1"}}\n')
+        r = doctor.check_workspace_harness()
+        self.assertEqual(r.status, doctor.WARN)
+        self.assertIn("charter did not write", r.detail + r.hint)
+
+    def test_the_row_names_the_harnesses_that_cannot_isolate(self):
+        r = doctor.check_workspace_harness()
+        self.assertIn("opencode", r.detail + r.hint)
+        self.assertIn("codex", r.detail + r.hint)
+
+    def test_the_check_is_in_the_preflight_and_in_its_pinned_names(self):
+        self.assertIn("workspace layer", doctor.check_names())
+
+    def test_the_check_writes_nothing(self):
+        self.settings().unlink()
+        doctor.check_workspace_harness()
+        self.assertFalse(self.settings().exists())
+
+
+class LaunchEnsuresTheBoundaryFirst(WorkspaceLayer):
+    def test_launch_root_makes_the_workspace_rather_than_falling_back_to_the_plane(self):
+        """Today a chat for a workspace with no directory records `workspace = <name>,
+        cwd = <plane root>` — a disagreement created at launch."""
+        from charter import commands_frame
+
+        self.assertFalse(workspace.workspace_dir("fresh").exists())
+        root = commands_frame._launch_root("fresh")
+        self.assertEqual(Path(root), workspace.workspace_dir("fresh"))
+        self.assertNotEqual(Path(root), Path(config.ROOT))
+
+    def test_the_ensured_workspace_carries_the_layer(self):
+        from charter import commands_frame
+
+        commands_frame._launch_root("fresh")
+        self.assertTrue((workspace.workspace_dir("fresh") / ".claude"
+                         / "settings.json").is_file())
+
+    def test_a_name_that_cannot_be_a_workspace_still_falls_back_to_the_plane(self):
+        """`_launch_root` is on a launch path with no operator waiting — it degrades, it
+        does not raise."""
+        from charter import commands_frame
+
+        self.assertEqual(Path(commands_frame._launch_root("..")), Path(config.ROOT))
+
+
+class TheGeneratorIsOnePlace(WorkspaceLayer):
+    def test_the_document_is_the_harnesss_own_and_is_written_verbatim(self):
+        files = claude_code.ClaudeCodeHarness().workspace_files()
+        self.assertEqual(sorted(files), [".claude/settings.json"])
+        self.assertEqual(self.settings().read_text(), files[".claude/settings.json"])
+
+    def test_the_marker_holds_a_digest_of_that_exact_text(self):
+        files = claude_code.ClaudeCodeHarness().workspace_files()
+        marker = json.loads(
+            (workspace.workspace_dir(self.ws) / workspace.GENERATED_MARKER).read_text())
+        self.assertEqual(marker[".claude/settings.json"],
+                         workspace.content_digest(files[".claude/settings.json"]))
+
+
+if __name__ == "__main__":  # pragma: no cover
+    import unittest
+
+    unittest.main()

--- a/tests/test_a_workspace_carries_charters_layer.py
+++ b/tests/test_a_workspace_carries_charters_layer.py
@@ -348,6 +348,45 @@ class TheGeneratorIsOnePlace(WorkspaceLayer):
                          workspace.content_digest(files[".claude/settings.json"]))
 
 
+class WhatThePlaneHasToOfferIsAskedThreeWays(WorkspaceLayer):
+    """`ClaudeCodeHarness.workspace_files` — the three states that answer nothing.
+
+    All three were sweep survivors, and they are not one question: *no settings file at
+    all*, *a settings file charter cannot parse*, and *a settings file with none of the
+    three mirrored keys* are different planes, and the middle one is the one charter must
+    not guess over. Its own docstring is the specification — *"Empty here means the
+    workspace gets no file and no marker at all, which is the honest rendering of 'there is
+    nothing to mirror'; writing an empty `{}` would look like a layer."*
+
+    The `k in settings` filter is the third: without it a plane declaring one of the three
+    keys would carry the other two as absent entries, and a workspace would hold a document
+    asserting something the plane never said.
+    """
+
+    def test_a_plane_with_no_settings_file_offers_nothing(self):
+        (config.ROOT / ".claude" / "settings.json").unlink()
+        self.assertEqual(claude_code.ClaudeCodeHarness().workspace_files(), {})
+
+    def test_a_plane_whose_settings_cannot_be_parsed_offers_nothing(self):
+        (config.ROOT / ".claude" / "settings.json").write_text("{ not json")
+        self.assertEqual(claude_code.ClaudeCodeHarness().workspace_files(), {},
+                         "charter guessed over a file somebody is holding")
+
+    def test_a_plane_declaring_none_of_the_three_keys_offers_nothing(self):
+        (config.ROOT / ".claude" / "settings.json").write_text(json.dumps(
+            {"permissions": {"allow": ["Bash(ls:*)"]}}))
+        self.assertEqual(claude_code.ClaudeCodeHarness().workspace_files(), {},
+                         "an empty document would look like a layer")
+
+    def test_only_the_keys_the_plane_actually_declares_travel(self):
+        (config.ROOT / ".claude" / "settings.json").write_text(json.dumps(
+            {"env": {"CHARTER_HARNESS": "claude-code"},
+             "permissions": {"allow": ["Bash(ls:*)"]}}))
+        files = claude_code.ClaudeCodeHarness().workspace_files()
+        doc = json.loads(next(iter(files.values())))
+        self.assertEqual(list(doc), ["env"])
+        self.assertNotIn("statusLine", doc)
+        self.assertNotIn("permissions", doc)
 class TheBoundaryAsksTheNameFirst(WorkspaceLayer):
     """`is_workspace_dir` — the parent comparison alone is not the boundary.
 

--- a/tests/test_a_workspace_carries_charters_layer.py
+++ b/tests/test_a_workspace_carries_charters_layer.py
@@ -348,6 +348,33 @@ class TheGeneratorIsOnePlace(WorkspaceLayer):
                          workspace.content_digest(files[".claude/settings.json"]))
 
 
+class OneMisbehavingHarnessDoesNotEmptyTheLayer(WorkspaceLayer):
+    """`h.workspace_files() or {}` — the fallback, and why it is tolerance rather than a
+    guard against something that happens.
+
+    No registered harness can reach it: `base.Harness.workspace_files` answers `{}` by
+    default and neither opencode nor Codex overrides it, so `None` requires a harness that
+    violates its own annotation. The sweep found the `or {}` as a survivor for that reason.
+
+    **It is kept because `_layer_files` iterates the whole registry.** A harness answering
+    `None` is a bug in that harness; without the fallback it is a `TypeError` that empties
+    the layer for **every** workspace and every other harness, so one broken integration
+    takes charter's own files down with it. `registry.deficits`' complaint is that an empty
+    dict and a ceiling are opposite facts — this is the third: a *wrong* answer, which must
+    cost only its own harness.
+
+    Charter still fails loudly about it elsewhere:
+    `test_every_registered_harness_either_carries_files_or_names_the_ceiling` is what goes
+    red the day a registered harness answers neither.
+    """
+
+    def test_a_harness_answering_none_costs_only_itself(self):
+        broken = SimpleNamespace(workspace_files=lambda: None)
+        real = claude_code.ClaudeCodeHarness()
+        with mock.patch.object(registry, "all", return_value=[broken, real]):
+            files = workspace._layer_files(self.ws)
+        self.assertEqual(sorted(files), [".claude/settings.json"],
+                         "a harness returning None emptied the whole layer")
 class WhatThePlaneHasToOfferIsAskedThreeWays(WorkspaceLayer):
     """`ClaudeCodeHarness.workspace_files` — the three states that answer nothing.
 

--- a/tests/test_a_workspace_tab_opens_what_it_names.py
+++ b/tests/test_a_workspace_tab_opens_what_it_names.py
@@ -379,15 +379,31 @@ class TheOpenUsesTheHarnessTheOperatorIsAlreadyIn(_OpensBeta):
         # (`tests/_tmuxsocket.py` measures the same trap for a socket path).
         self.assertEqual(seen, [os.path.realpath(config.WORKSPACES_DIR / "beta")])
 
-    def test_a_workspace_with_no_directory_of_its_own_falls_back_to_the_plane_root(self):
-        """The other half of the same expression. A workspace can be named by a chat
-        record and by the bar without having a directory yet, and a `chdir` into a path
-        that is not there would refuse the open for a workspace that is perfectly usable —
-        so the plane root is the answer, which is where a bare `charter` starts."""
+    def test_a_workspace_with_no_directory_of_its_own_is_made_rather_than_stood_beside(self):
+        """The other half of the same expression, and #850 changed which half. A workspace
+        can be named by a chat record and by the bar without having a directory yet; the
+        old answer was the plane root, which opened the tab into a directory that is not
+        the workspace it names — the chat then recorded `workspace = beta` beside
+        `cwd = <plane root>`, and stood outside the directory charter's per-workspace
+        layer lives in. `workspace.ensure` makes it, which is what a `charter --workspace
+        beta` typed in the plane would have done."""
         import shutil as _sh
         _sh.rmtree(config.WORKSPACES_DIR / "beta")
         seen = []
         self._run_watching_cwd(seen)
+        self.assertEqual(seen, [os.path.realpath(config.WORKSPACES_DIR / "beta")])
+        self.assertTrue((config.WORKSPACES_DIR / "beta").is_dir())
+
+    def test_a_workspace_charter_cannot_create_still_falls_back_to_the_plane_root(self):
+        """`ensure` raises for a `workspaces/` it cannot write, and this runs detached
+        with its streams on `/dev/null` — so it degrades to the answer it always gave
+        rather than taking the open down with a traceback nobody will ever see."""
+        import shutil as _sh
+        _sh.rmtree(config.WORKSPACES_DIR / "beta")
+        seen = []
+        with mock.patch("charter.commands_frame.workspace.ensure",
+                        side_effect=OSError(13, "denied")):
+            self._run_watching_cwd(seen)
         self.assertEqual(seen, [os.path.realpath(config.ROOT)])
 
     def test_a_directory_charter_cannot_enter_is_refused_before_the_launch(self):
@@ -410,17 +426,18 @@ class TheOpenUsesTheHarnessTheOperatorIsAlreadyIn(_OpensBeta):
         constant the code interpolates, which would be green under any containment at
         all: the raw two-line form must not appear, and the message must stay one line.
         """
-        # It has to EXIST, and getting that wrong is what this comment is for: `root` is
-        # `where if where.is_dir() else config.ROOT`, so a bad path that is not a real
-        # directory is replaced by the plane root and never reaches the sentence at all.
-        # The first version of this test made exactly that mistake and passed against an
-        # uncontained message. A newline is legal in a POSIX filename, so the directory is
-        # real.
+        # It has to be the path `_launch_root` HANDS BACK, and getting that wrong is what
+        # this comment is for: the first version of this test replaced a path that was not
+        # a real directory, which the fallback of the day swapped for the plane root, so
+        # it passed against an uncontained message. `_launch_root` is `workspace.ensure`
+        # since #850 — it creates rather than falling back — so this stubs the creator and
+        # the path it returns is the one that reaches the sentence. A newline is legal in a
+        # POSIX filename, so the directory is real and the `chdir` genuinely reaches it.
         bad = Path(str(config.WORKSPACES_DIR / "beta") + "\nworkspace → evil")
         bad.mkdir(parents=True, exist_ok=True)
-        self.addCleanup(bad.rmdir)
+        self.addCleanup(lambda: __import__("shutil").rmtree(bad, ignore_errors=True))
         self.assertTrue(bad.is_dir(), "the fixture's bad path must be a real directory")
-        with mock.patch("charter.commands_frame.workspace.workspace_dir",
+        with mock.patch("charter.commands_frame.workspace.ensure",
                         return_value=bad), \
                 mock.patch("charter.commands_frame.os.chdir",
                            side_effect=OSError(13, "denied")):

--- a/tests/test_codex_harness.py
+++ b/tests/test_codex_harness.py
@@ -32,7 +32,7 @@ class CodexIsRegistered(unittest.TestCase):
 class CodexCeilings(unittest.TestCase):
     def test_its_ceilings_are_named(self):
         keys = {d.key for d in registry.get("codex").deficits}
-        self.assertEqual(keys, {"status-bar", "session-lock"})
+        self.assertEqual(keys, {"status-bar", "session-lock", "workspace-scope"})
 
     def test_the_prompt_hook_is_not_a_ceiling(self):
         """Unlike opencode, Codex implements `UserPromptSubmit` — its hook contract is

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -34,7 +34,8 @@ class HarnessDeficits(unittest.TestCase):
 
     def test_opencode_names_the_capabilities_it_cannot_carry(self):
         keys = {d.key for d in harness.deficits(harness.OPENCODE)}
-        self.assertEqual(keys, {"status-bar", "prompt-hook", "ask-decisions"})
+        self.assertEqual(keys, {"status-bar", "prompt-hook", "ask-decisions",
+                                "workspace-scope"})
 
     def test_the_guards_that_refuse_are_not_a_ceiling(self):
         """`ask-decisions` is a narrow claim and must stay narrow. A DENY is carried in

--- a/tests/test_the_chat_bars_plus_makes_a_chat.py
+++ b/tests/test_the_chat_bars_plus_makes_a_chat.py
@@ -223,15 +223,17 @@ class ThePressRunsTheLauncherForThisWorkspace(_APlusOnAFrameInAlpha):
                          f"a window was measured with no pane to measure it from: "
                          f"{self.calls}")
 
-    def test_a_workspace_with_no_directory_yet_runs_from_the_planes_root(self):
+    def test_a_workspace_with_no_directory_yet_is_made_before_the_chat_goes_in_it(self):
         """**A real state, not a defensive one.** `switch.workspaces` folds
         `config.DEFAULT_WORKSPACE` into its list whether or not its directory exists —
-        `workspace.ensure` makes it on demand — so a plane that has never made one still
-        draws a tab for it and still offers a `+` in it. `config.ROOT` is where charter
-        would have created it, and it is where the launcher is run from.
+        so a plane that has never made one still draws a tab for it and still offers a
+        `+` in it.
 
-        The `else` this reaches was a sweep survivor: every other case here runs in a
-        workspace whose directory the fixture made.
+        It used to run the launcher from `config.ROOT`, and the chat then recorded
+        `workspace = alpha` beside `cwd = <plane root>` — a disagreement created at the
+        moment of launch, which also put the chat outside the directory #850's harness
+        layer lives in. `_launch_root` calls `workspace.ensure`, so the boundary exists
+        before a chat is put inside it.
         """
         seen: list[str] = []
 
@@ -244,8 +246,9 @@ class ThePressRunsTheLauncherForThisWorkspace(_APlusOnAFrameInAlpha):
         with mock.patch("charter.commands_frame.subprocess.run", side_effect=self._tmux), \
                 mock.patch("charter.commands_frame.cmd_launch", side_effect=fake_launch):
             commands_frame.cmd_new_chat(mock.Mock(chat=self.FID))
-        self.assertEqual(seen, [str(config.ROOT.resolve())],
-                         "a workspace with no directory did not fall back to the root")
+        self.assertEqual(seen, [str((config.WORKSPACES_DIR / "alpha").resolve())],
+                         "the launch did not run in the workspace the tab names")
+        self.assertTrue((config.WORKSPACES_DIR / "alpha").is_dir())
 
     def test_the_launch_runs_in_the_workspaces_own_directory(self):
         """`cmd_launch` reads `os.getcwd()` for the frame's cwd, and a panel process is

--- a/tests/test_todos_are_committed.py
+++ b/tests/test_todos_are_committed.py
@@ -223,12 +223,12 @@ class TestTheStructureBumpFlagsEveryOlderWorkspace(PersonaIso):
         workspace.reinit("alpha")
         self.assertFalse(change.changes_dir("alpha").exists())
 
-    def test_the_version_this_layout_stamps_is_three(self):
+    def test_the_version_this_layout_stamps_is_four(self):
         """The NUMBER, not merely that it moved. The marker file records this value on
         every machine that scaffolds a workspace, and `structure_status` compares against
         it — so it is the plane's upgrade anchor rather than a counter, and changing it is
         a deliberate act that belongs in the same commit as the layout it describes."""
-        self.assertEqual(workspace.STRUCTURE_VERSION, 3)
+        self.assertEqual(workspace.STRUCTURE_VERSION, 4)
 
     def test_a_fresh_workspace_is_current(self):
         """Positive control: the bump must flag OLD workspaces, not every workspace."""


### PR DESCRIPTION
Closes #850, following the design settled in [its comment](https://github.com/diazoxide/charter/issues/850) rather than the issue body — "move `charter@charter` to user scope" was withdrawn there, and the operator's requirement is **"in workspace user should be 100% isolated"**, which is the opposite of charter everywhere, identically.

## The defect

A chat launched with its cwd at `workspaces/<ws>/` — where the `+` and every workspace tab put it — got **none of charter's settings**. Claude Code reads project settings from the session's working directory and does not walk up. Agents, skills and CLAUDE.md *do* walk up and stop at a git boundary, and a workspace directory is not one, so those already arrived: what was missing was everything a settings file carries. No plugin, no status line, no `$CHARTER_HARNESS`.

## What is written, and where

One generated file per workspace: `workspaces/<ws>/.claude/settings.json`, holding the plane's own `enabledPlugins`, `statusLine` and `env`. A 1:1 sync of exactly those three keys.

**All three, because the plugin alone is not the layer.** Enabling `charter@charter` brings the hooks and the skills; `statusLine` has no plugin surface at all, and `env` is where `$CHARTER_HARNESS` comes from on a harness with no per-shell hook.

**Read from the plane's committed file, not composed from charter's constants.** That is what makes it a sync rather than a second generator: `commands._STATUSLINE` would otherwise be spelled twice, and a plane whose operator changed their status line by hand would get charter's default mirrored into every workspace — silently reverting a deliberate choice, in a new place, which is the one thing `_ensure_statusline` exists not to do.

**Nothing else.** No `skills/`, no `agents/`, no `CLAUDE.md`. A second copy of either would shadow the plugin's non-deterministically; Claude Code says so itself — *"is already taken by X, which takes precedence"*.

**Nothing at all inside a clone.** `workspaces/<ws>/<repo>/` is a repo charter does not own and `git add -A` there would stage it. The limit is stated rather than left to be discovered, in `docs/harnesses.md` and `docs/workspaces.md`: **in a clone you cannot delegate to a persona.**

## Ownership, and staleness

`.charter-generated` beside `.charter-structure` — `{relative path: sha256}` of what charter last wrote. **A sidecar, not a key inside the vendor's JSON**, for the same reason symlinking `.claude/` was wrong: that schema is Claude Code's. `persona sync-agents` can put its marker *inside* the file it generates because Markdown has a comment syntax; JSON has none.

A file whose hash matches is charter's, and gets **refreshed** — `ensure_shim`'s create-once restraint is right about the operator's files and wrong about charter's own, which is what left a 0.40.0-generated plugin in place through every upgrade (ADR 0015). A file whose hash does not match is the operator's: left untouched, never repaired, reported as `foreign`.

`charter doctor` grows a **`workspace layer`** row. It **regenerates and compares** — `persona lint --only stale`'s test (`commands_persona._agent_sync_issues`), not a second notion of staleness — and it **writes nothing**, because it runs from the SessionStart hook and a check that healed what it found would report every workspace current by having just made it so.

```
✓  workspace layer   1 generated file(s) across all workspaces, all current  (opencode,
                     codex: config is machine-global, so a workspace cannot diverge —
                     charter harness list)

!  workspace layer   api/.claude/settings.json (stale)
        → charter workspace reinit --all  (opencode, codex: …)

!  workspace layer   api/.claude/settings.json (foreign)
        → charter workspace reinit --all  (…)   A 'foreign' file is one charter did not
          write: it is left completely untouched and never repaired. Remove it to have
          charter generate its own again.
```

## opencode and Codex get a `Deficit`, not silence

Their config is machine-global — opencode reads `~/.config/opencode/` for every project, and Codex has **no project-level config at all** (a `.codex/config.toml` beside a project is ignored; measured by planting a deliberate type error in one and watching the config load anyway). So charter's layer is already live in a workspace on both, and per-workspace divergence is not buildable for either.

Each now declares `Deficit("workspace-scope", …)`, visible in `charter harness list` and in the `doctor` row. Reporting one row for the harness that can and nothing for the two that cannot would have read as three ticks — the failure `base.Deficit` exists to prevent.

## `workspace.ensure` before launch

`_launch_root` used to hand back `config.ROOT` when the workspace had no directory. That fallback was a real state rather than a defensive one — a plane draws a tab for its default workspace whether or not it has been made — and it created a disagreement at the moment of launch that nothing downstream could resolve: the chat recorded `workspace = <name>` beside `cwd = <plane root>`.

It calls `workspace.ensure` now, and `_launch` does the same for the path that does not `chdir` (`charter claude -w api` typed in a shell). Both still degrade to the plane root — for a name that cannot be a workspace, and for a `workspaces/` charter cannot write — because this runs detached with its streams on `/dev/null`, where a raise is invisible.

Measured: `_launch_root("fresh")` was `<plane>`; it is now `<plane>/workspaces/fresh`.

## The seam

`workspace_files()` on `Harness` — the fifth member, and base.py asks for an argument rather than a use.

`Harness.wire(root)` was the obvious candidate and could not take it, for two measured reasons. `wire` writes into somebody else's tree — the plane root's `.claude/settings.json` is user-owned and git-tracked — so its contract is *if absent, never repair*; a workspace file is charter's own and must be regenerable. And `doctor` needs the same answer **without writing**, from a SessionStart hook. A `dry_run` flag on `wire` would have bought the second and neither of the first, and would have put a branch for a workspace root inside every harness's writer — including two that can never be handed one.

So the harness returns **content** and the materialiser is one generic loop in `charter/workspace.py`: sidecar, digest, refresh-or-refuse, once rather than per harness. Same split as `ask_rule` returning a rule instead of writing one. Nothing names a harness anywhere — `registry.all()` is iterated, and a harness that returns no files must declare `WORKSPACE_SCOPE`; `test_every_registered_harness_either_carries_files_or_names_the_ceiling` is what fails the day one answers neither.

`init` at the plane root is byte-for-byte unchanged: `wire(config.ROOT)` still writes only the `env` key, and there is a test pinning that no `.charter-generated` appears there.

## Why this is not what ADR 0015 deleted

ADR 0015 removed a per-tree design of this shape — *"255 lines and a test file"* — and the caution is real. What it removed wrote the same **global** answer into every clone and worktree for a harness that reads one global file anyway: *"all correct, and all answering a question that does not need asking."* This writes config that is **meant** to differ per workspace, into a directory charter itself creates.

Two of that design's costs come back and one does not:

* **Staleness bookkeeping** — re-incurred, and paid for by the `doctor` row. It is worth it here because the generated document is *derived from a file that changes*: the plane's settings move when a plugin is enabled or the status line is edited, and without the row every workspace would drift silently, which is precisely the `ensure_shim` failure ADR 0015 records two paragraphs later.
* **A `.git/info/exclude` entry per checkout** — not re-incurred at all. `/workspaces/*/*` is already in the plane's `.gitignore` (`_ensure_gitignore`), gitignore patterns match leading dots, and the managed LIVE block un-ignores four named paths, none of them `.claude/`. Nothing generated here can reach a commit, so there is no evidence to hide.

## Two facts the design rests on

* **Trust is inherited up to the git root**, so `workspaces/<ws>/` inherits the plane's and needs no click.
* **Trust gates hook execution and the status line globally**, whichever settings source declared them — so "the plugin is enabled here" and "charter's hooks run here" are different questions, and this change only answers the first. Nothing here would help in an untrusted directory, and nothing here claims to.

## Adoption

`STRUCTURE_VERSION` 3 → 4, so every existing workspace flags itself in the status line and in `charter workspace list` until `charter workspace reinit --all`. The repair reports the layer as its own line rather than folding it into the structure one — it is a separate fact, and it is the one this command silently repaired while printing "nothing to do" until it was said out loud.

## Verification

* `python3 -m unittest discover -s tests` (the loader CI uses): **`Ran 10798 tests in 575.066s … OK (skipped=9)`** on the rebased tree.
* 35 new tests in `tests/test_a_workspace_carries_charters_layer.py`, plus the neighbours below.
* Deletion sweep: run in CI on this PR — the verdict is the check name (`deletion sweep / …`).

**Neighbouring tests that this made vacuous, and what replaced them** — the fallback branch these pinned no longer exists:

* `test_a_workspace_with_no_directory_of_its_own_falls_back_to_the_plane_root` → now asserts the directory is **made**, with a new sibling covering the degrade path (`ensure` raising `OSError`).
* `test_a_workspace_with_no_directory_yet_runs_from_the_planes_root` → same, from the chat bar's `+`.
* `test_the_refused_directory_is_contained_before_it_reaches_the_screen` stubbed `workspace_dir` and relied on the removed `is_dir()` swap to explain its fixture; it stubs `workspace.ensure` now, and its comment records why the old reasoning no longer applies.
* `test_the_version_this_layout_stamps_is_three` → `…_is_four`.
* The opencode and Codex deficit-key sets gained `workspace-scope`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Us4MbwkSCJCxwt1CjAd1sf
