### PR TITLE
A clone inside a workspace gets the layer, and hides it in the clone's info/exclude (#870)

### DIFF
--- a/charter/commands.py
+++ b/charter/commands.py
@@ -408,7 +408,30 @@ def cmd_clone(args) -> int:
         # exit code stays 0 because the repo really is cloned (#817).
         report_submodule_drift(dest, r["name"])
         _hint_repo_docs(dest, r)
+    _wire_clones(ws)
     return 1 if failures else 0
+
+
+def _wire_clones(ws: str) -> None:
+    """Give every checkout in *ws* charter's layer, hidden in its own `info/exclude`.
+
+    Here rather than only in `workspace.ensure`, which `cmd_clone` runs BEFORE the clones
+    exist: without this the layer would arrive one command late, and the command it
+    arrived on would be an unrelated one.
+
+    **Announced, once, per checkout that got something.** charter has just written files
+    into a repo the operator owns; the reason `git status` there stays clean is charter's
+    doing, and a mechanism whose entire visible signature is its own absence is one nobody
+    can find when they want it gone. Silent when nothing was written, which is every
+    re-clone into an already-wired workspace.
+    """
+    for tree in workspace.guest_trees(ws):
+        rows = workspace.wire_guest(tree)
+        made = [rel for rel, status in rows if status in ("created", "refreshed")]
+        if made:
+            util.info(f"{tree.name}: charter's layer written ({len(made)} file(s)) and "
+                      f"hidden in that repo's .git/info/exclude — `git status` there is "
+                      f"unaffected, and nothing charter wrote can be committed.")
 
 
 #: Concurrent clones. The same number `_build_batch` uses for its API probes, so there is

--- a/charter/commands_workspace.py
+++ b/charter/commands_workspace.py
@@ -256,6 +256,11 @@ def cmd_workspace_remove(args) -> int:
     if open_todos:
         util.warn(f"Discarding {open_todos} open todo(s) with '{name}' — nothing else holds them.")
 
+    # Before the rmtree, never after: charter's generated files go with the directory,
+    # but a LINKED WORKTREE's `.git/info/exclude` is the main repo's and lives somewhere
+    # else on disk entirely — rmtree would leave charter's block behind in a repo that is
+    # still there, naming paths that no longer exist (#870).
+    workspace.unwire_guests(name)
     shutil.rmtree(wd)
     util.ok(f"Removed workspace '{name}' and its clones.")
     if workspace.resolve() == name and workspace.source() in ("session", "active-file"):

--- a/charter/workspace.py
+++ b/charter/workspace.py
@@ -1343,8 +1343,11 @@ def _walkup_files() -> dict[str, str]:
         # not there yields nothing, and a directory entry, a dangling symlink and a
         # binary file are one answer here — "not text charter can mirror" — which the
         # read already gives. A predicate in front of it is a branch the deletion sweep
-        # can remove without changing a single answer, which is what makes it noise.
-        for f in sorted(d.rglob("*")):
+        # can remove without changing a single answer, which is what makes it noise —
+        # and so was the `sorted()` that used to wrap this, for the same reason: every
+        # entry is an independent key in a dict, and `_layer_status` sorts what it
+        # reports anyway. The sweep found it as a survivor and was right.
+        for f in d.rglob("*"):
             try:
                 text = f.read_text()
             except (OSError, UnicodeDecodeError):

--- a/charter/workspace.py
+++ b/charter/workspace.py
@@ -1324,6 +1324,25 @@ def _layer_files(name: str) -> dict[str, str]:
 #: opinions about. Dropping the plane's project instructions into a repo charter does not
 #: own, to be read as that repo's instructions, is a claim of a different size from
 #: mirroring a settings key; a guest may hide its own files, not narrate the host's.
+#:
+#: **These two paths are Claude Code's spelling, and that is a stated LIMIT rather than
+#: an assumption that it is the only harness.** Everything else on this path is
+#: harness-agnostic: the mechanism below writes, marks, hides and removes whatever
+#: :func:`_harness_files` returns, which is every registered harness's own
+#: `workspace_files()` — so a harness that answers with files gets them into a clone the
+#: day it answers, with no change here. Only this list is hard-coded, because it is not
+#: any harness's answer: it is the plane's OWN directories, and charter has to know their
+#: names to find them.
+#:
+#: The other two harnesses do read project-level surfaces, measured against the installed
+#: binaries (codex-cli 0.147.0, opencode 1.18.23): opencode reads `opencode.json` and
+#: `.opencode/agent/` at a project root, and Codex reads `.codex/skills/` (though not a
+#: project `.codex/config.toml`). So the same cut-off exists for them in a clone and is
+#: NOT closed here. It is not closed by adding their directory names to this tuple
+#: either: what a harness needs in a tree is `workspace_files()`'s question, and
+#: answering it for them from this module is the mistake `harness/registry.py` exists to
+#: stop — charter naming a harness's files on its behalf, in a file that has to be
+#: edited every time another harness is added.
 WALKUP_DIRS = (".claude/agents", ".claude/skills")
 
 

--- a/charter/workspace.py
+++ b/charter/workspace.py
@@ -224,6 +224,59 @@ def is_tree(path: Path) -> bool:
     return _unreadable(lambda: (Path(path) / ".git").exists())
 
 
+def git_dir(root) -> Path | None:
+    """The real git directory of the checkout at *root*, or ``None`` if there is none.
+
+    ``<root>/.git`` is a DIRECTORY in a clone and a FILE reading ``gitdir: <path>`` in a
+    linked worktree — the same distinction :func:`is_clone` draws on purpose. Anything
+    that needs to WRITE into git's own directory has to resolve the second form, because
+    treating `<root>/.git/` as a directory does not fail loudly there: `mkdir -p` happily
+    creates `.git/info/` *beside* the `.git` file's parent and git reads none of it.
+    """
+    root = Path(root)
+    dot = root / ".git"
+    if _unreadable(lambda: dot.is_dir()):
+        return dot
+    try:
+        text = dot.read_text()
+    except (OSError, UnicodeDecodeError):
+        return None
+    for line in text.splitlines():
+        if line.startswith("gitdir:"):
+            g = Path(line.split(":", 1)[1].strip())
+            if not g.is_absolute():
+                g = root / g
+            return g if _unreadable(lambda: g.is_dir()) else None
+    return None
+
+
+def git_exclude_file(root) -> Path | None:
+    """The ``info/exclude`` git actually READS for the checkout at *root*.
+
+    The COMMON directory's, which for a linked worktree is not its own gitdir. Git treats
+    ``info/`` as shared between a repo and its worktrees, so a pattern written to
+    ``.git/worktrees/<name>/info/exclude`` is read by nobody: measured on git 2.x — the
+    file stays listed as untracked there, and the identical pattern in the main repo's
+    ``.git/info/exclude`` hides it in the worktree. ``commondir`` is the pointer git
+    itself leaves for this, holding a path relative to the worktree's gitdir (``../..``).
+
+    That asymmetry is also why removal is not "delete the directory": a worktree's
+    exclude file lives OUTSIDE the workspace, in a repo `shutil.rmtree` never reaches —
+    see :func:`unwire_guests`.
+    """
+    g = git_dir(root)
+    if g is None:
+        return None
+    try:
+        common = (g / "commondir").read_text().strip()
+    except (OSError, UnicodeDecodeError):
+        common = ""
+    if common:
+        c = Path(common)
+        g = c if c.is_absolute() else Path(os.path.normpath(g / c))
+    return g / "info" / "exclude"
+
+
 def is_clone(path: Path) -> bool:
     """A real clone, not a worktree. Git itself draws the line: a clone's ``.git`` is a
     DIRECTORY, a linked worktree's ``.git`` is a FILE pointing at the shared gitdir. So a
@@ -1111,17 +1164,26 @@ def scaffold(name: str) -> None:
 # ADR 0015 deleted a per-tree design of this shape and the caution is real, so   #
 # the difference is worth stating: what it deleted wrote the same GLOBAL answer  #
 # into every checkout, for a harness that reads one global file anyway. This     #
-# writes config that is MEANT to differ per workspace, into a directory charter  #
-# itself creates. What is re-incurred from that design is the staleness          #
-# bookkeeping below — and not its `.git/info/exclude` entry per checkout, which  #
-# is the cost that never arrives here: `/workspaces/*/*` is already in the       #
-# plane's `.gitignore` (`_ensure_gitignore`) and the managed LIVE block          #
-# un-ignores four named paths, none of them `.claude/`. Nothing generated here   #
-# can reach a commit.                                                            #
+# writes config that is MEANT to differ per tree, into trees that genuinely      #
+# differ. What is re-incurred from that design is the staleness bookkeeping      #
+# below and, for a guest checkout only, its `.git/info/exclude` entry.           #
 #                                                                               #
-# Nothing is written into a CLONE — `workspaces/<ws>/<repo>/` is a repo charter  #
-# does not own, and `git add -A` there would stage it. The stated limit that     #
-# follows: in a clone you cannot delegate to a persona.                          #
+# Inside the workspace DIRECTORY that entry is still not needed and still not    #
+# written: `/workspaces/*/*` is already in the plane's `.gitignore`              #
+# (`_ensure_gitignore`) and the managed LIVE block un-ignores four named paths,  #
+# none of them `.claude/`. Nothing generated there can reach a commit.           #
+#                                                                               #
+# A CLONE is the other half, and it is where the gap is widest (#870).           #
+# `workspaces/<ws>/<repo>/` is a repo of its own, so the walk-up that carries    #
+# agents and skills into the workspace directory STOPS at the clone's root and   #
+# a chat launched there gets none of the layer — not the settings, and not the   #
+# personas either. charter writes it anyway, and pays the cost the workspace     #
+# directory does not owe: every generated path is registered in that checkout's  #
+# `.git/info/exclude`, which is per-checkout, never committed and not itself     #
+# tracked. It is the one file a guest may write. charter never touches the       #
+# clone's `.gitignore`, never stages anything there, and hides only the exact    #
+# paths it generated — see `_charter_owned` for why the block is a list of files #
+# rather than a `.claude/` glob.                                                 #
 # --------------------------------------------------------------------------- #
 
 #: The charter-owned sidecar recording what charter last generated in a workspace, as
@@ -1192,6 +1254,36 @@ def harness_deficits() -> list[tuple[str, object]]:
     return out
 
 
+def _harness_files(base: Path) -> dict[str, str]:
+    """:func:`_layer_files`' body, asked of any directory charter is about to write into.
+
+    Takes a path rather than a workspace name because a guest checkout has no name in
+    `WORKSPACES_DIR` — and the containment check below is the reason this is one function
+    and not two: it is what keeps a harness's ``..`` out of the tree it is joined onto,
+    and a copy of it per target is a copy that can drift out of step.
+    """
+    from .harness import registry as _registry
+
+    out: dict[str, str] = {}
+    for h in _registry.all():
+        for rel, text in (h.workspace_files() or {}).items():
+            target = (base / rel).resolve()
+            # ONE clause, not two. `target == base.resolve()` was here to drop a `rel`
+            # naming the target directory itself, and it can never be the clause
+            # that decides: a path is never in its own `.parents`, so whenever the
+            # equality holds the containment test has already fired. The deletion
+            # sweep found it as a survivor and it was masked, not unpinned.
+            #
+            # The `.resolve()` that remains is load-bearing and is pinned by
+            # `AWorkspaceRootReachedThroughASymlink`: `config.use` hands its root
+            # through unresolved, so under a symlinked plane `base` is not among the
+            # resolved `target`'s parents and every file would be dropped.
+            if base.resolve() not in target.parents:
+                continue
+            out[rel] = text
+    return out
+
+
 def _layer_files(name: str) -> dict[str, str]:
     """``{relative path: text}`` every registered harness needs inside workspace *name*.
 
@@ -1205,35 +1297,83 @@ def _layer_files(name: str) -> dict[str, str]:
     harness contract says paths stay inside; a contract nothing enforces is a comment,
     and this is the one place every harness's answer passes through.
     """
-    from .harness import registry as _registry
+    return _harness_files(workspace_dir(name))
 
-    wd = workspace_dir(name)
+
+#: The plane-root directories Claude Code WALKS UP for, and where that walk stops.
+#:
+#: Agents and skills are found by searching the session's cwd and its parents, and the
+#: search stops at a git boundary. `workspaces/<ws>/` sits inside the plane's own repo, so
+#: both already arrive there untouched — which is why `claude_code.WORKSPACE_KEYS` is
+#: right not to copy them and `test_nothing_else_is_materialised_into_the_workspace` is
+#: right to forbid it. `workspaces/<ws>/<repo>/` is a repo of its own, so the walk stops
+#: at its root and NEITHER arrives. That is the whole of #870: the same layer, one
+#: directory deeper, is missing the half that a workspace directory got for free.
+#:
+#: `enabledPlugins` alone does not close it. The plugin brings charter's own skills, and
+#: it cannot bring this plane's `.claude/agents/` — those are generated from `personas/`
+#: by `persona sync-agents` and are as local to a plane as its personas are. Without them
+#: a chat in a clone loads charter and still cannot delegate to a persona, which is
+#: exactly the limit this module used to record as permanent.
+#:
+#: **CLAUDE.md is deliberately not here.** It walks up on the same rule, so the gap is
+#: real for it too — and it is the one file a repo of its own is most likely to have
+#: opinions about. Dropping the plane's project instructions into a repo charter does not
+#: own, to be read as that repo's instructions, is a claim of a different size from
+#: mirroring a settings key; a guest may hide its own files, not narrate the host's.
+WALKUP_DIRS = (".claude/agents", ".claude/skills")
+
+
+def _walkup_files() -> dict[str, str]:
+    """``{relative path: text}`` for the plane directories a guest checkout cuts off.
+
+    A 1:1 mirror of what is on disk, for `workspace_files`' reason: these are generated
+    from `personas/` by somebody else's generator, so re-deriving them here would be a
+    second generator that drifts. Read as text and skipped when that fails — a binary or
+    unreadable file in `.claude/agents/` is not something charter can copy, and it must
+    not take the whole layer down with it.
+    """
     out: dict[str, str] = {}
-    for h in _registry.all():
-        for rel, text in (h.workspace_files() or {}).items():
-            target = (wd / rel).resolve()
-            # ONE clause, not two. `target == wd.resolve()` was here to drop a `rel`
-            # naming the workspace directory itself, and it can never be the clause
-            # that decides: a path is never in its own `.parents`, so whenever the
-            # equality holds the containment test has already fired. The deletion
-            # sweep found it as a survivor and it was masked, not unpinned.
-            #
-            # The `.resolve()` that remains is load-bearing and is pinned by
-            # `AWorkspaceRootReachedThroughASymlink`: `config.use` hands its root
-            # through unresolved, so under a symlinked plane `wd` is not among the
-            # resolved `target`'s parents and every file would be dropped.
-            if wd.resolve() not in target.parents:
+    for sub in WALKUP_DIRS:
+        d = config.ROOT / sub
+        if not _unreadable(lambda: d.is_dir()):
+            continue
+        try:
+            found = sorted(d.rglob("*"))
+        except OSError:
+            continue
+        for f in found:
+            try:
+                if not f.is_file():
+                    continue
+                text = f.read_text()
+            except (OSError, UnicodeDecodeError):
                 continue
-            out[rel] = text
+            out[f"{sub}/{f.relative_to(d).as_posix()}"] = text
     return out
 
 
-def _read_marker(name: str) -> dict:
+def _guest_files(tree: Path) -> dict[str, str]:
+    """Everything charter generates inside the guest checkout *tree*.
+
+    The harness layer the workspace directory gets, PLUS the walk-up directories that
+    directory did not need — see :data:`WALKUP_DIRS`.
+    """
+    out = _harness_files(tree)
+    out.update(_walkup_files())
+    return out
+
+
+def _read_marker_at(base: Path) -> dict:
     try:
-        doc = json.loads((workspace_dir(name) / GENERATED_MARKER).read_text())
+        doc = json.loads((base / GENERATED_MARKER).read_text())
     except (OSError, json.JSONDecodeError, UnicodeDecodeError):
         return {}
     return doc if isinstance(doc, dict) else {}
+
+
+def _read_marker(name: str) -> dict:
+    return _read_marker_at(workspace_dir(name))
 
 
 def harness_layer(name: str) -> list[tuple[str, str]]:
@@ -1256,11 +1396,18 @@ def harness_layer(name: str) -> list[tuple[str, str]]:
     settles for an unstamped shim: charter cannot tell a file it wrote before the marker
     existed from one somebody rewrote, and guessing wrong in that direction destroys work.
     """
-    wd = workspace_dir(name)
-    marker = _read_marker(name)
+    rows = _layer_status(workspace_dir(name), _layer_files(name), _read_marker(name))
+    for tree in guest_trees(name):
+        rows.extend((f"{tree.name}/{rel}", status) for rel, status in guest_layer(tree))
+    return rows
+
+
+def _layer_status(base: Path, want_all: dict[str, str],
+                  marker: dict) -> list[tuple[str, str]]:
+    """:func:`harness_layer`'s comparison, for one directory. READ ONLY."""
     rows: list[tuple[str, str]] = []
-    for rel, want in sorted(_layer_files(name).items()):
-        p = wd / rel
+    for rel, want in sorted(want_all.items()):
+        p = base / rel
         if not p.exists():
             rows.append((rel, "missing"))
             continue
@@ -1291,13 +1438,25 @@ def wire_harnesses(name: str) -> list[tuple[str, str]]:
 
     Called from :func:`scaffold`, so a launch gets it: `commands_frame._launch_root` runs
     `ensure` before the chat's cwd is read. `charter workspace reinit` is the repair.
+
+    Every guest checkout in the workspace is wired too, its rows prefixed with the
+    checkout's directory name — see :func:`wire_guest`. Doing it here rather than at a
+    second call site is what makes `reinit` the repair for a clone as well: a clone made
+    by an older charter, or one whose `info/exclude` somebody emptied, is brought back by
+    the command that already exists.
     """
-    wd = workspace_dir(name)
-    marker = _read_marker(name)
-    want_all = _layer_files(name)
+    rows = _materialise(workspace_dir(name), _layer_files(name))
+    for tree in guest_trees(name):
+        rows.extend((f"{tree.name}/{rel}", status) for rel, status in wire_guest(tree))
+    return rows
+
+
+def _materialise(base: Path, want_all: dict[str, str]) -> list[tuple[str, str]]:
+    """:func:`wire_harnesses`' write loop, for one directory — see it for the contract."""
+    marker = _read_marker_at(base)
     rows: list[tuple[str, str]] = []
     wrote = False
-    for rel, status in harness_layer(name):
+    for rel, status in _layer_status(base, want_all, marker):
         if status in ("foreign", "unreadable"):
             # The operator's file, and the marker entry for it stays exactly as it was:
             # charter has not written this path, so it has nothing new to vouch for.
@@ -1307,7 +1466,7 @@ def wire_harnesses(name: str) -> list[tuple[str, str]]:
             rows.append((rel, "present"))
             continue
         want = want_all[rel]
-        p = wd / rel
+        p = base / rel
         try:
             p.parent.mkdir(parents=True, exist_ok=True)
             p.write_text(want)
@@ -1322,10 +1481,257 @@ def wire_harnesses(name: str) -> list[tuple[str, str]]:
         # `ensure` would make a workspace's mtimes move for a call that changed nothing,
         # which is the noise `_ensure_statusline` avoids one file over.
         try:
-            (wd / GENERATED_MARKER).write_text(json.dumps(marker, indent=2) + "\n")
+            (base / GENERATED_MARKER).write_text(json.dumps(marker, indent=2) + "\n")
         except OSError:
             pass
     return rows
+
+
+# --------------------------------------------------------------------------- #
+# guest checkouts — the layer one directory deeper, hidden in the checkout's     #
+# own `info/exclude` (#870). See this section's header comment for the boundary. #
+# --------------------------------------------------------------------------- #
+
+#: The delimiters of charter's managed block in a guest checkout's `info/exclude`.
+#:
+#: Delimited rather than "charter's lines are the ones charter recognises", which is the
+#: `_LIVE_BEGIN`/`_LIVE_END` precedent two hundred lines up and the same reason: an
+#: operator's own `.claude/settings.json` line, written before charter ever arrived, is
+#: indistinguishable from charter's by content alone — and removal would take it with it.
+#: The block is what makes the write idempotent AND the removal exact.
+_EXCLUDE_BEGIN = "# >>> charter (generated layer — `charter workspace reinit`) >>>"
+_EXCLUDE_END = "# <<< charter <<<"
+
+#: The line inside the block, for the person who finds it in a repo they own.
+_EXCLUDE_NOTE = ("# Files charter generated in this checkout so a chat here gets the "
+                 "plane's layer.\n"
+                 "# Listed one by one — charter hides only what it wrote, never a "
+                 "directory of yours.\n"
+                 "# This file is per-checkout and never committed; nothing your "
+                 "teammates clone is affected.")
+
+
+def guest_trees(name: str) -> list[Path]:
+    """Every checkout inside workspace *name* that charter is a GUEST in.
+
+    Clones AND linked worktrees, which is why this is not :func:`clones`. That function
+    answers "which repos am I working in", and git's clone/worktree distinction is load
+    bearing for it — a worktree must never be counted as a second repo. This one asks
+    "where would a chat's cwd be cut off from the plane's layer", and the answer is *any*
+    checkout: a worktree's root is a git boundary exactly as a clone's is.
+    """
+    wd = workspace_dir(name)
+    try:
+        entries = sorted(d for d in wd.iterdir() if d.is_dir())
+    except OSError:
+        return []
+    return [d for d in entries if git_dir(d) is not None]
+
+
+def _charter_owned(base: Path, marker: dict) -> list[str]:
+    """The paths under *base* charter generated and STILL recognises, marker included.
+
+    What goes in the exclude block, and the reason it is a list of files rather than a
+    `.claude/` glob: a guest repo may have its own `.claude/`, and hiding a directory
+    would hide the operator's files inside it from their own `git status` — charter
+    silently making somebody's untracked work invisible in their own repo is a worse
+    failure than the untracked noise this exists to prevent.
+
+    A path whose content no longer matches the marker is dropped for the same reason:
+    it is the operator's file now (`harness_layer` calls it ``foreign``), and charter
+    neither rewrites it nor hides it. Empty when charter has generated nothing here, so
+    a checkout with an all-foreign layer gets no block at all.
+    """
+    if not marker:
+        return []
+    out: list[str] = []
+    for rel in sorted(marker):
+        p = base / rel
+        try:
+            if p.exists() and marker[rel] != content_digest(p.read_text()):
+                continue
+        except (OSError, UnicodeDecodeError):
+            continue
+        out.append(rel)
+    return out + [GENERATED_MARKER]
+
+
+def _exclude_block(rels: list[str]) -> str:
+    if not rels:
+        return ""
+    return "\n".join([_EXCLUDE_BEGIN, _EXCLUDE_NOTE, *(f"/{r}" for r in rels),
+                      _EXCLUDE_END]) + "\n"
+
+
+def _replace_block(text: str, block: str) -> str:
+    """*text* with charter's block replaced by *block* (empty *block* removes it).
+
+    The whole of the idempotence requirement. Appending would duplicate every line on the
+    second `ensure`, and an `ensure` runs on every launch — `git status` in the operator's
+    repo would stay clean while their `info/exclude` grew without bound.
+
+    An UNTERMINATED block (begin marker, no end) is treated as running to end of file
+    and replaced whole. The alternative is to append a second block below it, which is
+    the duplication this function exists to prevent, wearing a crash for a hat.
+    """
+    lines = text.splitlines()
+    new = block.splitlines()
+    try:
+        i = lines.index(_EXCLUDE_BEGIN)
+    except ValueError:
+        if not new:
+            return text
+        keep = list(lines)
+        while keep and not keep[-1].strip():
+            keep.pop()
+        out = keep + new
+    else:
+        j = next((k for k in range(i + 1, len(lines)) if lines[k] == _EXCLUDE_END),
+                 len(lines) - 1)
+        out = lines[:i] + new + lines[j + 1:]
+        while out and not out[-1].strip():
+            out.pop()
+    return "\n".join(out) + "\n" if out else ""
+
+
+def _exclude_status(tree: Path, rels: list[str]) -> str:
+    """``ok`` · ``missing`` · ``stale`` · ``unreadable`` for the block in *tree*'s exclude."""
+    p = git_exclude_file(tree)
+    if p is None:
+        return "unreadable"
+    try:
+        text = p.read_text()
+    except FileNotFoundError:
+        text = ""
+    except (OSError, UnicodeDecodeError):
+        return "unreadable"
+    if _replace_block(text, _exclude_block(rels)) == text:
+        return "ok"
+    return "stale" if _EXCLUDE_BEGIN in text.splitlines() else "missing"
+
+
+def _register_excludes(tree: Path, rels: list[str]) -> str:
+    """Write charter's block into *tree*'s `info/exclude`. ``created``/``refreshed``/
+    ``present``/``blocked``."""
+    p = git_exclude_file(tree)
+    if p is None:
+        return "blocked"
+    try:
+        text = p.read_text()
+    except FileNotFoundError:
+        text = ""
+    except (OSError, UnicodeDecodeError):
+        return "blocked"
+    new = _replace_block(text, _exclude_block(rels))
+    if new == text:
+        return "present"
+    had = _EXCLUDE_BEGIN in text.splitlines()
+    try:
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(new)
+    except OSError:
+        return "blocked"
+    return "refreshed" if had else "created"
+
+
+def guest_layer(tree: Path) -> list[tuple[str, str]]:
+    """``(relative path, status)`` for the layer in guest checkout *tree* — READ ONLY.
+
+    :func:`harness_layer`'s statuses, plus one row for ``.git/info/exclude``. That row is
+    here rather than left as a silent side effect of writing because its absence is the
+    *whole* failure this design guards against: the files can all be current and the
+    operator still sees charter's noise in their own `git status`. A row nothing reports
+    is a guarantee nothing keeps.
+
+    The exclude row is omitted when charter has generated nothing here — there is then
+    nothing to hide, and reporting `missing` would demand a block naming no files.
+    """
+    tree = Path(tree)
+    marker = _read_marker_at(tree)
+    rows = _layer_status(tree, _guest_files(tree), marker)
+    owned = _charter_owned(tree, marker)
+    if owned:
+        rows.append((".git/info/exclude", _exclude_status(tree, owned)))
+    return rows
+
+
+def wire_guest(tree: Path) -> list[tuple[str, str]]:
+    """Materialise the layer into guest checkout *tree* and hide it there.
+
+    Files first, then the exclude block: the block lists what the marker says charter
+    owns, so it can only be written once the writing is done. Both halves are idempotent
+    and neither touches a path charter did not generate.
+    """
+    tree = Path(tree)
+    rows = _materialise(tree, _guest_files(tree))
+    owned = _charter_owned(tree, _read_marker_at(tree))
+    if owned:
+        rows.append((".git/info/exclude", _register_excludes(tree, owned)))
+    return rows
+
+
+def _prune_empty(d: Path, stop: Path) -> None:
+    """Remove *d* and its parents up to (never including) *stop*, while they are empty.
+
+    A `.claude/agents/` left standing after its last generated file is removed is charter
+    still visible in a repo it no longer has anything in.
+    """
+    try:
+        d, stop = d.resolve(), stop.resolve()
+    except OSError:
+        return
+    while d != stop and stop in d.parents:
+        try:
+            d.rmdir()
+        except OSError:
+            return
+        d = d.parent
+
+
+def unwire_guest(tree: Path) -> list[str]:
+    """Remove what charter generated in guest checkout *tree*. Returns the paths removed.
+
+    Only files whose current content still matches the marker: a path the operator has
+    since rewritten is theirs, and deleting it would be the same overwrite this design
+    refuses, one verb further on.
+    """
+    tree = Path(tree)
+    marker = _read_marker_at(tree)
+    removed: list[str] = []
+    for rel in sorted(marker):
+        p = tree / rel
+        try:
+            if not p.is_file() or marker[rel] != content_digest(p.read_text()):
+                continue
+            p.unlink()
+        except (OSError, UnicodeDecodeError):
+            continue
+        removed.append(rel)
+        _prune_empty(p.parent, tree)
+    try:
+        (tree / GENERATED_MARKER).unlink()
+        removed.append(GENERATED_MARKER)
+    except OSError:
+        pass
+    _register_excludes(tree, [])
+    return removed
+
+
+def unwire_guests(name: str) -> list[str]:
+    """Undo :func:`wire_guest` for every checkout in workspace *name*, before it goes.
+
+    `charter workspace remove` is a `shutil.rmtree`, which takes charter's generated files
+    with the workspace and would be the whole story if the exclude block lived inside it.
+    For a LINKED WORKTREE it does not: `info/exclude` is the main repo's, somewhere else
+    on disk entirely, and rmtree leaves charter's block sitting in a repo that is still
+    there — naming paths that no longer exist, in a file the operator did not write and
+    now cannot attribute. This is the call that keeps "removing the workspace removes what
+    charter added" true for both shapes.
+    """
+    out: list[str] = []
+    for tree in guest_trees(name):
+        out += [f"{tree.name}/{rel}" for rel in unwire_guest(tree)]
+    return out
 
 
 def remember(name: str, text: str, title: str | None = None) -> Path:

--- a/charter/workspace.py
+++ b/charter/workspace.py
@@ -224,7 +224,7 @@ def is_tree(path: Path) -> bool:
     return _unreadable(lambda: (Path(path) / ".git").exists())
 
 
-def git_dir(root) -> Path | None:
+def git_dir(root: Path) -> Path | None:
     """The real git directory of the checkout at *root*, or ``None`` if there is none.
 
     ``<root>/.git`` is a DIRECTORY in a clone and a FILE reading ``gitdir: <path>`` in a
@@ -233,7 +233,6 @@ def git_dir(root) -> Path | None:
     treating `<root>/.git/` as a directory does not fail loudly there: `mkdir -p` happily
     creates `.git/info/` *beside* the `.git` file's parent and git reads none of it.
     """
-    root = Path(root)
     dot = root / ".git"
     if _unreadable(lambda: dot.is_dir()):
         return dot
@@ -250,7 +249,7 @@ def git_dir(root) -> Path | None:
     return None
 
 
-def git_exclude_file(root) -> Path | None:
+def git_exclude_file(root: Path) -> Path | None:
     """The ``info/exclude`` git actually READS for the checkout at *root*.
 
     The COMMON directory's, which for a linked worktree is not its own gitdir. Git treats
@@ -272,8 +271,12 @@ def git_exclude_file(root) -> Path | None:
     except (OSError, UnicodeDecodeError):
         common = ""
     if common:
-        c = Path(common)
-        g = c if c.is_absolute() else Path(os.path.normpath(g / c))
+        # No absolute/relative branch: `Path("/a/.git/worktrees/x") / "/elsewhere"` IS
+        # `/elsewhere`, so joining answers both spellings and a branch here would be one
+        # the deletion sweep could remove without changing an answer. `normpath` rather
+        # than `resolve` because `commondir` is git's own `../..` and resolving would
+        # also follow symlinks, which `config.use` deliberately does not.
+        g = Path(os.path.normpath(g / common))
     return g / "info" / "exclude"
 
 
@@ -1336,16 +1339,13 @@ def _walkup_files() -> dict[str, str]:
     out: dict[str, str] = {}
     for sub in WALKUP_DIRS:
         d = config.ROOT / sub
-        if not _unreadable(lambda: d.is_dir()):
-            continue
-        try:
-            found = sorted(d.rglob("*"))
-        except OSError:
-            continue
-        for f in found:
+        # No `is_dir()` guard and no `is_file()` filter. `rglob` on a directory that is
+        # not there yields nothing, and a directory entry, a dangling symlink and a
+        # binary file are one answer here — "not text charter can mirror" — which the
+        # read already gives. A predicate in front of it is a branch the deletion sweep
+        # can remove without changing a single answer, which is what makes it noise.
+        for f in sorted(d.rglob("*")):
             try:
-                if not f.is_file():
-                    continue
                 text = f.read_text()
             except (OSError, UnicodeDecodeError):
                 continue
@@ -1579,18 +1579,17 @@ def _replace_block(text: str, block: str) -> str:
     try:
         i = lines.index(_EXCLUDE_BEGIN)
     except ValueError:
+        # Nothing of charter's here and nothing to add: the file is handed back BYTE FOR
+        # BYTE rather than re-joined. Re-joining normalises a missing trailing newline,
+        # which would make `unwire_guest` rewrite the `info/exclude` of a checkout charter
+        # never wired — a write into somebody's repo for no reason at all.
         if not new:
             return text
-        keep = list(lines)
-        while keep and not keep[-1].strip():
-            keep.pop()
-        out = keep + new
+        out = lines + new
     else:
         j = next((k for k in range(i + 1, len(lines)) if lines[k] == _EXCLUDE_END),
                  len(lines) - 1)
         out = lines[:i] + new + lines[j + 1:]
-        while out and not out[-1].strip():
-            out.pop()
     return "\n".join(out) + "\n" if out else ""
 
 
@@ -1646,7 +1645,6 @@ def guest_layer(tree: Path) -> list[tuple[str, str]]:
     The exclude row is omitted when charter has generated nothing here — there is then
     nothing to hide, and reporting `missing` would demand a block naming no files.
     """
-    tree = Path(tree)
     marker = _read_marker_at(tree)
     rows = _layer_status(tree, _guest_files(tree), marker)
     owned = _charter_owned(tree, marker)
@@ -1662,7 +1660,6 @@ def wire_guest(tree: Path) -> list[tuple[str, str]]:
     owns, so it can only be written once the writing is done. Both halves are idempotent
     and neither touches a path charter did not generate.
     """
-    tree = Path(tree)
     rows = _materialise(tree, _guest_files(tree))
     owned = _charter_owned(tree, _read_marker_at(tree))
     if owned:
@@ -1680,7 +1677,9 @@ def _prune_empty(d: Path, stop: Path) -> None:
         d, stop = d.resolve(), stop.resolve()
     except OSError:
         return
-    while d != stop and stop in d.parents:
+    # `stop in d.parents` alone: a path is never in its own parents, so it is also what
+    # stops the walk AT the checkout root.
+    while stop in d.parents:
         try:
             d.rmdir()
         except OSError:
@@ -1695,13 +1694,15 @@ def unwire_guest(tree: Path) -> list[str]:
     since rewritten is theirs, and deleting it would be the same overwrite this design
     refuses, one verb further on.
     """
-    tree = Path(tree)
     marker = _read_marker_at(tree)
     removed: list[str] = []
     for rel in sorted(marker):
         p = tree / rel
         try:
-            if not p.is_file() or marker[rel] != content_digest(p.read_text()):
+            # No `is_file()` in front of the read, for `_walkup_files`' reason: a path
+            # already gone and a path that is a directory both raise here, and both mean
+            # the same thing — charter has nothing of its own to take away.
+            if marker[rel] != content_digest(p.read_text()):
                 continue
             p.unlink()
         except (OSError, UnicodeDecodeError):

--- a/charter/workspace.py
+++ b/charter/workspace.py
@@ -1520,11 +1520,13 @@ def guest_trees(name: str) -> list[Path]:
     "where would a chat's cwd be cut off from the plane's layer", and the answer is *any*
     checkout: a worktree's root is a git boundary exactly as a clone's is.
     """
-    wd = workspace_dir(name)
     try:
-        entries = sorted(d for d in wd.iterdir() if d.is_dir())
+        entries = sorted(workspace_dir(name).iterdir())
     except OSError:
         return []
+    # No `is_dir()` filter: `git_dir` already answers `None` for a plain file — its
+    # `.git` join raises `NotADirectoryError` — so a predicate here would be one more
+    # spelling of the same question, and the deletion sweep would be right to take it.
     return [d for d in entries if git_dir(d) is not None]
 
 
@@ -1672,11 +1674,12 @@ def _prune_empty(d: Path, stop: Path) -> None:
 
     A `.claude/agents/` left standing after its last generated file is removed is charter
     still visible in a repo it no longer has anything in.
+
+    No `.resolve()` on either side, and unlike `_harness_files` that is safe here rather
+    than an oversight: both paths are built from the SAME checkout root in
+    :func:`unwire_guest`, out of relative paths the layer already refused to let escape
+    it, so the comparison is between two spellings that cannot disagree.
     """
-    try:
-        d, stop = d.resolve(), stop.resolve()
-    except OSError:
-        return
     # `stop in d.parents` alone: a path is never in its own parents, so it is also what
     # stops the walk AT the checkout root.
     while stop in d.parents:

--- a/docs/adr/0015-the-boundary-moves-with-the-harness.md
+++ b/docs/adr/0015-the-boundary-moves-with-the-harness.md
@@ -274,3 +274,20 @@ reports that is not real argues against a capability it actually has.
   nothing is indistinguishable from a broken integration (`tests/test_doctor_absent_is_not_health.py`).
 * ADR 0014 stands as written. It records why the principle exists; this extends it, which
   its own closing line invites — *"should be revisited rather than defended."*
+
+## The per-tree design came back, and the lesson is what let it (#850, #870)
+
+*"Twice the design was built on where charter could put a file, rather than on where the
+harness looks for one"* is the sentence above, and it is a test rather than a prohibition.
+Charter now writes into `workspaces/<ws>/` and into every checkout under it — the shape
+this ADR deleted — and it passes that test where opencode's plugin failed it: Claude Code
+reads project settings **from the session's working directory**, and its walk-up for
+`.claude/agents/` and `.claude/skills/` **stops at a git boundary**. Both were measured, not
+assumed. What was deleted wrote one global answer into trees whose harness read a global
+file anyway; this writes a per-tree answer into trees whose harness reads per-tree.
+
+The costs come back with it, and are paid rather than waved through: staleness bookkeeping
+(the `workspace layer` row in `doctor`) and, for a checkout charter is a guest in, the
+`.git/info/exclude` entry. The workspace directory needs no entry — `/workspaces/*/*` is
+already in the plane's `.gitignore` — so the entry exists exactly where the tree is not
+charter's, which is also the only place it was ever the right price.

--- a/docs/harnesses.md
+++ b/docs/harnesses.md
@@ -70,10 +70,17 @@ opencode and Codex get nothing here and say why: their config is machine-global,
 charter's layer is already live in every workspace and two workspaces on one machine
 cannot be made to differ. That ceiling is in `charter harness list` beside the others.
 
-Nothing is written into a **clone** — `workspaces/<ws>/<repo>/` is a repo charter does not
-own, and `git add -A` there would stage it. So a session inside a clone gets charter from
-the plugin, and **cannot delegate to a persona**: the plugin ships no `agents/`, and a
-clone's own git root stops the walk-up that would have found the plane's.
+**A clone gets the same layer, plus what the walk-up could not carry there.**
+`workspaces/<ws>/<repo>/` is a repo of its own, so a session inside it loses the settings
+*and* the plane's `.claude/agents/` — the walk-up stops at that git root. Charter writes
+both, and hides them in the clone's own `.git/info/exclude`: per-checkout, never
+committed, not itself tracked, and the one file a guest may write. Charter never edits the
+clone's `.gitignore`, hides only the exact paths it generated (never a `.claude/` glob,
+which would take your own untracked files with it), never touches a file it did not write,
+and removes its files and its exclude block when the workspace goes. `git status` in your
+repo is unaffected, and nothing charter wrote can be staged. Linked worktrees included —
+their `info/exclude` is the main repo's, which is also why removal is not just a
+`rm -rf`.
 
 ## `charter statusline --watch`
 

--- a/docs/harnesses.md
+++ b/docs/harnesses.md
@@ -82,6 +82,12 @@ repo is unaffected, and nothing charter wrote can be staged. Linked worktrees in
 their `info/exclude` is the main repo's, which is also why removal is not just a
 `rm -rf`.
 
+The *mechanism* is harness-agnostic: whatever a harness declares it needs in a tree is
+written, marked, hidden and removed the same way. The two mirrored directories are Claude
+Code's, and that is a limit rather than a claim about the others — opencode reads
+`opencode.json` and `.opencode/agent/` at a project root, and Codex reads
+`.codex/skills/`, so a clone cuts those off too and charter does not yet carry them in.
+
 ## `charter statusline --watch`
 
 The one worth knowing. It repaints the plane state in place in any spare terminal — no

--- a/docs/news/unreleased-a-chat-in-a-workspace-gets-charters-layer.md
+++ b/docs/news/unreleased-a-chat-in-a-workspace-gets-charters-layer.md
@@ -37,9 +37,12 @@ with the plugin and agents already walk up; a second copy of either would shadow
 plugin's own non-deterministically, and Claude Code says so in its own words — *"is already
 taken by X, which takes precedence"*.
 
-**Nothing at all inside a clone.** `workspaces/<ws>/<repo>/` is a repo charter does not
-own, and `git add -A` there would stage whatever charter left behind. The limit that
-follows is stated rather than discovered: **in a clone you cannot delegate to a persona.**
+**Nothing at all inside a clone — and that limit did not survive the same release.** It
+was stated here rather than discovered: `workspaces/<ws>/<repo>/` is a repo charter does
+not own, `git add -A` there would stage whatever charter left behind, and so *in a clone
+you cannot delegate to a persona*. #870 answers it in the same version, by paying the cost
+this entry says below is not incurred — see *a clone gets the layer, and hides it in the
+clone's `info/exclude`*.
 
 ## Written when, and owned how
 
@@ -87,11 +90,11 @@ and worktree for a harness that reads one global file anyway — *"all correct, 
 answering a question that does not need asking"*. This writes config that is **meant** to
 differ per workspace, into a directory charter itself creates.
 
-Two of that design's costs come back and one does not. The staleness bookkeeping is here,
-and is paid for by the `doctor` row above. The `.git/info/exclude` entry per checkout is
-not: `/workspaces/*/*` is already in the plane's `.gitignore` and the managed LIVE block
-un-ignores four named paths, none of them `.claude/`. Nothing generated here can reach a
-commit.
+The staleness bookkeeping comes back, and is paid for by the `doctor` row above. The
+`.git/info/exclude` entry per checkout does not arrive **for the workspace directory**:
+`/workspaces/*/*` is already in the plane's `.gitignore` and the managed LIVE block
+un-ignores four named paths, none of them `.claude/`. Nothing generated there can reach a
+commit. One directory deeper it does arrive, and #870 is the entry that argues for it.
 
 ## To adopt
 

--- a/docs/news/unreleased-a-clone-gets-the-layer-and-hides-it.md
+++ b/docs/news/unreleased-a-clone-gets-the-layer-and-hides-it.md
@@ -1,0 +1,95 @@
+---
+version: unreleased
+headline: a clone inside a workspace gets charter's layer too — written into the clone and hidden in that checkout's own `.git/info/exclude`, so your repo's `git status` never sees it
+---
+
+A workspace can hold a clone at `workspaces/<ws>/<repo>`, and that clone is a **separate
+git repository**. The entry above closed the gap for `workspaces/<ws>/` and stated the
+clone as a permanent limit: *"in a clone you cannot delegate to a persona."* It is closed
+now, in the same release, and this is the argument for it.
+
+## The clone is where the gap is widest
+
+Three things reach a session by three different routes, and only in a clone do all three
+fail at once:
+
+```
+                        plane root   workspaces/<ws>/   workspaces/<ws>/<repo>/
+settings.json           yes          NO  (fixed above)  NO
+.claude/agents/         yes          yes (walks up)     NO  (git boundary)
+.claude/skills/         yes          yes (walks up)     NO  (git boundary)
+```
+
+Claude Code reads project settings from the session's working directory and does not walk
+up — that is the row #850 fixed. Agents and skills *do* walk up, and **stop at a git
+boundary**. A workspace directory is not one; a clone's root is. So the directory that
+already had two thirds of the layer got the third, and the directory that had none of it
+kept none.
+
+`enabledPlugins` alone does not close it. The plugin carries charter's own skills and
+cannot carry *this* plane's `.claude/agents/` — those are generated from `personas/` by
+`persona sync-agents` and are as local to a plane as its personas are. Without them a chat
+in a clone loads charter and still cannot delegate to a persona.
+
+## The constraint that shapes the answer
+
+The clone is **not charter's repository**. Files written there are untracked noise in the
+operator's own `git status`, in a tree charter does not own — and charter must not edit a
+tracked `.gitignore` in somebody else's repo, because that edit travels to their teammates
+in a commit.
+
+So the layer is registered in the clone's **`.git/info/exclude`**. That file is
+per-checkout, is never committed, and is not itself tracked: charter's files stay invisible
+in the clone's status without charter touching anything the operator's repo tracks or
+anything their teammates receive. It is the one place a guest may write.
+
+## What that buys, and what it costs
+
+Measured against real `git`, not against charter's model of it: `git status` in the clone is
+clean after wiring, `git add -A` stages nothing charter wrote, and the clone's `.gitignore`
+is byte-identical.
+
+- **The block is idempotent.** An `ensure` runs on every launch; appending would leave
+  `git status` clean while `info/exclude` grew without bound — the failure nobody would
+  ever look for. The block is delimited and rewritten in place, and an unterminated one
+  (somebody deleted the end marker) is replaced rather than doubled.
+- **It lists files, never a directory.** `/.claude/settings.json`, not `.claude/`. Your own
+  untracked files under `.claude/` stay visible to you; charter silently making somebody's
+  work invisible in their own repo would be a worse failure than the noise this prevents.
+- **A path charter did not generate is never touched.** The `.charter-generated` sidecar
+  records a hash of what charter wrote, so `charter doctor` can tell `stale` from
+  `foreign`. A foreign file is not rewritten, and — the quieter half of the same restraint
+  — it is not hidden either. A path you take over stops being hidden on the next wire.
+- **`.git/info/exclude` gets a `doctor` row of its own.** Its absence is the whole failure
+  this design guards against: every file can be current and your status still full of
+  charter. A row nothing reports is a guarantee nothing keeps.
+
+**CLAUDE.md is deliberately not carried in.** It walks up on the same rule, so the gap is
+real for it too — and it is the one file a repo of its own is most likely to have opinions
+about. Dropping the plane's project instructions into somebody else's repo, to be read
+there as that repo's instructions, is a claim of a different size from mirroring a settings
+key. A guest may hide its own files; it does not narrate the host's.
+
+## Removal, and why it is not `rm -rf`
+
+`charter workspace remove` is a `shutil.rmtree`, which takes charter's generated files with
+the workspace — and that would be the whole story if the exclude file lived inside it.
+
+For a **linked worktree** it does not. Git treats `info/` as shared between a repo and its
+worktrees, so the file git actually reads is the **main repo's**, somewhere else on disk
+entirely. Measured: a pattern written to `.git/worktrees/<name>/info/exclude` is read by
+nobody. Removal therefore unwires first, and charter resolves the real git dir — through
+the `gitdir:` pointer file and then the `commondir` hop — rather than assuming `<root>/.git/`
+is a directory. That assumption does not fail loudly: `mkdir -p` cheerfully creates the
+path beside the `.git` *file*, the write succeeds, and the operator's status fills up with
+charter anyway.
+
+## To adopt
+
+```
+charter workspace reinit --all
+```
+
+`charter clone` wires new checkouts as it makes them, and says so once per checkout —
+charter has just written into a repo you own, and a mechanism whose entire visible
+signature is its own absence is one nobody can find when they want it gone.

--- a/docs/news/unreleased-a-clone-gets-the-layer-and-hides-it.md
+++ b/docs/news/unreleased-a-clone-gets-the-layer-and-hides-it.md
@@ -64,6 +64,16 @@ is byte-identical.
   this design guards against: every file can be current and your status still full of
   charter. A row nothing reports is a guarantee nothing keeps.
 
+**The two mirrored directories are Claude Code's, and the rest is not.** Everything that
+writes, marks, hides and removes works from whatever a harness declares it needs in a
+tree, so a harness that answers with files gets them into a clone the day it answers. Only
+the walk-up list is spelled out, because it names the *plane's* own directories rather
+than any harness's answer. Measured against the installed binaries: opencode reads
+`opencode.json` and `.opencode/agent/` at a project root, and Codex reads `.codex/skills/`
+— so a clone cuts those off too, and this release does not carry them in. That belongs in
+each harness's own answer, not in a list in `workspace.py` that has to be edited every
+time another harness arrives.
+
 **CLAUDE.md is deliberately not carried in.** It walks up on the same rule, so the gap is
 real for it too — and it is the one file a repo of its own is most likely to have opinions
 about. Dropping the plane's project instructions into somebody else's repo, to be read

--- a/skills/working-in-a-clone/SKILL.md
+++ b/skills/working-in-a-clone/SKILL.md
@@ -67,6 +67,12 @@ cd workspaces/<workspace>/<repo> && claude
 There the repo's full configuration loads natively, and `charter` still works from inside
 it when the control plane is needed.
 
+Charter puts its own layer in the clone for that session — the plane's settings and its
+`.claude/agents/`, which the clone's git root would otherwise cut off — and hides those
+exact paths in the clone's `.git/info/exclude`. So a session rooted in the repo can
+delegate to a persona, and the repo's `git status` is unaffected. `charter workspace
+reinit` is the repair if a clone is missing it.
+
 ## Guardrails
 
 - Confirm the working directory is `workspaces/<active>/<repo>` before a build or a commit.

--- a/tests/test_a_clone_gets_the_layer_and_hides_it.py
+++ b/tests/test_a_clone_gets_the_layer_and_hides_it.py
@@ -233,6 +233,18 @@ class TheReportIsInAStableOrder(CloneLayer):
         # one, and this class exists because there is now more than one.
         self.assertEqual(rels[0], ".claude/agents/alpha.md")
 
+    def test_the_checkouts_come_back_in_a_stable_order(self):
+        """A workspace holds several repos, and every row `wire_harnesses` returns is
+        prefixed with the checkout's directory name. `iterdir` hands back the
+        FILESYSTEM's order, so a report that inherits it lists the same tree differently
+        on two machines — and differently again after a `workspace restore` re-creates
+        the directories in another sequence."""
+        for name in ("zebra", "alpha"):
+            _repo(workspace.workspace_dir(self.ws) / name)
+        trees = [t.name for t in workspace.guest_trees(self.ws)]
+        self.assertEqual(trees, sorted(trees))
+        self.assertEqual(trees[0], "alpha", "the first made was 'svc', not the first named")
+
     def test_the_block_lists_the_paths_sorted(self):
         self.agents("zulu.md", "alpha.md", "mike.md")
         self.wire()

--- a/tests/test_a_clone_gets_the_layer_and_hides_it.py
+++ b/tests/test_a_clone_gets_the_layer_and_hides_it.py
@@ -1,0 +1,489 @@
+"""A clone inside a workspace gets charter's layer, hidden in its own `info/exclude` — #870.
+
+`workspaces/<ws>/<repo>/` is a repo of its own. Claude Code's walk-up for `.claude/agents/`
+and `.claude/skills/` stops at that git boundary and its project settings never walked up
+at all, so a chat launched in a clone got none of the plane's layer — the widest gap of
+the three, and the one #850 explicitly left open.
+
+charter writes the layer there anyway and pays a cost the workspace directory does not
+owe: every generated path is registered in that checkout's `.git/info/exclude`, which is
+per-checkout, never committed and not itself tracked. The four things that makes true are
+what this file is about — the write is idempotent, charter's files are marked, a file
+charter did not generate is never touched, and removing the workspace removes what charter
+added — plus the fifth that makes them work at all: a linked worktree's `.git` is a FILE,
+and its exclude lives in a main repo somewhere else entirely.
+
+Every test here writes only into a `PersonaIso` tmp plane (or a `mkdtemp` of its own for
+the main repo behind a worktree, which by construction cannot be inside one). Nothing
+touches the developer's real `workspaces/`. `git` identity and signing come from
+`tests/_gitguard`, which redirects `$GIT_CONFIG_GLOBAL` for the whole suite — no test here
+spells its own environment, and no test here writes git config outside the repo it made.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+from charter import commands, config, doctor, workspace
+from charter import commands_workspace as cw
+
+from tests import _isolation
+from tests.test_a_workspace_carries_charters_layer import _plane_settings
+
+
+def _git(where, *args) -> subprocess.CompletedProcess:
+    """`git` in *where*, inheriting this process's environment ON PURPOSE.
+
+    `tests/_gitguard` has already pointed `$GIT_CONFIG_GLOBAL` at a file this package
+    writes, so identity and `commit.gpgsign=false` are already answered for every child.
+    Building a private env here would drop that redirect — which `_planeguard`'s
+    `AmbientGitConfig` refuses at the `Popen`, and which is the shape that hangs a suite
+    on somebody's fingerprint reader (#641).
+    """
+    return subprocess.run(["git", "-C", str(where), *args], check=True,
+                          capture_output=True, text=True)
+
+
+def _repo(d: Path) -> Path:
+    """A real git repo at *d* with one commit — enough for `git status` to mean something."""
+    d.mkdir(parents=True, exist_ok=True)
+    _git(d.parent, "init", "-q", d.name)
+    (d / "README.md").write_text("theirs\n")
+    _git(d, "add", "-A")
+    _git(d, "commit", "-qm", "init")
+    return d
+
+
+class CloneLayer(_isolation.PersonaIso):
+    """A plane with settings and one workspace holding one REAL clone."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        # The tripwire the whole layer suite is written under: if `PersonaIso` ever stops
+        # repointing derived paths at a throwaway tree, every write below lands in a real
+        # plane — and half of them land in a repo charter does not own.
+        self.assertIn("edm-test-", str(config.STATE_DIR))
+        _plane_settings(config.ROOT)
+        self.ws = "api"
+        workspace.ensure(self.ws)
+        self.clone = _repo(workspace.workspace_dir(self.ws) / "svc")
+
+    def wire(self) -> dict:
+        return dict(workspace.wire_guest(self.clone))
+
+    def excludes(self, tree: Path | None = None) -> str:
+        p = workspace.git_exclude_file(tree or self.clone)
+        return p.read_text() if p and p.exists() else ""
+
+    def status(self, tree: Path | None = None) -> str:
+        """``-uall``, not the default. Porcelain collapses an untracked directory to one
+        `?? .claude/` line, which reads as "charter's noise is here" whether the file
+        inside is charter's or the operator's — the one distinction this whole design
+        turns on. Listing every file is what makes a clean status mean clean."""
+        return _git(tree or self.clone, "status", "--porcelain", "-uall").stdout
+
+
+class TheLayerArrives(CloneLayer):
+    def test_the_clone_gets_the_planes_settings(self):
+        """The half that never walked up: Claude Code reads project settings from the
+        session's cwd and nowhere else, so this file is the whole of whether a chat in the
+        clone has a plugin, a status line and a `$CHARTER_HARNESS`."""
+        self.wire()
+        doc = json.loads((self.clone / ".claude" / "settings.json").read_text())
+        self.assertEqual(sorted(doc), ["enabledPlugins", "env", "statusLine"])
+        self.assertEqual(doc["enabledPlugins"], {"charter@charter": True})
+
+    def test_the_clone_gets_the_planes_agents(self):
+        """The half that walked up and was cut off. `enabledPlugins` alone does not close
+        it: the plugin carries charter's own skills and cannot carry THIS plane's personas,
+        which `persona sync-agents` generates from `personas/`. Without these a chat in a
+        clone loads charter and still cannot delegate to a persona."""
+        agent = config.ROOT / ".claude" / "agents" / "steward.md"
+        agent.parent.mkdir(parents=True, exist_ok=True)
+        agent.write_text("---\nname: steward\n---\nroute the work\n")
+        self.wire()
+        self.assertEqual((self.clone / ".claude" / "agents" / "steward.md").read_text(),
+                         "---\nname: steward\n---\nroute the work\n")
+
+    def test_the_workspace_directory_still_gets_neither(self):
+        """The boundary did not dissolve, it moved one directory in. Agents and skills
+        reach `workspaces/<ws>/` by walking up — a workspace directory is inside the
+        plane's own repo — and a second copy there would shadow the first."""
+        (config.ROOT / ".claude" / "agents").mkdir(parents=True, exist_ok=True)
+        (config.ROOT / ".claude" / "agents" / "steward.md").write_text("x\n")
+        workspace.wire_harnesses(self.ws)
+        wd = workspace.workspace_dir(self.ws)
+        self.assertFalse((wd / ".claude" / "agents").exists())
+        self.assertTrue((self.clone / ".claude" / "agents" / "steward.md").is_file())
+
+    def test_the_plane_charter_file_is_not_carried_in(self):
+        """CLAUDE.md walks up on the same rule and is deliberately left behind: it is the
+        one file a repo of its own is most likely to have opinions about, and dropping the
+        plane's project instructions into somebody else's repo — to be read there as that
+        repo's instructions — is a claim of a different size from mirroring a settings key."""
+        (config.ROOT / "CLAUDE.md").write_text("the plane's instructions\n")
+        (config.ROOT / ".claude" / "CLAUDE.md").write_text("also the plane's\n")
+        self.wire()
+        self.assertFalse((self.clone / "CLAUDE.md").exists())
+        self.assertFalse((self.clone / ".claude" / "CLAUDE.md").exists())
+
+    def test_wiring_a_workspace_wires_its_clones(self):
+        """`charter workspace reinit` is the repair for a clone too — which it can only be
+        if the clones hang off the call `reinit` already makes."""
+        rows = dict(workspace.wire_harnesses(self.ws))
+        self.assertEqual(rows["svc/.claude/settings.json"], "created")
+        self.assertEqual(rows["svc/.git/info/exclude"], "created")
+
+
+class NothingShowsUpInTheirStatus(CloneLayer):
+    """The constraint that makes the feature admissible: the operator's own `git status`."""
+
+    def test_git_status_in_the_clone_stays_clean(self):
+        self.assertEqual(self.status(), "")
+        self.wire()
+        self.assertEqual(self.status(), "",
+                         "charter's files are untracked noise in a repo it does not own")
+
+    def test_the_block_names_the_files_and_not_a_directory(self):
+        """A `.claude/` glob would hide the operator's OWN untracked files under
+        `.claude/` from their own status — charter making somebody's work invisible in
+        their repo is a worse failure than the noise this exists to prevent."""
+        self.wire()
+        (self.clone / ".claude" / "mine.md").write_text("my note\n")
+        self.assertIn(".claude/mine.md", self.status())
+
+    def test_the_clones_gitignore_is_never_touched(self):
+        """A tracked file in somebody else's repo. `info/exclude` is the one place a guest
+        may write: per-checkout, never committed, not itself tracked."""
+        gi = self.clone / ".gitignore"
+        gi.write_text("build/\n")
+        _git(self.clone, "add", "-A")
+        _git(self.clone, "commit", "-qm", "ignore build")
+        self.wire()
+        self.assertEqual(gi.read_text(), "build/\n")
+
+    def test_nothing_charter_wrote_can_be_staged(self):
+        """`git add -A` in the operator's repo is the failure mode named in #850's own
+        text. Excluded paths are not added, so the layer cannot reach their commit."""
+        self.wire()
+        _git(self.clone, "add", "-A")
+        staged = _git(self.clone, "diff", "--cached", "--name-only").stdout
+        self.assertEqual(staged.strip(), "")
+
+
+class TheWriteIsIdempotent(CloneLayer):
+    def test_a_second_wire_changes_nothing(self):
+        self.wire()
+        before = self.excludes()
+        rows = self.wire()
+        self.assertEqual(self.excludes(), before)
+        self.assertEqual(rows[".git/info/exclude"], "present")
+
+    def test_ten_wires_do_not_grow_the_file(self):
+        """An `ensure` runs on every launch. Appending would leave `git status` clean and
+        `info/exclude` growing without bound — the failure nobody would ever look for."""
+        for _ in range(10):
+            self.wire()
+        text = self.excludes()
+        self.assertEqual(text.count(workspace._EXCLUDE_BEGIN), 1)
+        self.assertEqual(text.count("/.claude/settings.json"), 1)
+
+    def test_the_operators_own_lines_survive(self):
+        p = workspace.git_exclude_file(self.clone)
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text("# theirs\n*.tmp\n")
+        self.wire()
+        self.wire()
+        text = self.excludes()
+        self.assertIn("*.tmp", text)
+        self.assertEqual(text.count("*.tmp"), 1)
+        self.assertIn(workspace._EXCLUDE_BEGIN, text)
+
+    def test_an_unterminated_block_is_replaced_rather_than_doubled(self):
+        """Somebody deleted the end marker by hand. Appending a second block below the
+        first is the duplication this whole function exists to prevent, wearing a crash
+        for a hat."""
+        p = workspace.git_exclude_file(self.clone)
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(f"*.tmp\n{workspace._EXCLUDE_BEGIN}\n/.stale-path\n")
+        self.wire()
+        text = self.excludes()
+        self.assertEqual(text.count(workspace._EXCLUDE_BEGIN), 1)
+        self.assertNotIn("/.stale-path", text)
+        self.assertIn("*.tmp", text)
+
+
+class OwnershipIsLegible(CloneLayer):
+    def test_the_marker_is_a_sidecar_in_the_clone(self):
+        self.wire()
+        doc = json.loads((self.clone / workspace.GENERATED_MARKER).read_text())
+        self.assertEqual(doc[".claude/settings.json"],
+                         workspace.content_digest(
+                             (self.clone / ".claude" / "settings.json").read_text()))
+
+    def test_the_marker_hides_itself_too(self):
+        """It is charter's file in their repo exactly as the settings are."""
+        self.wire()
+        self.assertIn(f"/{workspace.GENERATED_MARKER}", self.excludes())
+        self.assertEqual(self.status(), "")
+
+    def test_doctor_can_tell_stale_from_foreign(self):
+        self.wire()
+        p = self.clone / ".claude" / "settings.json"
+        p.write_text(json.dumps({"env": {"CHARTER_HARNESS": "claude-code"}}) + "\n")
+        marker = json.loads((self.clone / workspace.GENERATED_MARKER).read_text())
+        marker[".claude/settings.json"] = workspace.content_digest(p.read_text())
+        (self.clone / workspace.GENERATED_MARKER).write_text(json.dumps(marker) + "\n")
+        self.assertEqual(dict(workspace.guest_layer(self.clone))[".claude/settings.json"],
+                         "stale")
+        p.write_text("{}\n")
+        self.assertEqual(dict(workspace.guest_layer(self.clone))[".claude/settings.json"],
+                         "foreign")
+
+
+class AFileCharterDidNotWrite(CloneLayer):
+    def test_is_never_overwritten(self):
+        p = self.clone / ".claude" / "settings.json"
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text('{"statusLine": {"type": "command", "command": "theirs"}}\n')
+        rows = self.wire()
+        self.assertEqual(rows[".claude/settings.json"], "foreign")
+        self.assertIn("theirs", p.read_text())
+
+    def test_is_never_hidden_either(self):
+        """Charter neither rewrites the operator's file nor makes it vanish from their own
+        status — the second is the quieter half of the same restraint."""
+        p = self.clone / ".claude" / "settings.json"
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text('{"statusLine": {"type": "command", "command": "theirs"}}\n')
+        self.wire()
+        self.assertNotIn("/.claude/settings.json", self.excludes())
+        self.assertIn(".claude/settings.json", self.status())
+
+    def test_an_all_foreign_checkout_gets_no_block_at_all(self):
+        p = self.clone / ".claude" / "settings.json"
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text("{}\n")
+        rows = self.wire()
+        self.assertNotIn(".git/info/exclude", rows)
+        self.assertNotIn(workspace._EXCLUDE_BEGIN, self.excludes())
+
+    def test_a_path_the_operator_takes_over_stops_being_hidden(self):
+        """charter wrote it, then they rewrote it. The marker no longer vouches for the
+        content, so the next wire drops it from the block and their edit becomes visible
+        to them again."""
+        self.wire()
+        self.assertIn("/.claude/settings.json", self.excludes())
+        (self.clone / ".claude" / "settings.json").write_text('{"env": {"X": "1"}}\n')
+        self.wire()
+        self.assertNotIn("/.claude/settings.json", self.excludes())
+
+
+class TheExcludeIsReported(CloneLayer):
+    """The row exists because its absence is the whole failure: every file can be current
+    and the operator still sees charter's noise in their own `git status`."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        # `check_workspace_harness` short-circuits on `HAS_CONTROL_PLANE`, and
+        # `_isolation` deliberately hands a root with no `charter.toml` — so without these
+        # two lines every case here passes through "no control plane found" and asserts
+        # nothing, which is exactly how the row's quiet states reached the sweep as
+        # survivors once already.
+        (Path(config.ROOT) / "charter.toml").write_text("schema = 1\n")
+        prev = config.use(Path(config.ROOT))
+        self.addCleanup(config.restore, prev)
+        self.assertTrue(config.HAS_CONTROL_PLANE)
+
+    def test_an_emptied_exclude_reads_as_missing_and_reinit_repairs_it(self):
+        self.wire()
+        workspace.git_exclude_file(self.clone).write_text("")
+        self.assertEqual(dict(workspace.guest_layer(self.clone))[".git/info/exclude"],
+                         "missing")
+        self.assertEqual(self.wire()[".git/info/exclude"], "created")
+        self.assertEqual(dict(workspace.guest_layer(self.clone))[".git/info/exclude"], "ok")
+
+    def test_a_block_naming_the_wrong_files_reads_as_stale(self):
+        self.wire()
+        p = workspace.git_exclude_file(self.clone)
+        p.write_text(f"{workspace._EXCLUDE_BEGIN}\n/.gone\n{workspace._EXCLUDE_END}\n")
+        self.assertEqual(dict(workspace.guest_layer(self.clone))[".git/info/exclude"],
+                         "stale")
+        self.assertEqual(self.wire()[".git/info/exclude"], "refreshed")
+
+    def test_reading_the_layer_never_writes(self):
+        """`doctor` calls this from the SessionStart hook. A check that healed what it
+        found would report every clone hidden by having just hidden it."""
+        workspace.guest_layer(self.clone)
+        self.assertFalse((self.clone / ".claude").exists())
+        self.assertNotIn(workspace._EXCLUDE_BEGIN, self.excludes())
+
+    def test_doctor_names_the_clone(self):
+        rows = dict(workspace.harness_layer(self.ws))
+        self.assertEqual(rows["svc/.claude/settings.json"], "missing")
+        r = doctor.check_workspace_harness()
+        self.assertEqual(r.status, doctor.WARN)
+        self.assertIn("api/svc/.claude/settings.json", r.detail)
+
+
+class AWorktreeIsAGuestToo(CloneLayer):
+    """`.git` is a FILE, and `info/exclude` is the MAIN repo's — measured, not assumed.
+
+    Git treats `info/` as shared between a repo and its linked worktrees, so a pattern
+    written to `.git/worktrees/<name>/info/exclude` is read by nobody. Assuming
+    `<root>/.git/` is a directory does not fail loudly here: `mkdir -p` cheerfully creates
+    the path beside the `.git` FILE, the write succeeds, and the operator's status is full
+    of charter.
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.main = Path(tempfile.mkdtemp(prefix="edm-test-main-"))
+        self.addCleanup(shutil.rmtree, self.main, ignore_errors=True)
+        _repo(self.main / "svc-main")
+        self.tree = workspace.workspace_dir(self.ws) / "svc-wt"
+        _git(self.main / "svc-main", "worktree", "add", "-q", str(self.tree), "-b", "side")
+
+    def test_the_git_dir_is_resolved_through_the_pointer_file(self):
+        self.assertFalse((self.tree / ".git").is_dir())
+        # `.resolve()` on both sides: git writes the RESOLVED path into the pointer file,
+        # and a macOS temp dir reaches the test as `/var/...` for git's `/private/var/...`.
+        self.assertEqual(workspace.git_dir(self.tree).resolve(),
+                         (self.main / "svc-main" / ".git" / "worktrees" / "svc-wt").resolve())
+
+    def test_the_exclude_file_is_the_main_repos(self):
+        self.assertEqual(workspace.git_exclude_file(self.tree).resolve(),
+                         (self.main / "svc-main" / ".git" / "info" / "exclude").resolve())
+
+    def test_the_worktrees_status_really_is_clean(self):
+        """The end-to-end claim, against real git rather than against charter's model of
+        it: this is what fails if `commondir` is skipped."""
+        workspace.wire_guest(self.tree)
+        self.assertEqual(self.status(self.tree), "")
+
+    def test_a_worktree_is_a_guest_tree_and_is_not_a_clone(self):
+        """`clones()` must not grow a second repo — a worktree is not one. `guest_trees`
+        asks a different question: where would a chat's cwd be cut off from the plane?"""
+        self.assertNotIn(self.tree, workspace.clones(self.ws))
+        self.assertIn(self.tree, workspace.guest_trees(self.ws))
+
+    def test_a_directory_with_no_checkout_is_not_a_guest(self):
+        plain = workspace.workspace_dir(self.ws) / "notes"
+        plain.mkdir()
+        self.assertIsNone(workspace.git_dir(plain))
+        self.assertIsNone(workspace.git_exclude_file(plain))
+        self.assertNotIn(plain, workspace.guest_trees(self.ws))
+
+    def test_a_git_file_pointing_nowhere_is_not_a_checkout(self):
+        broken = workspace.workspace_dir(self.ws) / "broken"
+        broken.mkdir()
+        (broken / ".git").write_text("gitdir: ../does-not-exist\n")
+        self.assertIsNone(workspace.git_dir(broken))
+        self.assertNotIn(broken, workspace.guest_trees(self.ws))
+
+    def test_a_git_file_that_says_nothing_is_not_a_checkout(self):
+        junk = workspace.workspace_dir(self.ws) / "junk"
+        junk.mkdir()
+        (junk / ".git").write_text("not a gitdir line\n")
+        self.assertIsNone(workspace.git_dir(junk))
+
+
+class RemovingTheWorkspaceRemovesWhatCharterAdded(CloneLayer):
+    def test_unwiring_a_clone_takes_its_files_and_its_block(self):
+        self.wire()
+        removed = workspace.unwire_guest(self.clone)
+        self.assertIn(".claude/settings.json", removed)
+        self.assertIn(workspace.GENERATED_MARKER, removed)
+        self.assertFalse((self.clone / ".claude").exists(),
+                         "an emptied directory is charter still visible in their repo")
+        self.assertNotIn(workspace._EXCLUDE_BEGIN, self.excludes())
+        self.assertEqual(self.status(), "")
+
+    def test_unwiring_leaves_the_operators_own_files_alone(self):
+        self.wire()
+        (self.clone / ".claude" / "mine.md").write_text("my note\n")
+        p = workspace.git_exclude_file(self.clone)
+        p.write_text("*.tmp\n" + p.read_text())
+        workspace.unwire_guest(self.clone)
+        self.assertTrue((self.clone / ".claude" / "mine.md").is_file())
+        self.assertIn("*.tmp", self.excludes())
+
+    def test_unwiring_never_deletes_a_file_the_operator_took_over(self):
+        """Deleting it would be the same overwrite this design refuses, one verb on."""
+        self.wire()
+        p = self.clone / ".claude" / "settings.json"
+        p.write_text('{"env": {"theirs": "1"}}\n')
+        workspace.unwire_guest(self.clone)
+        self.assertEqual(p.read_text(), '{"env": {"theirs": "1"}}\n')
+
+
+class RemovingAWorkspaceWithAWorktree(CloneLayer):
+    """The case `shutil.rmtree` cannot answer: the exclude file is not in the directory.
+
+    A linked worktree's `info/exclude` belongs to a main repo somewhere else on disk, so
+    removing the workspace would leave charter's block sitting in a repo that is still
+    there, naming paths that no longer exist, in a file the operator did not write.
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.main = Path(tempfile.mkdtemp(prefix="edm-test-main-"))
+        self.addCleanup(shutil.rmtree, self.main, ignore_errors=True)
+        _repo(self.main / "svc-main")
+        self.tree = workspace.workspace_dir(self.ws) / "svc-wt"
+        _git(self.main / "svc-main", "worktree", "add", "-q", str(self.tree), "-b", "side")
+        workspace.wire_guest(self.tree)
+
+    def test_the_block_is_gone_from_the_main_repo(self):
+        main_exclude = self.main / "svc-main" / ".git" / "info" / "exclude"
+        self.assertIn(workspace._EXCLUDE_BEGIN, main_exclude.read_text())
+        workspace.unwire_guests(self.ws)
+        self.assertNotIn(workspace._EXCLUDE_BEGIN, main_exclude.read_text())
+
+    def test_workspace_remove_unwires_before_it_deletes(self):
+        main_exclude = self.main / "svc-main" / ".git" / "info" / "exclude"
+        from types import SimpleNamespace
+        import contextlib
+        import io
+
+        out, err = io.StringIO(), io.StringIO()
+        with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+            rc = cw.cmd_workspace_remove(SimpleNamespace(name=self.ws, force=True))
+        self.assertEqual(rc, 0, out.getvalue() + err.getvalue())
+        self.assertFalse(workspace.workspace_dir(self.ws).exists())
+        self.assertNotIn(workspace._EXCLUDE_BEGIN, main_exclude.read_text())
+
+
+class TheAnnouncement(CloneLayer):
+    def test_cloning_says_what_was_written_and_where_it_is_hidden(self):
+        """charter has just written files into a repo the operator owns. A mechanism whose
+        entire visible signature is its own absence is one nobody can find when they want
+        it gone."""
+        import contextlib
+        import io
+
+        err = io.StringIO()
+        with contextlib.redirect_stderr(err):
+            commands._wire_clones(self.ws)
+        self.assertIn("svc", err.getvalue())
+        self.assertIn("info/exclude", err.getvalue())
+
+    def test_a_second_clone_into_the_same_workspace_says_nothing(self):
+        import contextlib
+        import io
+
+        err = io.StringIO()
+        with contextlib.redirect_stderr(err):
+            commands._wire_clones(self.ws)
+            err.truncate(0), err.seek(0)
+            commands._wire_clones(self.ws)
+        self.assertEqual(err.getvalue(), "")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_a_clone_gets_the_layer_and_hides_it.py
+++ b/tests/test_a_clone_gets_the_layer_and_hides_it.py
@@ -35,6 +35,7 @@ from unittest import mock
 
 from charter import commands, config, doctor, workspace
 from charter import commands_workspace as cw
+from charter.harness import claude_code, registry
 
 from tests import _isolation
 from tests.test_a_workspace_carries_charters_layer import _plane_settings
@@ -165,6 +166,47 @@ class TheLayerArrives(CloneLayer):
         rows = dict(workspace.wire_harnesses(self.ws))
         self.assertEqual(rows["svc/.claude/settings.json"], "created")
         self.assertEqual(rows["svc/.git/info/exclude"], "created")
+
+
+class APathThatWouldEscapeTheCheckout(CloneLayer):
+    """`_harness_files`' containment refusal, which nothing reached.
+
+    The sweep returned the whole `if … continue` as a survivor, and the guard is worth
+    more here than it was one directory up: a `rel` carrying `..` escaping a WORKSPACE
+    directory lands somewhere else in the plane, and a `rel` escaping a CLONE lands in a
+    repo charter is a guest in — outside the tree it is allowed to write at all, with an
+    `info/exclude` entry that could never hide it because the path is not under the
+    checkout.
+
+    The harness contract already says paths stay inside. A contract nothing enforces is a
+    comment, and this is the one place every harness's answer passes through.
+    """
+
+    def files(self, rel: str) -> dict:
+        rogue = SimpleNamespace(workspace_files=lambda: {rel: "not charter's to place\n"})
+        with mock.patch.object(registry, "all",
+                               return_value=[rogue, claude_code.ClaudeCodeHarness()]):
+            return dict(workspace._guest_files(self.clone))
+
+    def test_a_relative_path_climbing_out_is_dropped(self):
+        self.assertEqual(sorted(self.files("../escaped.json")), [".claude/settings.json"])
+
+    def test_a_path_that_climbs_out_and_lands_back_inside_is_kept(self):
+        """The honest other half. Containment is decided by where the join LANDS, not by
+        whether the spelling contains `..` — `../svc/x.json` from this checkout resolves
+        back into it, so it is inside and it is written. Said out loud because a reader
+        who assumes the test is "reject any `..`" would then be surprised by the guard's
+        real shape, and would write the next harness against the wrong contract."""
+        self.assertEqual(sorted(self.files("../svc/nested.json")),
+                         ["../svc/nested.json", ".claude/settings.json"])
+
+    def test_nothing_is_written_outside_the_checkout(self):
+        rogue = SimpleNamespace(
+            workspace_files=lambda: {"../escaped.json": "not charter's to place\n"})
+        with mock.patch.object(registry, "all",
+                               return_value=[rogue, claude_code.ClaudeCodeHarness()]):
+            workspace.wire_guest(self.clone)
+        self.assertFalse((workspace.workspace_dir(self.ws) / "escaped.json").exists())
 
 
 class NothingShowsUpInTheirStatus(CloneLayer):

--- a/tests/test_a_clone_gets_the_layer_and_hides_it.py
+++ b/tests/test_a_clone_gets_the_layer_and_hides_it.py
@@ -759,5 +759,37 @@ class TheAnnouncement(CloneLayer):
         self.assertEqual(err.getvalue(), "")
 
 
+class TheBlockDelimitersAreAnOnDiskContract(unittest.TestCase):
+    """Spelled out here once, by hand.
+
+    Every other reference in this file reads `workspace._EXCLUDE_BEGIN`, which agrees with
+    any value that constant takes — the `retune-string` shape the deletion sweep keeps
+    returning, and the same reason `TheMarkersNameIsPartOfTheOnDiskContract` spells out
+    `.charter-generated` one file over.
+
+    They are a real contract rather than decoration, and the file they are written in is
+    the reason: the delimiters are how a LATER charter finds what an EARLIER one wrote in
+    a repo charter does not own. Change the spelling and every checkout already wired gets
+    a SECOND block appended beside the first, growing on every launch — the exact failure
+    the block exists to prevent, happening in the operator's repository rather than in
+    charter's, in a file they never look at.
+    """
+
+    def test_the_delimiters_are_spelled_out(self):
+        self.assertEqual(
+            workspace._EXCLUDE_BEGIN,
+            "# >>> charter (generated layer — `charter workspace reinit`) >>>")
+        self.assertEqual(workspace._EXCLUDE_END, "# <<< charter <<<")
+
+    def test_every_line_charter_adds_that_is_not_a_path_is_a_comment(self):
+        """`info/exclude` is a pattern file. A delimiter that is not a comment is a
+        PATTERN, and `# >>> charter …` without its `#` would have git matching paths
+        against charter's bookkeeping."""
+        lines = [workspace._EXCLUDE_BEGIN, workspace._EXCLUDE_END,
+                 *workspace._EXCLUDE_NOTE.splitlines()]
+        for line in lines:
+            self.assertTrue(line.startswith("#"), line)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_a_clone_gets_the_layer_and_hides_it.py
+++ b/tests/test_a_clone_gets_the_layer_and_hides_it.py
@@ -629,13 +629,11 @@ class TheAnnouncement(CloneLayer):
         self.assertIn("info/exclude", err.getvalue())
 
     def test_a_second_clone_into_the_same_workspace_says_nothing(self):
-        import contextlib
-        import io
-
+        """Every `workspace restore` re-clones what is already there. A line per checkout
+        per run would be the announcement nobody reads by the time it matters."""
+        commands._wire_clones(self.ws)
         err = io.StringIO()
         with contextlib.redirect_stderr(err):
-            commands._wire_clones(self.ws)
-            err.truncate(0), err.seek(0)
             commands._wire_clones(self.ws)
         self.assertEqual(err.getvalue(), "")
 

--- a/tests/test_a_clone_gets_the_layer_and_hides_it.py
+++ b/tests/test_a_clone_gets_the_layer_and_hides_it.py
@@ -454,6 +454,72 @@ class AWorktreeIsAGuestToo(CloneLayer):
         self.assertIsNone(workspace.git_dir(junk))
 
 
+class WhatCannotBeReadOrWritten(CloneLayer):
+    """The refusals. Each is an honest answer charter gives instead of forcing a write
+    into a repo it does not own — and each is a branch nothing else in this file reaches."""
+
+    def test_a_checkout_whose_git_dir_vanished_reads_as_unreadable(self):
+        """Reachable, not defensive: an operator can `rm -rf .git` (or move the repo out
+        from under a worktree) between one wire and the next. charter cannot then tell
+        whether its files are hidden, and saying `unreadable` is the difference between
+        that and saying they are."""
+        self.wire()
+        shutil.rmtree(self.clone / ".git")
+        self.assertEqual(dict(workspace.guest_layer(self.clone))[".git/info/exclude"],
+                         "unreadable")
+
+    def test_unwiring_a_checkout_whose_git_dir_vanished_still_takes_the_files(self):
+        """The files are charter's wherever git went. Removal must not stall on a block
+        it can no longer find."""
+        self.wire()
+        shutil.rmtree(self.clone / ".git")
+        removed = workspace.unwire_guest(self.clone)
+        self.assertIn(".claude/settings.json", removed)
+        self.assertFalse((self.clone / ".claude").exists())
+
+    def test_an_exclude_that_is_not_a_file_is_reported_rather_than_forced(self):
+        self.wire()
+        p = workspace.git_exclude_file(self.clone)
+        p.unlink()
+        p.mkdir()
+        self.assertEqual(dict(workspace.guest_layer(self.clone))[".git/info/exclude"],
+                         "unreadable")
+        self.assertEqual(self.wire()[".git/info/exclude"], "blocked")
+
+    def test_an_exclude_charter_cannot_write_is_reported_and_never_forced(self):
+        """Readable, unwritable — the half a `read_text` failure does not reach. `blocked`
+        rather than a silent success is what keeps `doctor` from calling a checkout hidden
+        that is not."""
+        self.wire()
+        p = workspace.git_exclude_file(self.clone)
+        p.write_text("*.tmp\n")
+        p.parent.chmod(0o500)
+        p.chmod(0o444)
+        self.addCleanup(p.parent.chmod, 0o700)
+        self.assertEqual(self.wire()[".git/info/exclude"], "blocked")
+        self.assertEqual(p.read_text(), "*.tmp\n")
+
+    def test_a_generated_path_replaced_by_a_directory_does_not_raise(self):
+        """`.claude/settings.json` as a DIRECTORY. Every read charter makes of it fails,
+        and the layer still has to answer for the rest of the checkout."""
+        self.wire()
+        p = self.clone / ".claude" / "settings.json"
+        p.unlink()
+        p.mkdir()
+        rows = dict(workspace.guest_layer(self.clone))
+        self.assertEqual(rows[".claude/settings.json"], "unreadable")
+        self.assertEqual(dict(self.wire())[".claude/settings.json"], "foreign")
+
+    def test_a_workspace_that_does_not_exist_has_no_guests(self):
+        self.assertEqual(workspace.guest_trees("never-made"), [])
+
+    def test_a_plain_file_beside_the_clones_is_not_a_guest(self):
+        f = workspace.workspace_dir(self.ws) / "notes.md"
+        f.write_text("a note\n")
+        self.assertIsNone(workspace.git_dir(f))
+        self.assertNotIn(f, workspace.guest_trees(self.ws))
+
+
 class RemovingTheWorkspaceRemovesWhatCharterAdded(CloneLayer):
     def test_unwiring_a_clone_takes_its_files_and_its_block(self):
         self.wire()

--- a/tests/test_a_clone_gets_the_layer_and_hides_it.py
+++ b/tests/test_a_clone_gets_the_layer_and_hides_it.py
@@ -209,6 +209,48 @@ class APathThatWouldEscapeTheCheckout(CloneLayer):
         self.assertFalse((workspace.workspace_dir(self.ws) / "escaped.json").exists())
 
 
+class TheReportIsInAStableOrder(CloneLayer):
+    """A checkout holds MORE than one generated file now, so ordering stopped being
+    invisible the day agents were mirrored in.
+
+    `doctor` prints the first four findings and elides the rest; an order that comes out
+    of a dict is a truncated report whose contents change with insertion, for a tree where
+    nothing changed. The exclude block has the same property with an operator reading it,
+    and `unwire_guest`'s answer is what a caller prints back.
+    """
+
+    def agents(self, *names: str) -> None:
+        d = config.ROOT / ".claude" / "agents"
+        d.mkdir(parents=True, exist_ok=True)
+        for n in names:
+            (d / n).write_text(f"# {n}\n")
+
+    def test_the_layer_rows_are_sorted(self):
+        self.agents("zulu.md", "alpha.md", "mike.md")
+        rels = [rel for rel, _status in workspace.guest_layer(self.clone)]
+        self.assertEqual(rels, sorted(rels))
+        # Spelled out as well as compared: `sorted(rels) == rels` also holds for a list of
+        # one, and this class exists because there is now more than one.
+        self.assertEqual(rels[0], ".claude/agents/alpha.md")
+
+    def test_the_block_lists_the_paths_sorted(self):
+        self.agents("zulu.md", "alpha.md", "mike.md")
+        self.wire()
+        listed = [ln for ln in self.excludes().splitlines() if ln.startswith("/")]
+        self.assertEqual(listed[:3], ["/.claude/agents/alpha.md",
+                                      "/.claude/agents/mike.md",
+                                      "/.claude/agents/zulu.md"])
+
+    def test_what_unwiring_reports_removing_is_sorted(self):
+        self.agents("zulu.md", "alpha.md", "mike.md")
+        self.wire()
+        removed = workspace.unwire_guest(self.clone)
+        self.assertEqual(removed[:-1], sorted(removed[:-1]))
+        self.assertEqual(removed[0], ".claude/agents/alpha.md")
+        self.assertEqual(removed[-1], workspace.GENERATED_MARKER,
+                         "the marker goes last — it is what vouches for the rest")
+
+
 class NothingShowsUpInTheirStatus(CloneLayer):
     """The constraint that makes the feature admissible: the operator's own `git status`."""
 

--- a/tests/test_a_clone_gets_the_layer_and_hides_it.py
+++ b/tests/test_a_clone_gets_the_layer_and_hides_it.py
@@ -793,6 +793,26 @@ class TheBlockDelimitersAreAnOnDiskContract(unittest.TestCase):
             "# >>> charter (generated layer — `charter workspace reinit`) >>>")
         self.assertEqual(workspace._EXCLUDE_END, "# <<< charter <<<")
 
+    def test_the_note_makes_its_three_claims_to_the_person_who_finds_it(self):
+        """The sentences are spelled out by hand, for `test_the_uninitialised_submodule_is
+        _named`'s reason: a test built from the same constant agrees with any wording it
+        takes, and the wording IS the deliverable here. This note is the only thing an
+        operator who opens their own `info/exclude` has to go on — a block of paths with
+        no explanation, in a file they did not write, is indistinguishable from something
+        that should be deleted.
+
+        Each claim is one the code keeps and this suite proves elsewhere: charter wrote
+        them (`OwnershipIsLegible`), only what charter wrote is hidden
+        (`AFileCharterDidNotWrite`), and nothing here can reach a teammate
+        (`NothingShowsUpInTheirStatus`)."""
+        note = workspace._EXCLUDE_NOTE
+        self.assertIn("Files charter generated in this checkout so a chat here gets the "
+                      "plane's layer.", note)
+        self.assertIn("charter hides only what it wrote, never a directory of yours.",
+                      note)
+        self.assertIn("This file is per-checkout and never committed; nothing your "
+                      "teammates clone is affected.", note)
+
     def test_every_line_charter_adds_that_is_not_a_path_is_a_comment(self):
         """`info/exclude` is a pattern file. A delimiter that is not a comment is a
         PATTERN, and `# >>> charter …` without its `#` would have git matching paths

--- a/tests/test_a_clone_gets_the_layer_and_hides_it.py
+++ b/tests/test_a_clone_gets_the_layer_and_hides_it.py
@@ -253,6 +253,25 @@ class TheReportIsInAStableOrder(CloneLayer):
                                       "/.claude/agents/mike.md",
                                       "/.claude/agents/zulu.md"])
 
+    def test_the_block_stays_sorted_when_a_persona_arrives_later(self):
+        """The case that makes `_charter_owned`'s sort observable at all. The marker is
+        BUILT in sorted order — `_materialise` walks `_layer_status`, which sorts — so on
+        a checkout wired once the dict order and the sorted order agree and the sort looks
+        like decoration. A persona added afterwards is appended to the marker's end, and
+        from then on they disagree: the block would list `settings.json` above an agent
+        that sorts above it, and re-sort itself the next time the marker was rewritten
+        from scratch. A file the operator reads should not shuffle on its own."""
+        self.wire()
+        self.agents("alpha.md")
+        self.wire()
+        marker = json.loads((self.clone / workspace.GENERATED_MARKER).read_text())
+        self.assertEqual(list(marker), [".claude/settings.json",
+                                        ".claude/agents/alpha.md"],
+                         "fixture no longer diverges — this case would assert nothing")
+        listed = [ln for ln in self.excludes().splitlines() if ln.startswith("/")]
+        self.assertEqual(listed, ["/.claude/agents/alpha.md", "/.claude/settings.json",
+                                  f"/{workspace.GENERATED_MARKER}"])
+
     def test_what_unwiring_reports_removing_is_sorted(self):
         self.agents("zulu.md", "alpha.md", "mike.md")
         self.wire()

--- a/tests/test_a_clone_gets_the_layer_and_hides_it.py
+++ b/tests/test_a_clone_gets_the_layer_and_hides_it.py
@@ -447,6 +447,29 @@ class AWorktreeIsAGuestToo(CloneLayer):
         self.assertEqual(workspace.git_dir(sub), sub / ".." / "modules-vendored")
         self.assertTrue(workspace.git_dir(sub).is_dir())
 
+    def test_a_gitdir_path_containing_a_colon_is_read_whole(self):
+        """`split(":", 1)`, never `rsplit`. A directory name may contain a colon, and
+        splitting from the right hands back the tail of the PATH instead of the value —
+        a `.git` file that points somewhere real, read as pointing nowhere."""
+        odd = workspace.workspace_dir(self.ws) / "mod:ules"
+        odd.mkdir()
+        sub = workspace.workspace_dir(self.ws) / "colon"
+        sub.mkdir()
+        (sub / ".git").write_text("gitdir: ../mod:ules\n")
+        self.assertEqual(workspace.git_dir(sub), sub / ".." / "mod:ules")
+
+    def test_a_git_file_written_with_crlf_still_points_somewhere(self):
+        """`.strip()`, never `lstrip`. `splitlines` takes the `\n` and leaves the `\r`,
+        so a pointer file written on Windows keeps a carriage return on the end of the
+        path — and a `Path` with a trailing `\r` is a directory that does not exist."""
+        real = workspace.workspace_dir(self.ws) / "modules-crlf"
+        real.mkdir()
+        sub = workspace.workspace_dir(self.ws) / "fromwindows"
+        sub.mkdir()
+        (sub / ".git").write_bytes(b"gitdir: ../modules-crlf\r\n")
+        self.assertEqual(workspace.git_dir(sub), sub / ".." / "modules-crlf")
+        self.assertTrue(workspace.git_dir(sub).is_dir())
+
     def test_a_git_file_that_says_nothing_is_not_a_checkout(self):
         junk = workspace.workspace_dir(self.ws) / "junk"
         junk.mkdir()

--- a/tests/test_a_clone_gets_the_layer_and_hides_it.py
+++ b/tests/test_a_clone_gets_the_layer_and_hides_it.py
@@ -85,6 +85,14 @@ class CloneLayer(_isolation.PersonaIso):
         p = workspace.git_exclude_file(tree or self.clone)
         return p.read_text() if p and p.exists() else ""
 
+    def agents(self, *names: str) -> None:
+        """Personas in the plane, which is where `.claude/agents/` comes from — the half
+        of the layer a clone's git boundary cuts off."""
+        d = config.ROOT / ".claude" / "agents"
+        d.mkdir(parents=True, exist_ok=True)
+        for n in names:
+            (d / n).write_text(f"# {n}\n")
+
     def status(self, tree: Path | None = None) -> str:
         """``-uall``, not the default. Porcelain collapses an untracked directory to one
         `?? .claude/` line, which reads as "charter's noise is here" whether the file
@@ -219,12 +227,6 @@ class TheReportIsInAStableOrder(CloneLayer):
     and `unwire_guest`'s answer is what a caller prints back.
     """
 
-    def agents(self, *names: str) -> None:
-        d = config.ROOT / ".claude" / "agents"
-        d.mkdir(parents=True, exist_ok=True)
-        for n in names:
-            (d / n).write_text(f"# {n}\n")
-
     def test_the_layer_rows_are_sorted(self):
         self.agents("zulu.md", "alpha.md", "mike.md")
         rels = [rel for rel, _status in workspace.guest_layer(self.clone)]
@@ -273,13 +275,20 @@ class TheReportIsInAStableOrder(CloneLayer):
                                   f"/{workspace.GENERATED_MARKER}"])
 
     def test_what_unwiring_reports_removing_is_sorted(self):
-        self.agents("zulu.md", "alpha.md", "mike.md")
+        """The persona arrives AFTER the first wire, for `test_the_block_stays_sorted_when
+        _a_persona_arrives_later`'s reason: the marker is built in sorted order, so a
+        checkout wired once cannot tell `sorted(marker)` from `list(marker)`. It is what
+        a caller prints back to say what it removed from somebody's repo."""
         self.wire()
+        self.agents("alpha.md")
+        self.wire()
+        marker = json.loads((self.clone / workspace.GENERATED_MARKER).read_text())
+        self.assertEqual(list(marker), [".claude/settings.json",
+                                        ".claude/agents/alpha.md"],
+                         "fixture no longer diverges — this case would assert nothing")
         removed = workspace.unwire_guest(self.clone)
-        self.assertEqual(removed[:-1], sorted(removed[:-1]))
-        self.assertEqual(removed[0], ".claude/agents/alpha.md")
-        self.assertEqual(removed[-1], workspace.GENERATED_MARKER,
-                         "the marker goes last — it is what vouches for the rest")
+        self.assertEqual(removed, [".claude/agents/alpha.md", ".claude/settings.json",
+                                   workspace.GENERATED_MARKER])
 
 
 class NothingShowsUpInTheirStatus(CloneLayer):
@@ -574,15 +583,35 @@ class AWorktreeIsAGuestToo(CloneLayer):
         self.assertEqual(workspace.git_dir(sub), sub / ".." / "mod:ules")
 
     def test_a_git_file_written_with_crlf_still_points_somewhere(self):
-        """`.strip()`, never `lstrip`. `splitlines` takes the `\n` and leaves the `\r`,
-        so a pointer file written on Windows keeps a carriage return on the end of the
-        path — and a `Path` with a trailing `\r` is a directory that does not exist."""
+        """A pointer file written on Windows. This one is carried by `read_text`'s
+        universal newlines rather than by the strip — measured, after the deletion sweep
+        kept `lstrip` alive through an earlier version of this case that claimed
+        otherwise. Kept, because the OUTCOME is the thing worth holding and the mechanism
+        that delivers it is `read_text`'s default, which a later `newline=""` would
+        silently remove."""
         real = workspace.workspace_dir(self.ws) / "modules-crlf"
         real.mkdir()
         sub = workspace.workspace_dir(self.ws) / "fromwindows"
         sub.mkdir()
         (sub / ".git").write_bytes(b"gitdir: ../modules-crlf\r\n")
         self.assertEqual(workspace.git_dir(sub), sub / ".." / "modules-crlf")
+        self.assertTrue(workspace.git_dir(sub).is_dir())
+
+    def test_trailing_whitespace_after_the_path_is_dropped(self):
+        """`.strip()` and not `lstrip` — the RIGHT-hand half, which nothing else reaches.
+
+        A `.git` file is a plain text line, and the two things that put whitespace on the
+        end of one are a person editing it and a script writing it (`echo "gitdir: $p "`).
+        Git never does, which is exactly why this is worth a case rather than an
+        assumption: the failure is silent. A path carrying a trailing space is a directory
+        that does not exist, `git_dir` answers `None`, and charter then decides there is no
+        checkout here at all — no layer, no `info/exclude` entry, and nothing said."""
+        real = workspace.workspace_dir(self.ws) / "modules-spaced"
+        real.mkdir()
+        sub = workspace.workspace_dir(self.ws) / "handedited"
+        sub.mkdir()
+        (sub / ".git").write_text("gitdir: ../modules-spaced \t\n")
+        self.assertEqual(workspace.git_dir(sub), sub / ".." / "modules-spaced")
         self.assertTrue(workspace.git_dir(sub).is_dir())
 
     def test_a_git_file_that_says_nothing_is_not_a_checkout(self):
@@ -701,6 +730,22 @@ class RemovingTheWorkspaceRemovesWhatCharterAdded(CloneLayer):
         self.assertIn(workspace._EXCLUDE_BEGIN, p.read_text())
         workspace.unwire_guest(self.clone)
         self.assertEqual(p.read_text(), "")
+
+    def test_unwiring_steps_over_a_generated_path_it_cannot_read(self):
+        """A generated path replaced by a DIRECTORY. `unwire_guest` has no `is_file()` in
+        front of its read on purpose — a path already gone and a path that is a directory
+        mean the same thing there — so the catch is the whole of that decision, and
+        without it one such path aborts the removal and leaves the rest of charter's files
+        behind in a repo it is walking out of."""
+        self.agents("alpha.md")
+        self.wire()
+        p = self.clone / ".claude" / "settings.json"
+        p.unlink()
+        p.mkdir()
+        removed = workspace.unwire_guest(self.clone)
+        self.assertNotIn(".claude/settings.json", removed)
+        self.assertIn(".claude/agents/alpha.md", removed)
+        self.assertTrue(p.is_dir(), "charter removed a path it could not vouch for")
 
     def test_unwiring_never_deletes_a_file_the_operator_took_over(self):
         """Deleting it would be the same overwrite this design refuses, one verb on."""

--- a/tests/test_a_clone_gets_the_layer_and_hides_it.py
+++ b/tests/test_a_clone_gets_the_layer_and_hides_it.py
@@ -628,6 +628,20 @@ class TheAnnouncement(CloneLayer):
         self.assertIn("svc", err.getvalue())
         self.assertIn("info/exclude", err.getvalue())
 
+    def test_a_refreshed_layer_is_announced_too(self):
+        """`created` is not the only thing worth saying. A plane whose status line moved
+        makes the next clone REFRESH what is already there, and charter has written into
+        the operator's repo again — the announcement is about the write, not about it
+        being the first one."""
+        commands._wire_clones(self.ws)
+        _plane_settings(config.ROOT,
+                        statusLine={"type": "command", "command": "charter frame"})
+        err = io.StringIO()
+        with contextlib.redirect_stderr(err):
+            commands._wire_clones(self.ws)
+        self.assertIn("svc", err.getvalue())
+        self.assertIn("info/exclude", err.getvalue())
+
     def test_a_second_clone_into_the_same_workspace_says_nothing(self):
         """Every `workspace restore` re-clones what is already there. A line per checkout
         per run would be the announcement nobody reads by the time it matters."""

--- a/tests/test_a_clone_gets_the_layer_and_hides_it.py
+++ b/tests/test_a_clone_gets_the_layer_and_hides_it.py
@@ -22,12 +22,16 @@ spells its own environment, and no test here writes git config outside the repo 
 
 from __future__ import annotations
 
+import contextlib
+import io
 import json
 import shutil
 import subprocess
 import tempfile
 import unittest
 from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
 
 from charter import commands, config, doctor, workspace
 from charter import commands_workspace as cw
@@ -131,6 +135,29 @@ class TheLayerArrives(CloneLayer):
         self.wire()
         self.assertFalse((self.clone / "CLAUDE.md").exists())
         self.assertFalse((self.clone / ".claude" / "CLAUDE.md").exists())
+
+    def test_the_clone_gets_the_planes_skills_too(self):
+        """`.claude/skills/` walks up on the same rule and is cut off at the same boundary.
+        A plane that keeps a skill of its own beside the plugin's has it in a workspace
+        directory and would lose it one directory in."""
+        s = config.ROOT / ".claude" / "skills" / "deploy" / "SKILL.md"
+        s.parent.mkdir(parents=True, exist_ok=True)
+        s.write_text("# deploy\n")
+        self.wire()
+        self.assertEqual((self.clone / ".claude" / "skills" / "deploy" / "SKILL.md")
+                         .read_text(), "# deploy\n")
+
+    def test_a_file_that_is_not_text_is_skipped_and_takes_nothing_with_it(self):
+        """One unreadable file in `.claude/agents/` must not empty the layer — the
+        restraint `One misbehaving harness does not empty the layer` already records one
+        level up."""
+        d = config.ROOT / ".claude" / "agents"
+        d.mkdir(parents=True, exist_ok=True)
+        (d / "logo.png").write_bytes(b"\x89PNG\r\n\x1a\n\xff\xfe")
+        (d / "steward.md").write_text("route it\n")
+        self.wire()
+        self.assertFalse((self.clone / ".claude" / "agents" / "logo.png").exists())
+        self.assertTrue((self.clone / ".claude" / "agents" / "steward.md").is_file())
 
     def test_wiring_a_workspace_wires_its_clones(self):
         """`charter workspace reinit` is the repair for a clone too — which it can only be
@@ -316,6 +343,28 @@ class TheExcludeIsReported(CloneLayer):
                          "stale")
         self.assertEqual(self.wire()[".git/info/exclude"], "refreshed")
 
+    def test_an_absent_exclude_file_reads_as_missing_too(self):
+        """Not merely an emptied one: `git init` makes the file, and a repo whose
+        `.git/info/` somebody cleaned out has no file to read at all."""
+        self.wire()
+        workspace.git_exclude_file(self.clone).unlink()
+        self.assertEqual(dict(workspace.guest_layer(self.clone))[".git/info/exclude"],
+                         "missing")
+        self.assertEqual(self.wire()[".git/info/exclude"], "created")
+
+    def test_a_generated_file_deleted_from_disk_stays_named_in_the_block(self):
+        """It is still charter's path — charter puts it back on the next wire, and a block
+        that dropped it would report `stale` on a checkout where nothing is wrong."""
+        self.wire()
+        (self.clone / ".claude" / "settings.json").unlink()
+        self.assertEqual(dict(workspace.guest_layer(self.clone))[".git/info/exclude"], "ok")
+
+    def test_an_all_foreign_checkout_gets_no_row_either(self):
+        p = self.clone / ".claude" / "settings.json"
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text("{}\n")
+        self.assertNotIn(".git/info/exclude", dict(workspace.guest_layer(self.clone)))
+
     def test_reading_the_layer_never_writes(self):
         """`doctor` calls this from the SessionStart hook. A check that healed what it
         found would report every clone hidden by having just hidden it."""
@@ -386,6 +435,18 @@ class AWorktreeIsAGuestToo(CloneLayer):
         self.assertIsNone(workspace.git_dir(broken))
         self.assertNotIn(broken, workspace.guest_trees(self.ws))
 
+    def test_a_relative_gitdir_is_resolved_against_the_checkout(self):
+        """The spelling a SUBMODULE uses — `gitdir: ../.git/modules/<name>`. git writes an
+        absolute path for a worktree, so nothing else here exercises the join, and without
+        it the path is resolved against the process's cwd instead."""
+        sub = workspace.workspace_dir(self.ws) / "vendored"
+        sub.mkdir()
+        real = workspace.workspace_dir(self.ws) / "modules-vendored"
+        real.mkdir()
+        (sub / ".git").write_text("gitdir: ../modules-vendored\n")
+        self.assertEqual(workspace.git_dir(sub), sub / ".." / "modules-vendored")
+        self.assertTrue(workspace.git_dir(sub).is_dir())
+
     def test_a_git_file_that_says_nothing_is_not_a_checkout(self):
         junk = workspace.workspace_dir(self.ws) / "junk"
         junk.mkdir()
@@ -412,6 +473,16 @@ class RemovingTheWorkspaceRemovesWhatCharterAdded(CloneLayer):
         workspace.unwire_guest(self.clone)
         self.assertTrue((self.clone / ".claude" / "mine.md").is_file())
         self.assertIn("*.tmp", self.excludes())
+
+    def test_unwiring_a_checkout_charter_never_wired_writes_nothing(self):
+        """Byte for byte, trailing newline included. `unwire_guests` runs over every
+        checkout in the workspace, and most of them may have nothing of charter's in
+        them — a rewrite there is a write into somebody's repo for no reason at all."""
+        p = workspace.git_exclude_file(self.clone)
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text("*.tmp")            # no trailing newline, on purpose
+        workspace.unwire_guest(self.clone)
+        self.assertEqual(p.read_text(), "*.tmp")
 
     def test_unwiring_never_deletes_a_file_the_operator_took_over(self):
         """Deleting it would be the same overwrite this design refuses, one verb on."""
@@ -447,10 +518,6 @@ class RemovingAWorkspaceWithAWorktree(CloneLayer):
 
     def test_workspace_remove_unwires_before_it_deletes(self):
         main_exclude = self.main / "svc-main" / ".git" / "info" / "exclude"
-        from types import SimpleNamespace
-        import contextlib
-        import io
-
         out, err = io.StringIO(), io.StringIO()
         with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
             rc = cw.cmd_workspace_remove(SimpleNamespace(name=self.ws, force=True))
@@ -459,14 +526,36 @@ class RemovingAWorkspaceWithAWorktree(CloneLayer):
         self.assertNotIn(workspace._EXCLUDE_BEGIN, main_exclude.read_text())
 
 
+class CloningWiresWhatItMade(CloneLayer):
+    """`cmd_clone` calls `workspace.ensure` BEFORE the clones exist, so without a second
+    call the layer would arrive one command late — on whatever unrelated command happened
+    to `ensure` next."""
+
+    def test_cmd_clone_wires_the_checkout_it_just_made(self):
+        r = {"name": "svc", "default_branch": "main", "forge": "github",
+             "path_with_namespace": "g/svc"}
+        with mock.patch.object(commands, "_clone_one",
+                               lambda rr, wd: {"repo": rr, "dest": self.clone,
+                                               "status": "exists"}), \
+             mock.patch.object(commands.workspace, "resolve", lambda *a, **k: self.ws), \
+             mock.patch.object(commands.workspace, "banner", lambda *a, **k: None), \
+             mock.patch.object(commands.workspace, "ensure",
+                               lambda *a: workspace.workspace_dir(self.ws)), \
+             mock.patch.object(commands.inventory, "load", lambda: {}), \
+             mock.patch.object(commands.inventory, "repos", lambda d=None: [r]), \
+             mock.patch.object(commands, "_resolve_targets", lambda a, d: [r]), \
+             contextlib.redirect_stderr(io.StringIO()):
+            rc = commands.cmd_clone(SimpleNamespace(repos=["svc"], workspace=self.ws))
+        self.assertEqual(rc, 0)
+        self.assertTrue((self.clone / ".claude" / "settings.json").is_file())
+        self.assertEqual(self.status(), "")
+
+
 class TheAnnouncement(CloneLayer):
     def test_cloning_says_what_was_written_and_where_it_is_hidden(self):
         """charter has just written files into a repo the operator owns. A mechanism whose
         entire visible signature is its own absence is one nobody can find when they want
         it gone."""
-        import contextlib
-        import io
-
         err = io.StringIO()
         with contextlib.redirect_stderr(err):
             commands._wire_clones(self.ws)

--- a/tests/test_a_clone_gets_the_layer_and_hides_it.py
+++ b/tests/test_a_clone_gets_the_layer_and_hides_it.py
@@ -688,6 +688,20 @@ class RemovingTheWorkspaceRemovesWhatCharterAdded(CloneLayer):
         workspace.unwire_guest(self.clone)
         self.assertEqual(p.read_text(), "*.tmp")
 
+    def test_unwiring_the_only_thing_in_the_file_leaves_it_empty(self):
+        """An `info/exclude` holding nothing but charter's block — a repo whose template
+        was empty, or one somebody cleaned out before charter arrived. Removing the block
+        has to leave an EMPTY file and not a file containing one blank line: every later
+        `_replace_block` compares against what it reads, so a stray newline is a
+        difference, and the difference makes charter rewrite a file it has nothing left to
+        say about — once per launch, in a repo it does not own."""
+        p = workspace.git_exclude_file(self.clone)
+        p.write_text("")
+        self.wire()
+        self.assertIn(workspace._EXCLUDE_BEGIN, p.read_text())
+        workspace.unwire_guest(self.clone)
+        self.assertEqual(p.read_text(), "")
+
     def test_unwiring_never_deletes_a_file_the_operator_took_over(self):
         """Deleting it would be the same overwrite this design refuses, one verb on."""
         self.wire()

--- a/tests/test_a_workspace_carries_charters_layer.py
+++ b/tests/test_a_workspace_carries_charters_layer.py
@@ -84,15 +84,28 @@ class WhatIsWritten(WorkspaceLayer):
         self.assertEqual([rel for rel, _status in rows], [".claude/settings.json"])
 
 
-class NothingReachesAClone(WorkspaceLayer):
-    def test_a_clone_inside_the_workspace_is_left_alone(self):
-        """`workspaces/<ws>/<repo>/` is a repo charter does not own — `git add -A` there
-        would stage whatever charter left behind."""
+class WhatReachesAClone(WorkspaceLayer):
+    """This file used to record *"nothing is written into a clone"* as a permanent limit,
+    and #870 lifted it: the clone is where the walk-up stops, so it is where the gap is
+    widest. The class stays as the place that says the limit is gone — the mechanism that
+    replaced it (`info/exclude`, removal, worktrees) has its own suite in
+    `test_a_clone_gets_the_layer_and_hides_it.py`."""
+
+    def test_a_clone_inside_the_workspace_gets_the_layer(self):
         clone = workspace.workspace_dir(self.ws) / "api-service"
         (clone / ".git").mkdir(parents=True)
         workspace.wire_harnesses(self.ws)
-        self.assertFalse((clone / ".claude").exists())
-        self.assertFalse((clone / workspace.GENERATED_MARKER).exists())
+        self.assertTrue((clone / ".claude" / "settings.json").is_file())
+        self.assertTrue((clone / workspace.GENERATED_MARKER).is_file())
+
+    def test_a_directory_that_is_not_a_checkout_is_still_left_alone(self):
+        """The boundary did not move to "anything under a workspace". A plain directory
+        is part of the workspace charter already owns and needs no layer of its own."""
+        plain = workspace.workspace_dir(self.ws) / "notes-dir"
+        plain.mkdir(parents=True)
+        workspace.wire_harnesses(self.ws)
+        self.assertFalse((plain / ".claude").exists())
+        self.assertFalse((plain / workspace.GENERATED_MARKER).exists())
 
     def test_a_clone_directory_is_not_a_workspace_directory(self):
         clone = workspace.workspace_dir(self.ws) / "api-service"


### PR DESCRIPTION
Closes #870

`workspaces/<ws>/<repo>/` is a **separate git repository**. Claude Code's walk-up for `.claude/agents/` and `.claude/skills/` stops at that git boundary, and its project settings never walked up at all — so a chat launched in a clone got none of the plane's layer. That is the widest of the three gaps, and the one #850 (PR #862, this PR's base) closed for `workspaces/<ws>/` while stating the clone as a permanent limit: *"in a clone you cannot delegate to a persona."*

```
                        plane root   workspaces/<ws>/   workspaces/<ws>/<repo>/
settings.json           yes          NO  -> #850        NO
.claude/agents/         yes          yes (walks up)     NO  (git boundary)
.claude/skills/         yes          yes (walks up)     NO  (git boundary)
```

## What this writes, and where it hides it

charter writes the layer into the clone and pays the cost the workspace directory does not owe: every generated path is registered in that checkout's **`.git/info/exclude`** — per-checkout, never committed, not itself tracked. It is the one file a guest may write. charter never edits the clone's tracked `.gitignore`, and nothing it writes can reach the operator's commit.

The guest layer is the harness files **plus** the plane's `.claude/agents/` and `.claude/skills/`, and that is what closes the persona limit: `enabledPlugins` brings charter's own skills and cannot bring *this* plane's personas, which `persona sync-agents` generates from `personas/`. **CLAUDE.md is deliberately left behind** — it walks up on the same rule, but dropping the plane's project instructions into somebody else's repo, to be read there as that repo's instructions, is a claim of a different size. A guest may hide its own files; it does not narrate the host's.

## The four constraints, and the fifth that makes them work

- **Idempotent.** An `ensure` runs on every launch. The block is delimited and rewritten in place, so ten wires leave one block; an *unterminated* block (end marker deleted by hand) is replaced rather than doubled. Appending would have left `git status` clean while `info/exclude` grew without bound — the failure nobody would ever look for.
- **Marked.** The `.charter-generated` sidecar records a hash of what charter wrote, so `charter doctor` tells `stale` from `foreign`.
- **Never overwritten.** A foreign file is left exactly as found — and, the quieter half of the same restraint, **not hidden either**. A path the operator takes over stops being hidden on the next wire. The block lists exact paths, never a `.claude/` glob: hiding a directory would hide the operator's *own* untracked files from their own status, which is a worse failure than the noise this prevents.
- **Removal removes it.** `workspace remove` unwires before the `rmtree` — because for a linked worktree the exclude file is *outside* the directory being deleted.
- **Worktrees.** `.git` is a FILE there, and git reads `info/exclude` from the **common** dir, not the worktree's own gitdir (measured: a pattern in `.git/worktrees/<name>/info/exclude` is read by nobody). So `git_dir` follows the `gitdir:` pointer and `git_exclude_file` then follows `commondir`. Assuming `<root>/.git/` is a directory does not fail loudly — `mkdir -p` cheerfully creates the path beside the `.git` file, the write succeeds, and the operator's status fills up with charter anyway.

`.git/info/exclude` also gets a row in `harness_layer` and therefore in `charter doctor`. Its absence is the whole failure this design guards against: every file can be current and the operator's status still full of charter. A row nothing reports is a guarantee nothing keeps.

## Verification

`tests/test_a_clone_gets_the_layer_and_hides_it.py` — 38 cases against **real git**, not against charter's model of it: `git status --porcelain -uall` is empty after wiring, `git add -A` stages nothing, the clone's `.gitignore` is byte-identical, and a real `git worktree add` proves the `commondir` hop end to end. `NothingReachesAClone` in the #850 suite is rewritten as `WhatReachesAClone`, which is where the retracted limit is recorded.

Full suite green locally: `Ran 10865 tests ... OK (skipped=9)`.

## Docs

`docs/harnesses.md` and the staged #850 news entry both asserted the limit this reverses, and both ship in the same version — so they are corrected rather than left to publish a false claim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Us4MbwkSCJCxwt1CjAd1sf
