### PR TITLE
A switch dresses the chat you are arriving at before it tidies the one you left (#844)

### DIFF
--- a/charter/commands_frame.py
+++ b/charter/commands_frame.py
@@ -5789,9 +5789,10 @@ def _relayout(socket: str, *, fid: str, harness_pane: str, panels: dict[str, str
 
 
 def _apply_sizes(socket: str, *, panes: dict[str, str], sizes: dict[str, int],
-                 flag: str) -> None:
+                 flag: str, then: list[tmuxctl.Write] = ()) -> None:
     """`resize-pane <flag>` every slot in *panes* that *sizes* has a number for and
-    `layout.resize_flag` answers exactly *flag* about.
+    `layout.resize_flag` answers exactly *flag* about, plus *then* — resizes that belong
+    to the same pass and have to land after them.
 
     One loop, called twice by :func:`_reassert_sizes` — once for the columns and once for
     the rows — rather than one loop over both, because the two are separated by a
@@ -5830,6 +5831,26 @@ def _apply_sizes(socket: str, *, panes: dict[str, str], sizes: dict[str, int],
     four separate repaints of a window whose panes were being shuffled into place. The two
     passes stay two batches: the measurement between them is what makes the second one
     truthful, and it is a READ.
+
+    ***then* is the rest of this pass, and #844 is why it is a parameter rather than a
+    second call.** The row pass ends on the HARNESS's own height, which
+    :func:`_reassert_sizes` used to send as an invocation of its own — so a frame's rows
+    landed as two command lists. Measured on tmux 3.7c and at the 3.2 floor with a real
+    attached client at 200x50: **every command list carrying a write redraws the whole
+    client**, and a `resize-pane` to a size the pane already has is no exception — 1672
+    bytes on 3.7c and 1811 at the floor, byte for byte what a real resize costs, while a
+    list of three no-op resizes costs exactly one of those and a pure `display-message -p`
+    costs none. So the count that decides how much the operator sees re-render is the
+    number of write-carrying LISTS, not the number of resizes in them and not whether any
+    of them changed a pane. These writes are one pass, they are computed from one *sizes*
+    map, and nothing between them reads anything — so they are one list.
+
+    **Order inside the list is preserved and is load-bearing**, which is what makes the
+    merge safe rather than merely cheaper: `resize-pane -y` moves exactly ONE boundary
+    (#515), so the harness's own row has to be asserted after the strips' — a chain runs
+    in the order it is given, so it still is. Measured on both versions: the final
+    geometry of a four-panel 200x50 frame is identical byte for byte to what the two
+    lists produced.
     """
     writes = [tmuxctl.Write(f"restoring the {slot} panel's size",
                             tmuxctl.server_argv(socket, "resize-pane", "-t", pane_id,
@@ -5838,7 +5859,8 @@ def _apply_sizes(socket: str, *, panes: dict[str, str], sizes: dict[str, int],
               for slot, pane_id in panes.items()
               if layout.resize_flag(slot) == flag and slot in sizes
               and _PANE_ID_RE.fullmatch(pane_id)]
-    tmuxctl.write_all(f"restoring this frame's panel sizes ({flag})", writes)
+    tmuxctl.write_all(f"restoring this frame's panel sizes ({flag})",
+                      writes + list(then))
 
 
 def _variable_pane_cols(socket: str, *, panes: dict[str, str], window_cols: int) -> int:
@@ -5973,6 +5995,14 @@ def _reassert_sizes(socket: str, *, fid: str, panes: dict[str, str], harness_pan
     heights are free; asserting all N is what made the result depend on the order, and
     asserting N-2 is what left a placed bar holding the table's rows.
 
+    **The harness's own row rides in the row pass's command list rather than in one of its
+    own** (#844, :func:`_apply_sizes`' *then*). It is the last write of that pass and
+    nothing between it and the strips reads anything, so the only thing a second
+    invocation bought was a second whole-client repaint — which a `resize-pane` costs
+    whether or not it moves a boundary. The ORDER is unchanged, and that is the half that
+    had to be: the harness is still asserted after the strips, because `resize-pane -y`
+    moves one boundary and a chain runs in the order it is given.
+
     *harness_pane* is checked like every other id here and for the same reason: it is read
     off disk (`state.harness_pane`) by `cmd_resize`, which is exactly the shape #475 was.
 
@@ -5994,14 +6024,21 @@ def _reassert_sizes(socket: str, *, fid: str, panes: dict[str, str], harness_pan
     sizes = _slot_sizes(
         fid, order, window_rows=window_rows, order=order, window_cols=window_cols,
         pane_cols=_variable_pane_cols(socket, panes=panes, window_cols=window_cols))
-    # Pass two: the ROWS, and the harness below them.
-    _apply_sizes(socket, panes=panes, sizes=sizes, flag="-y")
-    if _PANE_ID_RE.fullmatch(harness_pane or ""):
-        tmuxctl.run("restoring the harness pane's height",
-                    tmuxctl.server_argv(
-                        socket, "resize-pane", "-t", harness_pane, "-y",
-                        str(layout.harness_rows(sizes, window_rows=window_rows))),
-                    report=False)
+    # Pass two: the ROWS, and the harness below them — **one command list, not two**
+    # (#844). It was two, and the second carried one `resize-pane` that is very often a
+    # no-op; measured on 3.7c and at the 3.2 floor, a no-op write costs the client the
+    # same full redraw a real one does, so that list was a whole-window repaint bought for
+    # nothing. Nothing is read between the two, they share one *sizes* map, and a chain
+    # keeps their order — see :func:`_apply_sizes` for the measurement and for why the
+    # order is the part that matters.
+    _apply_sizes(socket, panes=panes, sizes=sizes, flag="-y",
+                 then=[tmuxctl.Write(
+                     "restoring the harness pane's height",
+                     tmuxctl.server_argv(
+                         socket, "resize-pane", "-t", harness_pane, "-y",
+                         str(layout.harness_rows(sizes, window_rows=window_rows))),
+                     report=False)]
+                 if _PANE_ID_RE.fullmatch(harness_pane or "") else [])
 
 
 def cmd_resize(args) -> int:
@@ -6819,7 +6856,7 @@ def cmd_chat(args) -> int:
        pointer `charter workspace use` wrote — so two
        chats can share a roster with their windows in two different tmux sessions — and
        `select-window` at another session's pane returns **0**, moves that session, and
-       leaves this client exactly where it was. Steps 1 and 2 then reported a switch that
+       leaves this client exactly where it was. Steps 1 and 4 then reported a switch that
        had not happened and tore down the panels of the chat still on screen.
     1. `select-window` at the target chat's own harness PANE. A pane id resolves to that
        pane's window — measured on tmux 3.7c and on tmux 3.2 — which is why charter needs
@@ -6830,25 +6867,36 @@ def cmd_chat(args) -> int:
        acted on the wrong target is indistinguishable from one that acted on the right
        one, so the teardown below is gated on the client having moved rather than on a
        return code.
-    2. :func:`_apply_arrangement` with ``want=[]`` on the chat being left, which tears its
-       panels down. Not a saving — a correctness rule. A background window keeps STALE
-       geometry (§7.4, measured identically on 3.7c and 3.2), so panels left running there
-       are not idle, they are rendering at a width that is no longer their window's, which
-       is the exact defect `panel._component_text`'s `width=slots._width()` guard exists
-       for.
-    3. :func:`_apply_arrangement` on the chat being entered, which splits its panels into
+    2. :func:`_apply_arrangement` on the chat being ENTERED, which splits its panels into
        the window **tmux has just resized**. Measured here on 3.7c and 3.2: the very next
        tmux invocation after `select-window` already reports the target window at the
        client's size (200x50 → 100x29 with no sleep at all). So the panels are born at the
        true width and there is nothing stale to repair —
-    4. **which is why the switch never asks for a `window-resized` hook, and must not.**
+    3. **which is why the switch never asks for a `window-resized` hook, and must not.**
        On tmux 3.2 — `tmuxctl.FLOOR` — `set-hook -w window-resized` answers `invalid
        option`, rc=1: the hook does not exist. A switch that relied on it would be correct
        on the author's tmux and silently wrong on the floor charter promises to run on.
        `_apply_arrangement` measures and re-asserts the layout itself, which is the same
        thing a density change already does and not a second path.
+    4. :func:`_apply_arrangement` with ``want=[]`` on the chat being left, which tears its
+       panels down. Not a saving — a correctness rule. A background window keeps STALE
+       geometry (§7.4, measured identically on 3.7c and 3.2), so panels left running there
+       are not idle, they are rendering at a width that is no longer their window's, which
+       is the exact defect `panel._component_text`'s `width=slots._width()` guard exists
+       for.
 
-    The bump is step 3's own last line (`_apply_arrangement`), so the new chat's panels
+    **Steps 2 and 4 are in that order because of what the operator is looking at while
+    they run** (#844). They were the other way round — tidy the departure, then dress the
+    arrival — and this docstring already said they were independent, so nothing had ever
+    pinned it. What it cost was measured end to end on tmux 3.7c with a real attached
+    client and four panels at 200x50: the client moves at invocation 3, the departure's
+    teardown then spends invocations 5 to 11 on a window nobody can see, and the arriving
+    frame's panels did not appear until invocation 15 — **66 ms of bare full-screen
+    harness pane**, which is a large part of what "the whole window re-renders" looks
+    like. The teardown is not dropped and not deferred to some later event: it is the same
+    work in the same switch, done in the half where nobody is waiting on it.
+
+    The bump is step 2's own last line (`_apply_arrangement`), so the new chat's panels
     repaint into the shape that has already settled — #411/#412's rule, and the reason
     this does not write a pointer of its own for anything to read.
 
@@ -6987,13 +7035,23 @@ def cmd_chat(args) -> int:
         _say_on_screen(fid, f"cannot switch: tmux selected chat '{target}' but this "
                             "client did not move, so this chat keeps its panels")
         return 0
-    here = _relayout_target(fid)
-    if here is not None:
-        _apply_arrangement(fid, where=here, want=[])
+    # **The ARRIVAL first, and the departure tidied behind it** (#844). Steps 2 and 3 ran
+    # the other way round for as long as this function has existed, and the docstring
+    # above has always said they are independent — so the order was never load-bearing,
+    # it was just the order they were written in. Measured end to end on tmux 3.7c with a
+    # real attached client, four panels at 200x50: the client moves at invocation 3 and
+    # the arriving window's panels used to appear at invocation 15, **66 ms** later, every
+    # one of those invocations tidying a window the operator has already stopped looking
+    # at. What they were looking at for those 66 ms was a bare full-screen harness pane.
+    # The teardown is not dropped and not deferred to some later event — it is the same
+    # work, done in the half of the switch where nobody is waiting on it.
     there = _relayout_target(target)
     if there is not None:
         _apply_arrangement(target, where=there,
                            want=_visible_now(target, config.FRAME))
+    here = _relayout_target(fid)
+    if here is not None:
+        _apply_arrangement(fid, where=here, want=[])
     return 0
 
 
@@ -7260,19 +7318,25 @@ def _switch_client(fid: str, ws: str, *, said: str) -> None:
        ones it can prove are looking at THIS chat: every client attached to this chat's
        session. They already share one current window (§2.10), so they were already looking
        at the same thing, and moving them together keeps them so.
-    2. **`_apply_arrangement(want=[])` on the chat being left**, which is #686's rule
-       unchanged: a background window keeps STALE geometry (§7.4, measured identically on
-       both versions), so panels left running in one are not idle, they are rendering at a
-       width that is no longer their window's. Only this chat has panels to lose — every
-       other chat of the workspace is a background window and lost its own the same way.
-    3. **`_apply_arrangement` on the chat tmux LANDED on**, unconditionally, which is §4b's
+    2. **`_apply_arrangement` on the chat tmux LANDED on**, unconditionally, which is §4b's
        "#686's treatment one scope out". Which chat that is, charter does not choose:
        `switch-client` restores the target session's own last active window, so the landing
        chat is read back off the server (:func:`_chat_showing`) rather than guessed from
        the seat :func:`_plane_session` happened to match. Re-dressing is not optional and
        not conditional on the geometry having changed — the panels there were torn down
        when that workspace went to the background, so they have to be split into a window
-       that tmux has just resized, and that is the same thing `cmd_chat` step 3 does.
+       that tmux has just resized, and that is the same thing `cmd_chat` step 2 does.
+    3. **`_apply_arrangement(want=[])` on the chat being left**, which is #686's rule
+       unchanged: a background window keeps STALE geometry (§7.4, measured identically on
+       both versions), so panels left running in one are not idle, they are rendering at a
+       width that is no longer their window's. Only this chat has panels to lose — every
+       other chat of the workspace is a background window and lost its own the same way.
+
+    **Steps 2 and 3 are in that order for `cmd_chat`'s reason** (#844): they are
+    independent, and the operator is already looking at the ARRIVING window while both
+    run, so every invocation spent tidying the one they left is time they spend on a bare
+    full-screen harness pane. Against this repository's own fakes, four panels at 200x50,
+    the client moved at invocation 4 and the panels appeared at invocation 17.
 
     **The teardown is gated on the client having MOVED, not on a command having exited 0**
     — #684's rule, re-asked here because the failure it names exists here too:
@@ -7390,13 +7454,18 @@ def _switch_client(fid: str, ws: str, *, said: str) -> None:
         return
     landed = _chat_showing(_window_seats(socket, "finding the chat this switch landed on"),
                            there[0])
-    left = _relayout_target(fid)
-    if left is not None:
-        _apply_arrangement(fid, where=left, want=[])
-    # Both re-layouts are attempted independently and a failure of the first does not
-    # cancel the second — `cmd_chat`'s rule, for its reason: the frame the operator is now
-    # looking at is the one that matters, and abandoning it because the workspace they just
-    # left could not be tidied would leave them on a bare harness pane.
+    # **The ARRIVAL first, and the departure tidied behind it** — `cmd_chat`'s ordering
+    # (#844), one scope out and for exactly its reason. Steps 2 and 3 are independent, so
+    # nothing pinned which went first; what decided it was that the operator is already
+    # looking at the arriving window by the time either runs, and every invocation spent
+    # on the workspace they LEFT is time they spend watching a bare full-screen harness
+    # pane. Measured against this repository's own fakes, four panels at 200x50: the
+    # client moved at invocation 4 and the panels appeared at invocation 17.
+    #
+    # Both re-layouts are still attempted independently and a failure of the first does
+    # not cancel the second — `cmd_chat`'s rule, for its reason: the frame the operator is
+    # now looking at is the one that matters, and abandoning it because the workspace they
+    # just left could not be tidied would leave them on a bare harness pane.
     arrived = _relayout_target(landed) if landed else None
     if arrived is not None:
         _apply_arrangement(landed, where=arrived,
@@ -7405,10 +7474,15 @@ def _switch_client(fid: str, ws: str, *, said: str) -> None:
     # is drawn by a panel out of a frame's own state, so it has to be written to the frame
     # they will be reading a moment from now. A workspace whose landing chat charter could
     # not name is left unsaid rather than announced on a frame nobody is looking at — the
-    # client visibly moved, which is the report, and `state.say` on the chat being left
-    # would write into panels that are being torn down two lines above.
+    # client visibly moved, which is the report. Said BEFORE the teardown below rather
+    # than after it, so the sentence lands with the panels that will draw it rather than a
+    # teardown's worth of round trips later; `state.say` on the chat being LEFT is still
+    # the thing this must not do, and that has never been about the order.
     if landed:
         _say_on_screen(landed, said, ok=True)
+    left = _relayout_target(fid)
+    if left is not None:
+        _apply_arrangement(fid, where=left, want=[])
 
 
 def _pressers_chat(args) -> str:

--- a/charter/commands_frame.py
+++ b/charter/commands_frame.py
@@ -5933,7 +5933,8 @@ def _variable_pane_cols(socket: str, *, panes: dict[str, str], window_cols: int)
     return layout.repos_cols(list(panes), window_cols=window_cols)
 
 
-def _reassert_sizes(socket: str, *, fid: str, panes: dict[str, str], harness_pane: str,
+def _reassert_sizes(socket: str, *, fid: str, panes: dict[str, str],
+                    harness_pane: str | None,
                     window_cols: int, window_rows: int) -> None:
     """Re-apply every pane in *panes* the size `layout.slot_sizes` says it should have in
     a *window_cols* x *window_rows* window.
@@ -6005,6 +6006,15 @@ def _reassert_sizes(socket: str, *, fid: str, panes: dict[str, str], harness_pan
 
     *harness_pane* is checked like every other id here and for the same reason: it is read
     off disk (`state.harness_pane`) by `cmd_resize`, which is exactly the shape #475 was.
+    **`None` is one of the values that record really answers with**, and the annotation
+    says so rather than leaving `or ""` looking like belt and braces: it is the half of
+    the check that decides whether a frame with no recorded harness pane resizes its
+    panels or dies, because `_PANE_ID_RE.fullmatch(None)` raises and this runs inside
+    `_relayout`, above the resize hook and above the `select-pane` that takes the keyboard
+    back off a panel. Neither caller can produce it today — `_relayout_target` answers
+    `None` for the whole frame rather than a tuple with one in it, and `cmd_resize` spells
+    its own `or ""` — which is why the deletion sweep found the line unpinned and
+    `test_reassert_sizes_takes_no_harness_pane_at_all_without_raising` now drives it.
 
     `report=False` throughout: a pane that has since died (the operator closed it, a panel
     crashed between the map being read and this running) makes `resize-pane` fail, and that
@@ -7035,7 +7045,7 @@ def cmd_chat(args) -> int:
         _say_on_screen(fid, f"cannot switch: tmux selected chat '{target}' but this "
                             "client did not move, so this chat keeps its panels")
         return 0
-    # **The ARRIVAL first, and the departure tidied behind it** (#844). Steps 2 and 3 ran
+    # **The ARRIVAL first, and the departure tidied behind it** (#844). Steps 2 and 4 ran
     # the other way round for as long as this function has existed, and the docstring
     # above has always said they are independent — so the order was never load-bearing,
     # it was just the order they were written in. Measured end to end on tmux 3.7c with a
@@ -7336,7 +7346,10 @@ def _switch_client(fid: str, ws: str, *, said: str) -> None:
     independent, and the operator is already looking at the ARRIVING window while both
     run, so every invocation spent tidying the one they left is time they spend on a bare
     full-screen harness pane. Against this repository's own fakes, four panels at 200x50,
-    the client moved at invocation 4 and the panels appeared at invocation 17.
+    the client moves at invocation 4 and the panels appeared at invocation 17 — they
+    appear at 10. Step 3 is also the one place the two chats can turn out to be the same
+    one, and it says so rather than relying on which of them runs last: see the guard on
+    it, and `_plane_session` for the recycled pane id that gets there.
 
     **The teardown is gated on the client having MOVED, not on a command having exited 0**
     — #684's rule, re-asked here because the failure it names exists here too:
@@ -7480,9 +7493,19 @@ def _switch_client(fid: str, ws: str, *, said: str) -> None:
     # the thing this must not do, and that has never been about the order.
     if landed:
         _say_on_screen(landed, said, ok=True)
-    left = _relayout_target(fid)
-    if left is not None:
-        _apply_arrangement(fid, where=left, want=[])
+    # **And the chat left behind is never the chat landed on**, which the order above is
+    # what makes worth saying (#844). `_chat_showing` reads the landing chat off the
+    # SERVER while `here` came from this chat's own recorded pane, and `_plane_session`'s
+    # docstring names the residual where those two disagree: a pane id restarts at `%0`
+    # when a server does, so a `%3` recorded for a chat that is over can name a live pane
+    # belonging to another session. In that state `landed` really can be *fid* — and with
+    # the arrival dressed first, an unguarded teardown would split this frame's panels
+    # back in and then kill them, leaving the operator on the bare harness pane this whole
+    # issue is about. Dressing last used to absorb that by accident; this says it.
+    if landed != fid:
+        left = _relayout_target(fid)
+        if left is not None:
+            _apply_arrangement(fid, where=left, want=[])
 
 
 def _pressers_chat(args) -> str:

--- a/docs/frame.md
+++ b/docs/frame.md
@@ -468,10 +468,12 @@ them.
 Measured on tmux 3.7c and at the 3.2 floor with a real client: `switch-client` moves the
 client, every pane on the server is still there afterwards with the same pid, and the
 `attach` process itself is untouched. The switch itself is about **5 ms** of tmux; what it
-costs beyond that is one re-layout at each end — the panels of the chat you left are torn
-down and the chat you arrive at gets fresh ones, for the same reason a chat switch does it
-(a background window keeps stale geometry). You land on whichever chat that workspace was
-last showing, which is tmux's own answer and not a record charter keeps.
+costs beyond that is one re-layout at each end — the chat you arrive at gets fresh panels
+and the panels of the chat you left are torn down, in that order and for a chat switch's
+reason (#844): you are already looking at the window you arrived at, so the tidying goes
+behind it. Both happen for the same reason a chat switch does them at all — a background
+window keeps stale geometry. You land on whichever chat that workspace was last showing,
+which is tmux's own answer and not a record charter keeps.
 
 **Switching is restricted to workspaces of this plane, and anything else is refused by
 name.** One tmux server serves every plane on the machine: the operator's own socket had
@@ -502,15 +504,32 @@ switch by hand.
 it is thrift. A tmux window that is not the current one keeps the size it had when it was —
 measured on tmux 3.7c and at the 3.2 floor alike — so panels left running in a chat you
 switched away from are not idle, they are drawing at a width that is not their window's.
-The switch therefore tears the old chat's panels down, selects the new window (tmux resizes
-it *at* that moment), and splits fresh panels into a window that is already the right size.
+The switch therefore selects the new window (tmux resizes it *at* that moment), splits
+fresh panels into a window that is already the right size, and then tears the old chat's
+panels down.
 
-**It costs about a seventh of a second.** Measured with a real client and four panels:
+**In that order, and the order is the difference between a switch you wait through and one
+you do not** (#844). Both re-layouts are independent, and the one you are looking at is the
+one you have already arrived at: the window a switch lands you on holds nothing but the
+harness pane at full window size, because its panels were killed when you last left it. So
+every tmux call spent tidying the window you left is a call you spend staring at a bare
+harness pane. Measured with a real client and four panels at 200x50:
+
+| | your client moves at | panels appear at | bare harness pane for |
+|---|---|---|---|
+| tmux 3.7c | invocation 3 | invocation 15 → **8** | 78 ms → **38 ms** |
+| at the 3.2 floor | invocation 3 | invocation 14 → **8** | 63 ms → **36 ms** |
+
+Nothing is dropped and nothing is deferred to some later event — it is the same teardown,
+in the same switch, done in the half where nobody is waiting on it.
+
+**It costs about a seventh of a second in total.** Measured with a real client and four
+panels:
 
 | | tmux invocations | wall clock | times your terminal is repainted |
 |---|---|---|---|
-| tmux 3.7c | 58 → **23** | 314 ms → **142 ms** | 45 → **14** |
-| at the 3.2 floor | 50 → **21** | 237 ms → **114 ms** | 41 → **12** |
+| tmux 3.7c | 58 → 23 → **22** | 314 ms → **142 ms** | 45 → **14** |
+| at the 3.2 floor | 50 → 21 → **20** | 237 ms → **114 ms** | 41 → **12** |
 
 That is the price of not keeping four panel processes per chat drawing at the wrong width,
 and it is the whole cost — nothing is lost, no harness is restarted, and the chat you left
@@ -526,11 +545,21 @@ sees while the panels are torn down and split back one at a time.
 
 Most of those commands read nothing back, so tmux takes them as one list. The four kills
 and their four disarms are one invocation now; so is each end's window dressing, so are the
-four splits, so is everything the four new panes are told about themselves, and so are the
-four respawn hooks. Nothing was dropped and nothing was
-reordered — the same commands, in the same order, in 40% of the invocations and a third of
-the repaints. It is not silent: 14 updates is still four panel processes coming up and
-painting themselves, which is a different cost and not this one.
+four splits, so is everything the four new panes are told about themselves, so are the
+four respawn hooks, and — since #844 — so are a frame's panel rows and the harness pane's
+own row. Nothing was dropped and nothing was reordered inside a list: the same commands, in
+the same order, in 38% of the invocations and a third of the repaints. It is not silent: 14
+updates is still four panel processes coming up and painting themselves, which is a
+different cost and not this one.
+
+**A write that changes nothing costs the same repaint as one that does**, which is why the
+list is the unit worth counting rather than the command. Measured on 3.7c and at the 3.2
+floor with a real client, 200x50: `resize-pane -x 22` on a pane that is *already* 22 wide
+sends no resize to the pane at all and still repaints the whole client — 1672 bytes on
+3.7c, 1811 at the floor, which is what a real resize costs. Three of them in one list cost
+one of those. A pure `display-message -p` costs nothing at all, which is why the
+measurement #510 puts between charter's two size passes is not something that had to be
+collapsed away.
 
 A switch is refused, with the reason on your own screen, for a chat this workspace does not
 have, one whose window has gone, one charter has no pane record for, and the chat you are

--- a/docs/news/unreleased-a-switch-dresses-where-you-are-going-first.md
+++ b/docs/news/unreleased-a-switch-dresses-where-you-are-going-first.md
@@ -1,0 +1,67 @@
+---
+version: unreleased
+headline: A switch draws the chat you are arriving at before it tidies the one you left, so the wait on a bare harness pane roughly halves
+---
+
+*"When switching workspaces or chat tabs I see one blink of the entire window, very fast —
+but all the window seems to be re-rendering."*
+
+## What was measured
+
+A chat switch (`charter frame-chat`, a chat tab, a palette row) and a workspace switch
+(`charter frame-switch --workspace`) do four things: read where both ends are, move the
+client, dress the frame you arrive at, and tear down the panels of the frame you left. The
+last two are independent and always have been — `cmd_chat`'s own docstring said so — and
+they ran in the wrong order.
+
+Measured end to end on tmux 3.7c with a real attached client, four panels at 200x50:
+
+| | client moves at | panels appear at | bare harness pane for |
+|---|---|---|---|
+| before | invocation 3 | invocation 15 | **78 ms** |
+| after | invocation 3 | invocation 8 | **38 ms** |
+
+At the 3.2 floor: invocation 14 → 8, 63 ms → 36 ms.
+
+The window you have just arrived at holds only the harness pane at full window size,
+because its panels were killed when you last left it. Everything charter did between the
+client moving and the panels appearing was tidying a window you had already stopped
+looking at. Nothing is dropped and nothing is deferred to a later event: it is the same
+teardown, in the same switch, done in the half where nobody is waiting on it.
+
+## And one fewer whole-window repaint
+
+The second half is smaller and needs its own measurement, because the obvious reasoning
+about it is wrong. tmux delivers a pane resize once per command **list**, and a
+`resize-pane` to a size a pane already has delivers no resize at all — so a re-assertion
+that changes nothing looks free. It is not. Measured on 3.7c and at the 3.2 floor with a
+real client:
+
+| one invocation carrying | 3.7c | 3.2 |
+|---|---|---|
+| `resize-pane -x 22` on a pane already 22 wide | 1672 bytes | 1811 bytes |
+| a real `resize-pane -x 30` | 1648 bytes | 1787 bytes |
+| three no-op `resize-pane`s in **one** list | 1672 bytes | 1811 bytes |
+| `display-message -p` — a pure read | 0 | 0 |
+
+**Every command list carrying a write repaints the whole client, whether or not the write
+changed anything, and a list of three costs one repaint rather than three.** So what
+decides how much of your window appears to re-render is the number of write-carrying
+lists.
+
+A frame's rows were two of them: every panel strip's height, and then the harness pane's
+own. They are one now. A four-panel chat switch is **22** tmux invocations where it was 23
+and 58 before that; a workspace switch is **24** where it was 25.
+
+The read between the two size passes (#510 — the table pane's width is asked of tmux, not
+derived from a file's key order) stays exactly where it is. A list that only reads draws
+nothing, so it costs no repaint to leave it there, and removing it would trade a repaint
+for a geometry charter believes instead of one tmux reports.
+
+## What did not change
+
+Panels are still torn down when you leave a chat or a workspace, and that is still
+correctness rather than thrift: a tmux window that is not the current one keeps the size it
+had when it was, so panels left running in one draw at a width that is no longer their
+window's. Keeping them alive instead would remove the rest of the blink and cost about
+576 MB resident with six chats open — that is a separate decision and #844 holds it.

--- a/tests/test_a_frame_sends_one_invocation_per_batch.py
+++ b/tests/test_a_frame_sends_one_invocation_per_batch.py
@@ -218,9 +218,9 @@ class WhatACommandListCostsTheOperatorsScreen(unittest.TestCase):
     #780 established that tmux redraws once per command LIST. #844 asked the next
     question, because the answer decides whether merging two lists is worth anything: does
     a list whose writes change NOTHING still redraw? The issue behind this assumed the
-    opposite — that a `resize-pane` to a size a pane already has is free because it
-    delivers no SIGWINCH to the pane. It delivers none; measured here, it costs the client
-    a full repaint anyway.
+    opposite — that a `resize-pane` to a size a pane already has is free, because it
+    delivers no SIGWINCH to the pane. It delivers none; it costs the client a full repaint
+    anyway.
 
     Measured by hand on tmux 3.7c and at the 3.2 floor, 200x50, three panes, before this
     class existed, and identically on both versions:
@@ -245,100 +245,168 @@ class WhatACommandListCostsTheOperatorsScreen(unittest.TestCase):
     one. It skips rather than fails where tmux will not attach one, naming what it could
     not get: a machine that cannot fork a pty client has measured nothing here, and a
     trial that measured nothing is not a result to assert on.
+
+    **One server and one client for the whole class, and the reason is a measurement
+    rather than tidiness.** On attach, tmux asks the terminal what it can do and holds a
+    repaint back until it has an answer — and a pty with nothing behind it never sends
+    one, so the answer is a timeout. Measured on 3.7c and at the 3.2 floor, watching every
+    byte tmux put on a fresh pty client: bursts at **6 ms** and again at **5006 ms**, and
+    nothing in between or after. Inside that window the first command of any kind flushes
+    the held repaint — a pure `display-message -p` that draws **0** bytes on a settled
+    client draws **617** (3.7c) or **625** (3.2) at one second. A fixture that measured
+    inside it would be timing tmux's startup and calling it the cost of a command; a
+    per-test client would pay that five seconds three times over. So the client is built
+    once, :meth:`_settle_the_client` waits the window out, and the tests share it.
+
+    Nothing here leaves the panes anywhere but where it found them, which is what lets
+    them share: every probe either re-asserts a size the pane already has or puts one back
+    before it measures.
     """
 
     SOCKET = _tmuxreap.name("redraw-cost")
 
-    def setUp(self):
-        self._tmux("kill-server")
-        made = self._tmux("new-session", "-d", "-s", "s", "-x", "200", "-y", "50",
-                          "-P", "-F", "#{pane_id}", "--", "cat")
-        self.assertEqual(made.returncode, 0, made.stderr)
-        # **The status line off, and that is what makes the byte counts below a
-        # measurement rather than a coin toss.** tmux redraws the status line on its own
-        # clock — `status-interval` is 15 seconds by default — so a probe that watches
-        # the client for a second has about a one-in-fifteen chance of catching a repaint
-        # nothing here asked for, which is exactly the shape that passes on a laptop and
-        # goes red on CI once a fortnight. The panes run `cat` and write nothing, so with
+    #: How long tmux holds its first repaint back waiting for a terminal that will never
+    #: answer — 5006 ms, measured on both versions (see the class docstring), plus enough
+    #: margin for a loaded box. Waited out ONCE.
+    SETTLE = 9.0
+
+    #: Nothing new on the client for this long is what "settled" means everywhere below.
+    STILL = 0.6
+
+    @classmethod
+    def setUpClass(cls):
+        cls.drawn: list[int] = []
+        cls._reading = False
+        cls._client = None
+        cls._tmux_cmd("kill-server")
+        made = cls._tmux_cmd("new-session", "-d", "-s", "s", "-x", "200", "-y", "50",
+                             "-P", "-F", "#{pane_id}", "--", "cat")
+        if made.returncode != 0:
+            raise AssertionError(f"tmux would not start a session: {made.stderr!r}")
+        cls.harness = made.stdout.strip()
+        # **The status line off**, so tmux's own 15-second clock cannot put a repaint
+        # nobody asked for inside a probe. The panes run `cat` and write nothing, so with
         # this off the only thing that can draw on the client is the command under test.
-        self._tmux("set-option", "-g", "status", "off")
-        self.harness = made.stdout.strip()
-        split = self._tmux("split-window", "-t", self.harness, "-h", "-l", "22",
-                           "-P", "-F", "#{pane_id}", "--", "cat")
-        self.assertEqual(split.returncode, 0, split.stderr)
-        self.side = split.stdout.strip()
-        self.addCleanup(self._reap)
-        self._attach()
+        cls._tmux_cmd("set-option", "-g", "status", "off")
+        split = cls._tmux_cmd("split-window", "-t", cls.harness, "-h", "-l", "22",
+                              "-P", "-F", "#{pane_id}", "--", "cat")
+        if split.returncode != 0:
+            raise AssertionError(f"tmux would not split a pane: {split.stderr!r}")
+        cls.side = split.stdout.strip()
+        cls._attach()
 
-    def _reap(self):
-        self._tmux("kill-server")
-        (_tmuxreap.socket_dir() / self.SOCKET).unlink(missing_ok=True)
+    @classmethod
+    def tearDownClass(cls):
+        if cls._client is not None:
+            pid, fd = cls._client
+            cls._reading = False
+            try:
+                os.kill(pid, signal.SIGKILL)
+                os.waitpid(pid, 0)
+            except OSError:
+                pass
+            try:
+                os.close(fd)
+            except OSError:
+                pass
+        cls._tmux_cmd("kill-server")
+        (_tmuxreap.socket_dir() / cls.SOCKET).unlink(missing_ok=True)
 
-    def _tmux(self, *args: str) -> subprocess.CompletedProcess:
-        return subprocess.run(["tmux", "-L", self.SOCKET, *args],
+    @classmethod
+    def _tmux_cmd(cls, *args: str) -> subprocess.CompletedProcess:
+        return subprocess.run(["tmux", "-L", cls.SOCKET, *args],
                               capture_output=True, text=True, timeout=20)
 
-    def _attach(self) -> None:
-        """A real pty client at 200x50, and a thread recording every byte tmux draws on
-        it. Skips where no terminal type will attach — see the class docstring."""
+    @classmethod
+    def _attach(cls) -> None:
+        """A real pty client at 200x50, a thread recording every byte tmux draws on it,
+        and the startup window waited out. ``_client`` stays ``None`` where no terminal
+        type will attach, and every test then skips."""
         for term in ("xterm-256color", "screen", "vt100"):
             pid, fd = pty.fork()
             if pid == 0:                                      # pragma: no cover - child
                 try:
                     os.environ["TERM"] = term
-                    os.execvp("tmux", ["tmux", "-L", self.SOCKET, "attach", "-t", "s"])
+                    os.execvp("tmux", ["tmux", "-L", cls.SOCKET, "attach", "-t", "s"])
                 finally:
                     os._exit(127)
             fcntl.ioctl(fd, termios.TIOCSWINSZ, struct.pack("HHHH", 50, 200, 0, 0))
-            self.addCleanup(self._close, pid, fd)
-            for _ in range(200):
-                seen = self._tmux("list-clients", "-t", "s", "-F", "#{client_name}")
+            for _ in range(250):
+                seen = cls._tmux_cmd("list-clients", "-t", "s", "-F", "#{client_name}")
                 if seen.returncode == 0 and seen.stdout.strip():
-                    self.drawn: list[int] = []
-                    self._reading = True
-                    threading.Thread(target=self._read, args=(fd,),
-                                     daemon=True).start()
-                    time.sleep(1.0)
+                    cls._client = (pid, fd)
+                    cls._reading = True
+                    threading.Thread(target=cls._read, args=(fd,), daemon=True).start()
+                    cls._settle_the_client()
                     return
                 time.sleep(0.02)
-        self.skipTest("no tmux client would attach on this machine, and there is no "
-                      "screen to measure a repaint on without one")
+            try:
+                os.kill(pid, signal.SIGKILL)
+                os.waitpid(pid, 0)
+                os.close(fd)
+            except OSError:
+                pass
 
-    def _close(self, pid: int, fd: int) -> None:
-        self._reading = False
-        try:
-            os.kill(pid, signal.SIGKILL)
-            os.waitpid(pid, 0)
-        except OSError:
-            pass
-        try:
-            os.close(fd)
-        except OSError:
-            pass
-
-    def _read(self, fd: int) -> None:                     # pragma: no cover - thread
-        while self._reading:
+    @classmethod
+    def _read(cls, fd: int) -> None:                      # pragma: no cover - thread
+        while cls._reading:
             try:
                 data = os.read(fd, 65536)
             except OSError:
                 return
             if not data:
                 return
-            self.drawn.append(len(data))
+            cls.drawn.append(len(data))
+
+    @classmethod
+    def _settle_the_client(cls) -> None:
+        """Wait :data:`SETTLE` out and then for the screen to go quiet.
+
+        Not a probe that stops when a read draws nothing — that would be this class's own
+        third assertion made into its fixture, and a test pinned by its fixture asserts
+        nothing. The wait is a duration because what is being waited out IS a duration:
+        tmux's terminal-feature query timing out against a pty that cannot answer it.
+        """
+        deadline = time.monotonic() + cls.SETTLE
+        while time.monotonic() < deadline:
+            time.sleep(0.1)
+        cls._quiet()
+
+    @classmethod
+    def _quiet(cls, deadline: float = 15.0) -> None:
+        """Return once nothing has been drawn on the client for :data:`STILL`.
+
+        A ceiling rather than a wait: a client that never stops being drawn on would hang
+        this class, and the byte count that then fails an assertion is a truer report than
+        a test that does not return.
+        """
+        end = time.monotonic() + deadline
+        seen, since = len(cls.drawn), time.monotonic()
+        while time.monotonic() < end:
+            time.sleep(0.05)
+            if len(cls.drawn) != seen:
+                seen, since = len(cls.drawn), time.monotonic()
+            elif time.monotonic() - since >= cls.STILL:
+                return
+
+    def setUp(self):
+        if self._client is None:
+            self.skipTest("no tmux client would attach on this machine, and there is no "
+                          "screen to measure a repaint on without one")
 
     def _bytes_drawn(self, *invocations: list[str]) -> int:
         """How many bytes tmux draws on the client for *invocations*, run in order.
 
-        Settled before and after: the panes run `cat` and write nothing of their own, so
-        everything counted here is tmux redrawing, and the sleeps are what keep one
-        probe's tail out of the next one's total.
+        The panes run `cat` and write nothing of their own, the status line is off and the
+        startup window is long past, so with the screen settled either side of the run
+        everything counted here is tmux repainting for the commands under test.
         """
-        time.sleep(0.5)
+        self._quiet()
         self.drawn.clear()
         for argv in invocations:
-            out = self._tmux(*argv)
+            out = self._tmux_cmd(*argv)
             self.assertEqual(out.returncode, 0, out.stderr)
-        time.sleep(0.5)
+        self._quiet()
         return sum(self.drawn)
 
     def test_a_write_that_changes_nothing_still_repaints_the_whole_client(self):
@@ -369,6 +437,9 @@ class WhatACommandListCostsTheOperatorsScreen(unittest.TestCase):
         """
         one = ["resize-pane", "-t", self.side, "-x", "22"]
         two = ["resize-pane", "-t", self.harness, "-y", "50"]
+        # Asserted once and thrown away, so that what is measured below is three writes
+        # that certainly change nothing whichever test ran before this one.
+        self._bytes_drawn(one, two)
         separately = self._bytes_drawn(one, two, one)
         together = self._bytes_drawn(one + [";"] + two + [";"] + one)
         self.assertGreater(separately, 0, "nothing was drawn at all — nothing measured")

--- a/tests/test_a_frame_sends_one_invocation_per_batch.py
+++ b/tests/test_a_frame_sends_one_invocation_per_batch.py
@@ -254,6 +254,14 @@ class WhatACommandListCostsTheOperatorsScreen(unittest.TestCase):
         made = self._tmux("new-session", "-d", "-s", "s", "-x", "200", "-y", "50",
                           "-P", "-F", "#{pane_id}", "--", "cat")
         self.assertEqual(made.returncode, 0, made.stderr)
+        # **The status line off, and that is what makes the byte counts below a
+        # measurement rather than a coin toss.** tmux redraws the status line on its own
+        # clock — `status-interval` is 15 seconds by default — so a probe that watches
+        # the client for a second has about a one-in-fifteen chance of catching a repaint
+        # nothing here asked for, which is exactly the shape that passes on a laptop and
+        # goes red on CI once a fortnight. The panes run `cat` and write nothing, so with
+        # this off the only thing that can draw on the client is the command under test.
+        self._tmux("set-option", "-g", "status", "off")
         self.harness = made.stdout.strip()
         split = self._tmux("split-window", "-t", self.harness, "-h", "-l", "22",
                            "-P", "-F", "#{pane_id}", "--", "cat")

--- a/tests/test_a_frame_sends_one_invocation_per_batch.py
+++ b/tests/test_a_frame_sends_one_invocation_per_batch.py
@@ -486,27 +486,31 @@ class ALaunchAndASwitchSpendWhatTheyMeasured(PersonaIso, unittest.TestCase):
         after the strips. A chain runs in the order it is given, so it still is.
         """
         fake = self._switch()
-        rows = [_tmuxchain.commands(inv) for inv in fake.invocations]
-        rows = [cmds for cmds in rows
+        lists = [_tmuxchain.commands(inv) for inv in fake.invocations]
+        rows = [i for i, cmds in enumerate(lists)
                 if len(cmds) > 1 and all("resize-pane" in c for c in cmds)]
         self.assertEqual(len(rows), 1,
                          "the arriving frame's rows are not one command list")
-        targets = [c[c.index("-t") + 1] for c in rows[0]]
+        in_list = lists[rows[0]]
+        self.assertTrue(all(c[-2] == "-y" for c in in_list), in_list)
+        targets = [c[c.index("-t") + 1] for c in in_list]
         self.assertEqual(targets[-1], "%2",
                          "the harness pane is not the last resize in the list — "
                          "`resize-pane -y` moves one boundary, so it has to be")
-        self.assertTrue(all(c[-2] == "-y" for c in rows[0]), rows[0])
         # And the read #510 put between the two passes is still a read of its own, still
         # after the columns and still before these rows. Collapsing THAT away is what this
-        # merge deliberately did not do.
-        verbs = [_tmuxchain.commands(inv) for inv in fake.invocations]
-        flat = [inv for inv in verbs]
-        widths = [i for i, cmds in enumerate(flat)
+        # merge deliberately did not do — a list that only reads repaints nothing, so
+        # leaving it where the measurement needs it costs the operator no repaint.
+        widths = [i for i, cmds in enumerate(lists)
                   if any(commands_frame._PANE_WIDTH_FORMAT in c for c in cmds)]
-        cols = [i for i, cmds in enumerate(flat)
+        cols = [i for i, cmds in enumerate(lists)
                 if any("resize-pane" in c and "-x" in c for c in cmds)]
-        self.assertTrue(cols and widths and cols[0] < widths[0]
-                        < flat.index(rows[0]), (cols, widths))
+        self.assertTrue(cols, "the arriving frame asserted no column at all")
+        self.assertTrue(widths, "#510's measurement of the variable pane is gone")
+        self.assertLess(cols[0], widths[0],
+                        "the columns no longer land before the pane is measured (#510)")
+        self.assertLess(widths[0], rows[0],
+                        "the rows no longer come after the measurement (#510)")
 
     def test_the_arriving_chat_is_dressed_before_the_one_being_left_is_tidied(self):
         """#844's ordering, pinned where the invocation counts are: **every** split of the

--- a/tests/test_a_frame_sends_one_invocation_per_batch.py
+++ b/tests/test_a_frame_sends_one_invocation_per_batch.py
@@ -41,8 +41,16 @@ four sent as one list are one. `docs/frame.md` carries the same table for a read
 
 from __future__ import annotations
 
+import fcntl
+import os
+import pty
 import shutil
+import signal
+import struct
 import subprocess
+import termios
+import threading
+import time
 import unittest
 from types import SimpleNamespace
 from unittest import mock
@@ -202,6 +210,178 @@ class WhatARealTmuxDoesWithACommandList(unittest.TestCase):
         self.assertEqual(out.returncode, 0, out.stderr)
 
 
+@unittest.skipUnless(_HAS_TMUX, "no tmux on this machine")
+class WhatACommandListCostsTheOperatorsScreen(unittest.TestCase):
+    """**#844's premise, asked of a real tmux with a real attached client rather than
+    believed** — and it is the reason a list is the unit worth counting at all.
+
+    #780 established that tmux redraws once per command LIST. #844 asked the next
+    question, because the answer decides whether merging two lists is worth anything: does
+    a list whose writes change NOTHING still redraw? The issue behind this assumed the
+    opposite — that a `resize-pane` to a size a pane already has is free because it
+    delivers no SIGWINCH to the pane. It delivers none; measured here, it costs the client
+    a full repaint anyway.
+
+    Measured by hand on tmux 3.7c and at the 3.2 floor, 200x50, three panes, before this
+    class existed, and identically on both versions:
+
+    ==========================================  =============  =============
+    one invocation carrying                     3.7c           3.2
+    ==========================================  =============  =============
+    `resize-pane -x 22` on a 22-wide pane       1672 bytes     1811 bytes
+    a real `resize-pane -x 30`                  1648 bytes     1787 bytes
+    three no-op `resize-pane`s in ONE list      1672 bytes     1811 bytes
+    `display-message -p` (a pure read)          0              0
+    ==========================================  =============  =============
+
+    So the count that decides how much of the operator's window appears to re-render is
+    the number of write-carrying LISTS — not the number of commands in them, not whether
+    any of them moved a boundary. That is what makes `_reassert_sizes`' harness row worth
+    merging into the row pass, and it is what a future tmux would have to change for that
+    merge to stop being worth anything.
+
+    **Needs a client, which is what separates it from
+    :class:`WhatARealTmuxDoesWithACommandList`** — there is no screen to repaint without
+    one. It skips rather than fails where tmux will not attach one, naming what it could
+    not get: a machine that cannot fork a pty client has measured nothing here, and a
+    trial that measured nothing is not a result to assert on.
+    """
+
+    SOCKET = _tmuxreap.name("redraw-cost")
+
+    def setUp(self):
+        self._tmux("kill-server")
+        made = self._tmux("new-session", "-d", "-s", "s", "-x", "200", "-y", "50",
+                          "-P", "-F", "#{pane_id}", "--", "cat")
+        self.assertEqual(made.returncode, 0, made.stderr)
+        self.harness = made.stdout.strip()
+        split = self._tmux("split-window", "-t", self.harness, "-h", "-l", "22",
+                           "-P", "-F", "#{pane_id}", "--", "cat")
+        self.assertEqual(split.returncode, 0, split.stderr)
+        self.side = split.stdout.strip()
+        self.addCleanup(self._reap)
+        self._attach()
+
+    def _reap(self):
+        self._tmux("kill-server")
+        (_tmuxreap.socket_dir() / self.SOCKET).unlink(missing_ok=True)
+
+    def _tmux(self, *args: str) -> subprocess.CompletedProcess:
+        return subprocess.run(["tmux", "-L", self.SOCKET, *args],
+                              capture_output=True, text=True, timeout=20)
+
+    def _attach(self) -> None:
+        """A real pty client at 200x50, and a thread recording every byte tmux draws on
+        it. Skips where no terminal type will attach — see the class docstring."""
+        for term in ("xterm-256color", "screen", "vt100"):
+            pid, fd = pty.fork()
+            if pid == 0:                                      # pragma: no cover - child
+                try:
+                    os.environ["TERM"] = term
+                    os.execvp("tmux", ["tmux", "-L", self.SOCKET, "attach", "-t", "s"])
+                finally:
+                    os._exit(127)
+            fcntl.ioctl(fd, termios.TIOCSWINSZ, struct.pack("HHHH", 50, 200, 0, 0))
+            self.addCleanup(self._close, pid, fd)
+            for _ in range(200):
+                seen = self._tmux("list-clients", "-t", "s", "-F", "#{client_name}")
+                if seen.returncode == 0 and seen.stdout.strip():
+                    self.drawn: list[int] = []
+                    self._reading = True
+                    threading.Thread(target=self._read, args=(fd,),
+                                     daemon=True).start()
+                    time.sleep(1.0)
+                    return
+                time.sleep(0.02)
+        self.skipTest("no tmux client would attach on this machine, and there is no "
+                      "screen to measure a repaint on without one")
+
+    def _close(self, pid: int, fd: int) -> None:
+        self._reading = False
+        try:
+            os.kill(pid, signal.SIGKILL)
+            os.waitpid(pid, 0)
+        except OSError:
+            pass
+        try:
+            os.close(fd)
+        except OSError:
+            pass
+
+    def _read(self, fd: int) -> None:                     # pragma: no cover - thread
+        while self._reading:
+            try:
+                data = os.read(fd, 65536)
+            except OSError:
+                return
+            if not data:
+                return
+            self.drawn.append(len(data))
+
+    def _bytes_drawn(self, *invocations: list[str]) -> int:
+        """How many bytes tmux draws on the client for *invocations*, run in order.
+
+        Settled before and after: the panes run `cat` and write nothing of their own, so
+        everything counted here is tmux redrawing, and the sleeps are what keep one
+        probe's tail out of the next one's total.
+        """
+        time.sleep(0.5)
+        self.drawn.clear()
+        for argv in invocations:
+            out = self._tmux(*argv)
+            self.assertEqual(out.returncode, 0, out.stderr)
+        time.sleep(0.5)
+        return sum(self.drawn)
+
+    def test_a_write_that_changes_nothing_still_repaints_the_whole_client(self):
+        """The measurement #844 turns on. `resize-pane -x 22` on a pane that is already 22
+        columns wide moves no boundary and delivers no SIGWINCH — and costs the client the
+        same repaint a real resize does."""
+        real = self._bytes_drawn(["resize-pane", "-t", self.side, "-x", "30"])
+        if not real:
+            self.skipTest("this client redrew nothing for a REAL resize, so it has "
+                          "measured nothing about a no-op one")
+        back = self._bytes_drawn(["resize-pane", "-t", self.side, "-x", "22"])
+        noop = self._bytes_drawn(["resize-pane", "-t", self.side, "-x", "22"])
+        self.assertGreater(noop, 0,
+                           "a no-op `resize-pane` drew nothing on the client — the merge "
+                           "in `_reassert_sizes` was made because it draws a full "
+                           "repaint, and this tmux no longer agrees")
+        self.assertGreater(noop, back // 2,
+                           f"a no-op resize ({noop} B) cost far less than a real one "
+                           f"({back} B), so a list of them is not the repaint #844 "
+                           "merged two lists to avoid")
+
+    def test_one_list_of_no_op_resizes_costs_one_repaint_where_three_cost_three(self):
+        """The half that makes the merge worth making: the repaint is per LIST.
+
+        Three `resize-pane`s that change nothing, sent one at a time, cost three repaints;
+        the same three in one invocation cost one. `_reassert_sizes` sends a frame's rows
+        and then the harness's own row, and since #844 that is one list rather than two.
+        """
+        one = ["resize-pane", "-t", self.side, "-x", "22"]
+        two = ["resize-pane", "-t", self.harness, "-y", "50"]
+        separately = self._bytes_drawn(one, two, one)
+        together = self._bytes_drawn(one + [";"] + two + [";"] + one)
+        self.assertGreater(separately, 0, "nothing was drawn at all — nothing measured")
+        self.assertLess(together, separately / 2,
+                        f"three writes as one list drew {together} B where three "
+                        f"invocations drew {separately} B — tmux no longer redraws once "
+                        "per command list, which is what every batch here is built on")
+
+    def test_a_pure_read_costs_the_client_nothing(self):
+        """The other side of the same rule, and the reason #510's `display-message`
+        between the two size passes is not what `_reassert_sizes` had to collapse: a list
+        that only READS draws nothing at all, so leaving it where the measurement needs it
+        costs the operator no repaint."""
+        drew = self._bytes_drawn(["display-message", "-p", "-t", self.side,
+                                  "#{pane_width}"])
+        self.assertEqual(drew, 0,
+                         "a pure `display-message -p` repainted the client, so a read is "
+                         "no longer free and #510's read between the size passes is now "
+                         "costing what a write costs")
+
+
 class TheFakesSplitExactlyWhatCharterJoined(unittest.TestCase):
     """`tests/_tmuxchain.commands` is the inverse of `tmuxctl.chain`, and this is what
     says so — because every other test in the suite now believes it.
@@ -273,14 +453,85 @@ class ALaunchAndASwitchSpendWhatTheyMeasured(PersonaIso, unittest.TestCase):
         self.assertEqual(sorted(state.panes(_the_chat(fake))),
                          ["bottom", "repos", "right", "top"])
 
-    def test_a_four_panel_switch_sends_twenty_three_invocations(self):
-        """The `charter frame-chat` path: tear four panels down, select the window, split
-        four fresh ones in.
+    def test_a_four_panel_switch_sends_twenty_two_invocations(self):
+        """The `charter frame-chat` path: select the window, split four fresh panels in,
+        then tear the four the operator left down. It was 58, then 23, and is 22.
 
-        The teardown's eight commands (a disarm and a kill per panel) are one invocation,
-        each end's window dressing is one, the four splits are one, every new pane's
-        options are one, and the four respawn hooks are one.
+        Each end's window dressing is one invocation, the four splits are one, every new
+        pane's options are one, the four respawn hooks are one, the teardown's eight
+        commands (a disarm and a kill per panel) are one, and — since #844 — a frame's
+        rows and the harness's own row are one rather than two.
         """
+        fake = self._switch()
+        self.assertEqual(len(fake.invocations), 22,
+                         [" ".join(c[3:])[:70] for c in fake.invocations])
+        self.assertEqual(len([c for c in fake.calls if "kill-pane" in c]), 4)
+        self.assertEqual(len([c for c in fake.calls if "split-window" in c]), 4)
+
+    def test_a_frames_rows_and_its_harnesss_row_are_one_command_list(self):
+        """#844's collapse, and the one thing a count alone would not say: which list.
+
+        `_reassert_sizes` sends the columns, reads the variable pane's width (#510's
+        measurement, which must stay a read between the passes), and then sends the rows.
+        The harness's own height is the last write of that second pass and used to be an
+        invocation of its own — so a frame's rows landed as two command lists and cost the
+        operator two whole-client repaints. Measured on tmux 3.7c and at the 3.2 floor
+        with a real attached client at 200x50: **every list carrying a write redraws the
+        client**, and a `resize-pane` to a size the pane already has is no exception (1672
+        bytes on 3.7c, 1811 at the floor — what a real resize costs), while a list of
+        three no-op resizes costs exactly one of those.
+
+        The ORDER inside the list is asserted too, and it is the half that had to survive
+        the merge: `resize-pane -y` moves one boundary (#515), so the harness is asserted
+        after the strips. A chain runs in the order it is given, so it still is.
+        """
+        fake = self._switch()
+        rows = [_tmuxchain.commands(inv) for inv in fake.invocations]
+        rows = [cmds for cmds in rows
+                if len(cmds) > 1 and all("resize-pane" in c for c in cmds)]
+        self.assertEqual(len(rows), 1,
+                         "the arriving frame's rows are not one command list")
+        targets = [c[c.index("-t") + 1] for c in rows[0]]
+        self.assertEqual(targets[-1], "%2",
+                         "the harness pane is not the last resize in the list — "
+                         "`resize-pane -y` moves one boundary, so it has to be")
+        self.assertTrue(all(c[-2] == "-y" for c in rows[0]), rows[0])
+        # And the read #510 put between the two passes is still a read of its own, still
+        # after the columns and still before these rows. Collapsing THAT away is what this
+        # merge deliberately did not do.
+        verbs = [_tmuxchain.commands(inv) for inv in fake.invocations]
+        flat = [inv for inv in verbs]
+        widths = [i for i, cmds in enumerate(flat)
+                  if any(commands_frame._PANE_WIDTH_FORMAT in c for c in cmds)]
+        cols = [i for i, cmds in enumerate(flat)
+                if any("resize-pane" in c and "-x" in c for c in cmds)]
+        self.assertTrue(cols and widths and cols[0] < widths[0]
+                        < flat.index(rows[0]), (cols, widths))
+
+    def test_the_arriving_chat_is_dressed_before_the_one_being_left_is_tidied(self):
+        """#844's ordering, pinned where the invocation counts are: **every** split of the
+        window the operator has just arrived at comes before **every** kill in the window
+        they left.
+
+        It ran the other way round, and `cmd_chat`'s own docstring has always said the two
+        re-layouts are independent — so nothing had ever pinned the order and nothing
+        needed to change for this but the two blocks swapping places. What it cost was
+        measured end to end on tmux 3.7c with a real attached client and four panels at
+        200x50: the client moves at invocation 3, and the arriving frame's panels used to
+        appear at invocation 15 — **66 ms** during which the operator is looking at a bare
+        full-screen harness pane while charter tidies a window nobody can see. They appear
+        at invocation 8 now, 38 ms after the move.
+        """
+        fake = self._switch()
+        splits = [i for i, c in enumerate(fake.calls) if "split-window" in c]
+        kills = [i for i, c in enumerate(fake.calls) if "kill-pane" in c]
+        self.assertEqual(len(splits), 4)
+        self.assertEqual(len(kills), 4)
+        self.assertLess(max(splits), min(kills),
+                        [" ".join(c[3:])[:60] for c in fake.calls])
+
+    def _switch(self) -> _FakeServer:
+        """One four-panel `cmd_chat` from `api.1` to `api.2`, and the fake it spent."""
         _plant("api.1", workspace="api", pane="%1")
         _plant("api.2", workspace="api", pane="%2")
         state.record_server("api.1", commands_frame.SOCKET)
@@ -295,10 +546,7 @@ class ALaunchAndASwitchSpendWhatTheyMeasured(PersonaIso, unittest.TestCase):
                                             "CHARTER_WORKSPACE": "api"}, clear=False):
             self.assertEqual(
                 commands_frame.cmd_chat(SimpleNamespace(chat_id="api.2")), 0)
-        self.assertEqual(len(fake.invocations), 23,
-                         [" ".join(c[3:])[:70] for c in fake.invocations])
-        self.assertEqual(len([c for c in fake.calls if "kill-pane" in c]), 4)
-        self.assertEqual(len([c for c in fake.calls if "split-window" in c]), 4)
+        return fake
 
 
 def _the_chat(fake) -> str:

--- a/tests/test_a_workspace_switch_moves_the_client.py
+++ b/tests/test_a_workspace_switch_moves_the_client.py
@@ -272,7 +272,30 @@ class TheSwitchItself(PersonaIso, unittest.TestCase):
         _a_chat("beta.2", ws="beta", pane="%3")
         self._switch(self._ordinary(landing=["$2\t0\tbeta.1", "$2\t1\tbeta.2"]))
         self.assertEqual([c[0][0] for c in self.laid_out.call_args_list],
-                         [self.FID, "beta.2"])
+                         ["beta.2", self.FID])
+
+    def test_the_workspace_arrived_at_is_dressed_before_the_one_left_is_tidied(self):
+        """#844, and it is `cmd_chat`'s ordering one scope out.
+
+        The two re-layouts are independent — §4b says so and this module's other cases
+        assert each on its own — so nothing pinned which went first, and what decided it
+        was the order they were written in. The operator is already looking at the
+        ARRIVING window by the time either runs: `switch-client` has moved their client
+        several invocations earlier. So every invocation spent tidying the workspace they
+        left is time they spend watching a bare full-screen harness pane — measured end to
+        end on tmux 3.7c with a real attached client and four panels at 200x50, 66 ms of
+        it on the chat path this shares its shape with.
+
+        Asserted as an ORDER rather than as two independent calls, because that is the
+        whole change: both calls were already made, and both still are.
+        """
+        self._switch(self._ordinary())
+        self.assertEqual([c[0][0] for c in self.laid_out.call_args_list],
+                         ["beta.1", self.FID],
+                         "the workspace being left is tidied before the one arrived at "
+                         "is dressed")
+        self.assertTrue(self.laid_out.call_args_list[0][1]["want"])
+        self.assertEqual(self.laid_out.call_args_list[1][1]["want"], [])
 
     def test_the_outcome_is_said_on_the_chat_the_operator_landed_on(self):
         """A notice is drawn by a panel out of a frame's own state, so it has to be

--- a/tests/test_a_workspace_switch_moves_the_client.py
+++ b/tests/test_a_workspace_switch_moves_the_client.py
@@ -297,6 +297,28 @@ class TheSwitchItself(PersonaIso, unittest.TestCase):
         self.assertTrue(self.laid_out.call_args_list[0][1]["want"])
         self.assertEqual(self.laid_out.call_args_list[1][1]["want"], [])
 
+    def test_a_switch_that_lands_back_on_this_chat_keeps_its_panels(self):
+        """The one state where the two re-layouts are the SAME frame, and #844's ordering
+        is what makes it worth a line of its own.
+
+        `_chat_showing` reads the landing chat off the SERVER, while `here` came from this
+        chat's own recorded harness pane — and `_plane_session`'s docstring names the
+        residual where those disagree: a pane id restarts at `%0` when a server does, so a
+        `%N` recorded for a chat that is over can name a live pane in another session. The
+        two readings then say this client is in `$1` and that `$2`'s current window is
+        drawing *this* chat.
+
+        With the arrival dressed last, the teardown was undone by accident. With it
+        dressed FIRST, an unguarded teardown would split this frame's panels back in and
+        then kill them — leaving the operator on the bare harness pane #844 is about. So
+        the chat left behind is compared, not assumed.
+        """
+        self._switch(self._ordinary(landing=[f"$2\t1\t{self.FID}"]))
+        self.assertEqual([c[0][0] for c in self.laid_out.call_args_list], [self.FID])
+        self.assertTrue(self.laid_out.call_args_list[0][1]["want"],
+                        "the chat this switch landed on was stripped of its panels by "
+                        "the teardown meant for the chat being LEFT")
+
     def test_the_outcome_is_said_on_the_chat_the_operator_landed_on(self):
         """A notice is drawn by a panel out of a frame's own state, so it has to be
         written to the frame the operator will be reading. Said on `alpha.1` it would go

--- a/tests/test_frame_density.py
+++ b/tests/test_frame_density.py
@@ -1315,15 +1315,42 @@ class LiveOverride(PersonaIso, unittest.TestCase):
         assertion cannot be satisfied by somebody else's guard. The HARNESS pane is
         hostile here too, and for the same reason: `cmd_resize` reads that one off disk as
         well, and #515 gave this function a `resize-pane -t <harness>` of its own."""
+        targets = self._sizes_for(harness_pane="%0;kill-server")
+        self.assertEqual(targets, ["%1"], targets)
+
+    def test_reassert_sizes_takes_no_harness_pane_at_all_without_raising(self):
+        """The other value `state.harness_pane` really answers with, and the one the
+        deletion sweep found nothing driving: **`None`**.
+
+        `harness_pane or ""` is what makes the shape check above total, and it is not
+        belt-and-braces over the check — it is the half that decides whether a frame with
+        no recorded harness pane resizes its panels or dies. `_PANE_ID_RE.fullmatch(None)`
+        raises `TypeError`, and this runs inside `_relayout`, so the panel sizes above it
+        would be applied and everything after it — the harness's own row, the resize hook,
+        the `select-pane` that takes the keyboard off a panel — would not.
+
+        Driven here rather than through a caller because neither caller can produce it:
+        `_relayout_target` answers `None` for the whole frame rather than a tuple with a
+        `None` in it, and `cmd_resize` spells its own `or ""` before the call. That is
+        exactly `_panel_died_hook_argv`'s rule and #475's history — a builder documented
+        as "safe because my caller checked" grows a second caller — asked of the type
+        `state.harness_pane` is annotated to return rather than of the two strings its
+        callers happen to hand over today.
+        """
+        targets = self._sizes_for(harness_pane=None)
+        self.assertEqual(targets, ["%1"], targets)
+
+    def _sizes_for(self, *, harness_pane) -> list[str]:
+        """Which panes `_reassert_sizes` really resized, called directly with a map whose
+        second id is hostile and a *harness_pane* the caller chooses."""
         calls = []
         with mock.patch("charter.frame.tmuxctl.run", _tmuxchain.recorder(calls)):
             commands_frame._reassert_sizes(
                 "charter", fid=self.fid,
                 panes={"top": "%1", "bottom": "%2;kill-server"},
-                harness_pane="%0;kill-server",
+                harness_pane=harness_pane,
                 window_cols=200, window_rows=50)
-        targets = [c[c.index("-t") + 1] for c in calls if "resize-pane" in c]
-        self.assertEqual(targets, ["%1"], calls)
+        return [c[c.index("-t") + 1] for c in calls if "resize-pane" in c]
 
     def test_the_harness_pane_gets_focus_back(self):
         """`split-window` makes each new pane ACTIVE — without this the operator is left

--- a/tests/test_plane_spawn_guard.py
+++ b/tests/test_plane_spawn_guard.py
@@ -934,6 +934,12 @@ class NoCharterEscapesThroughTheExecFamily(unittest.TestCase):
             "`charter frame-palette` and `charter frame-switch --persona`, and a mouse "
             "report still has to be put on a real client's terminal for tmux to route it "
             "anywhere. `os._exit`s in its `finally`.",
+        "tests/test_a_frame_sends_one_invocation_per_batch.py:execvp":
+            "The same `tmux attach` inside a `pty.fork` child, for the reason #844's "
+            "measurement is ABOUT: what a command list costs the operator is what tmux "
+            "DRAWS for it, and there is no screen to draw on without a real client on a "
+            "real terminal — a detached server repaints nothing at all. `os._exit`s in "
+            "its `finally`.",
     }
 
     _WATCHED = ("execl", "execle", "execlp", "execlpe", "execv", "execve", "execvp",


### PR DESCRIPTION
Closes #844 — the two fixes it marks safe. **(c) is deliberately not done**: it is the
spec-level decision the issue exists to hold.

## What the measurement actually said

The issue's mechanism is **wrong**, and the correction is what makes (b) worth doing at
all. Measured end to end on tmux 3.7c with a **real attached pty client**, four panels at
200x50, driving the real `cmd_chat`:

> **The arriving harness pane is dealt exactly ONE SIGWINCH by a whole arrival** — from
> the four `split-window`s in their single command list. The three `resize-pane` lists
> after it deliver **none**: they re-assert sizes the panes already have, and the issue's
> own second tmux fact says a same-size `resize-pane` is a true no-op.

So "four geometry changes, each making Claude Code redraw its whole rectangle" is not what
happens. What *does* happen is one level out. Probed on 3.7c and at the 3.2 floor,
identically:

| one invocation carrying | 3.7c | 3.2 |
|---|---|---|
| `resize-pane -x 22` on a pane already 22 wide | 1672 B | 1811 B |
| a real `resize-pane -x 30` | 1648 B | 1787 B |
| three no-op `resize-pane`s in **one** list | 1672 B | 1811 B |
| `set-option -w @probe 1`, twice running | 1672 B | 1811 B |
| `display-message -p` — a pure read | **0** | **0** |

**Every command list carrying a write repaints the whole client, whether or not the write
changed anything; a list of three costs one repaint, and a pure read costs none.** The
blink is tmux redrawing the client, not the agent TUI reflowing — which is exactly *"all
the window seems to be re-rendering"*. The unit worth counting is the write-carrying
**list**.

## (a) Dress the arrival before tidying the departure

`cmd_chat` and `_switch_client` did the two independent re-layouts in the order they were
written. The client has already moved by then, so the operator spends the whole teardown
looking at a bare full-screen harness pane.

| | client moves at | panels appear at | bare harness pane for |
|---|---|---|---|
| tmux 3.7c | invocation 3 | 15 → **8** | 78 ms → **38 ms** |
| at the 3.2 floor | invocation 3 | 14 → **8** | 63 ms → **36 ms** |

Nothing is dropped and nothing is deferred: the same teardown, in the same switch, in the
half where nobody is waiting on it. Pure ordering — the two blocks swap places.

## (b) One command list for a frame's rows

`_reassert_sizes` sent the panel strips' `-y` and then the harness pane's own `-y` as two
invocations. They share one `sizes` map, nothing between them reads anything, and a chain
preserves order (which matters: `resize-pane -y` moves one boundary, so the harness still
goes last). One list now — one repaint instead of two, on both ends of both switch kinds
and on every density change and window resize.

**#510's read is untouched.** It must stay after the columns and it is a *read*, and a
read repaints nothing — so it costs the operator nothing where it is. The column pass
cannot join the splits either: a split list reads pane ids back and `write_all` must never
replay one. The arrival is therefore **three** geometry lists rather than four, not one.

## Counts

| | invocations | tmux commands |
|---|---|---|
| chat switch (`cmd_chat`) | 23 → **22** | 58 (unchanged) |
| workspace switch (`_switch_client`) | 25 → **24** | 60 (unchanged) |

Final pane geometry after a switch is identical on both tmux versions, byte for byte
(`%N 177x1 top / 177x43 harness / 177x1 repos / 177x1 bottom / 22x49 right`).

## Two lines the reorder makes load-bearing

* **`landed != fid`** in `_switch_client`. `_chat_showing` reads the landing chat off the
  server while `here` came from this chat's own recorded pane, and `_plane_session`'s
  docstring names the residual where those disagree (a pane id restarts at `%0` when a
  server does). `landed` really can be `fid` there. Dressing last used to undo an
  unguarded teardown by accident; dressing first would split this frame's panels in and
  then kill them.
* **`harness_pane or ""`** — the sweep's one survivor, and it is pinned rather than
  deleted. `state.harness_pane` really answers `None`, `fullmatch(None)` raises, and this
  runs inside `_relayout` above the resize hook and the `select-pane` that takes the
  keyboard back off a panel. Annotation is now `str | None`.

## Verification

* Full suite: `Ran 10809 tests in 582.022s — OK (skipped=9)`.
* Local deletion sweep against `origin/main`: baseline `Ran 10807 tests — OK`, then
  **4 pinned / 1 survivor**, which is the `or ""` above — now pinned, and re-swept.
* Three new **real-tmux, real-client** cases carry the table above, so a later tmux that
  changes its mind fails loudly instead of leaving a merge that buys nothing.
* Both new guards hand-checked with a cleared `__pycache__`: deleting either turns its own
  test red.
* Exercised at the **3.2 floor** as well as 3.7c — the ordering, the merged list, the final
  geometry and the redraw costs all behave identically.

## Not done, on purpose

Keeping panels alive on leave (#844's option (c)) would take the switch to 22 invocations
with zero splits and essentially remove the blink — and it inverts #668/#686's rule and
keeps four ~24 MB processes per backgrounded chat, ~576 MB with six. That is the decision
#844 exists to hold, and it is not taken here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Us4MbwkSCJCxwt1CjAd1sf

---

### One more tmux fact, found while making the probes trustworthy

The redraw class went red once in a full-suite run and the cause was not load. **On
attach, tmux holds a repaint back until the terminal answers its feature query — and a
pty with nothing behind it never answers, so the answer is a five-second timeout.**
Watching every byte on a fresh pty client, on 3.7c and at the 3.2 floor: bursts at **6 ms**
and again at **5006 ms**, nothing in between or after. Inside that window the *first*
command of any kind flushes the held repaint, so a pure `display-message -p` that draws
**0** bytes on a settled client draws **617** (3.7c) / **625** (3.2) at one second.

The fixture now builds one client for the class and waits that window out once, rather
than three clients each paying it. The settle is a duration and deliberately **not** a
probe that stops when a read draws nothing — that would be this class's own third
assertion turned into its fixture, and a test pinned by its fixture asserts nothing.
