### PR TITLE
A restored chat comes back in its workspace, and says where it had been (#867)

### DIFF
--- a/charter/commands_frame.py
+++ b/charter/commands_frame.py
@@ -9192,18 +9192,36 @@ def _restore_root(c):
     has a bigger problem than one chat, and saying so beats dropping the chat into the
     plane root and calling it restored.
     """
+    # **`os.path.isdir` alone, with no `c.cwd and` in front of it**, in both places below.
+    # The deletion sweep survived that conjunct and it was right to: `reopen._chat` reads
+    # every text field as ``raw.get(k) if isinstance(..., str) else ""``, so `cwd` off the
+    # manifest is a `str` and nothing else, and `os.path.isdir("")` is already `False`.
+    # A guard that cannot change an answer is dead code wearing a guard's clothes.
     if not workspace.valid_name(c.workspace):
         # A chat that names no workspace has no boundary to land in, so the recorded cwd is
         # still the best answer available and the plane root is still the fallback. Off the
         # manifest this cannot happen — `reopen._usable` refuses such a record and
         # `leave.NOT_REOPENED` already said why — so this is the direct caller's branch,
         # kept total rather than left to raise on a value the record can hold.
-        return c.cwd if c.cwd and os.path.isdir(c.cwd) else config.ROOT
-    if c.cwd and os.path.isdir(c.cwd) and workspace.contains(c.workspace, c.cwd):
+        return c.cwd if os.path.isdir(c.cwd) else config.ROOT
+    # **`os.path.isdir` as well as `workspace.contains`, and the two are not the same
+    # question.** `contains` is path arithmetic — it answers *yes* for
+    # ``workspaces/<ws>/<repo>`` whether or not that clone is still on disk — so a chat
+    # recorded in a clone somebody has since removed would be sent back to a directory that
+    # is not there, `os.chdir` would refuse it, and the chat would not be reopened at all.
+    # Its workspace is the better answer, and asking whether the directory EXISTS is what
+    # reaches it.
+    if os.path.isdir(c.cwd) and workspace.contains(c.workspace, c.cwd):
         return c.cwd
     try:
         return workspace.ensure(c.workspace)
-    except (ValueError, OSError):
+    except OSError:
+        # **`OSError` and not `(ValueError, OSError)`.** `ensure` raises `ValueError` for a
+        # name `valid_name` refuses — which the guard at the top of this function has
+        # already asked of the same value, so the two cannot disagree and that half was
+        # unreachable. What is left is a plane whose ``workspaces/`` cannot be written to,
+        # and it is reported rather than swallowed: the directory comes back unmade,
+        # `os.chdir` refuses it, and `_reopen_one` says the chat was not reopened.
         return workspace.workspace_dir(c.workspace)
 
 

--- a/charter/commands_frame.py
+++ b/charter/commands_frame.py
@@ -9152,6 +9152,105 @@ def _consume(m, done, *, quiet: bool = False) -> None:
                 "recorded — `charter reopen` again to retry just those")
 
 
+def _restore_root(c):
+    """The directory a restore of recorded chat *c* stands in — its WORKSPACE's — #867.
+
+    **The record stores the literal cwd and the restore lands in the isolation boundary**,
+    which is the pair the grilling behind #845 settled. #849 built the recording half; this
+    is the other one, and it is a deliberate reversal of what a reopen used to do.
+
+    Reusing the recorded cwd verbatim was option (a), and it was rejected for being
+    *faithful to a state everyone has already agreed is wrong*: a chat started by typing
+    `charter` in the plane root — before the tab machinery existed — recorded the plane
+    root, and every restore since has reproduced that one old disagreement. Measured on the
+    operator's own plane: ``harness-wrapper.1`` with ``ws=harness-wrapper`` and ``cwd=``
+    the plane root, beside two chats opened through the frame that were both correct.
+    Landing in the workspace and forgetting the cwd was option (b), rejected for losing
+    information and moving the operator in silence. This is (c): land in the workspace, and
+    let `_reopen_one` say where the chat had actually been.
+
+    **The test is containment, never equality**, and that is the half that is easy to get
+    wrong. A chat recorded in ``workspaces/<ws>/<repo>`` is standing in one of that
+    workspace's clones on purpose, and hauling it up to the workspace root would be a new
+    silent move in place of the old one — the same defect wearing the fix's clothes. The
+    disagreement worth correcting is a cwd *outside* the subtree. `workspace.contains` is
+    that question, and it is asked rather than spelled here because a worktree lives
+    outside ``workspaces/`` altogether and is just as much the workspace's own tree.
+
+    **`workspace.ensure`, not `_launch_root`**, and that is #867's second half. Both
+    answer "where would a launch for this workspace run", but `_launch_root` falls back to
+    `config.ROOT` for a workspace with no directory yet — a real state, since
+    `switch.workspaces` offers `default` whether or not its directory exists. Reusing it
+    would let the very defect being closed back in through a second door, and by the worse
+    route: a restore that reports landing in the workspace while standing in the plane
+    root. Making the boundary before putting a chat inside it is what #850 settles for the
+    launch path; this is the same treatment on the restore path.
+
+    **A workspace charter cannot make hands its directory back unmade**, and that is the
+    honest end rather than an oversight: `os.chdir` then refuses it and `_reopen_one`
+    reports the chat as not reopened. A plane whose ``workspaces/`` cannot be written to
+    has a bigger problem than one chat, and saying so beats dropping the chat into the
+    plane root and calling it restored.
+    """
+    if not workspace.valid_name(c.workspace):
+        # A chat that names no workspace has no boundary to land in, so the recorded cwd is
+        # still the best answer available and the plane root is still the fallback. Off the
+        # manifest this cannot happen — `reopen._usable` refuses such a record and
+        # `leave.NOT_REOPENED` already said why — so this is the direct caller's branch,
+        # kept total rather than left to raise on a value the record can hold.
+        return c.cwd if c.cwd and os.path.isdir(c.cwd) else config.ROOT
+    if c.cwd and os.path.isdir(c.cwd) and workspace.contains(c.workspace, c.cwd):
+        return c.cwd
+    try:
+        return workspace.ensure(c.workspace)
+    except (ValueError, OSError):
+        return workspace.workspace_dir(c.workspace)
+
+
+def _same_directory(a, b) -> bool:
+    """Whether *a* and *b* name the same place on disk — so a restore that moved nothing
+    says nothing.
+
+    **A string compare is not this question.** A record's `cwd` came off `os.getcwd()`,
+    which returns the links already walked, while the workspace directory is joined from
+    the plane root as configured — and on macOS a plane under ``/var/folders`` is reached
+    through a link to ``/private/var``. Compared as text those two disagree for a chat that
+    has not moved an inch, which would print #867's own report line on every restore in the
+    test harness and on any plane behind a linked mount.
+
+    **An empty *b* is never the same place as anything.** A chat with no recorded directory
+    at all HAS moved — from nowhere in particular into its workspace — and that is worth
+    the sentence rather than silence. Spelled here because `os.path.realpath("")` answers
+    the *process's* cwd, which is a third directory that has nothing to do with either.
+    """
+    if not b:
+        return False
+    try:
+        return os.path.realpath(a) == os.path.realpath(b)
+    except (OSError, ValueError):
+        return False
+
+
+def _was_standing_in(c) -> str:
+    """How a restore names the directory it is NOT putting chat *c* back into.
+
+    Three states, kept apart because they are three different things to know and an
+    operator acts differently on each: a cwd charter never recorded (a chat launched by a
+    charter older than `state.record_cwd`), one that has since gone, and one that is still
+    there and simply outside the workspace. The last is what #867 is actually about, and it
+    is the one where naming the path answers the operator's question — *why is this chat
+    somewhere else now* — rather than merely apologising for it.
+
+    Contained on the way out (`contain.readable`) because the value came off a plain file
+    that outlives the process, and this sentence reaches a terminal.
+    """
+    if not c.cwd:
+        return "no directory was ever recorded for it"
+    if not os.path.isdir(c.cwd):
+        return f"its recorded directory {contain.readable(c.cwd)} is gone"
+    return f"it had been standing in {contain.readable(c.cwd)}"
+
+
 def _reopen_one(c, *, quiet: bool = False) -> "Reopening | None":
     """Put one recorded chat back. The launch's own record, or ``None`` when it did not run.
 
@@ -9173,6 +9272,12 @@ def _reopen_one(c, *, quiet: bool = False) -> "Reopening | None":
     parameter for it would be a second way to say the same thing. Restored in a `finally`:
     the next chat in the manifest has its own directory, and a launcher left standing in
     somebody else's is exactly the silent wrongness §4e's cwd item exists to close.
+
+    **Which directory that is, is `_restore_root`'s answer and not the record's** (#867):
+    the workspace, unless the recorded cwd is already inside it. What is left here is the
+    one sentence that decision owes the operator — where the chat came back, and where it
+    had been — because a restore that moves somebody without saying so is option (b), and
+    option (b) is the one #845's grilling threw out.
     """
     h = next((x for x in harness.all() if x.name == c.harness), None)
     if h is None or not h.cli_name:
@@ -9192,12 +9297,21 @@ def _reopen_one(c, *, quiet: bool = False) -> "Reopening | None":
     rest: list[str] = []
     if c.resume and leave.resumable_harness(c.harness):
         rest = ["--resume", c.resume]
-    where = c.cwd if c.cwd and os.path.isdir(c.cwd) else str(config.ROOT)
-    if where != c.cwd:
+    # **Asked BEFORE `_restore_root`, which MAKES the workspace directory when it is gone**
+    # (#867). The note below is about the plane the operator left, not about the one this
+    # function has just repaired — asked after the `ensure` it would answer "present" for
+    # every chat, and the only warning a deleted workspace gets would vanish silently.
+    homeless = workspace.valid_name(c.workspace) and not workspace.exists(c.workspace)
+    where = _restore_root(c)
+    if not _same_directory(where, c.cwd):
+        # "its workspace directory" is a claim, so it is only made where it is true: the
+        # branch of `_restore_root` that has no workspace to name lands somewhere for a
+        # different reason and says so in plainer words.
+        landing = (f"its workspace directory {contain.readable(where)}"
+                   if workspace.valid_name(c.workspace) else contain.readable(where))
         _report(quiet, util.warn,
-                f"charter reopen: {c.chat}'s directory "
-                f"{contain.readable(c.cwd) or 'was never recorded'} — reopening in "
-                f"{where}")
+                f"charter reopen: {c.chat} comes back in {landing} — "
+                f"{_was_standing_in(c)}")
     r = Reopening(c)
     argv_args = _reopen_args(c, harness_name=h.cli_name, rest=rest, reopening=r)
     here = os.getcwd()
@@ -9221,8 +9335,7 @@ def _reopen_one(c, *, quiet: bool = False) -> "Reopening | None":
         return None
     _report(quiet, util.info,
             f"  {c.chat} → {r.fid} · {leave.RESUMES if rest else 'empty'}"
-            + (" · workspace is missing" if c.workspace
-               and not workspace.exists(c.workspace) else ""))
+            + (" · workspace was missing — remade empty" if homeless else ""))
     return r
 
 

--- a/charter/frame/leave.py
+++ b/charter/frame/leave.py
@@ -90,12 +90,25 @@ class Doomed(NamedTuple):
     #: :func:`plan` has one place that drops it.
     closed: bool
     #: Whether the workspace this chat belongs to still has a directory on disk
-    #: (`workspace.exists`, the one predicate the repo pane asks too — #752). §4j forbids
-    #: re-homing a chat, so a missing workspace is *reported*, never repaired; a RENAMED
-    #: one is not missing at all, because `workspace.rename` repoints the chat (#795).
+    #: (`workspace.exists`, the one predicate the repo pane asks too — #752). A RENAMED
+    #: workspace is not missing at all, because `workspace.rename` repoints the chat
+    #: (#795).
+    #:
+    #: **§4j still forbids re-homing and a reopen still does not do it** — the chat comes
+    #: back in the workspace it named, under the id it named. What changed with #867 is
+    #: that the DIRECTORY is remade (`workspace.ensure`) instead of the chat being stood in
+    #: the plane root, which is repairing the boundary rather than moving the chat out of
+    #: it. Its clones are still gone, so the row goes on saying the workspace was missing.
     homeless: bool
     #: Whether the recorded cwd is still a directory.
     cwd_gone: bool
+    #: Whether the recorded cwd is a directory OUTSIDE this chat's workspace — the state
+    #: #867 is about, and the one a preview used to say nothing at all about. A restore
+    #: lands in the workspace (`commands_frame._restore_root`), so a cwd standing outside
+    #: it is a chat that WILL be moved, and the row that promises what a reopen gives back
+    #: has to say so. ``False`` for a cwd that is gone, for one that was never recorded and
+    #: for a chat with no workspace: none of those is a chat standing somewhere else.
+    cwd_outside: bool
 
 
 class Plan(NamedTuple):
@@ -166,6 +179,11 @@ def plan(*, live, focus: str, only: str = "") -> Plan:
             closed=False,
             homeless=bool(ws) and not ws_mod.exists(ws),
             cwd_gone=bool(cwd) and not os.path.isdir(cwd),
+            # `ws_mod.contains` and not a `workspaces/<ws>/` prefix test, because it is the
+            # same predicate `commands_frame._restore_root` decides with — the promise and
+            # the act have to be one reading, which is this record's whole reason.
+            cwd_outside=(bool(cwd) and bool(ws) and os.path.isdir(cwd)
+                         and not ws_mod.contains(ws, cwd)),
         ))
     return Plan(chats=tuple(out), focus=focus)
 
@@ -315,11 +333,21 @@ def note(c: Doomed) -> str:
         return JOIN.join([NOT_REOPENED] + _ended(c))
     parts = [_resume_clause(c)]
     if c.homeless:
-        parts.append(f"workspace '{c.workspace}' is gone — reopens saying so")
+        parts.append(f"workspace '{c.workspace}' is gone — reopens in a remade, empty one")
+    # **All three cwd clauses now end in the workspace, and that is #867 rather than a
+    # reword.** A reopen used to stand the chat in its recorded cwd and fall back to the
+    # plane root, so "reopens in the plane root" was what a lost directory cost; it now
+    # lands in the workspace, which is the isolation boundary the chat belongs to, and a
+    # row still promising the plane root would be promising something charter stopped
+    # doing. The third clause is new because the state it names used to cost nothing to
+    # say: a cwd standing OUTSIDE the workspace was restored verbatim, and is now moved.
     if c.cwd_gone:
-        parts.append(f"its directory {c.cwd} is gone — reopens in the plane root")
+        parts.append(f"its directory {c.cwd} is gone — reopens in its workspace")
+    elif c.cwd_outside:
+        parts.append(f"it is standing in {c.cwd}, outside its workspace — reopens in the "
+                     f"workspace")
     elif not c.cwd:
-        parts.append("no directory recorded — reopens in the plane root")
+        parts.append("no directory recorded — reopens in its workspace")
     return JOIN.join(parts + _ended(c))
 
 

--- a/charter/workspace.py
+++ b/charter/workspace.py
@@ -295,6 +295,47 @@ def from_path(path=None) -> str | None:
     return parts[0] if len(parts) >= 2 else None
 
 
+def contains(name: str, path) -> bool:
+    """Whether *path* is inside workspace *name*'s own subtree — #867.
+
+    **The isolation boundary as a containment question, which is a different one from
+    :func:`from_path`.** That function asks "which workspace's *tree* is this", and
+    answers ``None`` for ``workspaces/<ws>`` itself, deliberately: the workspace directory
+    is the container and not a repo, and a status line naming a workspace for a path with
+    no repo in it would be claiming a tree that is not there. This asks the question a
+    *boundary* has to answer, where the container counts — so it is that predicate plus the
+    directory itself, rather than a loosening of it.
+
+    Used by `commands_frame._restore_root`, to decide whether a recorded cwd is one a
+    restore may keep, and by `frame/leave.plan`, so the quit preview promises the same
+    thing the restore then does. Spelled once for `_launch_root`'s reason: it was about to
+    be the same three lines twice, in two modules that must not come to disagree.
+
+    **A prefix test on `workspaces/<ws>/` would be wrong**, and that is why this delegates
+    rather than joining paths. A worktree lives at ``<[plane] worktrees>/<ws>/<repo>/…``,
+    outside ``workspaces/`` entirely, and is every bit as much that workspace's own tree as
+    a clone is; `from_path` already tries both roots (`worktree.locate`), and a second
+    reading here would be a second answer to go stale.
+
+    Resolved on both sides, like :func:`contain.within_data`: a recorded cwd came off
+    `os.getcwd()`, which returns a path with the links already walked, while
+    ``WORKSPACES_DIR`` is joined from the plane root as configured — and on macOS a plane
+    under ``/var/folders`` is reached through a link to ``/private/var``. Comparing the two
+    as text answers *outside* for a path that is plainly inside.
+
+    Never creates and never raises, like every predicate here: an unresolvable path is
+    simply not contained.
+    """
+    if not valid_name(name) or not path:
+        return False
+    if from_path(path) == name:
+        return True
+    try:
+        return os.path.realpath(path) == os.path.realpath(workspace_dir(name))
+    except (OSError, ValueError):
+        return False
+
+
 def clone_of(path=None) -> tuple[str, str] | None:
     """``(workspace, repo)`` when *path* is inside a **clone**, else ``None``.
 

--- a/charter/workspace.py
+++ b/charter/workspace.py
@@ -247,7 +247,7 @@ def exists(name: str) -> bool:
 
     **The name check is part of the predicate and not the caller's job, and that is what
     is new here.** The same question was spelled inline in `frame/leave.plan` (`homeless`)
-    and in `commands_frame._reopen_one`'s `· workspace is missing`, and both are fed from
+    and in `commands_frame._reopen_one`'s `· workspace was missing`, and both are fed from
     `state.own_workspace`, which name-checks every rung it returns — so a bare
     `workspace_dir(ws).is_dir()` was safe *there* because of something true one call up.
     The pane's name comes from `state.workspace_for`, whose LAST rung is a bare
@@ -324,13 +324,16 @@ def contains(name: str, path) -> bool:
     as text answers *outside* for a path that is plainly inside.
 
     Never creates and never raises, like every predicate here: an unresolvable path is
-    simply not contained.
+    simply not contained. **`from_path` is inside the guard and not in front of it**, which
+    is the difference between promising that and merely intending it — it catches
+    ``(OSError, RuntimeError)`` and `Path.resolve` raises `ValueError` on a path with an
+    embedded NUL, which is a value a hand-edited `reopen.json` can carry to both callers.
     """
     if not valid_name(name) or not path:
         return False
-    if from_path(path) == name:
-        return True
     try:
+        if from_path(path) == name:
+            return True
         return os.path.realpath(path) == os.path.realpath(workspace_dir(name))
     except (OSError, ValueError):
         return False

--- a/docs/frame.md
+++ b/docs/frame.md
@@ -831,11 +831,38 @@ to record it is exactly the invasive quit this exists to prevent, so that refuse
 nothing.
 
 **`charter reopen` puts the recorded plane back.** Every workspace, every chat, each one's
-persona and the directory it was started in — and, for Claude Code, the conversation, by
+persona and the directory it belongs in — and, for Claude Code, the conversation, by
 resuming it. It attaches you to the workspace you pressed quit in, on the chat that was in
 front of you. The record describes one quit and is consumed chat by chat, so running it
 twice does not double your tabs — and if some chat could not be started, exactly that chat
 stays recorded, so a second `charter reopen` retries just it.
+
+**A chat comes back in its workspace, and is told when that is not where it had been.** The
+record stores the directory the harness was actually standing in; the restore lands in
+`workspaces/<ws>/`, which is the isolation boundary the chat belongs to. The two agree for
+every chat opened through the frame. Where they disagree — a chat started by typing
+`charter` in the plane root, before the tab machinery existed, and carrying that as its
+directory ever since — a restore that reproduced it faithfully would be reproducing a state
+already agreed wrong, on every launch rather than once. So it lands in the workspace and
+says where it had been:
+
+```
+⚠ charter reopen: harness-wrapper.1 comes back in its workspace directory
+  …/workspaces/harness-wrapper — it had been standing in /Users/aharon/IdeaProjects/charter
+```
+
+**A directory *inside* the workspace is kept exactly as it is**, because the test is
+containment and not equality: a chat recorded in `workspaces/<ws>/<repo>` is standing in one
+of that workspace's clones on purpose, and moving it up to the workspace root would be a new
+silent move in place of the old one. Worktrees count as well, wherever `[plane] worktrees`
+puts them. Nothing is said about a chat that was already where it belongs.
+
+**The workspace directory is made before the chat is put in it.** A workspace with no
+directory yet is ordinary — `default` is offered whether or not anybody has made one — and
+falling back to the plane root there would be the same wrongness by a second route. A
+workspace whose directory has been deleted is remade the same way, empty, and the chat's
+line says so; its clones are still gone, and charter still never re-homes a chat into a
+workspace it did not name.
 
 Run it from an ordinary shell. **Inside a tmux you already have it refuses**, because charter
 builds a frame there as a window on your own server and that launcher stays awake for the
@@ -906,8 +933,9 @@ it.
 own session id from Claude Code's status-line hook, which is the only harness that supplies
 one — so it is the only harness whose conversation charter can ask for back. A chat that
 cannot be resumed still comes back: its directory, its workspace and its persona return, and
-only the conversation is gone. A chat whose *workspace* has been deleted comes back too, and
-says the workspace is missing; charter never quietly re-homes a chat.
+only the conversation is gone. A chat whose *workspace* has been deleted comes back too, into
+a remade and empty one, and says the workspace was missing; charter never quietly re-homes a
+chat, and a workspace it re-makes is the chat's own.
 
 **`F2 → chat: previous transcript`** opens what a chat had on screen before it was last
 stopped, in a pager, in a window of its own. tmux history dies with its session and

--- a/docs/news/unreleased-a-renamed-workspace-keeps-its-chats-and-a-deleted-one-says-so.md
+++ b/docs/news/unreleased-a-renamed-workspace-keeps-its-chats-and-a-deleted-one-says-so.md
@@ -120,8 +120,8 @@ true; you decide.
 for the seconds it was always right for, in a workspace that exists.
 
 **One predicate, three surfaces.** `charter quit` already recorded a chat whose workspace had
-gone (`homeless`) and `charter reopen` already printed `· workspace is missing`. Both spelled
-the question inline; all three now ask `workspace.exists`, so the frame and the quit path
-cannot come to disagree about whether a workspace is there.
+gone (`homeless`) and `charter reopen` already noted it on that chat's line. Both spelled the
+question inline; all three now ask `workspace.exists`, so the frame and the quit path cannot
+come to disagree about whether a workspace is there.
 
 Closes #752, #795.

--- a/docs/news/unreleased-a-restored-chat-comes-back-in-its-workspace.md
+++ b/docs/news/unreleased-a-restored-chat-comes-back-in-its-workspace.md
@@ -1,0 +1,77 @@
+---
+version: unreleased
+headline: a restored chat comes back in its workspace, and says where it had been
+---
+
+*"When opening chat and opening new session automatically — opening session in plane
+directory not workspace directory."*
+
+A restore stood each chat back in the directory its record carried. Measured on the
+operator's own plane, with three chats recorded:
+
+```
+fleet.1                  ws=fleet                  cwd=…/workspaces/fleet                  ✓
+opencode-integration.1   ws=opencode-integration   cwd=…/workspaces/opencode-integration   ✓
+harness-wrapper.1        ws=harness-wrapper        cwd=/Users/aharon/IdeaProjects/charter  ← the plane root
+```
+
+The two opened through the frame landed in their workspaces. The third was started by
+typing `charter` in the plane root, years of sessions ago and before the tab machinery
+existed, and recorded that as its directory. Nothing was wrong with the restore: it was
+faithful. What it was faithful to was one old disagreement — and now that the plane is
+recorded as it changes, a restore happens on every launch instead of once, so that
+disagreement came back every time.
+
+**A restore now lands in the chat's workspace**, which is the isolation boundary the chat
+belongs to, and says so when that is not where the chat had been:
+
+```
+⚠ charter reopen: harness-wrapper.1 comes back in its workspace directory
+  …/workspaces/harness-wrapper — it had been standing in /Users/aharon/IdeaProjects/charter
+```
+
+The record still stores the literal directory. That pair — store the cwd, restore to the
+workspace, say so when they differ — is what the design settled; only the recording half
+had been built. Restoring the directory verbatim reproduces a state already agreed wrong;
+landing in the workspace and saying nothing loses the information and moves you in
+silence. The line is what makes it neither.
+
+## A chat standing in a clone stays in that clone
+
+The test is containment, not equality. `workspaces/<ws>/<repo>` is *inside* the workspace,
+and a chat recorded there is standing in a clone on purpose — hauling it up to the
+workspace root would be a new silent move put in place of the old one. Worktrees count
+too, wherever `[plane] worktrees` puts them: a worktree is that workspace's tree as much
+as a clone is.
+
+So the chats that were already right are untouched, and say nothing. What moves is a
+chat standing somewhere outside its own workspace.
+
+## The workspace is made before the chat is put in it
+
+A workspace with no directory yet is an ordinary state — `default` is offered whether or
+not anybody has made it. A restore now creates it rather than falling back to the plane
+root, which would have been the same defect arriving by a second door. A workspace whose
+directory has been *deleted* is remade the same way, empty, and the chat's line says so:
+
+```
+  harness-wrapper.1 → harness-wrapper.1 · conversation resumes · workspace was missing — remade empty
+```
+
+Its clones are still gone. Charter re-makes the boundary; it does not invent what was
+inside it, and it still never re-homes a chat into a workspace it did not name.
+
+## What quit promises now matches what a reopen does
+
+The rows under `F2 → charter: quit` say what each chat gets back, and three of them used
+to end in the plane root:
+
+```
+alpha.1 · claude-code   conversation resumes · its directory /gone is gone — reopens in its workspace
+alpha.2 · claude-code   conversation resumes · it is standing in /elsewhere, outside its
+                        workspace — reopens in the workspace
+```
+
+The second is new. That state used to cost you nothing to be told about, because the
+restore stood the chat straight back in it. It now moves the chat, so the row says so
+before you press anything.

--- a/tests/test_a_filesystem_that_refuses_costs_what_it_says.py
+++ b/tests/test_a_filesystem_that_refuses_costs_what_it_says.py
@@ -46,6 +46,7 @@ from pathlib import Path
 from unittest import mock
 
 from charter import commands_frame, config, inflight, persona, util
+from charter import workspace as ws_mod
 from charter.frame import leave, reopen, state
 
 from tests._isolation import PersonaIso
@@ -369,10 +370,12 @@ class AReopenThatCannotStandSomewhereSaysSo(_FrameRoot):
         self.assertEqual(out.fid, "alpha.1")
         self.assertEqual(len(calls), 1)
         # And the cost, stated rather than tidied away: the process really is left in the
-        # recorded directory. Nothing in `_reopen_one` can fix that — the `finally` already
-        # tried — so the honest assertion is that it happened, and `setUp`'s cleanup is
-        # what puts the RUNNER back before the tmp plane is removed.
-        self.assertEqual(os.getcwd(), str(config.ROOT.resolve()))
+        # directory the restore chose — the chat's WORKSPACE since #867, which is also what
+        # the recorded plane root is no longer. Nothing in `_reopen_one` can fix that — the
+        # `finally` already tried — so the honest assertion is that it happened, and
+        # `setUp`'s cleanup is what puts the RUNNER back before the tmp plane is removed.
+        self.assertEqual(os.getcwd(),
+                         str(ws_mod.workspace_dir("alpha").resolve()))
 
 
 if __name__ == "__main__":

--- a/tests/test_a_renamed_workspace_keeps_its_chats_and_a_gone_one_says_so.py
+++ b/tests/test_a_renamed_workspace_keeps_its_chats_and_a_gone_one_says_so.py
@@ -91,7 +91,7 @@ class AWorkspaceIsThereOrItIsNot(PersonaIso, unittest.TestCase):
     """`workspace.exists` — the one predicate three surfaces now ask.
 
     It was spelled inline twice before this (`frame/leave.plan`'s `homeless`, and the
-    `· workspace is missing` note `commands_frame._reopen_one` prints), both of them fed
+    `· workspace was missing` note `commands_frame._reopen_one` prints), both of them fed
     from `state.own_workspace`, which name-checks its answer. The pane does NOT get its
     workspace from there — `state.workspace_for`'s last rung is a bare
     `workspace.resolve()`, which hands back `$CHARTER_WORKSPACE` stripped and otherwise

--- a/tests/test_a_reopen_says_what_it_cannot_bring_back.py
+++ b/tests/test_a_reopen_says_what_it_cannot_bring_back.py
@@ -360,7 +360,12 @@ class WhatAReopenPutsBack(PersonaIso, unittest.TestCase):
 
     def test_a_directory_that_has_gone_falls_back_to_the_workspace(self):
         """It used to fall back to the plane root, which #867 is the end of: a workspace
-        the chat named is a better answer than the one directory every workspace shares."""
+        the chat named is a better answer than the one directory every workspace shares.
+
+        The workspace is made FIRST here, so this case is only about the cwd — the one
+        below is the same fallback with the workspace missing too, which is a different
+        branch and used to reach the plane root by a second route."""
+        ws_mod.ensure("alpha")
         self._record(self._chat(cwd="/nowhere-at-all"))
 
         self.assertEqual(self._reopen(), 0)
@@ -814,6 +819,72 @@ class ARefusedDoorwaySaysItsReasonOnScreen(PersonaIso, unittest.TestCase):
                             lambda r: r.refused)
 
         said.assert_not_called()
+
+
+class TheBoundaryARestoreDecidesWith(PersonaIso, unittest.TestCase):
+    """`workspace.contains` — #867's predicate, asked of the predicate itself.
+
+    Here rather than beside `workspace.exists` because what it answers is *where a chat
+    comes back*, which is this file's subject. The cases above measure it through the
+    restore and through the quit row; these measure it directly, so a failure says which
+    of the two the defect is in — the boundary, or what the caller does with it.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.assertIn("edm-test-", str(config.STATE_DIR))
+
+    def test_the_workspace_directory_itself_is_inside_its_own_boundary(self):
+        """The one case `from_path` deliberately answers `None` for — `workspaces/<ws>`
+        is the container and not a tree — and the one a *boundary* has to say yes to. A
+        `contains` that were merely `from_path(...) == name` would report the workspace
+        root as outside the workspace and move a chat standing in it."""
+        wd = ws_mod.ensure("alpha")
+
+        self.assertIsNone(ws_mod.from_path(wd), "or this case measures nothing")
+        self.assertTrue(ws_mod.contains("alpha", wd))
+
+    def test_a_clone_under_the_workspace_is_inside_it(self):
+        clone = ws_mod.ensure("alpha") / "some-repo"
+        clone.mkdir()
+
+        self.assertTrue(ws_mod.contains("alpha", clone))
+        self.assertFalse(ws_mod.contains("beta", clone))
+
+    def test_the_plane_root_is_not_inside_any_workspace(self):
+        """#867's own case: the directory `harness-wrapper.1` recorded."""
+        ws_mod.ensure("alpha")
+
+        self.assertFalse(ws_mod.contains("alpha", config.ROOT))
+
+    def test_a_sibling_named_like_the_workspace_is_not_inside_it(self):
+        """`workspaces/alpha-old` is not `workspaces/alpha`, and a prefix test on the
+        string would say it is."""
+        ws_mod.ensure("alpha")
+        sibling = config.WORKSPACES_DIR / "alpha-old"
+        sibling.mkdir()
+
+        self.assertFalse(ws_mod.contains("alpha", sibling))
+
+    def test_a_name_that_cannot_name_a_workspace_contains_nothing(self):
+        """`valid_name` first, for `workspace.exists`' reason: ``WORKSPACES_DIR / ".."``
+        is the plane root, so a predicate that only resolved paths would answer True for
+        a name no `ensure` will ever make."""
+        config.WORKSPACES_DIR.mkdir(parents=True, exist_ok=True)
+
+        self.assertFalse(ws_mod.contains("..", config.ROOT))
+        self.assertFalse(ws_mod.contains("", config.WORKSPACES_DIR))
+        self.assertFalse(ws_mod.contains("alpha", ""))
+
+    def test_a_path_that_cannot_be_resolved_is_simply_not_contained(self):
+        """The docstring says *never raises*, and this is what makes that a fact rather
+        than an intention. `Path.resolve` raises `ValueError` on an embedded NUL and
+        `from_path` catches only `(OSError, RuntimeError)`, so the guard has to be in
+        front of that call and not merely around the comparison below it. The value can
+        arrive: `reopen.json` is a plain file that outlives the process."""
+        ws_mod.ensure("alpha")
+
+        self.assertFalse(ws_mod.contains("alpha", "/some\x00where"))
 
 
 if __name__ == "__main__":       # pragma: no cover

--- a/tests/test_a_reopen_says_what_it_cannot_bring_back.py
+++ b/tests/test_a_reopen_says_what_it_cannot_bring_back.py
@@ -29,6 +29,7 @@ from types import SimpleNamespace
 from unittest import mock
 
 from charter import commands_frame, config, persona
+from charter import workspace as ws_mod
 from charter.frame import leave, reopen, state
 
 from tests._isolation import PersonaIso
@@ -44,7 +45,8 @@ def _doomed(**kw):
     """
     base = dict(chat="alpha.1", workspace="alpha", persona="", harness="claude-code",
                 cwd="/tmp", resume="", server=SERVER, live=True, active=False,
-                exit_code=None, closed=False, homeless=False, cwd_gone=False)
+                exit_code=None, closed=False, homeless=False, cwd_gone=False,
+                cwd_outside=False)
     base.update(kw)
     return leave.Doomed(**base)
 
@@ -76,10 +78,14 @@ class TheWarningNamesWhatEachChatLoses(PersonaIso, unittest.TestCase):
         self.assertFalse(leave.resumable_harness(""))
 
     def test_a_missing_workspace_is_reported_and_never_re_homed(self):
+        """Still the chat's own workspace and still reported — what #867 changed is that
+        its DIRECTORY is remade rather than the chat being stood in the plane root, which
+        is repairing the boundary, not moving the chat out of it."""
         note = leave.note(_doomed(resume="c", workspace="gone", homeless=True))
 
         self.assertIn("gone", note)
         self.assertIn(leave.RESUMES, note)
+        self.assertIn("remade", note)
 
     def test_a_chat_with_no_workspace_record_is_told_it_cannot_be_reopened(self):
         # The one chat this design cannot bring back, and the note promises nothing —
@@ -95,10 +101,35 @@ class TheWarningNamesWhatEachChatLoses(PersonaIso, unittest.TestCase):
                          f"{leave.NOT_REOPENED} · already ended on its own (3)")
 
     def test_a_directory_that_has_gone_names_the_fallback(self):
+        """And the fallback is the WORKSPACE, since #867 — a row still promising the plane
+        root would be promising something the restore stopped doing."""
         note = leave.note(_doomed(resume="c", cwd="/nowhere", cwd_gone=True))
 
         self.assertIn("/nowhere", note)
-        self.assertIn("plane root", note)
+        self.assertIn("reopens in its workspace", note)
+        self.assertNotIn("plane root", note)
+
+    def test_a_directory_outside_the_workspace_says_the_chat_will_be_moved(self):
+        """The clause #867 added, and the reason it had to exist: this state used to cost
+        the operator nothing to be told about, because the restore stood the chat back in
+        that directory. It now moves it, and a preview that said nothing would be option
+        (b) — *"loses information and silently moves you"* — arriving on the quit surface
+        instead of the restore one."""
+        note = leave.note(_doomed(resume="c", cwd="/elsewhere", cwd_outside=True))
+
+        self.assertIn("/elsewhere", note)
+        self.assertIn("outside its workspace", note)
+
+    def test_a_directory_inside_the_workspace_is_not_worth_a_clause(self):
+        """`cwd_outside=False` — the ordinary chat, whose directory comes back as it is."""
+        self.assertEqual(leave.note(_doomed(resume="c", cwd="/tmp")), leave.RESUMES)
+
+    def test_no_directory_recorded_names_the_workspace_too(self):
+        """The third cwd clause, which the same reword moved off the plane root."""
+        note = leave.note(_doomed(resume="c", cwd=""))
+
+        self.assertIn("no directory recorded", note)
+        self.assertIn("reopens in its workspace", note)
 
     def test_a_chat_that_already_ended_says_with_which_code(self):
         self.assertIn("(7)", leave.note(_doomed(resume="c", exit_code=7)))
@@ -297,7 +328,13 @@ class WhatAReopenPutsBack(PersonaIso, unittest.TestCase):
         self.assertEqual(self.calls[0].rest, [])
         self.assertEqual(len(self.calls), 1, "it was reopened rather than dropped")
 
-    def test_the_workspace_and_the_directory_are_the_recorded_ones(self):
+    def test_a_recorded_directory_outside_the_workspace_is_not_where_it_comes_back(self):
+        """#867, end to end: the workspace is the isolation boundary, so that is where the
+        launcher is standing — not in the directory the record happens to carry.
+
+        The fixture is the operator's own `harness-wrapper.1`, in miniature: a chat that
+        says ``workspace = alpha`` and ``cwd =`` somewhere else entirely, which is the state
+        typing `charter` in the plane root produced before the tab machinery existed."""
         where = config.ROOT / "somewhere"
         where.mkdir()
         self._record(self._chat(workspace="alpha", cwd=str(where)))
@@ -305,14 +342,46 @@ class WhatAReopenPutsBack(PersonaIso, unittest.TestCase):
         self.assertEqual(self._reopen(), 0)
 
         self.assertEqual(self.calls[0].workspace, "alpha")
-        self.assertEqual(self.calls[0].cwd, str(where.resolve()))
+        self.assertEqual(self.calls[0].cwd,
+                         str(ws_mod.workspace_dir("alpha").resolve()))
 
-    def test_a_directory_that_has_gone_falls_back_to_the_plane_root(self):
+    def test_a_recorded_directory_inside_the_workspace_is_kept_exactly(self):
+        """The other half of the same rule, and the reason the test is containment rather
+        than equality: a chat recorded in ``workspaces/<ws>/<repo>`` is standing in one of
+        that workspace's clones ON PURPOSE, and hauling it up to the workspace root would
+        be a new silent move put in place of the old one."""
+        clone = ws_mod.ensure("alpha") / "some-repo"
+        clone.mkdir()
+        self._record(self._chat(workspace="alpha", cwd=str(clone)))
+
+        self.assertEqual(self._reopen(), 0)
+
+        self.assertEqual(self.calls[0].cwd, str(clone.resolve()))
+
+    def test_a_directory_that_has_gone_falls_back_to_the_workspace(self):
+        """It used to fall back to the plane root, which #867 is the end of: a workspace
+        the chat named is a better answer than the one directory every workspace shares."""
         self._record(self._chat(cwd="/nowhere-at-all"))
 
         self.assertEqual(self._reopen(), 0)
 
-        self.assertEqual(self.calls[0].cwd, str(config.ROOT.resolve()))
+        self.assertEqual(self.calls[0].cwd,
+                         str(ws_mod.workspace_dir("alpha").resolve()))
+
+    def test_a_workspace_with_no_directory_yet_is_made_before_the_chat_lands_in_it(self):
+        """#867's second half. `_launch_root` answers `config.ROOT` for a workspace that has
+        no directory — a real state, since `switch.workspaces` offers `default` whether or
+        not its directory exists — so a restore that reused it would put the chat in the
+        plane root by a second route while reporting the workspace."""
+        self.assertFalse(ws_mod.workspace_dir("alpha").exists(),
+                         "or this case is not about a workspace that has to be made")
+        self._record(self._chat(cwd="/nowhere-at-all"))
+
+        self.assertEqual(self._reopen(), 0)
+
+        self.assertTrue(ws_mod.workspace_dir("alpha").is_dir())
+        self.assertEqual(self.calls[0].cwd,
+                         str(ws_mod.workspace_dir("alpha").resolve()))
 
     def test_the_launcher_is_left_standing_where_it_started(self):
         import os

--- a/tests/test_charter_records_the_plane_as_it_changes.py
+++ b/tests/test_charter_records_the_plane_as_it_changes.py
@@ -1184,7 +1184,8 @@ def _doomed(**kw):
     """One `leave.Doomed` with every field defaulted, so a case states only what it means."""
     base = dict(chat="alpha.1", workspace="alpha", persona="", harness="claude-code",
                 cwd="", resume="", server=commands_frame.SOCKET, live=True, active=False,
-                exit_code=None, closed=False, homeless=False, cwd_gone=False)
+                exit_code=None, closed=False, homeless=False, cwd_gone=False,
+                cwd_outside=False)
     base.update(kw)
     return leave.Doomed(**base)
 

--- a/tests/test_the_branch_not_taken_is_still_a_promise.py
+++ b/tests/test_the_branch_not_taken_is_still_a_promise.py
@@ -637,6 +637,34 @@ class ReopeningOneChatSaysWhatItChanged(PersonaIso):
         self.assertFalse([s for s in said if "comes back in" in s],
                          "a restore that moved nothing has nothing to report")
 
+    def test_a_launcher_standing_in_the_workspace_already_still_gets_the_line(self):
+        """`_same_directory`'s ``if not b`` guard, and it cannot be pinned by an ordinary
+        fixture. `os.path.realpath("")` answers the **process's** working directory, so a
+        chat with no recorded cwd is compared against wherever the runner happens to
+        stand — which is normally somewhere else, and the line is printed for the wrong
+        reason. This case puts the process in the very directory the restore chose, which
+        is the one arrangement where dropping the guard silences a report that is true."""
+        where = ws_mod.ensure("alpha")
+        os.chdir(where)
+
+        _out, said, _seen = self._reopen(_chat(cwd=""))
+
+        self.assertTrue([s for s in said if "comes back in" in s],
+                        "a chat that recorded no directory has moved, and is told so")
+
+    def test_a_recorded_directory_that_is_not_a_path_at_all_is_reported_not_raised(self):
+        """`_same_directory`'s `except`, on the one value that reaches it. `os.path.isdir`
+        swallows an embedded NUL and answers `False`, so `_restore_root` never offers such
+        a cwd to `os.chdir` — but `os.path.realpath` RAISES `ValueError` on it, and the
+        manifest is a plain file that outlives the process and can be hand-edited. Without
+        the guard this is a traceback out of a restore, taking every later chat with it."""
+        _out, said, seen = self._reopen(_chat(cwd="/some\x00where"))
+
+        self.assertTrue(seen, "the chat is still reopened")
+        line = next(s for s in said if "comes back in" in s)
+        self.assertIn("is gone", line)
+        self.assertNotIn("\x00", line, "the NUL reached the terminal unescaped")
+
     def test_a_chat_with_no_workspace_is_not_told_it_landed_in_one(self):
         """The `landing` conditional. `_restore_root`'s no-workspace branch falls back to
         the plane root, and calling that *"its workspace directory"* would be charter
@@ -688,8 +716,10 @@ class ReopeningOneChatSaysWhatItChanged(PersonaIso):
         self.assertIsNone(seen[0].workspace)
         # And the other conjunct on the report line: a chat that names NO workspace is not
         # a chat whose workspace is missing — `leave.NOT_REOPENED` already said what it is,
-        # and this line would name the empty string.
-        self.assertFalse([s for s in said if "workspace is missing" in s])
+        # and this line would name the empty string. It is `valid_name` and no longer a
+        # bare truthiness test since #867, because that conjunct now also decides whether
+        # `_restore_root` will have MADE a directory to report on.
+        self.assertFalse([s for s in said if "workspace was missing" in s])
 
     def test_a_launcher_that_failed_reports_the_chat_as_not_come_back(self):
         out, said, _seen = self._reopen(_chat(), rc=1)

--- a/tests/test_the_branch_not_taken_is_still_a_promise.py
+++ b/tests/test_the_branch_not_taken_is_still_a_promise.py
@@ -29,6 +29,7 @@ from types import SimpleNamespace
 from unittest import mock
 
 from charter import commands_frame, config, inflight, util
+from charter import workspace as ws_mod
 from charter.frame import chats, leave, reopen, state
 
 from tests._isolation import PersonaIso
@@ -66,7 +67,7 @@ def _doomed(**kw):
     base = dict(chat="alpha.1", workspace="alpha", persona="", harness="claude-code",
                 cwd="/tmp", resume="", server=commands_frame.SOCKET, live=True,
                 active=False, exit_code=None, closed=False, homeless=False,
-                cwd_gone=False)
+                cwd_gone=False, cwd_outside=False)
     base.update(kw)
     return leave.Doomed(**base)
 
@@ -595,18 +596,56 @@ class ReopeningOneChatSaysWhatItChanged(PersonaIso):
         self.assertEqual(seen[0].harness, "claude")
         self.assertTrue(any("reopening it under claude" in s for s in said))
 
-    def test_a_directory_that_has_gone_falls_back_to_the_plane_root_and_says_so(self):
-        """`if where != c.cwd:` — the warning that only exists when the fallback fired."""
+    def test_a_directory_that_has_gone_is_named_beside_the_one_it_comes_back_in(self):
+        """`_was_standing_in`'s middle branch — a cwd that was recorded and has since
+        gone."""
         out, said, seen = self._reopen(_chat(cwd="/nowhere-at-all"))
 
         self.assertIsNotNone(out)
-        self.assertTrue(any("directory" in s and "reopening in" in s for s in said))
+        line = next(s for s in said if "comes back in" in s)
+        self.assertIn("/nowhere-at-all", line)
+        self.assertIn("is gone", line)
+        self.assertIn(str(ws_mod.workspace_dir("alpha")), line)
 
-    def test_a_directory_that_is_there_says_nothing_about_it(self):
+    def test_a_directory_that_was_never_recorded_says_that_rather_than_naming_none(self):
+        """`_was_standing_in`'s first branch. A chat launched by a charter older than
+        `state.record_cwd` carries ``""``, and a line reading *"it had been standing in"*
+        with nothing after it would be charter naming a directory it never had."""
+        _out, said, _seen = self._reopen(_chat(cwd=""))
+
+        line = next(s for s in said if "comes back in" in s)
+        self.assertIn("no directory was ever recorded for it", line)
+
+    def test_a_directory_outside_the_workspace_names_where_it_had_been_standing(self):
+        """#867's own case, and the third branch: the cwd is a perfectly good directory,
+        it is simply not the chat's workspace. The plane root is exactly how the operator's
+        `harness-wrapper.1` got there, so it is what the fixture stands in."""
         _out, said, _seen = self._reopen(_chat(cwd=str(config.ROOT)))
 
-        self.assertFalse([s for s in said if "reopening in" in s],
-                         "a fallback that did not fire has nothing to report")
+        line = next(s for s in said if "comes back in" in s)
+        self.assertIn(f"it had been standing in {config.ROOT}", line)
+        self.assertIn(f"its workspace directory {ws_mod.workspace_dir('alpha')}", line)
+
+    def test_a_directory_inside_the_workspace_says_nothing_and_moves_nothing(self):
+        """The chat that was already where it belongs, which is most of them: a restore
+        that reported a move it did not make would put #867's line on every launch."""
+        clone = ws_mod.ensure("alpha") / "some-repo"
+        clone.mkdir()
+
+        _out, said, _seen = self._reopen(_chat(cwd=str(clone)))
+
+        self.assertFalse([s for s in said if "comes back in" in s],
+                         "a restore that moved nothing has nothing to report")
+
+    def test_a_chat_with_no_workspace_is_not_told_it_landed_in_one(self):
+        """The `landing` conditional. `_restore_root`'s no-workspace branch falls back to
+        the plane root, and calling that *"its workspace directory"* would be charter
+        claiming a boundary this chat does not have."""
+        _out, said, _seen = self._reopen(_chat(workspace="", cwd="/nowhere-at-all"))
+
+        line = next(s for s in said if "comes back in" in s)
+        self.assertIn(f"comes back in {config.ROOT}", line)
+        self.assertNotIn("its workspace directory", line)
 
     def test_a_chat_with_no_id_is_reported_as_coming_back_empty(self):
         """`leave.RESUMES if rest else 'empty'`. Both halves, because the constant half was
@@ -618,17 +657,28 @@ class ReopeningOneChatSaysWhatItChanged(PersonaIso):
         self.assertTrue(any(f"· {leave.RESUMES}" in s for s in said))
 
     def test_a_chat_whose_workspace_is_gone_is_reported_as_missing(self):
-        """`" · workspace is missing" if c.workspace and not workspace_dir(...).is_dir()`.
-        Both conjuncts: a chat with no workspace at all says nothing (it is `_usable`'s
-        business, and this line would name the empty string), and one whose workspace
-        directory is there says nothing either."""
+        """`" · workspace was missing — remade empty" if homeless`. Both conjuncts: a chat
+        with no workspace at all says nothing (it is `_usable`'s business, and this line
+        would name the empty string), and one whose workspace directory is there says
+        nothing either."""
         _out, said, _seen = self._reopen(_chat(workspace="ghost"))
-        self.assertTrue(any("workspace is missing" in s for s in said))
+        self.assertTrue(any("workspace was missing" in s for s in said))
 
-        from charter import workspace as ws_mod
         config.private_mkdir(ws_mod.workspace_dir("alpha"))
         _out, said, _seen = self._reopen(_chat(workspace="alpha"))
-        self.assertFalse([s for s in said if "workspace is missing" in s])
+        self.assertFalse([s for s in said if "workspace was missing" in s])
+
+    def test_the_workspace_a_restore_remade_is_still_reported_as_having_been_gone(self):
+        """**Asked before `_restore_root`, which is the whole of this case.** #867 makes the
+        restore CREATE the workspace directory it is about to stand the chat in, so a note
+        read off disk afterwards would answer "present" for every chat and delete the only
+        warning a deleted workspace gets — silently, and with the code still there to read.
+        """
+        _out, said, _seen = self._reopen(_chat(workspace="ghost"))
+
+        self.assertTrue(ws_mod.workspace_dir("ghost").is_dir(),
+                        "or this case is not about a workspace the restore had to make")
+        self.assertTrue(any("workspace was missing" in s for s in said))
 
     def test_a_chat_with_no_workspace_hands_the_launcher_none_and_not_an_empty_name(self):
         """`workspace=c.workspace or None` — `cmd_launch` reads `None` as "resolve one" and

--- a/tests/test_the_branch_not_taken_is_still_a_promise.py
+++ b/tests/test_the_branch_not_taken_is_still_a_promise.py
@@ -675,6 +675,65 @@ class ReopeningOneChatSaysWhatItChanged(PersonaIso):
         self.assertIn(f"comes back in {config.ROOT}", line)
         self.assertNotIn("its workspace directory", line)
 
+    def test_a_chat_with_no_workspace_still_comes_back_where_it_was(self):
+        """**The other half of that same fallback, and the sweep found it missing.**
+        Every case above hands the no-workspace branch a cwd it cannot use, so the plane
+        root answered every time and `c.cwd` was never the answer — the whole expression
+        collapsed to `config.ROOT` with the suite still green.
+
+        It matters because it is the only thing this chat has. There is no workspace to
+        land in, so a restore that ignored a perfectly good recorded directory would move
+        the chat for no reason at all and then have nothing better to offer it."""
+        where = ws_mod.ensure("alpha") / "somewhere"
+        where.mkdir()
+
+        _out, said, seen = self._reopen(_chat(workspace="", cwd=str(where)))
+
+        self.assertTrue(seen, "the chat is reopened")
+        self.assertFalse([s for s in said if "comes back in" in s],
+                         "it came back where it was, so there was nothing to report")
+
+    def test_a_clone_that_has_gone_falls_back_to_the_workspace_not_to_a_refusal(self):
+        """`os.path.isdir(c.cwd)` beside `workspace.contains`, which the sweep survived
+        without.
+
+        The two ask different things. `contains` is path arithmetic — it answers *yes* for
+        ``workspaces/<ws>/<repo>`` whether or not that clone is still on disk — so a chat
+        recorded in a clone somebody has since removed passes containment. Without the
+        existence check it would be sent straight back to the missing directory, `os.chdir`
+        would refuse it, and a chat that could perfectly well have come back in its
+        workspace would not come back at all."""
+        clone = ws_mod.ensure("alpha") / "some-repo"
+
+        self.assertTrue(ws_mod.contains("alpha", clone),
+                        "or this case is not about a path containment accepts")
+        self.assertFalse(clone.exists(), "and one that is not there")
+
+        out, said, _seen = self._reopen(_chat(cwd=str(clone)))
+
+        self.assertIsNotNone(out, "it comes back rather than being refused")
+        self.assertFalse([s for s in said if "cannot enter" in s])
+        line = next(s for s in said if "comes back in" in s)
+        self.assertIn(str(ws_mod.workspace_dir("alpha")), line)
+
+    def test_a_workspace_charter_cannot_make_is_a_chat_it_does_not_reopen(self):
+        """`except OSError` around `workspace.ensure`, which nothing made fail before.
+
+        It is `OSError` alone and no longer `(ValueError, OSError)`: `ensure` raises
+        `ValueError` for a name `valid_name` refuses, and `_restore_root` has already asked
+        `valid_name` of that same value, so the two cannot disagree and that half was
+        unreachable. What is left is a plane whose ``workspaces/`` cannot be written to —
+        and the honest end is the chat NOT coming back, rather than being dropped into the
+        plane root and called restored."""
+        with mock.patch.object(commands_frame.workspace, "ensure",
+                               side_effect=OSError(13, "refused")):
+            out, said, seen = self._reopen(_chat(cwd="/nowhere-at-all"))
+
+        self.assertIsNone(out)
+        self.assertEqual(seen, [], "the launcher was never reached")
+        line = next(s for s in said if "cannot enter" in s)
+        self.assertIn(str(ws_mod.workspace_dir("alpha")), line)
+
     def test_a_chat_with_no_id_is_reported_as_coming_back_empty(self):
         """`leave.RESUMES if rest else 'empty'`. Both halves, because the constant half was
         the only one any case had ever rendered."""

--- a/tests/test_what_a_quit_says_is_spelled_where_it_is_asserted.py
+++ b/tests/test_what_a_quit_says_is_spelled_where_it_is_asserted.py
@@ -332,6 +332,49 @@ class AValueOffTheManifestCannotOwnTheLine(PersonaIso):
         line = next(s for s in said if "directory" in s)
         self.assertContained(line)
 
+    def test_a_recorded_directory_that_is_still_there_is_shown_not_executed(self):
+        """**`_was_standing_in`'s third branch has its own wrapper, and the case above
+        cannot reach it.** That one hands in a path `os.path.isdir` refuses, which is the
+        *"is gone"* sentence; this is the one #867 exists for — a cwd that is a perfectly
+        good directory and simply not the chat's workspace, named so the operator can see
+        where the chat had been. Two sentences, two wrappers, and the deletion sweep
+        survived the second one until this case existed.
+
+        `isdir` is patched rather than a hostile directory being created, because the
+        property is about the SENTENCE and a filesystem that accepts an escape in a name is
+        not something a test should need."""
+        with mock.patch.object(commands_frame.os.path, "isdir", return_value=True):
+            said = self._warnings(self._chat(cwd=HOSTILE))
+
+        line = next(s for s in said if "it had been standing in" in s)
+        self.assertContained(line)
+
+    def test_the_directory_a_restore_landed_in_is_shown_not_executed(self):
+        """**Both wrappers on `landing`, and the value is NOT the manifest's** — which is
+        the whole reason this case has to say what it is measuring.
+
+        `where` is composed by charter: the workspace's own directory, or `config.ROOT`
+        for a chat that names no workspace. What makes it worth containing anyway is that
+        both are built from the PLANE ROOT, which is `$CHARTER_ROOT` or a directory the
+        operator made — not a charter literal. So the escape can arrive, by a different
+        door from the manifest's, and the same wrapper answers for both.
+
+        The report line is reached but the launcher never is: `os.chdir` refuses the path,
+        which is the third wrapper's own case one line further down."""
+        hostile_root = f"{config.ROOT}{HOSTILE}"
+        with mock.patch.object(commands_frame, "_restore_root",
+                               return_value=hostile_root):
+            said = self._warnings(self._chat(cwd=str(config.ROOT)))
+            homeless = self._warnings(self._chat(workspace="", cwd=str(config.ROOT)))
+
+        line = next(s for s in said if "its workspace directory" in s)
+        self.assertContained(line)
+        # The `else` half, which names the path with no claim in front of it: a chat with
+        # no workspace has no workspace directory to have landed in.
+        other = next(s for s in homeless if "comes back in" in s)
+        self.assertNotIn("its workspace directory", other)
+        self.assertContained(other)
+
     def test_a_directory_charter_cannot_enter_is_shown_not_executed(self):
         """The third wrapper, on the value that reached `os.chdir` and refused.
 

--- a/tests/test_what_a_quit_says_is_spelled_where_it_is_asserted.py
+++ b/tests/test_what_a_quit_says_is_spelled_where_it_is_asserted.py
@@ -71,6 +71,7 @@ from types import SimpleNamespace
 from unittest import mock
 
 from charter import commands_frame, config, contain, util
+from charter import workspace as ws_mod
 from charter.frame import builtin_actions, component, leave, palette, reopen, state
 
 from tests._isolation import PersonaIso
@@ -86,7 +87,8 @@ HOSTILE = "claude\x1b[2Jcode\nrm -rf /"
 def _doomed(**kw):
     base = dict(chat="alpha.1", workspace="alpha", persona="", harness="claude-code",
                 cwd="/tmp", resume="", server=SERVER, live=True, active=False,
-                exit_code=None, closed=False, homeless=False, cwd_gone=False)
+                exit_code=None, closed=False, homeless=False, cwd_gone=False,
+                cwd_outside=False)
     base.update(kw)
     return leave.Doomed(**base)
 
@@ -331,8 +333,15 @@ class AValueOffTheManifestCannotOwnTheLine(PersonaIso):
         self.assertContained(line)
 
     def test_a_directory_charter_cannot_enter_is_shown_not_executed(self):
-        """The third wrapper, on the value that reached `os.chdir` and refused."""
-        where = config.ROOT / "gone"
+        """The third wrapper, on the value that reached `os.chdir` and refused.
+
+        **The hostile path is INSIDE the workspace**, and that is #867 rather than a
+        detail: a restore only stands in a recorded cwd it has contained
+        (`_restore_root`), so the manifest value that can still reach `os.chdir` is one
+        under ``workspaces/<ws>/``. A fixture standing outside it would now measure the
+        workspace directory charter composed itself, which no manifest can influence and
+        which needs no wrapper."""
+        where = ws_mod.workspace_dir("alpha") / "clone"
         with mock.patch.object(commands_frame.os, "chdir",
                                side_effect=OSError(13, "refused")), \
                 mock.patch.object(commands_frame.os.path, "isdir", return_value=True):


### PR DESCRIPTION
Closes #867

`charter reopen` stood each chat back in the directory its record carried, with the plane root as a fallback for an unusable one:

```python
where = c.cwd if c.cwd and os.path.isdir(c.cwd) else str(config.ROOT)
```

So every restore faithfully reproduced a disagreement created once. On the operator's own plane, `harness-wrapper.1` records `ws=harness-wrapper` and `cwd=/Users/aharon/IdeaProjects/charter` — it was started by typing `charter` in the plane root before the tab machinery existed. #849 made restores automatic, so that one old wrong cwd came back on every launch rather than once.

## What this builds

The grilling behind #845 settled the pair: **the record stores the literal cwd and the restore lands in the workspace, saying so when they differ.** #849 built the recording half; this is the other one — option **(c)**. Option (a) reproduces a state already agreed wrong; option (b) loses information and moves the operator in silence.

```
⚠ charter reopen: harness-wrapper.1 comes back in its workspace directory
  …/workspaces/harness-wrapper — it had been standing in /Users/aharon/IdeaProjects/charter
```

**The test is containment, never equality.** A chat recorded in `workspaces/<ws>/<repo>` is standing in one of that workspace's clones on purpose; hauling it up to the workspace root would be a new silent move in place of the old one. `workspace.contains` is that question — spelled once, used by both the restore and the quit preview — and it delegates to `workspace.from_path` rather than testing a `workspaces/<ws>/` prefix, because a worktree lives under `[plane] worktrees`, outside `workspaces/` altogether, and is just as much the workspace's own tree. It adds back the workspace directory itself, which `from_path` deliberately answers `None` for.

**`workspace.ensure`, not `_launch_root`** — #867's second half. `_launch_root` falls back to `config.ROOT` for a workspace with no directory yet, which is a real state (`switch.workspaces` offers `default` whether or not its directory exists), so reusing it would let the same defect in by a second door, and by the worse route: a restore reporting the workspace while standing in the plane root. A workspace charter cannot make hands its directory back unmade; `os.chdir` refuses it and the chat is reported as not reopened rather than dropped in the root.

**`homeless` is read before the ensure**, deliberately: the note is about the plane the operator left, not the one the restore just repaired. Asked afterwards it would answer "present" for every chat and delete the only warning a deleted workspace gets, silently, with the code still sitting there to read. It now says `· workspace was missing — remade empty`.

## The quit preview moves with it

A row that promises what a reopen gives back has to promise what the reopen now does. All three cwd clauses in `leave.note` ended in the plane root; they end in the workspace. A missing workspace says its directory is remade. And a cwd standing *outside* the workspace gets a clause it never needed before — that state used to cost nothing to be told about, because the restore stood the chat straight back in it:

```
alpha.2 · claude-code   conversation resumes · it is standing in /elsewhere, outside its
                        workspace — reopens in the workspace
```

`Doomed` gains `cwd_outside` for it, computed in `plan` from the same `workspace.contains` the restore decides with, so the promise and the act are one reading.

## Tests

Full suite green locally: `Ran 10818 tests ... OK (skipped=9)`.

New cases, all through the real code path with only the launcher stood in:

* a recorded directory outside the workspace is not where it comes back (the `harness-wrapper.1` fixture, in miniature);
* a recorded directory **inside** the workspace is kept exactly — the containment half;
* a gone directory falls back to the workspace, not the plane root;
* a workspace with no directory yet is made before the chat lands in it;
* each of `_was_standing_in`'s three branches, by the words an operator reads;
* a chat that moved nothing says nothing;
* a chat with no workspace is not told it landed in one;
* the workspace a restore remade is still reported as having been gone;
* the four preview clauses, including the new one and the ordinary chat that gets none.

Four existing cases changed their expectation rather than their subject, and two changed their fixture for a stated reason: the manifest value that can still reach `os.chdir` is one *inside* the workspace, so the containment test for a hostile path had to move inside it too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Us4MbwkSCJCxwt1CjAd1sf
