### PR TITLE
A chat tab shows when its harness is working (#853)

### DIFF
--- a/charter/frame/panel.py
+++ b/charter/frame/panel.py
@@ -595,6 +595,87 @@ def _running(cache: dict) -> int:
         return 0
 
 
+def _new_working_cache() -> dict:
+    """:func:`_new_inflight_cache` for the turn tracker — the state :func:`_working`
+    carries between ticks, in the same shape and for the same reason.
+
+    Its own cache rather than a second field on the other one: the two watch different
+    directories, expire on different horizons and are read by different slots, and a
+    single dict would have every `bottom` panel paying for the chat tracker's `stat` and
+    every `chats` panel paying for the dispatch tracker's — which is precisely the
+    unscoped cost `slots.ANIMATED` exists to prevent, arriving one level down.
+
+    **``recheck``'s starting value is never read, and it is here anyway.** The deadline is
+    only consulted while something is working (`working` is the left operand of an `and`
+    that short-circuits at 0), and the two are assigned together — so no call can reach
+    this ``0.0``. It stays because the cache has one SHAPE, the three keys
+    :func:`_new_working_cache`'s twin has, and a dict that omits a key its own reader
+    indexes is a landmine for the next edit rather than a saving. The deletion sweep
+    reports it and it is the same answer for `_new_inflight_cache`, which shipped it.
+    """
+    return {"stamp": None, "working": 0, "recheck": 0.0}
+
+
+def _working(cache: dict) -> int:
+    """How many chats' harnesses are working right now — one `stat` when nothing changed.
+
+    :func:`_running` one tracker over, and deliberately the same three-part cache, because
+    the two questions have the same shape: an answer that changes when a record is created
+    or removed (`inflight.turn_stamp`, whose mtime moves on exactly those two events), and
+    an answer that ALSO changes with no file moving at all, when a mark crosses
+    `inflight.TURN_STALE_SECONDS` — so the earliest such deadline is held beside it and
+    consulted only while something is actually working. An idle plane pays one `stat`.
+
+    **A refresh is free, and that is a property of the writer.** `inflight.turn_bump` calls
+    `utime` on a file that already exists, which does not move the directory's mtime — so a
+    turn issuing tool calls once a second re-reads nothing here. Only a turn STARTING and a
+    turn ENDING cost this panel a read of the directory, which is the same "the set moved"
+    rule `inflight.stamp` states for the other tracker.
+
+    Counts chats, not marks — one per chat by construction, since the file's name is the
+    chat's. The number itself is never drawn: `_watch` asks only whether it is non-zero,
+    and `slots.working_chats` re-reads for the names, which is the same split
+    :func:`_running` has against `slots._inflight_field`. Kept as a count rather than a
+    bool because the cache has to distinguish "nothing is working" from "nothing has been
+    read yet", and 0 does that without a second sentinel — `_new_inflight_cache`'s own
+    argument about `None`.
+
+    **Plane-scoped rather than workspace-scoped, and the cost of that is stated.** A mark
+    says which CHAT is working and the strip draws only the chats of its own workspace, so
+    a chat working in another workspace ticks this panel while changing nothing it draws —
+    one repaint of `slots.chats_bar` (429.8µs measured, 0.21% of a core at 5Hz) for as long
+    as that turn runs. Narrowing it would put `chats.roster` on the gate path, which is the
+    424µs this design exists to keep behind a 4.6µs `stat`; and on a plane with one
+    workspace, which is the ordinary shape, every working chat is on the strip anyway.
+
+    Never raises, for :func:`_running`'s reason: this sits in a run loop where an exception
+    ends the pane, and a tracker charter cannot read is stillness, which is what this whole
+    feature promises when it does not know.
+    """
+    from .. import inflight
+    try:
+        stamp = inflight.turn_stamp()
+        # `>=` for `inflight.working_chats`' reason, one deadline over: the boundary is a
+        # float equality, both spellings make the same claim about the mark, and what is
+        # pinned is the direction. `_running` above spells it identically.
+        stale = cache["working"] and time.time() >= cache["recheck"]
+        if stamp == cache["stamp"] and not stale:
+            return cache["working"]
+        marks = inflight.working_chats()
+        cache["stamp"] = stamp
+        cache["working"] = len(marks)
+        cache["recheck"] = min((seen for _chat, seen in marks),
+                               default=0.0) + inflight.TURN_STALE_SECONDS
+        return cache["working"]
+    except Exception:
+        # The stamp is NOT reset — :func:`_running` carries the full argument, and it is
+        # the same one: it is only ever assigned after a read that completed, so leaving it
+        # describes the last directory state charter understood and the next change to the
+        # set re-reads, instead of retrying a raising read five times a second.
+        cache["working"] = 0
+        return 0
+
+
 def _install_sigwinch(resized: dict) -> object:
     """Arm the resize handler, returning whatever was installed before it so `run` can
     put it back rather than leaking a handler past this process's own lifetime — a
@@ -762,6 +843,7 @@ def _watch(slot: str, fid: str, *, once: bool, paint=None, evs=None) -> int:
     """
     resized = {"flag": True}  # the first pass always paints, resized or not
     inflight_cache = _new_inflight_cache()
+    working_cache = _new_working_cache()
     # Scoped to THIS slot, and the `and` short-circuits: a panel whose renderer draws
     # nothing that moves never repaints for the spinner and never even pays the `stat`
     # that would have told it to. `_watch` runs one process per slot, so an unscoped
@@ -769,6 +851,11 @@ def _watch(slot: str, fid: str, *, once: bool, paint=None, evs=None) -> int:
     # byte-identical output, and `right` costs 4.8ms a render to do it (see
     # `slots.ANIMATED`).
     animates = slot in slots.ANIMATED
+    # The chat strip's own gate, and a SECOND name rather than a widened first one
+    # (`slots.BAR_ANIMATED` carries the argument). The two conditions are unrelated —
+    # plane-wide in-flight work against this plane's chat turns — so a panel pays for
+    # exactly the one its renderer draws, and a panel in neither set pays for neither.
+    spins = slot in slots.BAR_ANIMATED
     old_handler = _install_sigwinch(resized)
     try:
         # INSIDE the `try`, and that placement is the whole of the second paragraph
@@ -782,10 +869,16 @@ def _watch(slot: str, fid: str, *, once: bool, paint=None, evs=None) -> int:
             evs.open()
         seen, handled, was_ticking = "", False, False
         while True:
-            # `animates and ...` still short-circuits, so a `top`, `left` or `right`
-            # panel pays neither the `stat` nor the notice read — see `animates` above.
-            ticking = animates and (bool(_running(inflight_cache))
-                                    or _notice_pending(fid))
+            # Both `and`s short-circuit, so a panel pays for exactly the gates its own
+            # renderer draws from: `top` and `right` are in neither set and pay neither
+            # `stat` nor the notice read, `bottom` pays the dispatch tracker's and `chats`
+            # the turn tracker's — see `animates` and `spins` above. Written as one
+            # expression rather than two `if`s because what it computes is one fact:
+            # whether what this panel would draw NOW differs from what is on screen for a
+            # reason no version bump, resize or event will announce.
+            ticking = (animates and (bool(_running(inflight_cache))
+                                     or _notice_pending(fid))
+                       or spins and bool(_working(working_cache)))
             # `or was_ticking` is the FALLING EDGE (#727), and it is one term rather
             # than two because both clock-driven fields need exactly the same thing.
             # Without it, the tick after the last in-flight record cleared had no reason

--- a/charter/frame/slots.py
+++ b/charter/frame/slots.py
@@ -109,6 +109,24 @@ def spinner_frame(now: float | None = None) -> str:
     return SPINNER[int(t / SPINNER_PERIOD) % len(SPINNER)]
 
 
+def tab_spinner_frame(now: float | None = None) -> str:
+    """Which frame of :data:`TAB_SPINNER` this instant shows.
+
+    :func:`spinner_frame`'s twin over the other sequence, and a second function rather
+    than a *seq* parameter on the first: a caller that could pass a sequence could pass
+    :data:`SPINNER` — braille, which is not held to this row's width rule — and the whole
+    of :data:`TAB_SPINNER`'s docstring is about which characters may go on a strip whose
+    click map is per column. One name, one sequence, one place the rule is written down.
+
+    Every tab spinning on a strip shows the SAME frame at any instant, because both read
+    the clock rather than a per-tab counter. That is the readable answer as well as the
+    cheap one: a row of tabs pulsing out of step reads as noise, and a row pulsing
+    together reads as *these two are working*.
+    """
+    t = time.monotonic() if now is None else now
+    return TAB_SPINNER[int(t / SPINNER_PERIOD) % len(TAB_SPINNER)]
+
+
 def verbosity(fid: str) -> str:
     """How much this frame's panels say: ``"terse"`` or ``"normal"``.
 
@@ -3212,6 +3230,60 @@ SLOTS = {"top": _top, "bottom": _bottom, "repos": _repos, "right": _right}
 #: columns the names are competing for.
 _BAR_MARK = ("*", " ")
 
+#: The frames a chat tab cycles through while that chat's harness is working (#853).
+#:
+#: **It takes the mark's cell rather than adding one, and that is the whole of why a
+#: spinner is affordable on a strip whose click map is per COLUMN.** Every tab already
+#: carries a one-cell prefix (:data:`_BAR_MARK`) and every frame here is one cell, so a
+#: chat starting a turn changes not one column of the strip's arithmetic: the cut
+#: (:func:`_cuts`), the row count (:func:`bar_rows_wanted`) and the map
+#: (:func:`_tab_columns`) all answer exactly what they answered when nothing was working.
+#: A spinner drawn *beside* a name instead would re-cut the strip the moment a sibling
+#: started thinking, and the cell an operator was about to press would hold another chat's
+#: name — the double-press #767 exists to prevent, arriving through a spinner.
+#:
+#: **The ACTIVE chat keeps its `*` and never shows this**, which is a limit rather than an
+#: oversight. There is one cell and the two facts compete for it; `*` wins because it is
+#: the only one of the two that has no other way to be seen. `chrome.block` paints the
+#: active tab in reverse video, but `[frame] chrome = "off"` is the shipped default and
+#: `panel._write` strips SGR under `NO_COLOR`, so on a plain plane the `*` is the ONLY
+#: thing saying where you are (:func:`_compose` says so at the paint). The chat you are
+#: typing in, meanwhile, is the one whose harness you can watch directly. The readout is
+#: for the chats you are not looking at.
+#:
+#: **Which glyphs, and the two that were asked for and refused.** The request was Claude
+#: Code's own spinner, `· ✢ ✶ ✳ ✽ ✻`. `tui.width` answers 1 for all six, and `tui.width` is
+#: not the whole question on this row: it reads the East-Asian tables, and an *Ambiguous*
+#: character is one a terminal may draw two cells wide while those tables say one. That is
+#: the failure :data:`_BAR_RULE` is ASCII to avoid and the one `statusline._persona_chips`
+#: records breaking this project's layout twice. Measured with `unicodedata`:
+#:
+#: ==========  ========  =====  ==========================================
+#: glyph       codepoint  EAW   verdict
+#: ==========  ========  =====  ==========================================
+#: ``·``       U+00B7    **A**  refused — Ambiguous
+#: ``✢``       U+2722    N      kept
+#: ``✳``       U+2733    N      refused — carries an emoji presentation
+#:                              (``✳️``, U+2733 U+FE0F), so a terminal with
+#:                              an emoji fallback font may draw it wide
+#: ``✶``       U+2736    N      kept
+#: ``✽``       U+273D    **A**  refused — Ambiguous
+#: ``✻``       U+273B    N      kept
+#: ==========  ========  =====  ==========================================
+#:
+#: What survives is Neutral, which is the property `statusline`'s own marker test asserts
+#: (`▪▸▫`, chosen after `◈`/`◆` shipped broken) and the strongest one available short of
+#: ASCII. **None of them is a character a chat id may contain** (`chats.ID_RE` is
+#: ``[A-Za-z0-9._-]``), and that is a separate requirement with its own reason: the mark
+#: sits flush against the name, so an ASCII pulse like ``.oOo`` would draw ``Oapi.3`` and
+#: put a character that could be part of a name where the operator reads the name.
+#:
+#: Three frames, cycled out and back so the sparkle grows and shrinks the way the
+#: requested one does. It reads off the same clock as :data:`SPINNER` — see
+#: :data:`SPINNER_PERIOD`, whose argument (short enough to be seen, long enough to be
+#: worth a repaint) is about `panel.TICK` and is the same argument here.
+TAB_SPINNER = "✢✶✻✶"
+
 #: Columns a bar spends between two names. Two, so a name reads as one name — a single
 #: space runs `api.1 api.2` together at the widths where this matters most.
 #:
@@ -3699,7 +3771,7 @@ def _cuts(fields: list[str], room: int, gap: int) -> list[int]:
 
 
 def _bar(head: str, names: list[str], here: str, width: int, *,
-         note: str = "", rows: int = 1) -> list[str]:
+         note: str = "", rows: int = 1, busy=()) -> list[str]:
     """One bar: *head*, then *names* with *here* marked, in *rows* x *width* cells.
 
     :func:`_compose` composes it and this is what PUBLISHES it — the one call that writes
@@ -3709,14 +3781,17 @@ def _bar(head: str, names: list[str], here: str, width: int, *,
     (:func:`bar_rows_wanted`), and a sizing question that published a click map would have
     the launcher's answer overwrite the panel's — a map describing a strip nobody is
     looking at.
+
+    *busy* is :func:`_compose`'s and is passed straight through — see there.
     """
-    lines, cols, more, add = _compose(head, names, here, width, note=note, rows=rows)
+    lines, cols, more, add = _compose(head, names, here, width,
+                                      note=note, rows=rows, busy=busy)
     TABS.publish(cols, here, more, add)
     return lines
 
 
 def _compose(head: str, names: list[str], here: str, width: int, *,
-             note: str = "", rows: int = 1):
+             note: str = "", rows: int = 1, busy=()):
     """The strip *head*/*names*/*here* composes to, and the cells its tabs landed in.
 
     Answers ``(lines, columns, more, add)`` — the rows to draw, the ``(row, col)`` map
@@ -3797,6 +3872,18 @@ def _compose(head: str, names: list[str], here: str, width: int, *,
     *note* is an extra field drawn after the names when there is room for it whole — the
     "add chat" affordance, and nothing else today. Dropped first, before any name, because
     it is a reminder and the names are the readout.
+
+    *busy* is the names whose harness is working right now (#853) — chat ids, straight off
+    `inflight.working_chats`. Each one drawn on the strip gets :data:`TAB_SPINNER` in the
+    cell :data:`_BAR_MARK` would otherwise leave blank, so **the ladder above cannot see
+    it**: every field is the width it was without it, the cut is the cut it always was, and
+    :func:`bar_rows_wanted` — which runs in the LAUNCHER, where nothing knows or should
+    know which chat is thinking — composes the same rows it will draw. That is why *busy*
+    defaults to empty here rather than being read inside: the sizer and the renderer ask
+    one arithmetic, and only the renderer has an opinion about the clock.
+
+    Empty for the `workspaces` strip, which is not a strip of chats and has no harness to
+    be working.
 
     **Every rung answers with its own cell map**, which is what makes the bar clickable at
     all and is the same discipline `_repos` keeps for the table's rows: the handler
@@ -3901,7 +3988,20 @@ def _compose(head: str, names: list[str], here: str, width: int, *,
     # the raw name beside the drawn field: a click has to switch to what is on disk.
     at = names.index(here) if here in names else -1
     shown = [contain.one_line(n) for n in names]
-    marked = [f"{_BAR_MARK[0] if i == at else _BAR_MARK[1]}{n}"
+    # **The mark's cell carries the spinner too, and it is decided on the RAW name for the
+    # reason the paragraph above gives about the index**: `busy` holds chat ids off disk,
+    # `shown` holds text `contain.one_line` may have repaired, and matching a mark against
+    # the repaired form would follow the repair rather than the identity.
+    #
+    # `i != at` before the membership test, so the active tab keeps its `*` — see
+    # :data:`TAB_SPINNER` for why that one cell goes to the mark rather than to the
+    # spinner. Read once, outside the comprehension: every tab on a strip shows the same
+    # frame (`tab_spinner_frame`), and reading the clock per name would let a wide strip
+    # start a row on one frame and finish it on the next. Read unconditionally, too: an
+    # `if busy` in front of it would change no output at all, only one `time.monotonic()`,
+    # which is the equivalent mutant this repository deletes rather than documents.
+    frame = tab_spinner_frame()
+    marked = [f"{_BAR_MARK[0] if i == at else (frame if names[i] in busy else _BAR_MARK[1])}{n}"
               for i, n in enumerate(shown)]
     # **The same fields twice: one set to MEASURE and one set to DRAW.** `chrome.block`
     # adds no cell — `tui.width` counts no SGR — so the two are the same width by
@@ -4066,6 +4166,28 @@ def _compose(head: str, names: list[str], here: str, width: int, *,
 ADD_CHAT = "+"
 
 
+def working_chats() -> frozenset:
+    """Which chats' harnesses are working right now — a set of chat ids, possibly empty.
+
+    The renderer's half of the turn tracker (`inflight.working_chats`), and a wrapper
+    rather than a direct call for the reason every read on this repaint path has one:
+    **never raises.** A panel that threw out of `render` loses its pane, and a tracker
+    charter cannot read is "nothing is working" — which degrades to the strip that was
+    drawn before this feature existed rather than to a hole in the frame.
+
+    A set rather than the tracker's `(chat, last_seen)` pairs: what a strip does with this
+    is one membership test per name, and the times are the PANEL's half of the same read
+    (`panel._working`, which needs them to know when its cached answer expires). Two
+    readers of one tracker, each taking the part it has a use for — `inflight.live_records`
+    and `inflight.live` are the same split one tracker over.
+    """
+    from .. import inflight
+    try:
+        return frozenset(chat for chat, _seen in inflight.working_chats())
+    except Exception:  # noqa: BLE001 - a readout must never cost a pane
+        return frozenset()
+
+
 def _chats_strip(fid: str):
     """What the chat strip is a strip OF — its heading, its names, the one you are typing
     in, and its note.
@@ -4196,9 +4318,16 @@ def chats_bar(fid: str, width: int, rows: int = 1) -> list[str]:
     *rows* is the pane's height, which the strip grows into only as far as its names need.
     It defaults to one because one is the shape every caller had before #829 and the shape
     a strip whose names fit still has.
+
+    **The one field on this strip that moves on its own** (#853): a chat whose harness is
+    working shows :data:`TAB_SPINNER` where an idle one shows a blank. That is why `chats`
+    is in :data:`BAR_ANIMATED` and why `panel._watch` gives it a ticking gate of its own —
+    a gate `slots.ANIMATED`'s cannot serve, since that one asks about plane-wide in-flight
+    dispatches and this chat's notice dwell, and neither is "a sibling chat's harness
+    started working".
     """
     head, names, here, note = _chats_strip(fid)
-    return _bar(head, names, here, width, note=note, rows=rows)
+    return _bar(head, names, here, width, note=note, rows=rows, busy=working_chats())
 
 
 def workspaces_bar(fid: str, width: int, rows: int = 1) -> list[str]:
@@ -4231,6 +4360,28 @@ def workspaces_bar(fid: str, width: int, rows: int = 1) -> list[str]:
 #: for exactly the names in here — so a renderer that gains a spinner without joining this
 #: set, or leaves one behind without leaving it, is red rather than silently still.
 ANIMATED = frozenset({"bottom"})
+
+#: Which BAR slots draw something that changes on its own — the tab spinner, and today
+#: `chats` and only `chats` (:data:`TAB_SPINNER`, through :func:`working_chats`).
+#:
+#: **A second set rather than a `chats` added to :data:`ANIMATED`, because the two name
+#: different GATES and not merely different slots.** `panel._watch` ticks an `ANIMATED`
+#: slot while `_running(inflight_cache) or _notice_pending(fid)` — plane-wide in-flight
+#: dispatches, and this frame's own switch-notice dwell. Neither has anything to do with
+#: whether a sibling chat's harness is thinking: a plane with no dispatch running would
+#: never tick, and a plane with one running would tick the strip for half an hour with
+#: every tab idle. Folding the two together would make each condition wake the other's
+#: pane, which is exactly the unscoped repaint `ANIMATED` was written to prevent.
+#:
+#: So `chats` gets `panel._working`'s gate — `inflight.turn_stamp`, one `stat` — and
+#: `bottom` keeps `panel._running`'s. A slot may legitimately end up in both sets one day;
+#: `_watch` ORs them and neither membership implies the other.
+#:
+#: Kept honest the same way :data:`ANIMATED` is, by
+#: `tests.test_a_chat_tab_shows_its_harness_working.OnlyTheChatStripSpins`: every slot is
+#: rendered twice at two clock readings with a chat marked as working, and the output must
+#: differ for exactly the names in here.
+BAR_ANIMATED = frozenset({"chats"})
 
 
 def unimplemented(configured) -> list[str]:

--- a/charter/hooks.py
+++ b/charter/hooks.py
@@ -4271,6 +4271,106 @@ def _in_a_plane() -> bool:
     return bool(_cfg.HAS_CONTROL_PLANE)
 
 
+# --------------------------------------------------------------------------- #
+# The chat's own turn — the one thing about a harness that only a hook can see.  #
+#                                                                               #
+# charter does not own the harness's SCREEN (ADR 0018 permits `capture-pane` at  #
+# exactly two moments, both of them moments the pane is about to stop existing). #
+# It owns the harness's HOOKS, and a hook process runs inside the chat's pane,   #
+# whose window the launcher created with `-e CHARTER_SESSION_ID=<chat id>`       #
+# (`commands_frame._session_id_env_argv`, `frame/layout.py`). So a hook already  #
+# knows exactly which chat it is in, and the three edges of a turn — it began,   #
+# it is still going, it ended — are three hooks charter is already dispatched    #
+# into. `frame/slots.py` draws them; `charter/inflight.py` holds them.           #
+# --------------------------------------------------------------------------- #
+
+
+def _chat_id() -> str | None:
+    """Which chat this hook is running inside, or ``None`` when it is not inside one.
+
+    ``$CHARTER_SESSION_ID`` and nothing else, which is the same rung
+    `frame/notify.plane_changed` reads one line into its own body: inside a frame that
+    variable holds the FRAME's id (`session.current` says so explicitly — it *shadows*
+    Claude Code's own session id there), and outside one it is unset, which is the common
+    case since most sessions run with no frame at all.
+
+    **Neither stripped nor defaulted here**, and both omissions are the same rule. The
+    value goes to `inflight._turn_file`, which is the seam that turns it into a PATH and
+    has to answer for whatever a caller hands it — so it normalises, and a second
+    normalisation on the way in would be one nothing could observe. An unset variable reads
+    as ``None``, which the emptiness test in the three functions below already refuses; a
+    value of blanks reaches `_turn_file`, which strips it and refuses what is left.
+    """
+    return os.environ.get("CHARTER_SESSION_ID")
+
+
+def _turn_begin() -> None:
+    """This chat's harness has started working. `userpromptsubmit` and nothing else.
+
+    **Gated on the harness charter will hear the END from, and that gate is the whole of
+    the honesty here.** The falling edge is a `Stop` hook. Claude Code fires one; opencode
+    sets ``$CHARTER_SESSION_ID`` on its tool hooks and has no session-stop event at all,
+    and Codex is tool-hooks only. A mark charter can raise and cannot lower is not a
+    "working" light — it is a recency mark, claiming *now* while measuring *recently*, and
+    the operator cannot tell which one they are looking at. `state.harness_session` already
+    answers ``None`` rather than guessing for exactly these harnesses, and a chat charter
+    cannot honestly animate shows what it shows today: nothing.
+
+    So the gate is on ``$CHARTER_HARNESS``, which `commands_frame._frame_env` sets on every
+    chat it launches, and an ABSENT one is refused with the rest. "charter does not know
+    which harness this is" and "charter knows this harness reports no stop" reach the same
+    picture on purpose — the four-reasons-one-answer rule `state.harness_session` states.
+
+    Plane-gated with its callers (#852): the mark lands under ``config.STATE_DIR``, which
+    outside a plane is a `.charter/` in a stranger's checkout.
+    """
+    chat = _chat_id()
+    if not chat or not _in_a_plane():
+        return
+    try:
+        from .harness import claude_code
+        # No `or ""` and no `.strip()`: `None` and every other value already compare
+        # unequal, and `commands_frame._frame_env` writes this variable from a module
+        # constant through `tmux -e`, so there is no whitespace for a repair to remove.
+        if os.environ.get("CHARTER_HARNESS") != claude_code.NAME:
+            return
+        from . import inflight
+        inflight.turn_begin(chat)
+    except Exception:  # noqa: BLE001 - a readout must never break a turn
+        pass
+
+
+def _turn_bump() -> None:
+    """This chat's turn is still going — refresh its TTL, never raise a mark.
+
+    Called from every `pretooluse*` and `posttooluse*` handler, which is what makes
+    `inflight.TURN_STALE_SECONDS` a bound on a stretch with NO tool call rather than a
+    bound on a turn. `inflight.turn_bump` does nothing when there is no mark, so this
+    needs no harness gate of its own: only :func:`_turn_begin` can create one, and it is
+    where the gate lives.
+    """
+    chat = _chat_id()
+    if not chat or not _in_a_plane():
+        return
+    try:
+        from . import inflight
+        inflight.turn_bump(chat)
+    except Exception:  # noqa: BLE001
+        pass
+
+
+def _turn_end() -> None:
+    """This chat's harness has stopped. `stop` and nothing else — see :func:`stop`."""
+    chat = _chat_id()
+    if not chat or not _in_a_plane():
+        return
+    try:
+        from . import inflight
+        inflight.turn_end(chat)
+    except Exception:  # noqa: BLE001
+        pass
+
+
 def _trace(event, session, **f):
     """Record one tally row. **A no-op outside a plane, and that is the one place a
     verdict and its bookkeeping come apart** (#852).
@@ -4426,6 +4526,7 @@ def pretooluse_read() -> int:
     that they must never disagree about what a vault is. Deciding is fallible and is
     excused; *refusing* is not, and now cannot be: see :func:`_deny`.
     """
+    _turn_bump()      # this chat's turn is still going (`inflight.TURN_STALE_SECONDS`)
     data = _read_stdin()
     _touch_piece(data)
     try:
@@ -4563,6 +4664,10 @@ def pretooluse() -> int:
         # `.charter/` charter would be creating in a stranger's checkout to hold it.
         _mark_guard_seen()
         _touch_piece(data)
+    # OUTSIDE the `if plane:` above, and that is not an oversight: `_turn_bump` carries the
+    # plane gate itself, because `pretooluse_read` — which is deliberately ungated — calls
+    # it too. A second `if plane` here would be a conjunct no input could make observable.
+    _turn_bump()      # this chat's turn is still going (`inflight.TURN_STALE_SECONDS`)
     ti = data.get("tool_input") or {}
     cmd = ti.get("command", "") or ""
     cwd = data.get("cwd") or ""
@@ -5461,6 +5566,7 @@ def posttooluse() -> int:
     # was not a plane (#852).
     if not _in_a_plane():
         return 0
+    _turn_bump()      # this chat's turn is still going (`inflight.TURN_STALE_SECONDS`)
     from .frame import notify
     notify.plane_changed()
     data = _read_stdin()
@@ -5621,6 +5727,7 @@ def pretooluse_dispatch() -> int:
     """
     if not _in_a_plane():
         return 0  # no personas to overlap, and `inflight.start` would write a claim file
+    _turn_bump()      # this chat's turn is still going (`inflight.TURN_STALE_SECONDS`)
     data = _read_stdin()
     # Clear the routing mark first — the dispatch IS the routing, and clearing ahead of the
     # early returns below means a read-only fan-out counts as routing too.
@@ -5696,6 +5803,7 @@ def posttooluse_bash() -> int:
     # gate belongs here now, not in the changelist that finally adds the nudge.
     if not _in_a_plane():
         return 0
+    _turn_bump()      # this chat's turn is still going (`inflight.TURN_STALE_SECONDS`)
     from .frame import notify
     notify.plane_changed()
     _ask_approved(_read_stdin())
@@ -5716,6 +5824,7 @@ def posttooluse_skill() -> int:
     """
     if not _in_a_plane():
         return 0  # `skilluse.record` tallies against this plane's personas
+    _turn_bump()      # this chat's turn is still going (`inflight.TURN_STALE_SECONDS`)
     from .frame import notify
     notify.plane_changed()
     data = _read_stdin()
@@ -5805,6 +5914,7 @@ def posttooluse_message() -> int:
     """
     if not _in_a_plane():
         return 0  # the tally, and the agent-id map beside it, belong to a plane
+    _turn_bump()      # this chat's turn is still going (`inflight.TURN_STALE_SECONDS`)
     from .frame import notify
     notify.plane_changed()
     data = _read_stdin()
@@ -5831,6 +5941,7 @@ def posttooluse_dispatch() -> int:
     # `?? personas/` carrying this machine's hostname in anything else (#852).
     if not _in_a_plane():
         return 0
+    _turn_bump()      # this chat's turn is still going (`inflight.TURN_STALE_SECONDS`)
     from .frame import notify
     notify.plane_changed()
     data = _read_stdin()
@@ -6136,6 +6247,7 @@ def pretooluse_edit() -> int:
     # the roster this plane declares, and there is no roster outside a plane (#852).
     if not _in_a_plane():
         return 0
+    _turn_bump()      # this chat's turn is still going (`inflight.TURN_STALE_SECONDS`)
     data = _read_stdin()
     # A hard deny, before the routing ask: this one is a permission question, and asking
     # the agent to approve a write that widens the agent's own permissions is no guard.
@@ -6274,6 +6386,7 @@ def userpromptsubmit() -> int:
     # `.charter/sessions/<sid>.configver` into it on the first prompt (#852).
     if not _in_a_plane():
         return 0
+    _turn_begin()     # the turn's RISING edge — the one moment the harness reports
     from .frame import notify
     notify.plane_changed()
     data = _read_stdin()
@@ -6303,6 +6416,55 @@ def userpromptsubmit() -> int:
             "hookEventName": "UserPromptSubmit",
             "additionalContext": "\n\n".join(parts),
         }})
+    return 0
+
+
+def stop() -> int:
+    """The turn is over — the FALLING edge, and the whole of what was missing.
+
+    The rising edge has been on disk since `userpromptsubmit` first called
+    `frame.notify.plane_changed`; `Stop` in `hooks/hooks.json` ran `charter workspace
+    _autosave` and this dispatch table had no entry at all, so nothing charter kept could
+    ever be *lowered*. Everything a turn-scoped readout needs was already here except this.
+
+    **`Stop` and not `SubagentStop`.** They are wired to the same autosave beside this one
+    because a memo is worth writing when either fires, and they are emphatically not the
+    same event here: a dispatched sub-agent finishing does not end the turn that dispatched
+    it, and clearing the mark on `SubagentStop` would blink the tab off in the middle of
+    work that is still going — several times over, on a fan-out.
+
+    **It says nothing and refuses nothing.** `Stop` can block, by exit 2 or by
+    ``{"decision": "block"}``, and blocking here would make the harness keep going on the
+    strength of a *drawing* charter failed to update. This handler exists to stop claiming
+    something; a claim it could not retract is not worth a turn.
+
+    **It reads no stdin, and that is measured rather than assumed.** Every other handler
+    reads the payload because it needs it; this one does not — the chat is
+    ``$CHARTER_SESSION_ID``, out of the pane's own environment, so a malformed or truncated
+    payload must not be able to leave a chat marked as working forever. Nor is a hook that
+    never drains its stdin a new shape on this event: `charter workspace _autosave` has been
+    wired to `Stop` and `SubagentStop` in `hooks/hooks.json` since long before this, and it
+    is an ordinary argparse command that reads nothing.
+
+    **No `notify.plane_changed()` either, and its absence is the design working.** That call
+    bumps the frame's version so panels repaint, and the panels that care about this one
+    already repaint without it: clearing the mark moves the tracker directory's mtime, which
+    is exactly the number `frame/panel.py` watches for the chat strip
+    (`inflight.turn_stamp`), and `_watch`'s falling edge turns "was ticking, is not now"
+    into the one repaint that takes the spinner off. A version bump here would be a second
+    mechanism for an edge that already has one.
+
+    **The plane gate is `_turn_end`'s and is deliberately not repeated here** (#852). The
+    mark lives under `config.STATE_DIR`, which outside a plane is a `.charter/` in a
+    stranger's checkout — so clearing one there would be charter deleting a file a cloned
+    repository supplied, which is `posttooluse_bash`'s ask-marker finding one directory
+    over. The gate sits at the SEAM rather than at the call sites for :func:`_trace`'s
+    reason, and here it is not a preference: `pretooluse_read` is ungated by design and
+    calls `_turn_bump`, so the three helpers have to answer for themselves. Asking twice
+    would leave whichever is asked second a line no input could make observable — which is
+    the shape this repository deletes rather than documents.
+    """
+    _turn_end()
     return 0
 
 
@@ -6515,6 +6677,7 @@ _HANDLERS = {
     "posttooluse-skill": posttooluse_skill,
     "posttooluse-dispatch": posttooluse_dispatch,
     "posttooluse-message": posttooluse_message,
+    "stop": stop,
 }
 
 

--- a/charter/inflight.py
+++ b/charter/inflight.py
@@ -361,3 +361,228 @@ def prune_all() -> int:
         except OSError:
             continue
     return gone
+
+
+# --------------------------------------------------------------------------- #
+# A CHAT'S OWN TURN.                                                          #
+#                                                                             #
+# Everything above is keyed by AGENT and says nothing about where the work is  #
+# happening: a record is `{"agent", "kind", "ts"}` — "no fid, no chat, no      #
+# workspace" (:func:`prune_all`). That is the right shape for what it feeds    #
+# (the dispatch-overlap nudge, `bottom`'s ⏳ N) and the wrong shape for the     #
+# question a tab strip asks, which is *is THIS chat's harness working*. So     #
+# this is a second tracker rather than a fifth :data:`DISPATCH` kind: the      #
+# records have a different key, a different horizon and a different reader,    #
+# and folding them into one directory would put chat ids in front of the       #
+# nudge that reads agent names back to an operator as a sentence — #420's own  #
+# failure, arriving through the other axis.                                    #
+#                                                                             #
+# It shares the SHAPE and nothing else: one directory whose mtime is the       #
+# cheap gate (:func:`turn_stamp`, :func:`stamp`'s twin), one small file per    #
+# live record, an age past which charter stops claiming anything, and          #
+# best-effort everywhere — a tracker that breaks a turn is worse than one that #
+# misses a turn.                                                               #
+# --------------------------------------------------------------------------- #
+
+#: How long a turn charter never saw the end of keeps claiming to be working.
+#:
+#: **The falling edge is a `Stop` hook, and a turn can end without one.** Pressing Esc
+#: mid-turn fires no `Stop` at all, so without this a chat that was interrupted would
+#: spin for the rest of the plane's life. Every `pretooluse*`/`posttooluse*` handler
+#: refreshes the mark (`hooks._turn_bump`), so this is not "how long may a turn take" —
+#: it is **how long a live turn may go without touching a single tool**, which is a much
+#: shorter thing. A turn issuing tool calls refreshes its own mark indefinitely and is
+#: never cut off by this number.
+#:
+#: **Its own constant, not :data:`PRESUMED_DEAD_SECONDS`, for the reason that number's own
+#: header gives about #308**: two jobs with opposite horizons sharing one number is what
+#: made the old single TTL wrong. That one is a DISPLAY threshold — the record survives it
+#: and is drawn differently (`45m?`) — because "a dispatch that has outlived every
+#: reasonable expectation" is the most interesting thing that tracker holds. This one is
+#: the opposite: past it charter does not know whether the harness is working, and the
+#: honest picture for *does not know* is the same as for *is not* — nothing drawn at all,
+#: which is `state.harness_session`'s rule one surface over.
+#:
+#: **Ten minutes, and the trade is stated rather than measured away.** A long TOOLLESS
+#: think bumps nothing, so a TTL short enough to catch an abandoned turn also blinks off
+#: during deep thinking; the two cannot both be had from this signal. Both errors cost the
+#: operator the same single switch to look, and they differ in how they end: a blink-off
+#: is repaired by the turn's very next tool call, while a stale spinner stands until this
+#: number runs out. So it is set generously against the cadence it actually measures — ten
+#: minutes with no tool call whatsoever is far outside what a working turn does — and no
+#: further, because the direction charter errs in is *not claiming* (`inflight`'s own
+#: `⋯ stalled` stops animating for exactly this reason).
+TURN_STALE_SECONDS = 10 * 60
+
+
+def _turn_dir() -> Path:
+    from . import config
+    return config.STATE_DIR / "chat-turns"
+
+
+def _turn_file(chat: str | None) -> Path | None:
+    """The one file that stands for *chat*'s turn, or ``None`` for a name that cannot
+    have one.
+
+    The name comes from ``$CHARTER_SESSION_ID`` inside a harness pane, which the frame
+    launcher set (`commands_frame._session_id_env_argv`) and which anything in that shell
+    can therefore also set to something else — so this is where a chosen string would
+    become a chosen PATH, and it is the only place that has to answer for it.
+
+    **:func:`_safe_name` is asked as a QUESTION here, never used as a mangling**, and that
+    is what lets the file's NAME be the chat's id. It admits exactly the alphabet a chat id
+    travels to tmux under (`frame/chats.ID_RE`), so a value it would change is a value that
+    is not a chat id — refused — and one it would leave alone is a name this directory can
+    hold losslessly. :func:`working_chats` therefore reads the id off the directory entry
+    and never opens a file, and there is no mangled form for a reader to have to invert.
+    ``../../.ssh/authorized_keys`` is refused rather than flattened, which is the same
+    answer `chats.check` gives a name off an argv.
+
+    Refusing rather than repairing costs one real case and it is stated rather than hidden:
+    `_safe_name` truncates at 64 characters, so a chat id longer than that has no mark. A
+    chat with no mark shows what every chat showed before this existed.
+
+    ``.`` and ``..`` pass that question — they are made entirely of admitted characters —
+    and are refused by name, because a chat "called" ``..`` would have :func:`turn_end`
+    unlink the tracker's parent directory rather than a record.
+    """
+    # ``str | None`` rather than ``str``, and `(chat or "")` beside it, because
+    # `hooks._chat_id` answers with `os.environ.get` unrepaired — an unset
+    # ``$CHARTER_SESSION_ID`` is a `None` this seam is the right place to absorb.
+    # :func:`start` spells the same line for the same reason one tracker up.
+    chat = (chat or "").strip()
+    if not chat or _safe_name(chat) != chat or chat in (".", ".."):
+        return None
+    return _turn_dir() / chat
+
+
+def turn_stamp() -> int | None:
+    """:func:`stamp` for the turn tracker — one ``stat``, or ``None`` for no directory.
+
+    Same contract and the same two halves, so `frame/panel.py` can cache against it the
+    way it already caches against the other: the mtime moves when a record is CREATED or
+    REMOVED, which is the only way the SET of working chats can change, and it does NOT
+    move when :func:`turn_bump` refreshes one — a refresh changes no answer, only a
+    deadline. The deadline half is the caller's, exactly as it is for :func:`stamp`: a
+    mark crossing :data:`TURN_STALE_SECONDS` changes what charter may claim while touching
+    no file at all, so the panel also re-reads when the earliest such deadline passes.
+
+    That split is what keeps an idle plane at one syscall per tick: no marks means no
+    deadline to hold and nothing to compare against.
+    """
+    try:
+        return _turn_dir().stat().st_mtime_ns
+    except OSError:
+        return None
+
+
+def turn_begin(chat: str | None) -> None:
+    """Mark *chat*'s harness as working. The RISING edge, and its only writer is the
+    `UserPromptSubmit` hook.
+
+    **Creating is deliberately separate from refreshing** (:func:`turn_bump`). A tool hook
+    fires for a sub-agent's tools as well as the session's own, and it fires in whatever
+    turn happens to be running; if a tool hook could CREATE a mark, a chat would start
+    claiming to be working on evidence that a tool ran rather than on evidence that a turn
+    began — and there would then be no single moment charter could point at as the start.
+    A prompt is that moment, it is the one edge the harness reports unambiguously, and it
+    is already on disk (`hooks.userpromptsubmit`).
+
+    **The file is empty, and `config.touch_for` is what makes it.** A mark carries its
+    meaning in EXISTING and in its mtime — which is that helper's own sentence, and here
+    it is exact: the id is the file's name (:func:`_turn_file`), the TTL is its mtime, and
+    there is nothing left for bytes to say. `touch_for` and not `Path.touch` because
+    everything under `config.STATE_DIR` is charter's own state, and a bare `touch` creates
+    at ``0o666 & ~umask`` in a directory charter does not always own (#331, #505).
+
+    Best-effort: a tracker that cannot write is a strip that shows nothing, which is what
+    it showed before this existed.
+    """
+    p = _turn_file(chat)
+    if p is None:
+        return
+    try:
+        from . import config
+        config.private_mkdir(_turn_dir())
+        config.touch_for(p)
+    except OSError:
+        return
+
+
+def turn_bump(chat: str | None) -> None:
+    """Refresh *chat*'s mark — the TTL only, never the mark itself.
+
+    One ``utime`` on a file that already exists, and **nothing at all when it does not**:
+    that missing-file case is the whole reason this is not :func:`turn_begin` with a
+    different name. It is also why a refresh is free for the panel — `utime` does not move
+    the directory's mtime, so :func:`turn_stamp` does not move and nothing re-reads.
+
+    Called from every `pretooluse*` and `posttooluse*` handler, which is what makes
+    :data:`TURN_STALE_SECONDS` a bound on a toolless STRETCH rather than on a turn.
+    """
+    p = _turn_file(chat)
+    if p is None:
+        return
+    try:
+        os.utime(p)
+    except OSError:
+        return
+
+
+def turn_end(chat: str | None) -> None:
+    """Clear *chat*'s mark. The FALLING edge — `hooks.stop`, and nothing else.
+
+    `SubagentStop` deliberately does not call this: a sub-agent finishing does not end
+    the turn that dispatched it, and clearing here would blink the tab off in the middle
+    of work that is still going.
+    """
+    p = _turn_file(chat)
+    if p is None:
+        return
+    try:
+        p.unlink(missing_ok=True)
+    except OSError:
+        return
+
+
+def working_chats() -> list[tuple[str, float]]:
+    """``(chat, last_seen)`` per chat whose harness charter can still claim is working.
+
+    :func:`live_records` one tracker over, and the same two readers: `frame/panel.py`
+    takes the times, to know when its cached answer expires with no file having changed;
+    `frame/slots.py` takes the names, to decide which tabs get a spinner.
+
+    A mark past :data:`TURN_STALE_SECONDS` is **deleted here** rather than merely skipped,
+    and that is the opposite of what :func:`live_records` does with a presumed-dead
+    dispatch — on purpose. There, an outlived record is the most interesting thing the
+    tracker holds and is kept so it can be drawn. Here there is nothing to draw: past the
+    TTL charter does not know, so the record has no reader left, and deleting it moves the
+    directory mtime — which turns an expiry that no file announced into an ordinary
+    :func:`turn_stamp` change for every panel watching. A chat that never gets a `Stop`
+    would otherwise leave one file behind for good.
+
+    **One `stat` per entry and no file is ever opened**, because the id is the entry's own
+    name — see :func:`_turn_file` for why that is lossless rather than convenient. So this
+    costs a `readdir` and one `stat` per working chat, and a plane with nothing working
+    does not get here at all.
+    """
+    d = _turn_dir()
+    if not d.exists():
+        return []
+    out: list[tuple[str, float]] = []
+    now = time.time()
+    for p in d.iterdir():
+        try:
+            seen = p.stat().st_mtime
+            # `>` and not `>=`, and the deletion sweep asks which. Only the DIRECTION is
+            # pinned, deliberately: `now - seen` is a float measured against a ten-minute
+            # constant, so the two spellings differ on one instant no run arrives at, and
+            # both say the same thing about the chat — it has gone the whole TTL without a
+            # tool call. A test asserting one of them would be pinning a coin-flip.
+            if now - seen > TURN_STALE_SECONDS:
+                p.unlink(missing_ok=True)
+                continue
+        except OSError:
+            continue
+        out.append((p.name, seen))
+    return out

--- a/docs/frame.md
+++ b/docs/frame.md
@@ -600,6 +600,24 @@ draw it two cells wide where charter measured one — and on a row whose clicks 
 by *column*, ten separators drawn a cell wide each would put your press ten columns off the
 tab you aimed at.
 
+**A chat whose harness is working spins where an idle one shows a blank.** The mark column
+in front of each name carries it — `✢`, `✶`, `✻` and back — so the strip is exactly as wide
+while three chats are thinking as while none is, and no tab moves under a press. The chat
+you are typing in keeps its `*` instead: it is the one whose harness you can watch
+directly, and the `*` is the only thing that survives `NO_COLOR`.
+
+charter reads this off the harness's hooks, never off its screen. Claude Code reports the
+start of a turn (`UserPromptSubmit`) and the end of one (`Stop`); a chat running a harness
+that reports no stop — opencode and Codex both hook tool calls only — shows nothing at all
+rather than a mark charter could raise and never lower.
+
+Two costs, both real. A turn interrupted with Esc fires no `Stop`, so its tab keeps spinning
+until the mark decays — **ten minutes**, refreshed by every tool call the turn makes, so
+what has to elapse is ten minutes with no tool call at all. The same number is why a turn
+that thinks for longer than that with no tool call blinks off and comes back on its next
+one. There is no third answer available from a hook channel that reports prompts and tool
+calls: charter can be late to stop claiming, or early, and it is set to be early.
+
 **The chat bar ends in a `+`, and pressing it opens another chat.** Same workspace, same
 harness you are already in, its id allocated for you — which is why it takes nothing and
 asks nothing. It runs `charter frame-new-chat`, which is `charter <harness>` in this

--- a/docs/news/unreleased-a-chat-tab-shows-when-its-harness-is-working.md
+++ b/docs/news/unreleased-a-chat-tab-shows-when-its-harness-is-working.md
@@ -1,0 +1,189 @@
+---
+version: unreleased
+headline: a chat tab spins while that chat's harness is working — the turn's start was already on disk, the Stop hook that ends it was not
+---
+
+The chat bar says which chats exist and which one you are in. It did not say which of them
+was *doing* anything, so the only way to find out whether the chat in the next tab had
+finished was to switch to it and look.
+
+```
+before
+  chats   api.1  *api.2   api.3   docs.1  +
+
+after — api.1 and docs.1 are working, api.3 is not
+  chats  ✻api.1  *api.2   api.3  ✻docs.1  +
+```
+
+## charter owns the harness's hooks, and half of this already worked
+
+charter does not own the harness's *screen* — ADR 0018 permits reading that pane at
+*"exactly two moments, both of which are moments the pane is about to stop existing"*. It
+owns the harness's *hooks*, and that turns out to be enough:
+
+* `hooks/hooks.json` wires `UserPromptSubmit`. The hook process runs inside the chat's own
+  harness pane, and the launcher created that window with `-e CHARTER_SESSION_ID=<chat id>`
+  — so a hook has always known exactly which chat it is in.
+* `hooks.userpromptsubmit` has called `notify.plane_changed()` since it was written. **The
+  turn-start edge was already on disk.**
+
+**The whole gap was the falling edge.** `Stop` in `hooks/hooks.json` ran `charter workspace
+_autosave`, and `hooks._HANDLERS` had eleven entries — `sessionstart`, `userpromptsubmit`,
+four `pretooluse*`, five `posttooluse*` — and **no `stop` at all**. Nothing charter raised
+could be lowered, which is why the thing to build was one handler and a tracker, not a
+mechanism for watching a terminal.
+
+`Stop`, and deliberately not `SubagentStop`. They share the autosave beside this because a
+memo is worth writing when either fires; they must not share this one, because a dispatched
+sub-agent finishing does not end the turn that dispatched it — on a fan-out the tab would
+blink off once per worker.
+
+## A turn that nobody ends: ten minutes, and why that number
+
+Pressing Esc mid-turn fires no `Stop`. Without a fallback the mark would stand for the rest
+of the plane's life, so a mark decays: `inflight.TURN_STALE_SECONDS`, **ten minutes**.
+
+That is not "how long may a turn take". Every `pretooluse*` and `posttooluse*` handler
+refreshes the mark, so a turn issuing tool calls refreshes its own TTL indefinitely and is
+never cut off. What ten minutes bounds is a stretch **with no tool call whatsoever**.
+
+**The limit is real and cannot be measured away.** A long *toolless* think refreshes
+nothing, so a TTL short enough to catch an abandoned turn also blinks off during deep
+thinking; that tab comes back on the turn's next tool call. Both errors cost you the same
+single switch to look, and they differ in how they end — a blink-off is repaired by the
+next tool call, a stale spinner stands until the number runs out. So the number errs on the
+side charter always errs on: *not claiming*. `TheLimitIsAToollessThink` is a test rather
+than a paragraph, so moving the number means coming back and restating the trade.
+
+Its own constant, not `inflight.PRESUMED_DEAD_SECONDS`, for the reason that number's own
+header gives about #308: two jobs with opposite horizons sharing one number is what made
+the single old TTL wrong. That one is a *display* threshold — the record survives it and is
+drawn differently (`45m?`), because a dispatch that has outlived every expectation is the
+most interesting thing that tracker holds. This one is the opposite: past it charter does
+not know, and the honest picture for *does not know* is the picture for *is not*.
+
+## A chat on a harness charter cannot hear the end from shows nothing
+
+opencode sets `$CHARTER_SESSION_ID` on its tool hooks and has no session-stop event —
+`opencode.SHIM` hooks exactly `shell.env`, `tool.execute.before` and `tool.execute.after`.
+Codex is tool-hooks only. Neither can dispatch `stop`, and neither can dispatch
+`userpromptsubmit` either, which `tests/test_opencode_dispatches_every_hook` has recorded
+as a declared deficit since #433.
+
+A mark charter can raise and cannot lower is not a working light — it is a recency mark,
+claiming *now* while measuring *recently*, and you cannot tell the two apart by looking. So
+the rising edge is gated on the harness by name and a non-Claude chat is drawn exactly as
+it is drawn today: nothing. `state.harness_session` already answers `None` rather than
+guessing for these same harnesses, and *"charter does not know which harness this is"*
+reaches the same picture as *"charter knows this one reports no stop"*, on purpose.
+
+## The spinner takes the mark's cell, and the strip does not move
+
+Every tab already carries a one-cell prefix — `*` for the chat you are in, a blank for the
+others. The spinner goes **in that cell**, so a chat starting a turn changes not one column
+of the strip: the cut, the row count and the click map all answer exactly what they
+answered when nothing was working.
+
+That matters more here than it sounds. `slots.TABS` resolves a click **by column**, so a
+spinner drawn *beside* a name would re-cut the strip the moment a sibling started thinking,
+and the cell you were about to press would hold another chat's name a moment later — the
+double-press #767 exists to prevent, arriving through an animation. It is asserted at every
+width from 0 to 120: the map and the row widths are identical with two chats working and
+with none.
+
+The active tab keeps its `*`. One cell, two facts, and `*` wins because it is the only one
+of the two with no other way to be seen — `[frame] chrome = "off"` is the shipped default
+and `NO_COLOR` strips the reverse-video block — and because the chat you are typing in is
+the one whose harness you can already watch.
+
+### Three of the six glyphs that were asked for did not go on the row
+
+The request was Claude Code's own spinner, `· ✢ ✶ ✳ ✽ ✻`. `tui.width` answers **1** for all
+six, and on this row `tui.width` is not the whole question: it reads the East-Asian tables,
+and an *Ambiguous* character is one a terminal may draw two cells wide while those tables
+say one. That is what `slots._BAR_RULE` is ASCII to avoid, and `statusline._persona_chips`
+records two Ambiguous glyphs breaking this project's layout already.
+
+| glyph | codepoint | East-Asian width | verdict |
+|---|---|---|---|
+| `·` | U+00B7 | **Ambiguous** | refused |
+| `✢` | U+2722 | Neutral | kept |
+| `✳` | U+2733 | Neutral | refused — carries an emoji presentation variant (`✳️`), so a terminal with an emoji fallback font may draw it wide |
+| `✶` | U+2736 | Neutral | kept |
+| `✽` | U+273D | **Ambiguous** | refused |
+| `✻` | U+273B | Neutral | kept |
+
+What ships is `✢ ✶ ✻ ✶` — the three that survive, cycled out and back so the sparkle grows
+and shrinks the way the requested one does. Neutral is the property `statusline`'s own
+marker test asserts (`▪▸▫`, chosen after `◈`/`◆` shipped broken), and it is the strongest
+one available short of ASCII.
+
+**ASCII was tried first and is worse here**, for a reason that is not about width at all: a
+chat id is `[A-Za-z0-9._-]`, so a pulse like `.oOo` draws `Oapi.3` and puts a character you
+read as part of a name where the name begins. None of the three that shipped is a character
+a chat id may contain, and that is asserted as its own property.
+
+## What it costs, measured on this machine
+
+The strip does not tick unless a chat is actually working, and learning that costs one
+`stat`:
+
+| | measured | at 5 Hz |
+|---|---|---|
+| `inflight.turn_stamp()`, nothing working | 4.6 µs | 23 µs/s — **0.002% of a core** |
+| `inflight.working_chats()`, 3 marks | 31.9 µs | — |
+| `slots.chats_bar`, 3 chats, none working | 429.8 µs | 0.215% of a core |
+| `slots.chats_bar`, 3 chats, two working | 454.1 µs | **0.227% of a core** |
+| `inflight.turn_bump()`, one hook | 11.5 µs | per tool call |
+
+An idle plane pays the 4.8 µs and nothing else, forever — and only on the pane that draws
+the strip. Against `slots.ANIMATED`'s own recorded budget, *"one `render("right")` costs
+4 816 µs … at 5Hz that one pane alone is ~2.4% of a core"*, an animated chat strip is a
+tenth of what this frame already animates.
+
+A refresh is free by construction: `turn_bump` is a `utime` on a file that already exists,
+which does not move the tracker directory's mtime — so a turn issuing a tool call a second
+re-reads nothing. Only a turn *starting* and a turn *ending* cost a panel a read.
+
+#780 is not what this contradicts. That finding prices a **tmux round trip** at ~7–13 ms and
+is why a renderer may not make one; `slots.chats_bar` calls `chats.roster` and nothing else,
+and `frame/chats.py` says outright that *"nothing here touches tmux and nothing here starts
+anything"*. It settles the read, not the tick.
+
+## Its own gate, not the one `bottom` uses
+
+`panel._watch` ticks an animated slot while `_running(inflight_cache) or
+_notice_pending(fid)` — plane-wide in-flight dispatches, and this frame's own switch-notice
+dwell. Neither has anything to do with whether a sibling chat's harness is thinking: a plane
+with no dispatch running would never tick the strip, and one with a dispatch running would
+tick it for half an hour with every tab idle.
+
+So `chats` gets a second set (`slots.BAR_ANIMATED`) and a gate of its own, and each panel
+pays for exactly the gate its own renderer draws from. `OnlyTheChatStripSpins` keeps that
+honest the way `OnlyTheAnimatedSlotAnimates` does: every renderer in the frame is drawn
+twice at two clock readings with a chat marked as working, and the output must differ for
+exactly the names in the set.
+
+## Where it lives
+
+A second tracker in `charter/inflight.py`, keyed by **chat**, beside the one keyed by
+**agent**. They are not merged: a dispatch record is `{"agent", "kind", "ts"}` — *"no fid,
+no chat, no workspace"* — which is the right shape for the dispatch-overlap nudge that reads
+agent names back to you as a sentence, and a chat id reaching that nudge is #420's
+wrong-and-confident failure arriving through the other axis.
+
+Nothing leaves the plane and nothing is committed: one **empty** file per working chat under
+`.charter/chat-turns/`, made through `config.touch_for` like every other piece of charter's
+own state. It carries its meaning in existing and in its mtime, which is that helper's own
+sentence and is exact here — the chat's id is the file's *name*, and the TTL is its mtime,
+so there is nothing left for bytes to say and a reader never opens one.
+
+That works because a name that could not be a chat id is **refused rather than repaired**.
+`$CHARTER_SESSION_ID` is an environment variable, so the value that becomes a filename is
+one anything in that shell can choose; `_safe_name` is asked as a question there instead of
+being used as a mangling, so `../../.ssh/authorized_keys` gets no mark at all rather than a
+flattened one — the same answer `chats.check` gives a name off an argv. `.` and `..` spell
+themselves and are refused by name on top of that, because a chat "called" `..` would
+otherwise have the falling edge unlink a directory. The cost is stated rather than hidden: a
+chat id longer than 64 characters gets no mark, and shows what every chat showed before this
+existed.

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -139,6 +139,11 @@
         "hooks": [
           {
             "type": "command",
+            "command": "charter hook stop --plugin-version 0.55.0",
+            "timeout": 5
+          },
+          {
+            "type": "command",
             "command": "charter workspace _autosave >/dev/null 2>&1",
             "timeout": 15
           }

--- a/tests/test_a_chat_tab_shows_its_harness_working.py
+++ b/tests/test_a_chat_tab_shows_its_harness_working.py
@@ -1,0 +1,806 @@
+"""A chat tab spins while that chat's harness is working — #853.
+
+**The whole gap was the falling edge, and everything else was already on disk.** charter
+does not own the harness's screen; it owns its HOOKS, and a hook process runs inside the
+chat's own pane, whose window the launcher created with ``-e CHARTER_SESSION_ID=<chat id>``
+— so a hook has always known exactly which chat it is in. `hooks.userpromptsubmit` already
+fired at the start of every turn. `Stop` in `hooks/hooks.json` ran `charter workspace
+_autosave` and `hooks._HANDLERS` had **no entry at all**, so nothing charter raised could
+ever be lowered.
+
+Four properties, each failing in a different direction:
+
+1. :class:`TheTurnTrackerHoldsOneChatAtATime` — the tracker itself. A mark goes up, comes
+   down, decays, and cannot be talked into naming a path outside its own directory.
+2. :class:`TheThreeEdgesAreThreeHooks` — the rising edge, the refresh and the falling
+   edge, driven through the real handlers, plus the harnesses that get no mark at all.
+3. :class:`TheStripDrawsItWithoutMovingACell` — the strip. The spinner takes the mark's
+   cell, so a chat starting a turn moves not one column of a map that resolves clicks BY
+   column.
+4. :class:`OnlyTheChatStripSpins` — the cost property, `slots.ANIMATED`'s one bar over: a
+   panel pays for the gate its own renderer draws from and for no other.
+
+**The honest limit, asserted rather than hidden** (:class:`TheLimitIsAToollessThink`): a
+long toolless think refreshes nothing, so `inflight.TURN_STALE_SECONDS` cannot both catch
+an abandoned turn and cover an arbitrarily long silence. The tracker decays, and the test
+that says so is the record of the trade.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import os
+import sys
+import time
+import unicodedata
+import unittest
+from contextlib import redirect_stdout
+from pathlib import Path
+from unittest import mock
+
+from charter import config, hooks, inflight, tui
+from charter.frame import chats, gather, panel, slots, state
+from tests._isolation import PersonaIso, PlaneIso
+from tests.test_frame_chat_switch import _plant
+
+
+def _run(fn, payload: dict) -> tuple[int, str]:
+    """Call a handler with *payload* on stdin; return ``(exit code, stdout)``."""
+    old = sys.stdin
+    sys.stdin = io.StringIO(json.dumps(payload))
+    buf = io.StringIO()
+    try:
+        with redirect_stdout(buf):
+            rc = fn()
+    finally:
+        sys.stdin = old
+    return rc, buf.getvalue().strip()
+
+
+#: The environment a hook process actually has inside a chat's harness pane. Spelled out
+#: rather than taken off `commands_frame._FRAME_IDENTITY`: a test that reads the tuple it
+#: is checking agrees with a tuple edited to nothing, and what is being asserted here is
+#: that CHARTER'S OWN two variables decide this — which chat, and which harness.
+#:
+#: `claude-code` is hand-spelled for the same reason. It is `harness.claude_code.NAME`, and
+#: a comparison against that constant would pass against a constant edited to `""`, which
+#: is exactly the value an absent `$CHARTER_HARNESS` supplies.
+CHAT_ENV = {"CHARTER_SESSION_ID": "api.2", "CHARTER_HARNESS": "claude-code"}
+
+
+def _mark(chat: str) -> Path:
+    """Where the tracker puts *chat*'s mark, spelled here rather than asked of the module.
+
+    The path is the interface between a hook process and a panel process, so a test that
+    asked `inflight._turn_file` for it would agree with any path that function came to
+    answer — including one under a directory `frame/panel.py` is not watching.
+    """
+    return Path(config.STATE_DIR) / "chat-turns" / chat
+
+
+class TheTurnTrackerHoldsOneChatAtATime(PersonaIso, unittest.TestCase):
+    """`inflight`'s second tracker: keyed by CHAT, where the first is keyed by AGENT.
+
+    The one above is `{"agent", "kind", "ts"}` — *"no fid, no chat, no workspace"*
+    (`inflight.prune_all`) — which is the right shape for the dispatch-overlap nudge and
+    `bottom`'s `⏳ N`, and cannot answer *which chat is busy* at all. That is why this is a
+    second tracker rather than a fifth `kind`.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.assertIn("edm-test-", str(config.STATE_DIR),
+                      "precondition: this case writes, and must write into its own tmp")
+
+    def test_a_marked_chat_is_reported_and_an_unmarked_one_is_not(self):
+        self.assertEqual([], inflight.working_chats())
+        inflight.turn_begin("api.2")
+        self.assertEqual(["api.2"], [c for c, _ in inflight.working_chats()])
+
+    def test_the_falling_edge_takes_the_mark_away(self):
+        inflight.turn_begin("api.2")
+        self.assertTrue(_mark("api.2").is_file(), "precondition: the mark must be up")
+        inflight.turn_end("api.2")
+        self.assertEqual([], inflight.working_chats())
+        self.assertFalse(_mark("api.2").exists())
+
+    def test_a_mark_nobody_ever_lowered_decays_and_is_swept(self):
+        """The turn that never gets a `Stop` — Esc mid-turn fires none.
+
+        Both halves: charter stops CLAIMING (the reader drops it) and stops KEEPING (the
+        file goes). The second is what makes the expiry an ordinary `turn_stamp` change,
+        so a panel learns of it through the number it already watches rather than needing
+        a deadline of its own for a chat that no longer exists.
+        """
+        inflight.turn_begin("api.2")
+        p = _mark("api.2")
+        old = time.time() - inflight.TURN_STALE_SECONDS - 1
+        os.utime(p, (old, old))
+        self.assertEqual([], inflight.working_chats())
+        self.assertFalse(p.exists(), "an expired mark was left on disk for good")
+
+    def test_a_bump_rescues_a_mark_that_was_about_to_expire(self):
+        """The other direction, so the decay above cannot be satisfied by never refreshing.
+
+        This is what makes `TURN_STALE_SECONDS` a bound on a stretch with NO tool call
+        rather than a bound on a turn: every `pretooluse*`/`posttooluse*` handler calls it.
+        """
+        inflight.turn_begin("api.2")
+        old = time.time() - inflight.TURN_STALE_SECONDS - 1
+        os.utime(_mark("api.2"), (old, old))
+        inflight.turn_bump("api.2")
+        self.assertEqual(["api.2"], [c for c, _ in inflight.working_chats()])
+
+    def test_a_bump_raises_nothing_by_itself(self):
+        """A tool hook fires for a sub-agent's tools as well as the session's own, and it
+        fires in whatever turn happens to be running. If a bump could CREATE, a chat would
+        start claiming to be working on evidence that a tool ran rather than on evidence
+        that a turn began — and there would be no single moment charter could point at."""
+        inflight.turn_bump("api.2")
+        self.assertEqual([], inflight.working_chats())
+        self.assertFalse(_mark("api.2").exists())
+
+    def test_a_refresh_moves_no_stamp_and_the_two_edges_do(self):
+        """`turn_stamp` is the panel's whole idle cost, and this is the property that makes
+        it affordable: a turn issuing a tool call a second re-reads nothing, because
+        `utime` on an existing file does not move its directory's mtime. Only the SET
+        changing costs a read — which is `inflight.stamp`'s rule for the other tracker."""
+        inflight.turn_begin("api.2")
+        up = inflight.turn_stamp()
+        inflight.turn_bump("api.2")
+        self.assertEqual(up, inflight.turn_stamp(), "a refresh made every panel re-read")
+        inflight.turn_end("api.2")
+        self.assertNotEqual(up, inflight.turn_stamp(),
+                            "the falling edge announced itself to nobody")
+
+    def test_no_directory_at_all_is_an_answer_rather_than_an_error(self):
+        self.assertIsNone(inflight.turn_stamp())
+        self.assertEqual([], inflight.working_chats())
+
+    def test_a_chat_id_that_could_name_a_path_is_refused_rather_than_repaired(self):
+        """``$CHARTER_SESSION_ID`` is an environment variable, so anything in that shell can
+        set it — and the value becomes a filename. A name outside the alphabet a chat id
+        reaches tmux under is not a chat id, so it gets no mark at all: nothing lands
+        outside the directory, and nothing lands inside it under a repaired name either.
+        """
+        for chat in ("../escaped", "/etc/passwd", "a/b", "with space",
+                     "x" * 65):
+            with self.subTest(chat=chat):
+                self.assertIsNone(inflight._turn_file(chat))
+                inflight.turn_begin(chat)
+                self.assertEqual([], inflight.working_chats())
+        self.assertFalse((Path(config.STATE_DIR) / "escaped").exists())
+
+    def test_a_real_chat_id_is_the_marks_own_name(self):
+        """What the refusal above buys: the reader takes the id off the directory entry,
+        so there is no mangled form for it to have to invert and no file to open."""
+        inflight.turn_begin("api.2")
+        self.assertTrue(_mark("api.2").is_file())
+        self.assertEqual(["api.2"], [c for c, _ in inflight.working_chats()])
+
+    def test_a_name_that_is_nothing_but_blanks_is_no_name(self):
+        """`$CHARTER_SESSION_ID=" "` is a value a shell can supply, and it is not a chat.
+        Normalised HERE and nowhere else — this is the seam that turns the value into a
+        path, and `hooks._chat_id` deliberately does not strip a second time."""
+        for chat in (None, "", "   ", "\n"):
+            with self.subTest(chat=repr(chat)):
+                self.assertIsNone(inflight._turn_file(chat))
+                inflight.turn_begin(chat)
+                self.assertEqual([], inflight.working_chats())
+
+    def test_the_blanks_are_taken_off_both_ends(self):
+        """Both ends, and asserted as one case rather than as a tidiness note: with the
+        normalisation reduced to either half, `  api.2  ` no longer spells itself and the
+        mark is refused outright — so the chat that WOULD have been marked shows nothing.
+        """
+        inflight.turn_begin("  api.2  ")
+        self.assertEqual(["api.2"], [c for c, _ in inflight.working_chats()])
+        self.assertTrue(_mark("api.2").is_file())
+
+    def test_every_edge_refuses_a_name_that_is_not_one(self):
+        """`turn_begin`'s refusal is asserted by what does NOT appear on disk; the other
+        two have nothing to leave behind, so what pins theirs is that they do not raise —
+        without it `turn_bump` reaches `os.utime(None)`, which is a `TypeError` and not
+        the `OSError` its own catch is for."""
+        for edge in (inflight.turn_begin, inflight.turn_bump, inflight.turn_end):
+            for chat in (None, "", "..", "../escaped"):
+                with self.subTest(edge=edge.__name__, chat=repr(chat)):
+                    edge(chat)
+        self.assertEqual([], inflight.working_chats())
+
+    def test_a_filesystem_that_refuses_costs_a_mark_and_never_a_turn(self):
+        """Each edge's `except OSError` on its own syscall. A tracker that cannot be
+        written, refreshed or cleared is a strip that shows nothing — which is what the
+        strip showed before this existed — and never an exception out of a hook.
+
+        **The `stat` failure is aimed at ONE entry and not at `Path.stat`**, and the first
+        cut of this case is why. Failing every `stat` also fails the `d.exists()` that
+        opens `working_chats`, and `pathlib.Path.exists` does not swallow an arbitrary
+        `OSError`: it asks `_ignore_error`, which reads `errno`, and an `OSError` raised
+        with a message and no errno is re-raised. That made the case pass on 3.14 (whose
+        `exists` is written differently) and error on 3.11 and 3.12 — a fixture measuring
+        the standard library rather than this tracker. What the loop's `continue` is
+        actually for is an entry that vanishes between the `readdir` and the `stat`, and
+        that is what this now does.
+        """
+        gone = OSError("the disk has opinions")
+        with mock.patch("charter.config.touch_for", side_effect=gone):
+            inflight.turn_begin("api.2")
+        self.assertEqual([], inflight.working_chats())
+        inflight.turn_begin("api.2")
+        with mock.patch("charter.inflight.os.utime", side_effect=gone):
+            inflight.turn_bump("api.2")
+        with mock.patch.object(Path, "unlink", side_effect=gone):
+            inflight.turn_end("api.2")
+        self.assertEqual(["api.2"], [c for c, _ in inflight.working_chats()],
+                         "the unlink was refused, so the mark is still up")
+        real_stat = Path.stat
+
+        def vanished(self, *a, **kw):
+            if self.name == "api.2":
+                raise gone
+            return real_stat(self, *a, **kw)
+
+        with mock.patch.object(Path, "stat", vanished):
+            self.assertEqual([], inflight.working_chats())
+
+    def test_the_two_names_a_mangling_cannot_make_safe_are_refused(self):
+        """``.`` and ``..`` are made entirely of admitted characters, so they survive
+        `_safe_name` intact — and `turn_end` on one would unlink a DIRECTORY rather than a
+        record. Refused by name, which is the only thing left that can refuse them."""
+        for chat in (".", ".."):
+            with self.subTest(chat=chat):
+                self.assertIsNone(inflight._turn_file(chat))
+                inflight.turn_begin(chat)
+                self.assertEqual([], inflight.working_chats())
+
+    def test_the_two_trackers_do_not_read_each_others_records(self):
+        """The reason this is a second directory and not a fifth `kind`: the same records
+        feed the dispatch-overlap nudge, which reads agent names back to an operator as a
+        sentence, and a chat id reaching it would produce #420's own wrong-and-confident
+        failure through the other axis."""
+        inflight.turn_begin("api.2")
+        self.assertEqual([], inflight.live(kind=None))
+        token = inflight.start("steward")
+        self.addCleanup(inflight.finish, "steward", token=token)
+        self.assertEqual(["api.2"], [c for c, _ in inflight.working_chats()])
+
+
+class TheThreeEdgesAreThreeHooks(PlaneIso, unittest.TestCase):
+    """The rising edge, the refresh and the falling edge, through the real handlers.
+
+    `PlaneIso`, because since #852 every handler opens on the plane gate and a case on a
+    root with no marker asserts nothing at all.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.assertIn("edm-test-", str(config.STATE_DIR))
+        self.payload = {"cwd": str(config.ROOT), "session_id": "s853"}
+
+    def _hook(self, fn, **extra):
+        with mock.patch.dict(os.environ, {**CHAT_ENV, **extra}):
+            return _run(fn, dict(self.payload, **{}))
+
+    def test_a_prompt_raises_the_mark(self):
+        self._hook(hooks.userpromptsubmit)
+        self.assertEqual(["api.2"], [c for c, _ in inflight.working_chats()])
+
+    def test_the_stop_hook_lowers_it(self):
+        """The line that did not exist. `hooks._HANDLERS` had eleven entries and none of
+        them was `stop`, so `hooks/hooks.json`'s `Stop` ran an autosave and charter's own
+        dispatch table never heard the turn end."""
+        self._hook(hooks.userpromptsubmit)
+        self.assertTrue(inflight.working_chats(), "precondition: something must be up")
+        self._hook(hooks.stop)
+        self.assertEqual([], inflight.working_chats())
+
+    def test_a_tool_call_mid_turn_refreshes_it(self):
+        self._hook(hooks.userpromptsubmit)
+        old = time.time() - inflight.TURN_STALE_SECONDS - 1
+        os.utime(_mark("api.2"), (old, old))
+        self.assertEqual([], inflight.working_chats(),
+                         "precondition: the mark must have been about to expire")
+        # It was swept by the read above, so put it back the way a turn does.
+        self._hook(hooks.userpromptsubmit)
+        os.utime(_mark("api.2"), (old, old))
+        self._hook(hooks.posttooluse, **{})
+        self.assertEqual(["api.2"], [c for c, _ in inflight.working_chats()])
+
+    def test_a_tool_call_outside_a_turn_raises_nothing(self):
+        """The bump/begin split, end to end. Without it a `posttooluse` from a sub-agent
+        would put a tab back up after its parent's `Stop` had taken it down."""
+        self._hook(hooks.posttooluse)
+        self.assertEqual([], inflight.working_chats())
+
+    def test_a_harness_charter_will_never_hear_the_end_from_gets_no_mark(self):
+        """*"A recency mark would claim now while measuring recently."*
+
+        opencode sets ``$CHARTER_SESSION_ID`` on its tool hooks and has no session-stop
+        event; Codex is tool-hooks only. A mark charter can raise and cannot lower is not a
+        working light, and the operator cannot tell the two apart by looking. Both names
+        are hand-spelled — a test comparing against `harness.opencode.NAME` would agree
+        with that constant edited to `claude-code`.
+        """
+        for harness in ("opencode", "codex"):
+            with self.subTest(harness=harness):
+                self._hook(hooks.userpromptsubmit, CHARTER_HARNESS=harness)
+                self.assertEqual([], inflight.working_chats())
+
+    def test_a_session_that_does_not_say_which_harness_gets_no_mark_either(self):
+        """"charter does not know which harness this is" and "charter knows this harness
+        reports no stop" reach the same picture on purpose — `state.harness_session`'s
+        four-reasons-one-answer rule, one surface over."""
+        with mock.patch.dict(os.environ, {"CHARTER_SESSION_ID": "api.2"}):
+            os.environ.pop("CHARTER_HARNESS", None)
+            _run(hooks.userpromptsubmit, self.payload)
+        self.assertEqual([], inflight.working_chats())
+
+    def test_a_session_outside_a_frame_asks_the_tracker_nothing_at_all(self):
+        """Most sessions run with no frame at all, so this is the common path and it must
+        cost nothing — not merely write nothing. `notify.plane_changed` makes the same
+        check for the same reason one function over: *"both checks happen before `gather`
+        is even imported, so the common 'no frame' path never touches the gather module at
+        all"*.
+
+        **A recording mock and not a raising one**, which is the difference between a pin
+        and a test that only looks like one: `hooks._turn_begin` and its two siblings
+        swallow every exception on purpose — a readout must never break a turn — so a
+        `side_effect=AssertionError` here would be caught by the very code under test and
+        the case would pass with the guard deleted.
+        """
+        for fn in (hooks.userpromptsubmit, hooks.posttooluse, hooks.stop):
+            calls = {name: mock.DEFAULT for name in ("turn_begin", "turn_bump", "turn_end")}
+            with self.subTest(hook=fn.__name__), \
+                 mock.patch.dict(os.environ, {"CHARTER_HARNESS": "claude-code"}), \
+                 mock.patch.multiple("charter.inflight", **calls) as patched:
+                os.environ.pop("CHARTER_SESSION_ID", None)
+                _run(fn, self.payload)
+                for m in patched.values():
+                    m.assert_not_called()
+        self.assertFalse((Path(config.STATE_DIR) / "chat-turns").exists())
+
+    def test_a_tracker_that_raises_does_not_break_the_turn(self):
+        """The rule every hook in this module keeps and these three are no exception: a
+        readout is not worth a turn. All three edges, because each reaches the tracker
+        through its own import and its own syscall, and a catch is only a promise on the
+        function that carries it."""
+        boom = ValueError("tracker is having a day")
+        for fn, target in ((hooks.userpromptsubmit, "turn_begin"),
+                           (hooks.posttooluse, "turn_bump"),
+                           (hooks.stop, "turn_end")):
+            with self.subTest(hook=fn.__name__):
+                with mock.patch(f"charter.inflight.{target}", side_effect=boom):
+                    rc, out = self._hook(fn)
+                self.assertEqual((0, ""), (rc, out))
+
+    def test_the_stop_handler_says_nothing_and_refuses_nothing(self):
+        """`Stop` can block, by exit 2 or by ``{"decision": "block"}``. This handler exists
+        to STOP claiming something; a claim it could not retract is not worth a turn."""
+        rc, out = self._hook(hooks.stop)
+        self.assertEqual((0, ""), (rc, out))
+
+    def test_a_subagent_finishing_does_not_take_the_tab_down(self):
+        """`Stop` and `SubagentStop` share the autosave in `hooks/hooks.json` and must not
+        share this: a dispatched sub-agent finishing does not end the turn that dispatched
+        it, and on a fan-out the tab would blink off once per worker.
+
+        Read off the manifest, because that is the artifact that decides it — the CLI
+        cannot tell which event invoked it.
+        """
+        doc = json.loads((Path(__file__).resolve().parents[1]
+                          / "hooks" / "hooks.json").read_text())["hooks"]
+        cmds = [h["command"] for entry in doc["SubagentStop"] for h in entry["hooks"]]
+        self.assertTrue(cmds, "precondition: SubagentStop must still be wired to something")
+        self.assertEqual([], [c for c in cmds if "charter hook stop" in c])
+
+
+class TheSeamAnswersForTheStrangersRepo(PersonaIso, unittest.TestCase):
+    """Outside a plane the tracker writes nothing, touches nothing and deletes nothing.
+
+    `PersonaIso` and NOT `PlaneIso`: this case is about the gate, so its root must not be a
+    plane. Outside one ``config.STATE_DIR`` is ``<cwd>/.charter``, so every file below is
+    one a repository you cloned can simply contain and commit —
+    `test_a_repo_that_is_not_a_plane_gets_no_housekeeping`'s finding, and the reason the
+    three seams carry the gate rather than their call sites: `hooks.pretooluse_read` is
+    deliberately ungated and calls `_turn_bump`.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.assertFalse(config.HAS_CONTROL_PLANE,
+                         "precondition: this case is vacuous inside a plane")
+
+    def test_a_prompt_creates_no_mark_in_a_repo_charter_does_not_own(self):
+        with mock.patch.dict(os.environ, CHAT_ENV):
+            hooks._turn_begin()
+        self.assertFalse((Path(config.STATE_DIR) / "chat-turns").exists())
+
+    def test_a_committed_mark_is_not_consumed(self):
+        """`_turn_end` **unlinks**, so out here it would be charter deleting a file the
+        checkout supplied — `posttooluse_bash`'s ask-marker finding, one directory over.
+        Driven through `hooks.stop`, which carries no gate of its own precisely so that
+        this one is the only thing standing between the handler and the unlink."""
+        p = _mark("api.2")
+        config.private_mkdir(p.parent)
+        p.write_text("api.2")
+        self.assertTrue(p.is_file(), "precondition: the mark must exist to be taken")
+        with mock.patch.dict(os.environ, CHAT_ENV):
+            rc, out = _run(hooks.stop, {"cwd": str(config.ROOT)})
+        self.assertEqual((0, ""), (rc, out))
+        self.assertTrue(p.is_file(), "charter deleted a file from a repo it does not own")
+
+    def test_a_committed_marks_timestamp_is_left_alone(self):
+        """`_turn_bump` writes no bytes, so `assertUntouched`-style content snapshots
+        cannot see it — and an mtime charter moved in somebody else's checkout is still a
+        write, one that a `make` there would act on. Driven through `pretooluse_read`,
+        the one handler with no plane gate at all."""
+        p = _mark("api.2")
+        config.private_mkdir(p.parent)
+        p.write_text("api.2")
+        old = time.time() - 5_000
+        os.utime(p, (old, old))
+        before = p.stat().st_mtime
+        with mock.patch.dict(os.environ, CHAT_ENV):
+            _run(hooks.pretooluse_read, {"cwd": str(config.ROOT), "tool_name": "Read",
+                                         "tool_input": {"file_path": "README.md"}})
+        self.assertEqual(before, p.stat().st_mtime,
+                         "charter touched a file in a repo it does not own")
+
+
+class TheStripDrawsItWithoutMovingACell(PersonaIso, unittest.TestCase):
+    """The strip. What is drawn, and — harder — what is NOT moved by drawing it."""
+
+    NAMES = ["api.1", "api.2", "api.3"]
+
+    def setUp(self):
+        super().setUp()
+        slots.TABS.forget()
+        self.addCleanup(slots.TABS.forget)
+
+    def _row(self, busy=(), width=200, here="api.2", now=0.0):
+        with mock.patch("charter.frame.slots.time.monotonic", return_value=now):
+            rows = slots._bar("chats", list(self.NAMES), here, width, busy=busy)
+        return tui.strip_ansi(rows[0]) if rows else ""
+
+    def test_an_idle_strip_is_the_strip_that_shipped(self):
+        self.assertEqual("chats   api.1  *api.2   api.3", self._row().strip())
+
+    def test_a_working_chat_wears_the_spinner_where_an_idle_one_wears_a_blank(self):
+        """Hand-spelled, and the whole row, because what is being asserted is a POSITION:
+        the glyph is in the cell `slots._BAR_MARK[1]` would have left blank, and every
+        other character of the row is where it was."""
+        self.assertEqual("chats  ✢api.1  *api.2   api.3",
+                         self._row(busy={"api.1"}, now=0.0).strip())
+        self.assertEqual("chats   api.1  *api.2  ✶api.3",
+                         self._row(busy={"api.3"}, now=slots.SPINNER_PERIOD).strip())
+
+    def test_the_chat_you_are_typing_in_keeps_its_star(self):
+        """One cell, two facts, and `*` wins. `chrome.block` paints the active tab in
+        reverse video, but `[frame] chrome = "off"` is the shipped default and
+        `panel._write` strips SGR under `NO_COLOR` — so on a plain plane the `*` is the
+        only thing saying where you are. The chat you are IN is also the one whose harness
+        you can watch directly."""
+        self.assertEqual("chats   api.1  *api.2   api.3",
+                         self._row(busy={"api.2"}).strip())
+
+    def test_every_tab_on_a_row_shows_the_same_frame(self):
+        row = self._row(busy={"api.1", "api.3"}, now=slots.SPINNER_PERIOD * 2)
+        self.assertEqual("chats  ✻api.1  *api.2  ✻api.3", row.strip())
+
+    def test_a_chat_starting_a_turn_moves_no_column_of_the_click_map(self):
+        """**The property the whole design turns on.** The map resolves a click BY COLUMN,
+        so a spinner drawn beside a name instead of in the mark's cell would re-cut the
+        strip the moment a sibling started thinking — and the cell the operator was about
+        to press would hold another chat's name. Asserted at every width, because the
+        rungs that window the list are exactly where a stray cell would show up."""
+        for width in range(0, 120):
+            with self.subTest(width=width):
+                slots.TABS.forget()
+                idle = slots._bar("chats", list(self.NAMES), "api.2", width)
+                idle_map = dict(slots.TABS._cols)
+                slots.TABS.forget()
+                with mock.patch("charter.frame.slots.time.monotonic", return_value=0.0):
+                    busy = slots._bar("chats", list(self.NAMES), "api.2", width,
+                                      busy={"api.1", "api.3"})
+                self.assertEqual(idle_map, dict(slots.TABS._cols))
+                self.assertEqual([tui.width(r) for r in idle],
+                                 [tui.width(r) for r in busy])
+
+    def test_a_click_on_a_spinning_tab_switches_to_that_chat(self):
+        """The other half: the mark cell belongs to the tab it marks, and that stays true
+        when the mark is a spinner. `_tab_columns` gives a tab the cells of the whole
+        field, and there is nothing else a click on that cell could be about."""
+        row = self._row(busy={"api.1"})
+        col = row.index("✢")
+        self.assertEqual("api.1", slots.TABS.switch_to(0, col))
+
+    def test_the_row_count_the_launcher_asks_for_does_not_depend_on_the_clock(self):
+        """`bar_rows_wanted` runs in the LAUNCHER and in the `frame-resize` child, where
+        nothing knows or should know which chat is thinking. It composes through the same
+        ladder, with `busy` left empty — so the pane is sized for the strip that will be
+        drawn into it whatever any harness is doing."""
+        for n in range(1, 9):
+            _plant(f"ws.{n}", workspace="ws")
+        inflight.turn_begin("ws.3")
+        with mock.patch("charter.frame.slots.working_chats",
+                        side_effect=AssertionError("the sizer asked about the clock")):
+            for cols in (60, 100, 160):
+                with self.subTest(cols=cols):
+                    slots.bar_rows_wanted("ws.1", "chats", pane_cols=cols, cap=3)
+
+    def test_the_workspaces_bar_never_spins(self):
+        """It is not a strip of chats. A workspace has no harness to be working, so
+        `workspaces_bar` asks nothing and passes no `busy` at all."""
+        _plant("ws.1", workspace="ws")
+        inflight.turn_begin("ws.1")
+        with mock.patch("charter.frame.slots.working_chats",
+                        side_effect=AssertionError("the workspaces bar asked")):
+            slots.workspaces_bar("ws.1", 120)
+
+    def test_an_unreadable_tracker_draws_the_strip_that_shipped(self):
+        """A panel that threw out of `render` loses its pane, so the readout degrades to
+        stillness rather than to a hole in the frame."""
+        with mock.patch("charter.inflight.working_chats", side_effect=OSError("gone")):
+            self.assertEqual(frozenset(), slots.working_chats())
+
+
+class TheGlyphsAreCheckedBeforeTheyGoOnARow(unittest.TestCase):
+    """`slots.TAB_SPINNER`, held to the row's own rules rather than to a list of characters.
+
+    The request was Claude Code's spinner, `· ✢ ✶ ✳ ✽ ✻`. `tui.width` answers **1** for all
+    six of them and that is not the whole question: it reads the East-Asian tables, and an
+    *Ambiguous* character is one a terminal may draw two cells wide while those tables say
+    one. That is what `slots._BAR_RULE` is ASCII to avoid and what
+    `statusline._persona_chips` records breaking this project's layout twice — and on a
+    strip whose click map is per COLUMN, one glyph a cell wider than it was measured shifts
+    every tab right of it.
+
+    So two of the six are refused outright (`·` U+00B7 and `✽` U+273D are Ambiguous) and a
+    third is refused for a reason the tables cannot state (`✳` U+2733 carries an emoji
+    presentation variant, `✳️`, so a terminal with an emoji fallback font may draw it wide).
+    The properties are asserted, never the characters, so a future redesign can pick
+    different glyphs and still be safe.
+    """
+
+    def test_every_frame_is_exactly_one_cell(self):
+        for ch in slots.TAB_SPINNER:
+            with self.subTest(glyph=ch):
+                self.assertEqual(1, tui.width(ch))
+
+    def test_no_frame_is_east_asian_ambiguous(self):
+        for ch in slots.TAB_SPINNER:
+            with self.subTest(glyph=ch):
+                eaw = unicodedata.east_asian_width(ch)
+                self.assertIn(eaw, ("N", "Na"),
+                              f"{ch!r} (U+{ord(ch):04X}) is East-Asian {eaw} — a terminal "
+                              f"may draw it two cells and shift every tab right of it, "
+                              f"and a click then lands on the neighbouring chat")
+
+    def test_no_frame_is_a_character_a_chat_id_may_contain(self):
+        """The mark sits flush against the name, so a glyph out of `chats.ID_RE`'s alphabet
+        would draw `Oapi.3` and put a character the operator reads as part of a name where
+        the name begins. It is why the ASCII pulse this reached for first — `.oOo` — is not
+        what shipped: every one of its frames is a legal chat-id character."""
+        for ch in slots.TAB_SPINNER:
+            with self.subTest(glyph=ch):
+                self.assertIsNone(chats.ID_RE.fullmatch(ch))
+
+    def test_the_two_ambiguous_glyphs_that_were_asked_for_are_not_on_the_row(self):
+        """The refusal, hand-spelled by codepoint. A test asserting only the property above
+        would go green against a `TAB_SPINNER` that had quietly regained `·` on a Python
+        whose Unicode tables reclassified it."""
+        for cp in (0x00B7, 0x273D, 0x2733):
+            with self.subTest(codepoint=f"U+{cp:04X}"):
+                self.assertNotIn(chr(cp), slots.TAB_SPINNER)
+
+    def test_the_frame_is_read_off_the_clock_a_caller_names(self):
+        """The *now* seam `spinner_frame` documents — *"for tests, which need a specific
+        frame rather than whichever one the clock happened to be on"* — asked directly
+        rather than through a patched `time.monotonic`, so the parameter is a thing the
+        suite exercises and not a branch nothing reaches.
+
+        The instants are named as multiples of `SPINNER_PERIOD` plus a nudge, because
+        `int(t / p)` on an exact multiple is a float-division boundary — `0.6 / 0.2` is
+        2.9999999999999996 — and a frame table is not the place to assert a rounding rule.
+        """
+        eighth = slots.SPINNER_PERIOD / 8
+        for i, want in enumerate(slots.TAB_SPINNER):
+            with self.subTest(frame=i):
+                at = slots.SPINNER_PERIOD * i + eighth
+                self.assertEqual(want, slots.tab_spinner_frame(at))
+                self.assertEqual(want, slots.tab_spinner_frame(
+                    at + slots.SPINNER_PERIOD * len(slots.TAB_SPINNER)),
+                    "the sequence must repeat rather than run out")
+
+    def test_the_mark_and_the_spinner_are_the_same_width(self):
+        """The load-bearing equality: the spinner takes the mark's cell, so the two must
+        measure alike or the strip is one cell wider exactly while a chat is working."""
+        for ch in slots.TAB_SPINNER:
+            with self.subTest(glyph=ch):
+                self.assertEqual(tui.width(slots._BAR_MARK[1]), tui.width(ch))
+
+
+class OnlyTheChatStripSpins(PersonaIso, unittest.TestCase):
+    """`slots.BAR_ANIMATED` must name exactly the renderers a working chat moves.
+
+    `slots.ANIMATED`'s cost property, one gate over, and it is a cost property rather than a
+    tidiness one for the same reason: `panel._watch` runs one process per slot, so an
+    unscoped "is a chat working" would repaint every panel at `panel.TICK` for the whole
+    length of every turn — `right` costs 4 816µs a render to redraw byte-identical output.
+
+    A second SET rather than a `chats` added to `ANIMATED`, because the two name different
+    GATES: that one ticks on plane-wide in-flight dispatches and this frame's notice dwell,
+    neither of which has anything to do with whether a sibling chat's harness is thinking.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.fid = "w.1"
+        _plant(self.fid, workspace="w")
+        _plant("w.9", workspace="w")
+        inflight.turn_begin("w.9")
+        gather.save(self.fid, {"gathered_at": 0.0, "workspace": "w",
+                               "current_repo": None, "repos": [], "worktrees": []})
+
+    def _render_at(self, slot, now):
+        """Draw *slot* the way the panel process holding it would.
+
+        Two paths, because there are two: `slots.render` is charter's four panes, and the
+        two strips are components whose renderers are reached by name (`builtins._chats`
+        calls `slots.chats_bar` and `_workspaces` calls `slots.workspaces_bar`). Asking
+        `slots.render` for `chats` answers `unknown slot`, which is a string that does not
+        change with the clock — and would make this whole property vacuous for exactly the
+        slot it is about.
+        """
+        bars = {"chats": slots.chats_bar, "workspaces": slots.workspaces_bar}
+        with mock.patch("charter.frame.slots.time.monotonic", return_value=now), \
+             mock.patch.object(sys.stdout, "fileno", return_value=1, create=True), \
+             mock.patch("os.get_terminal_size",
+                        return_value=os.terminal_size((120, 40))):
+            if slot in bars:
+                return "\n".join(bars[slot](self.fid, 120))
+            return slots.render(slot, self.fid)
+
+    def test_exactly_the_slots_in_BAR_ANIMATED_move_while_a_chat_works(self):
+        moving = set()
+        for slot in sorted(set(slots.SLOTS) | set(slots.BARS)):
+            with self.subTest(slot=slot):
+                first = self._render_at(slot, 0.0)
+                later = self._render_at(slot, slots.SPINNER_PERIOD)
+                if first != later:
+                    moving.add(slot)
+        self.assertEqual(moving, set(slots.BAR_ANIMATED),
+                         f"`slots.BAR_ANIMATED` says {sorted(slots.BAR_ANIMATED)} but the "
+                         f"renderers a working chat actually moves are {sorted(moving)}")
+
+    def test_a_slot_that_draws_no_tab_strip_never_asks_whether_a_chat_is_working(self):
+        """The short-circuit, which is what makes a `top`/`bottom`/`right`/`workspaces`
+        panel cost exactly what it cost before this feature existed — not merely repaint
+        less."""
+        for slot in sorted((set(slots.SLOTS) | set(slots.BARS)) - set(slots.BAR_ANIMATED)):
+            with self.subTest(slot=slot):
+                with mock.patch("charter.frame.panel._working",
+                                side_effect=AssertionError("asked, and must not")), \
+                     mock.patch("charter.frame.panel._paint"):
+                    panel._watch(slot, self.fid, once=True)
+
+    def test_the_chat_strip_does_ask(self):
+        """The other direction, so the test above cannot be satisfied by never asking."""
+        with mock.patch("charter.frame.panel._working", return_value=1) as asked, \
+             mock.patch("charter.frame.panel._paint"):
+            panel._watch("chats", self.fid, once=True)
+        asked.assert_called_once()
+
+    def test_every_name_in_BAR_ANIMATED_is_a_strip_that_exists(self):
+        """The set is hand-maintained and holds NAMES, and the name is a string two other
+        things spell independently: `slots.BARS`, and the launcher's own
+        `charter panel chats --session <fid>`. A strip renamed in one and not here leaves a
+        gate that can never fire — silently, because a gate that never fires looks exactly
+        like a chat that is never working."""
+        self.assertLessEqual(set(slots.BAR_ANIMATED), set(slots.BARS))
+        self.assertTrue(slots.BAR_ANIMATED)
+
+    def test_the_chat_strip_does_not_ride_the_dispatch_trackers_gate(self):
+        """The two gates are separate all the way down. A dispatch running says nothing
+        about whether any chat's harness is thinking, and a strip ticking for half an hour
+        with every tab idle is the unscoped repaint `ANIMATED` exists to prevent."""
+        with mock.patch("charter.frame.panel._running",
+                        side_effect=AssertionError("the chat strip asked about dispatches")), \
+             mock.patch("charter.frame.panel._paint"):
+            panel._watch("chats", self.fid, once=True)
+
+
+class IdleCostsOneStat(PersonaIso, unittest.TestCase):
+    """`panel._working` — how a chat strip learns a sibling is working without paying for
+    it. `panel._running`'s property one tracker over, and the reason this can be on by
+    default: the expensive answer is behind a single `stat` of the tracker's directory."""
+
+    def setUp(self):
+        super().setUp()
+        self.cache = panel._new_working_cache()
+
+    def test_an_idle_plane_reads_nothing_at_all(self):
+        with mock.patch("charter.inflight.working_chats",
+                        side_effect=AssertionError("read on an idle plane")):
+            self.assertEqual(0, panel._working(self.cache))
+
+    def test_the_records_are_read_once_and_then_cached(self):
+        inflight.turn_begin("api.2")
+        self.assertEqual(1, panel._working(self.cache))
+        with mock.patch("charter.inflight.working_chats",
+                        side_effect=AssertionError("re-read with nothing changed")):
+            self.assertEqual(1, panel._working(self.cache))
+
+    def test_a_mark_going_up_or_down_is_read_again(self):
+        inflight.turn_begin("api.2")
+        self.assertEqual(1, panel._working(self.cache))
+        inflight.turn_end("api.2")
+        self.assertEqual(0, panel._working(self.cache))
+
+    def test_the_expiry_is_re_read_although_no_file_moved(self):
+        """The half a directory mtime cannot carry: a mark crosses
+        `inflight.TURN_STALE_SECONDS` with nothing on disk changing, so the panel holds the
+        earliest such deadline beside its cached answer — `panel._running`'s presumed-dead
+        recheck, one tracker over.
+
+        The CLOCK is moved rather than the file, deliberately: an mtime pushed backwards
+        is not a state production can reach (a bump only ever moves one forward), and a
+        test that reached it would be asserting against a fixture rather than against the
+        thing that actually happens, which is time passing while nothing is written.
+        """
+        inflight.turn_begin("api.2")
+        self.assertEqual(1, panel._working(self.cache))
+        later = time.time() + inflight.TURN_STALE_SECONDS + 1
+        with mock.patch("time.time", return_value=later):
+            self.assertEqual(0, panel._working(self.cache))
+
+    def test_a_tracker_that_cannot_be_read_is_stillness(self):
+        with mock.patch("charter.inflight.turn_stamp", side_effect=OSError("gone")):
+            self.assertEqual(0, panel._working(self.cache))
+
+    def test_a_failed_read_clears_the_cached_answer_rather_than_leaving_it(self):
+        """The other half of the failure path, and the half a `return 0` alone does not
+        give: the STAMP is deliberately left describing the last directory state charter
+        understood, so the next call short-circuits on it — and would hand back the count
+        from before the failure if the failure had not written 0 over it. Stillness is the
+        safe direction here (`_running` carries the argument), and it has to survive the
+        cache as well as the one call."""
+        inflight.turn_begin("api.2")
+        self.assertEqual(1, panel._working(self.cache))
+        with mock.patch("charter.inflight.turn_stamp", side_effect=OSError("gone")):
+            self.assertEqual(0, panel._working(self.cache))
+        self.assertEqual(0, panel._working(self.cache),
+                         "the cache handed back the count from before the failure")
+
+
+class TheLimitIsAToollessThink(PersonaIso, unittest.TestCase):
+    """The cost of this signal, written down as a test rather than as a paragraph.
+
+    A long **toolless** think refreshes nothing — no `pretooluse`, no `posttooluse` — so a
+    TTL short enough to catch a turn that was abandoned with Esc also blinks off during
+    deep thinking. The two cannot both be had from a hook channel that reports tool calls
+    and prompts. `inflight.TURN_STALE_SECONDS` is where the trade is set, and the direction
+    it errs in is *not claiming*.
+    """
+
+    def test_a_turn_that_thinks_for_longer_than_the_ttl_blinks_off(self):
+        inflight.turn_begin("api.2")
+        old = time.time() - inflight.TURN_STALE_SECONDS - 1
+        os.utime(_mark("api.2"), (old, old))
+        self.assertEqual([], inflight.working_chats(),
+                         "the honest limit changed — say so in the news entry")
+
+    def test_the_ttl_is_generous_against_the_cadence_it_measures(self):
+        """A bound on a stretch with NO tool call, not on a turn. Hand-spelled: a test
+        comparing `TURN_STALE_SECONDS` against an expression built from itself agrees with
+        any value it comes to take, which is exactly how a number quietly reaches zero."""
+        self.assertEqual(600, inflight.TURN_STALE_SECONDS)
+        self.assertLess(inflight.TURN_STALE_SECONDS, inflight.PRESUMED_DEAD_SECONDS,
+                        "a chat charter cannot see the end of must stop claiming sooner "
+                        "than a dispatch it is deliberately still drawing")
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()

--- a/tests/test_a_repo_that_is_not_a_plane_gets_no_housekeeping.py
+++ b/tests/test_a_repo_that_is_not_a_plane_gets_no_housekeeping.py
@@ -134,6 +134,10 @@ def _payloads(cwd: str, sid: str) -> dict[str, dict]:
                                  "tool_response": "agentId: a1b2c3d4e5f6"},
         "posttooluse-message": {"cwd": cwd, "session_id": sid, "tool_name": "SendMessage",
                                 "tool_input": {"to": "reviewer"}},
+        # `Stop` carries no tool at all — it is the end of the turn, not the end of a
+        # call — so the payload names none. `stop_hook_active` is what the host sends and
+        # what a handler that decided to block would have to read; charter's never blocks.
+        "stop": {"cwd": cwd, "session_id": sid, "stop_hook_active": False},
     }
 
 

--- a/tests/test_opencode_dispatches_every_hook.py
+++ b/tests/test_opencode_dispatches_every_hook.py
@@ -70,6 +70,16 @@ _UNREACHABLE = {
     # invalid, question, bash, read, glob, grep, edit, write, task, webfetch, todowrite,
     # skill — no `SendMessage`, so there is nothing to dispatch on.
     "posttooluse-message": "opencode 1.18.21 has no SendMessage tool",
+    # #853's falling edge. The generated plugin hooks exactly three events —
+    # `shell.env`, `tool.execute.before` and `tool.execute.after` (`opencode.SHIM`) —
+    # and there is no session-stop event among them, nor anywhere in opencode's plugin
+    # surface at 1.18.21, to hook. This one is not a gap left open either: `stop` is the
+    # falling edge of a mark whose RISING edge is `userpromptsubmit`, two rows up, which
+    # opencode cannot dispatch for its own reason. So neither edge fires there and no
+    # chat on that harness is ever marked as working — which is the honest answer rather
+    # than a degraded one, and is why `hooks._turn_begin` gates on the harness by name.
+    "stop": "no session-stop event: the shim hooks shell.env and tool.execute.*, and "
+            "the rising edge (`userpromptsubmit`) is unreachable there too",
 }
 
 

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -119,6 +119,12 @@ class TestPluginManifest(unittest.TestCase):
             # Resumes: more work handed to a persona already running. Its own matcher
             # because `Task|Agent` fires when a sub-agent is CREATED and never again.
             ("PostToolUse", "charter hook posttooluse-message --plugin-version"),
+            # The turn's FALLING edge (#853). `Stop` and NOT `SubagentStop`: a sub-agent
+            # finishing does not end the turn that dispatched it, so clearing the chat's
+            # working mark there would blink the tab off mid-fan-out. It rides the same
+            # entry as the autosave and goes FIRST — the autosave carries a 15s timeout
+            # and this is a readout the operator is looking at.
+            ("Stop", "charter hook stop --plugin-version"),
             ("Stop", "charter workspace _autosave"),             # debounced auto-save
             ("SubagentStop", "charter workspace _autosave"),     # ditto, per dispatch
         ]
@@ -159,7 +165,7 @@ class TestPluginManifest(unittest.TestCase):
         version string in a test, which is how a stale one gets waved through.
         """
         engine = {"sessionstart": 5, "userpromptsubmit": 5, "pretooluse": 10,
-                  "posttooluse": 5, "posttooluse-dispatch": 5}
+                  "posttooluse": 5, "posttooluse-dispatch": 5, "stop": 5}
         expected = {f"charter hook {name} --plugin-version {__version__}": t
                     for name, t in engine.items()}
         expected["charter workspace _reconcile >/dev/null 2>&1"] = 5


### PR DESCRIPTION
Closes #853.

The chat bar said which chats exist and which one you are in, never which of them was *doing* anything — so the only way to learn whether the chat in the next tab had finished was to switch to it and look.

```
before
  chats   api.1  *api.2   api.3   docs.1  +

after — api.1 and docs.1 are working, api.3 is not
  chats  ✻api.1  *api.2   api.3  ✻docs.1  +
```

## Where the falling edge lives

`hooks.stop`, new in `charter/hooks.py` and registered in `hooks._HANDLERS`, dispatched from a new `charter hook stop --plugin-version 0.55.0` entry on `hooks/hooks.json`'s **`Stop`** — first in that entry, ahead of the 15s `charter workspace _autosave` that was previously the whole of it.

Everything else was already on disk, exactly as #853 measured. charter does not own the harness's screen (ADR 0018); it owns its hooks, and a hook process runs inside the chat's own pane whose window the launcher created with `-e CHARTER_SESSION_ID=<chat id>`. `hooks.userpromptsubmit` has fired at the start of every turn since it was written. `_HANDLERS` had eleven entries and none of them was `stop`, so nothing charter raised could be lowered.

**`Stop` and deliberately not `SubagentStop`.** They share the autosave beside this because a memo is worth writing when either fires; they must not share this, because a dispatched sub-agent finishing does not end the turn that dispatched it — on a fan-out the tab would blink off once per worker. The test reads that off the manifest, which is the artifact that decides it.

## The TTL, and why ten minutes

`inflight.TURN_STALE_SECONDS = 10 * 60`.

It is **not** "how long may a turn take". Every `pretooluse*` and `posttooluse*` handler refreshes the mark, so a turn issuing tool calls refreshes its own TTL indefinitely and is never cut off. What ten minutes bounds is a stretch **with no tool call whatsoever**.

Its own constant rather than `inflight.PRESUMED_DEAD_SECONDS`, for the reason that number's own header gives about #308: two jobs with opposite horizons sharing one number is what made the single old TTL wrong. That one is a *display* threshold — the record survives it and is drawn differently (`45m?`), because a dispatch that has outlived every expectation is the most interesting thing that tracker holds. This one is the opposite: past it charter does not know, and the honest picture for *does not know* is the picture for *is not*.

### The honest limit, stated

**A long toolless think bumps nothing.** So a TTL short enough to catch a turn abandoned with Esc (which fires no `Stop`) also blinks off during deep thinking, and that tab comes back on the turn's next tool call. The two cannot both be had from a hook channel that reports prompts and tool calls.

Both errors cost the operator the same single switch to look. They differ in how they end: a blink-off is repaired by the next tool call, a stale spinner stands until the number runs out. So it is set generously against the cadence it actually measures — ten minutes with no tool call at all is far outside what a working turn does — and no further, because the direction charter errs in is *not claiming*. `TheLimitIsAToollessThink` is a test rather than a paragraph, so moving the number means coming back and restating the trade.

## What a non-Claude chat shows: nothing

opencode sets `$CHARTER_SESSION_ID` on its tool hooks and has no session-stop event — `opencode.SHIM` hooks exactly `shell.env`, `tool.execute.before` and `tool.execute.after`. Codex is tool-hooks only.

A mark charter can raise and cannot lower is not a working light — it is a recency mark, claiming *now* while measuring *recently*, and the operator cannot tell the two apart. So the **rising edge** is gated on `$CHARTER_HARNESS`, and an absent value is refused with the rest: *"charter does not know which harness this is"* and *"charter knows this one reports no stop"* reach the same picture, which is `state.harness_session`'s four-reasons-one-answer rule one surface over.

`tests/test_opencode_dispatches_every_hook` already declares `userpromptsubmit` unreachable on opencode (the `prompt-hook` deficit, #433). `stop` joins it in `_UNREACHABLE` with the reason checked and written down — so on that harness **neither** edge fires, which is why the gate is honest rather than merely defensive. `harness/opencode.py` itself is untouched (#862 is live there).

## The glyphs' measured widths

The ask was Claude Code's own spinner, `· ✢ ✶ ✳ ✽ ✻`. `tui.width` answers **1** for all six — and on this row `tui.width` is not the whole question. It reads the East-Asian tables, and an *Ambiguous* character is one a terminal may draw two cells wide while those tables say one. That is what `slots._BAR_RULE` is ASCII to avoid, and `statusline._persona_chips` records two Ambiguous glyphs breaking this project's layout already.

| glyph | codepoint | `tui.width` | East-Asian width | verdict |
|---|---|---|---|---|
| `·` | U+00B7 | 1 | **A (Ambiguous)** | **refused** |
| `✢` | U+2722 | 1 | N | kept |
| `✳` | U+2733 | 1 | N | **refused** — carries an emoji presentation variant (`✳️`, U+2733 U+FE0F), so a terminal with an emoji fallback font may draw it wide |
| `✶` | U+2736 | 1 | N | kept |
| `✽` | U+273D | 1 | **A (Ambiguous)** | **refused** |
| `✻` | U+273B | 1 | N | kept |

`slots.TAB_SPINNER = "✢✶✻✶"` — the three that survive, cycled out and back so the sparkle grows and shrinks the way the requested one does. Neutral is the property `statusline`'s own marker test asserts (`▪▸▫`, chosen after `◈`/`◆` shipped broken), and it is the strongest class available short of ASCII.

**ASCII was tried first and is worse here**, for a reason that is not about width: a chat id is `[A-Za-z0-9._-]`, so a pulse like `.oOo` draws `Oapi.3` and puts a character the operator reads as part of a name where the name begins. None of the three that shipped is a character a chat id may contain, and that is asserted as its own property beside the width one.

## The spinner takes the mark's cell, so the strip does not move

Every tab already carries a one-cell prefix — `*` for the chat you are in, a blank for the others. The spinner goes **in that cell**. So the cut, the row count and the click map all answer exactly what they answered when nothing was working, and `bar_rows_wanted` — which runs in the launcher, where nothing knows which chat is thinking — composes the same rows it will draw.

`slots.TABS` resolves a click **by column**, so a spinner drawn *beside* a name would re-cut the strip the moment a sibling started thinking, and the cell the operator was about to press would hold another chat's name — the double-press #767 exists to prevent, arriving through an animation. Asserted at every width from 0 to 120: map and row widths identical with two chats working and with none.

The active tab keeps its `*`. One cell, two facts, and `*` wins because it is the only one of the two with no other way to be seen (`[frame] chrome = "off"` is the shipped default and `NO_COLOR` strips the reverse-video block), and because the chat you are typing in is the one whose harness you can already watch.

## Its own gate, not `ANIMATED`'s

`slots.BAR_ANIMATED = {"chats"}` and `panel._working`, a `_running`-shaped cache over `inflight.turn_stamp`. `_watch` ORs the two gates and both `and`s short-circuit, so a panel pays for exactly the gate its own renderer draws from.

A refresh is free by construction: `turn_bump` is a `utime` on a file that already exists, which does not move the tracker directory's mtime — so a turn issuing a tool call a second re-reads nothing. Only a turn *starting* and a turn *ending* cost a panel a read.

The gate is plane-scoped rather than workspace-scoped, and that cost is written down where it lives: a chat working in another workspace ticks this panel while changing nothing it draws. Narrowing it would put `chats.roster` on the gate path — the 424 µs this design exists to keep behind a 4.6 µs `stat` — and on a one-workspace plane every working chat is on the strip anyway.

## Measured on this machine

| | measured | at 5 Hz |
|---|---|---|
| `inflight.turn_stamp()`, nothing working | 4.6 µs | 23 µs/s — **0.002% of a core** |
| `inflight.working_chats()`, 3 marks | 31.9 µs | — |
| `slots.chats_bar`, 3 chats, none working | 429.8 µs | 0.215% of a core |
| `slots.chats_bar`, 3 chats, two working | 454.1 µs | **0.227% of a core** |
| `inflight.turn_bump()`, one hook | 11.5 µs | per tool call |

Against `slots.ANIMATED`'s own recorded budget — *"one `render("right")` costs 4 816 µs … at 5Hz that one pane alone is ~2.4% of a core"* — an animated chat strip is a tenth of what this frame already animates. #780 prices a **tmux round trip** at ~7–13 ms and is why a renderer may not make one; `chats_bar` calls `chats.roster` and nothing else, and `frame/chats.py` says outright that *"nothing here touches tmux and nothing here starts anything"*.

## Where the state lives

A second tracker in `charter/inflight.py`, keyed by **chat** where the first is keyed by **agent**. Not merged: a dispatch record is `{"agent", "kind", "ts"}` — *"no fid, no chat, no workspace"* — and a chat id reaching the dispatch-overlap nudge that reads agent names back as a sentence is #420's wrong-and-confident failure arriving through the other axis.

One **empty** file per working chat under `.charter/chat-turns/`, made through `config.touch_for` like every other piece of charter's own state (#331/#505 — `tests/test_the_state_directory_is_charters_to_choose` caught the first cut writing at the umask). It carries its meaning in existing and in its mtime, which is that helper's own sentence and is exact here: the chat's id is the file's **name**, the TTL is its mtime, so there is nothing left for bytes to say and a reader never opens one.

That works because a name that could not be a chat id is **refused rather than repaired**. `$CHARTER_SESSION_ID` is an environment variable, so the value that becomes a filename is one anything in that shell can choose; `_safe_name` is asked as a *question* there instead of used as a mangling, so `../../.ssh/authorized_keys` gets no mark at all rather than a flattened one — the same answer `chats.check` gives a name off an argv. `.` and `..` spell themselves and are refused by name on top of that, because a chat "called" `..` would otherwise have the falling edge unlink a directory. The cost is stated rather than hidden: a chat id longer than 64 characters gets no mark, and shows what every chat showed before this existed.

## Verification

* Full suite on the pushed tree: **`Ran 10857 tests in 576.807s` … `OK (skipped=9)`** on 3.12, and the same trailer on 3.14. (Quoted rather than inferred — an earlier backgrounded run reported exit 0 over a `FAILED (failures=1)`, which is how `test_claims` caught an unbounded sentence in one of these docstrings.)
* `tests/test_a_chat_tab_shows_its_harness_working.py` — 56 cases in seven classes: the tracker, the three hook edges, the stranger's-repo gate, the strip, the glyph rules, the cost property and the honest limit.
* Four guards hand-mutated and confirmed red, `__pycache__` cleared between each: deleting `not chat` from `_turn_begin`, deleting the plane gate from `_turn_end`, putting `·` back into `TAB_SPINNER`, and drawing the spinner *after* the name instead of in the mark cell (96 failures — the width property).
* Test-side updates: `test_plugin` (the `Stop` pair and its 5s timeout), `test_a_repo_that_is_not_a_plane_gets_no_housekeeping` (the `stop` payload the `_HANDLERS`-driven property demands), `test_opencode_dispatches_every_hook` (`stop` in `_UNREACHABLE`, with the reason).
* **Deletion sweep: `deletion sweep / 3 survivors`** — 44 of 47 mutations pinned. The first pass said `9 survivors` with every shard green (the trap this repo records: the verdict is the check NAME). Nine were pinned and each confirmed red by hand, `__pycache__` cleared between every one: `cache["working"] = 0` on `_working`'s failure path, `tab_spinner_frame`'s `now` seam, `except Exception` on `_turn_bump`/`_turn_end`, `if p is None` in `turn_bump`/`turn_end`, and `except OSError` in `turn_begin`/`turn_end`/`working_chats`.
* **The three that remain are declared where they live, not papered over.** `_new_working_cache`'s `"recheck": 0.0` is unreachable — the deadline is only read while `working` is non-zero, the `and` short-circuits at 0, and the two are assigned together — and is kept so the cache has one shape, the three keys `_new_inflight_cache` ships. The two `>` / `>=` deadline comparisons (`_working`, `working_chats`) differ on a single float instant no run arrives at, where both spellings make the same claim about the mark, so only the direction is pinned; a test asserting one would be pinning a coin-flip.
* A run in between reported `deletion sweep / no verdict: 2 of 2 shards did not report` — the #617 sentence, and it was earned: a fixture in the new test file patched `Path.stat` with a bare `OSError`, which `pathlib.Path.exists` re-raises because `_ignore_error` reads `errno`. That made the sweep's own 3.12 baseline red. The fixture now fails one directory entry's `stat`, which is what the loop's `except OSError: continue` is actually for, and CI is green on 3.11, 3.12, 3.13 and 3.14.
* `git diff --diff-filter=D --name-only origin/main...HEAD` is empty — nothing deleted.
* News entry: `docs/news/unreleased-a-chat-tab-shows-when-its-harness-is-working.md`. `docs/frame.md` gains the paragraph.

Out of #862's way: `charter/workspace.py`, `commands_workspace.py`, `doctor.py`, `harness/*` and `commands_frame.py` are all untouched. The spinner needed nothing from `commands_frame.py` — the launcher's `-e CHARTER_SESSION_ID` was already there, and the strip's height is deliberately independent of who is working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Us4MbwkSCJCxwt1CjAd1sf
