### PR TITLE
a green doctor row keeps nothing back (#856)

### DIFF
--- a/charter/doctor.py
+++ b/charter/doctor.py
@@ -1120,7 +1120,7 @@ def check_frame() -> Result:
     # and a status line blanked because a frame is drawing is nothing to do anything about.
     # That is the same distinction the paragraph above draws in refusing to make it a
     # `ceilings` entry, now carried through to how it is printed.
-    quiet = _statusline_suppressed_note().strip()
+    quiet = _statusline_suppressed_note()
     detail = f"tmux {v[0]}.{v[1]}"
     if quiet:
         detail += f"\n        ↳ {quiet}"
@@ -1130,7 +1130,14 @@ def check_frame() -> Result:
 
 
 def _statusline_suppressed_note() -> str:
-    """`" …"` naming the frame this session's status line is being blanked for, or `""`.
+    """The sentence naming the frame this session's status line is being blanked for, or `""`.
+
+    **No leading space, and the caller does no stripping.** It carried one, and its single
+    caller stripped it straight back off — the sweep found that `.strip()` as a survivor and
+    was right to: the note is either empty or one leading space and never any trailing
+    whitespace, so `strip` and `lstrip` answer identically for every value this can return.
+    A normalisation nothing can observe is not a guard, and pinning it would have been a test
+    asserting that two spellings of the same answer agree.
 
     Asks the same question `statusline.main` asks, through the same function, so the two
     can never disagree about whether a line is suppressed — the failure this note exists
@@ -1147,7 +1154,7 @@ def _statusline_suppressed_note() -> str:
     fid = os.environ.get("CHARTER_SESSION_ID", "")
     if not fid or not frame_state.is_live(fid, pane=os.environ.get("TMUX_PANE", "")):
         return ""
-    return (f" This session's status line is intentionally blank: frame {fid} is drawing "
+    return (f"This session's status line is intentionally blank: frame {fid} is drawing "
             f"the plane instead (ADR 0019). `charter statusline` still runs — it records "
             f"this session's token usage — and still prints in full when you run it "
             f"yourself.")

--- a/charter/doctor.py
+++ b/charter/doctor.py
@@ -53,6 +53,19 @@ class Result:
 
         A row rendered with no width stated is as wide as itself, which is what a single
         `Result` printed on its own should be.
+
+        **A hint is a remedy, so a green row has none and does not print one.** ``→`` in
+        this table means *do this*; there is nothing to do about a check that passed, and a
+        column of green arrows is how the yellow ones stop being read. A fact a passing row
+        still needs to state goes in :attr:`detail`, on a ``↳`` continuation line — the
+        shape `check_harness` uses for its capability ceilings and `check_frame` for a
+        status line a frame is deliberately blanking.
+
+        That rule is only safe while it is loud, and for one release it was not:
+        `check_frame` passed its status-line note as a hint on the OK path and the note
+        was silently discarded on every healthy machine (#856). `TestAGreenRowKeepsNothingBack`
+        holds every check to it, so the next row to try this fails the suite rather than
+        losing a sentence.
         """
         code, glyph = _SYMBOL[self.status]
         if _color():
@@ -1094,12 +1107,26 @@ def check_frame() -> Result:
     # it: it is a statement of fact about right now, never a warning — which is also why
     # it is not a `ceilings` entry: every one of those is a capability this machine does
     # not have, and a suppressed status line is a capability working as designed.
-    quiet = _statusline_suppressed_note()
+    #
+    # **Said in the DETAIL, never in the hint (#856).** `Result.render` prints a hint only
+    # on a row that is not green, so on the clean path — a current tmux, every slot
+    # implemented, which is the ordinary machine and the one most likely to be running a
+    # frame — this note was constructed, handed to `Result`, and dropped without a trace.
+    # The one row written to admit the blank footer was silent in exactly the situation
+    # that produces one, which is the failure it exists to prevent, one level down.
+    #
+    # A `↳` continuation, the shape `check_harness` already uses for its ceilings, rather
+    # than a `→` remedy: in this table `→` means *do this* and `↳` means *and also this*,
+    # and a status line blanked because a frame is drawing is nothing to do anything about.
+    # That is the same distinction the paragraph above draws in refusing to make it a
+    # `ceilings` entry, now carried through to how it is printed.
+    quiet = _statusline_suppressed_note().strip()
+    detail = f"tmux {v[0]}.{v[1]}"
+    if quiet:
+        detail += f"\n        ↳ {quiet}"
     if ceilings:
-        return Result(name, WARN, detail=f"tmux {v[0]}.{v[1]}",
-                      hint=" ".join(ceilings) + quiet)
-    return Result(name, OK, detail=f"tmux {v[0]}.{v[1]}",
-                  hint=quiet.strip() or None)
+        return Result(name, WARN, detail=detail, hint=" ".join(ceilings))
+    return Result(name, OK, detail=detail)
 
 
 def _statusline_suppressed_note() -> str:

--- a/docs/news/unreleased-a-green-doctor-row-keeps-nothing-back.md
+++ b/docs/news/unreleased-a-green-doctor-row-keeps-nothing-back.md
@@ -1,0 +1,55 @@
+---
+version: unreleased
+headline: 'The `frame` row says a blank status line is deliberate on a healthy machine too, instead of only on an old tmux'
+---
+
+*"My footer went blank. `charter doctor` says the frame is fine and mentions nothing."*
+
+## What was measured
+
+`Result.render` prints a hint only on a row that is **not** green:
+
+```
+OK row render:   '  ✓  frame  tmux 3.5'
+WARN row render: '  !  frame  tmux 3.5\n        → this hint should show'
+```
+
+Same `Result`, same hint. `check_frame`'s clean path handed its status-line note over as a
+hint, so on every machine with a current tmux it was built, passed, and discarded without a
+trace.
+
+## Why that is the one sentence that must not be lost
+
+`_statusline_suppressed_note` exists for exactly one reason, in its own words: *"the failure
+this note exists to make impossible is an operator seeing a blank footer and finding nothing
+anywhere that admits it is deliberate."* ADR 0019's rule is that a surface which vanished for
+an invisible reason is the worst outcome available.
+
+It reached the reader **only** on the path where tmux is below a version ceiling. So on a
+current tmux — the ordinary machine, and the one most likely to be running a frame over its
+own footer — the row written to admit the blank footer was silent in precisely the situation
+that produces one. The defect it exists to prevent, one level down.
+
+## What happens now
+
+The note moves into the `detail`, which a green row does print, on a `↳` continuation line:
+
+```
+  ✓  frame            tmux 3.7
+        ↳ This session's status line is intentionally blank: frame f3 is drawing the plane
+          instead (ADR 0019). `charter statusline` still runs — it records this session's
+          token usage — and still prints in full when you run it yourself.
+```
+
+`↳` and not `→`, deliberately. In this table `→` means *do this* and `↳` means *and also
+this* — the shape `check_harness` already uses for its capability ceilings. A status line
+blanked because a frame is drawing is a capability working exactly as designed, and there is
+nothing to do about it. That is the same distinction `check_frame` was already drawing in
+refusing to file the note as a `ceilings` entry; it is now carried through to how it prints.
+
+**A green row still has no hint, and that stays right.** A column of green `→` arrows is how
+the yellow ones stop being read. The rule was not wrong — what was missing was anything that
+says so out loud, so a check could break it silently and lose a sentence. `Result.render`'s
+docstring now states it, and one test holds every check in `doctor.run_all()` to it: a row
+that passes a hint while green fails the suite on the commit that adds it, instead of
+quietly printing less than it meant to.

--- a/tests/test_a_green_doctor_row_keeps_nothing_back.py
+++ b/tests/test_a_green_doctor_row_keeps_nothing_back.py
@@ -1,0 +1,135 @@
+"""A green preflight row drops its hint, so the one sentence written to admit a blank
+status line was never printed on a healthy machine (#856).
+
+`Result.render` prints a hint only when the row is not green — which is right, because `→`
+in that table means *do this* and a column of green arrows is how the yellow ones stop being
+read. `check_frame` did not know that. Its clean path built
+`_statusline_suppressed_note()` and handed it over as a `hint`, where it was discarded
+without a trace:
+
+    OK row render:   '  ✓  frame  tmux 3.5'
+    WARN row render: '  !  frame  tmux 3.5\\n        → this hint should show'
+
+Same `Result`, same hint. The green one loses it.
+
+**The sentence it lost is the one ADR 0019 is about.** `_statusline_suppressed_note`'s own
+docstring says why it exists: *"the failure this note exists to make impossible is an
+operator seeing a blank footer and finding nothing anywhere that admits it is deliberate"*,
+and ADR 0019's rule is that a surface which vanished for an invisible reason is the worst
+outcome available. It reached the reader only on the path where tmux is below a version
+ceiling — so on a current tmux, the ordinary machine and the one most likely to be running a
+frame, the row was silent in exactly the situation that produces the blank footer.
+
+Fixed in the `detail`, which a green row does print, on a `↳` continuation line — the shape
+`check_harness` already uses for its ceilings. `↳` means *and also this*, and a status line
+blanked because a frame is drawing is a capability working as designed, not a task. That is
+the same distinction `check_frame` already draws in refusing to file it as a `ceilings`
+entry; it is now carried through to how it is printed.
+"""
+
+from __future__ import annotations
+
+import unittest
+from unittest import mock
+
+from charter import doctor
+from tests import _envguard
+from tests._isolation import PersonaIso
+
+OK, WARN = doctor.OK, doctor.WARN
+
+#: Hand-spelled. Asserting against `_statusline_suppressed_note()`'s own output would pass
+#: just as happily over the empty string it returns outside a frame — which is the state
+#: this whole module is about not being able to tell apart from a working one.
+_NOTE = " This session's status line is intentionally blank: frame f1 is drawing the plane."
+
+
+class TheRenderContract(unittest.TestCase):
+    def test_a_row_that_is_not_green_prints_its_hint(self):
+        r = doctor.Result("frame", WARN, detail="tmux 3.5", hint="do the thing")
+        self.assertIn("do the thing", r.render())
+
+    def test_a_green_row_does_not(self):
+        """Not a bug to be fixed by printing it — `→` is a remedy, and a passed check has
+        none. The bug is a check that puts a fact where a remedy goes."""
+        r = doctor.Result("frame", OK, detail="tmux 3.5", hint="do the thing")
+        self.assertNotIn("do the thing", r.render())
+
+    def test_a_green_row_prints_a_continuation_line_in_its_detail(self):
+        """Which is where a fact a passing row still needs to state belongs."""
+        r = doctor.Result("frame", OK, detail="tmux 3.5\n        ↳ and also this")
+        self.assertIn("and also this", r.render())
+
+
+class TheFrameRowSaysItOnEveryPath(unittest.TestCase):
+    def setUp(self) -> None:
+        # Outside a frame unless a test says otherwise, stated rather than inherited from
+        # the shell the suite was launched from (#519, #521, #528).
+        _envguard.unset_all()
+        self.note = self.enterContext(
+            mock.patch.object(doctor, "_statusline_suppressed_note", return_value=_NOTE))
+
+    def _row(self, version=(3, 7), slots=("top", "bottom")):
+        from charter import config
+        with mock.patch("charter.frame.tmuxctl.version", return_value=version), \
+             mock.patch.dict(config.FRAME, {"slots": list(slots)}):
+            return doctor.check_frame()
+
+    def test_a_healthy_machine_still_says_the_status_line_is_blank_on_purpose(self):
+        """The regression. A current tmux with every slot implemented is the green path,
+        and it is the machine most likely to have a frame drawing over its footer."""
+        r = self._row()
+        self.assertEqual(r.status, OK)
+        self.assertIn("intentionally blank", r.render())
+
+    def test_a_machine_below_a_ceiling_still_says_it_too(self):
+        """It reached the reader here before, appended to the hint. Moving it must not
+        trade one path for the other."""
+        r = self._row(version=(3, 2))
+        self.assertEqual(r.status, WARN)
+        self.assertIn("intentionally blank", r.render())
+
+    def test_the_ceiling_it_shares_the_row_with_is_still_reported(self):
+        r = self._row(version=(3, 2))
+        self.assertIn("charter frame-resize", r.render())
+
+    def test_a_session_whose_footer_is_not_suppressed_says_nothing_about_it(self):
+        """The other half of "never a warning": the note is a statement about right now,
+        and a row that carried it always would be carrying noise."""
+        self.note.return_value = ""
+        r = self._row()
+        self.assertEqual(r.status, OK)
+        self.assertNotIn("intentionally blank", r.render())
+        self.assertNotIn("↳", r.render())
+
+
+class TestAGreenRowKeepsNothingBack(PersonaIso):
+    def setUp(self) -> None:
+        super().setUp()
+        # **The note is forced on, and without this the whole check is vacuous.** Outside a
+        # live frame `_statusline_suppressed_note` returns `""`, so `check_frame` passed
+        # `hint=None` and the sweep below found nothing to object to — measured against the
+        # unfixed tree, where this class passed while the defect was fully present. A
+        # property test that only holds in the environment where the property already holds
+        # is the shape #851 was about, one layer up.
+        self.enterContext(mock.patch.object(
+            doctor, "_statusline_suppressed_note", return_value=_NOTE))
+
+    def test_no_check_hides_a_sentence_in_a_hint_it_will_never_print(self):
+        """Held against the real check set rather than against `check_frame` alone.
+
+        The defect was not that `check_frame` was written carelessly — it was that
+        `Result` accepts a hint on a green row and says nothing, so the mistake is
+        invisible at the call site and invisible in the output. This is the assertion
+        that makes it visible, on the commit that introduces it.
+        """
+        for r in doctor.run_all():
+            if r.status == OK and r.hint:
+                self.fail(
+                    f"the {r.name!r} row passes a hint on a green row, and `Result.render` "
+                    f"drops it — nobody will ever read {r.hint!r}. A fact a passing row "
+                    f"needs to state goes in its detail, on a `↳` continuation line.")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_frame_owns_the_surface.py
+++ b/tests/test_frame_owns_the_surface.py
@@ -316,20 +316,29 @@ class SuppressionSaysSoOnDemand(PersonaIso, unittest.TestCase):
             return doctor.check_frame()
 
     def test_the_frame_row_names_the_frame_that_is_drawing_instead(self):
+        """**Asserted on what the row PRINTS, never on which field it was put in (#856).**
+
+        This test read `row.hint`, and it was true and about the wrong thing:
+        `Result.render` drops a hint on a green row, so on the ordinary machine this test
+        covers — a current tmux, every slot implemented — the sentence it was checking for
+        reached nobody. Its own docstring promises the note is *explained somewhere*, and
+        `row.hint` is not somewhere; `row.render()` is the operator's actual reading
+        surface, and it is the only one that can keep that promise."""
         fid = f"demo-{os.getpid()}"
         state.bump(fid)
         state.record_server(fid, "charter")
         state.record_harness_pane(fid, "%7")
         row = self._row({"CHARTER_SESSION_ID": fid, "TMUX_PANE": "%7"})
-        self.assertIn(fid, row.hint or "",
-                      "a suppressed status line must be explained somewhere")
-        self.assertIn("blank", (row.hint or "").lower())
+        printed = row.render()
+        self.assertIn(fid, printed,
+                      "a suppressed status line must be explained somewhere the reader "
+                      "actually sees")
+        self.assertIn("blank", printed.lower())
 
     def test_a_session_that_is_not_suppressed_is_not_told_that_it_is(self):
         """The control, and the one that fails if the row simply always says it: an
         ordinary session's frame row must carry no such note."""
-        row = self._row({})
-        self.assertNotIn("blank", (row.hint or "").lower())
+        self.assertNotIn("blank", self._row({}).render().lower())
 
 
 class PanelFollowsWorkspaceUseOnAFrameWithNoRecord(PersonaIso, unittest.TestCase):


### PR DESCRIPTION
Fixes #856.

## Measured

`doctor.Result.render` prints a hint only on a row that is **not** green:

```python
if self.hint and self.status != OK:
    line += f"\n        → {self.hint}"
```

On 0.55.0, same `Result`, same hint:

```
OK row render:   '  ✓  frame  tmux 3.5'
WARN row render: '  !  frame  tmux 3.5\n        → this hint should show'
```

`check_frame`'s clean path handed its status-line note over as a hint:

```python
return Result(name, OK, detail=f"tmux {v[0]}.{v[1]}", hint=quiet.strip() or None)
```

so on every machine with a current tmux the note was built, passed, and discarded.

## Why that particular sentence

`_statusline_suppressed_note` exists for one reason, in its own words: *"the failure this
note exists to make impossible is an operator seeing a blank footer and finding nothing
anywhere that admits it is deliberate."* ADR 0019's rule is that a surface which vanished for
an invisible reason is the worst outcome available.

It reached the reader **only** on the path where tmux is below a version ceiling. So on a
current tmux — the ordinary machine, and the one most likely to be running a frame over its
own footer — the row written to admit the blank footer was silent in precisely the situation
that produces one.

## The fix

The note moves into `detail`, which a green row does print, on a `↳` continuation line:

```
  ✓  frame            tmux 3.7
        ↳ This session's status line is intentionally blank: frame f3 is drawing the plane
          instead (ADR 0019). `charter statusline` still runs — it records this session's
          token usage — and still prints in full when you run it yourself.
```

`↳`, not `→`. In this table `→` means *do this* and `↳` means *and also this* — the shape
`check_harness` already uses for its capability ceilings. A status line blanked because a
frame is drawing is a capability working exactly as designed. That is the same distinction
`check_frame` was already drawing in refusing to file the note as a `ceilings` entry; it is
now carried through to how it prints.

**Green rows still carry no hint, and that stays right** — a column of green `→` arrows is
how the yellow ones stop being read. The rule was not wrong; nothing said it out loud, so a
check could break it silently and lose a sentence. `Result.render`'s docstring now states it,
and `TestAGreenRowKeepsNothingBack` holds every check in `run_all()` to it: a row that passes
a hint while green fails the suite on the commit that adds it.

## The neighbour that should have caught this

`test_frame_owns_the_surface.SuppressionSaysSoOnDemand` is the test for exactly this
behaviour, and it went red here — it asserted on `row.hint`:

```python
self.assertIn(fid, row.hint or "", "a suppressed status line must be explained somewhere")
```

True, and about the wrong thing. `row.hint` is not *somewhere* on a green row. It now asserts
on `row.render()`, the operator's actual reading surface — the only one that can keep the
promise its own message makes.

That property test needed the same treatment. Its first version ran `run_all()` unpatched,
and outside a live frame `_statusline_suppressed_note()` returns `""` — so `check_frame`
passed `hint=None` and the class went green **against the unfixed tree**, measured. It now
forces the note on in `setUp`.

## Verification

Full suite, run the way CI runs it, on this branch rebased onto `main` (with #854 and #860):

```
python3 -m unittest discover -s tests
Ran 10770 tests in 572.059s
OK (skipped=9)
```

Red-green, with `__pycache__` cleared between mutation and run: the new module and the
repointed neighbour, run against `main`'s `check_frame` with the tests kept —
`FAILED (failures=3)`; with the fix — `OK`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Us4MbwkSCJCxwt1CjAd1sf
