### PR TITLE
doctor answers whether a session started here can see charter's layer, and whether anything here is trusted to run it (#869, #859)

### DIFF
--- a/charter/doctor.py
+++ b/charter/doctor.py
@@ -895,10 +895,13 @@ def _git_root_of(here: Path) -> Path | None:
     """
     try:
         res = _git_in(here, "rev-parse", "--show-toplevel")
-    except Exception:
-        # `util.run` raises `ProcTimeout` on a stalled network mount and `ProcError` never
-        # (check=False), but a missing `git` reaches here as an OSError from the exec
-        # itself. A preflight row must render something.
+    except (util.ProcTimeout, OSError):
+        # The same two `check_plane_root` catches, for the same two reasons: `util.run`
+        # raises `ProcTimeout` on a stalled network mount, and a missing or unusable
+        # `git` reaches here as an OSError from the exec itself. Narrow rather than
+        # `Exception`, per `check_memory_indexes`: a broad catch there once swallowed a
+        # `NameError` and reported OK. `ProcError` is not among them — `_git_in` passes
+        # `check=False`, so a non-zero exit comes back as a result and is read below.
         return None
     top = res.stdout.strip()
     if res.returncode != 0 or not top:
@@ -986,7 +989,11 @@ def check_session_layer() -> Result:
     # A `charter doctor` typed in a plain terminal has no harness to report for, and
     # picking one would be a guess — so it answers for each, which is also the only
     # rendering that shows an operator what a *different* harness would find here.
-    live = _registry.get(current) if current else None
+    # No `if current` guard. `registry.get` already answers ``None`` for a name that is
+    # None (`KINDS.get(name or "")`), so the guard could never decide anything — the
+    # deletion sweep charged it as a survivor and was right: an equivalent mutant and dead
+    # code are the same finding.
+    live = _registry.get(current)
     harnesses = [live] if live else _registry.all()
 
     bound = _git_root_of(here)
@@ -1018,7 +1025,13 @@ def check_session_layer() -> Result:
     # gate. Repeating it per harness would put a sentence about Claude Code's trust model
     # under opencode's name, which is the kind of borrowed answer this row refuses above.
     if own_repo and gated:
-        what = " / ".join(sorted({h.trust_gate for h in gated}))
+        # Registration order, deduplicated — `dict.fromkeys` and NOT a set, which has no
+        # order a reader or a test can rely on: string hashing is randomised per process,
+        # so two harnesses naming two gates would render this sentence differently from
+        # one run to the next. Registration order rather than alphabetical because that is
+        # the order `registry.all` hands them over and the order every other harness
+        # listing in charter prints.
+        what = " / ".join(dict.fromkeys(h.trust_gate for h in gated))
         lines.append(
             f"trust: {bound} is a git root of its own, so it carries its own trust "
             f"acceptance — until that is given, {what} do not run here whatever any "

--- a/charter/doctor.py
+++ b/charter/doctor.py
@@ -743,16 +743,34 @@ def _settings_files(root: Path | None = None) -> list[Path]:
             Path.home() / ".claude" / "settings.json"]
 
 
-def _enabled_plugin_ids(root: Path | None = None) -> set[str]:
-    """Plugin ids the host has ENABLED. Installed is not enabled (#177)."""
-    out: set[str] = set()
+def _settings_docs(root: Path | None = None) -> list[dict]:
+    """Every settings document the host resolves from *root*, parsed, unreadable ones dropped.
+
+    One reader for :func:`_settings_files`, because two of them drifted once already: the
+    hook half read the files as TEXT and the plugin half as JSON, and a `charter hook
+    pretooluse` line inside a comment-shaped string would have counted for one and not the
+    other. Anything asking a *structured* question about the session's settings asks here.
+
+    A file that is absent, unreadable or not a JSON object is simply not in the list.
+    "The host would read nothing from it" is the same answer in all three cases, and a
+    checker that treated a malformed file as a declaration would report a layer that is
+    not there.
+    """
+    out: list[dict] = []
     for p in _settings_files(root):
         try:
             doc = json.loads(p.read_text())
         except (OSError, ValueError, UnicodeDecodeError):
             continue
-        if not isinstance(doc, dict):
-            continue
+        if isinstance(doc, dict):
+            out.append(doc)
+    return out
+
+
+def _enabled_plugin_ids(root: Path | None = None) -> set[str]:
+    """Plugin ids the host has ENABLED. Installed is not enabled (#177)."""
+    out: set[str] = set()
+    for doc in _settings_docs(root):
         for pid, on in (doc.get("enabledPlugins") or {}).items():
             if on:
                 out.add(pid)
@@ -862,6 +880,152 @@ def check_session_root() -> Result:
                 f"        ↳ the plane is still this session's identity: personas, the "
                 f"vault, memory and workspaces resolve to {_config.ROOT} from anywhere "
                 f"inside it"))
+
+
+def _git_root_of(here: Path) -> Path | None:
+    """The git repository *here* stands in, or ``None`` when it is in none.
+
+    **A linked worktree answers with the WORKTREE**, not with the main clone, and that is
+    the answer both callers want: git's own boundary is the unit an agent runtime's
+    upward search stops at, and it is the unit trust is inherited to (#859).
+
+    Never raises and never blocks: this runs from the SessionStart hook, so it is timed
+    out like every other git question in this file (`_git_in`), and a repository charter
+    cannot interrogate answers ``None`` rather than a traceback.
+    """
+    try:
+        res = _git_in(here, "rev-parse", "--show-toplevel")
+    except Exception:
+        # `util.run` raises `ProcTimeout` on a stalled network mount and `ProcError` never
+        # (check=False), but a missing `git` reaches here as an OSError from the exec
+        # itself. A preflight row must render something.
+        return None
+    top = res.stdout.strip()
+    if res.returncode != 0 or not top:
+        return None
+    return _canonical(Path(top))
+
+
+def check_session_layer() -> Result:
+    """Can a session started HERE see charter's layer? (#869, #859)
+
+    An operator opened a chat in a workspace directory, found no skills, no agents and no
+    plugin, and **no row said why**. Every row was individually telling the truth: the
+    artefacts are discovered by different rules, so no single one of them could carry the
+    answer, and *"charter is set up"* was never one fact. Measured on Claude Code 2.1.259:
+
+    * ``.claude/settings.json`` — the session's own directory, **no walk-up**.
+    * ``.claude/agents/`` and ``.claude/skills/`` — walk up, **stopping at the git root**.
+    * ``CLAUDE.md`` — walks up and is **not** git-bounded, so it arrives almost anywhere.
+
+    That last rule is why such a chat reads as half-configured rather than as empty:
+    charter's prose reaches it and none of charter's machinery does. The row says so.
+
+    **About the LAYER, not the plugin, so `check_guard_wired`'s reasoning stays intact.**
+    That check argues — rightly — that *"Whether the plane runs as a plugin is an
+    implementation detail. Whether the guard fires is the fact the operator needs"*, and
+    nothing here reopens it. This row never reports on a plugin; it reports on what a
+    session standing in this directory can reach, which is a different question with a
+    different answer, and the guard keeps its own two rows.
+
+    **The rules live on the HARNESS, never here** (`base.LayerPart`, `Harness.layer`).
+    Written into this function they would be the hardcoded-literal-per-harness failure
+    `harness/registry.py` exists to end, and the day a fourth harness is registered it
+    would silently be reported under Claude Code's rules — verifying a proxy instead of
+    the fact, which is #168, #177, #261 and #851 in one line. A harness charter writes no
+    in-repo layer for says where its layer comes from instead (`Harness.layer_note`), and
+    one charter has never measured says exactly that rather than borrowing an answer.
+
+    **A fact, never a verdict.** `check_session_root`'s discipline, for its reason: a chat
+    rooted in a clone reaches none of this and that is the designed workflow — charter
+    deliberately writes nothing inside `workspaces/<ws>/<repo>/` — so a row that warned
+    there is a row operators learn to skip, the cry-wolf failure `check_memory_indexes`
+    and `check_harness` each record. Whatever is genuinely missing AND fixable warns on
+    its own row, where it can name its own remedy: `workspace layer` for a generated file
+    that has gone stale or vanished, `plane-root guard` for the guard.
+
+    **Trust is a CONDITION, not a verdict (#859).** The harness gates hook execution and
+    the status line on the directory being trusted, globally — the gate takes no argument
+    saying which settings source declared them — so *"a file this session reads declares
+    `charter hook pretooluse`"* and *"the guard will fire here"* are two facts, and an
+    untrusted directory answers yes to the first and no to the second. Charter asks the
+    question it **owns**: trust is inherited up to the git root, so a directory with a git
+    root of its own needs its own acceptance. That comes from `git rev-parse
+    --show-toplevel` and no host-private state. ``~/.claude.json`` is deliberately not
+    read — a missing project entry there means *never opened* just as readily as
+    *refused*, and reading absence as refusal would warn at planes that are fine, which is
+    the failure two other checks in this file already record. Weaker than a verdict on
+    purpose: it names a condition, and it cannot be wrong in the direction that matters.
+
+    It also says why `guard seen` cannot stand in. `guardseen` state lives under
+    `config.STATE_DIR`, so that row answers **per plane**: a guard that fired in the plane
+    last week still shows a recent sighting for a session rooted in a clone where nothing
+    has ever dispatched.
+    """
+    from . import config as _config
+    from .harness import base as _base
+    from .harness import registry as _registry
+
+    name = "session layer"
+    here = session_root()
+    if not _config.HAS_CONTROL_PLANE:
+        return Result(name, OK, detail=f"{here} — no control plane found")
+
+    current = _registry.current()
+    if current and _registry.get(current) is None:
+        # `check_harness` already warns about the unregistered runtime itself. What must
+        # not happen here is answering for it anyway: charter has not measured how this
+        # thing finds anything, and reporting Claude Code's rules over it would be a
+        # confident sentence about a binary nobody has run a probe against.
+        return Result(name, OK,
+                      detail=f"{here} — charter has no record of how {current} finds an "
+                             f"in-repo layer, so this row has nothing to say about it")
+
+    # The running harness when something names one; every registered harness otherwise.
+    # A `charter doctor` typed in a plain terminal has no harness to report for, and
+    # picking one would be a guess — so it answers for each, which is also the only
+    # rendering that shows an operator what a *different* harness would find here.
+    live = _registry.get(current) if current else None
+    harnesses = [live] if live else _registry.all()
+
+    bound = _git_root_of(here)
+    plane_bound = _git_root_of(Path(_config.ROOT))
+    # Its OWN git root — not merely "a git root". `workspaces/<ws>/` is a plain directory
+    # inside the plane's repository, so it rides the plane's acceptance and must not be
+    # warned about; a clone at `workspaces/<ws>/<repo>` and a linked worktree do not.
+    own_repo = bound is not None and bound != plane_bound
+
+    lines = [f"{here} — what a session started here would find in the repo"]
+    gated = []
+    for h in harnesses:
+        if not h.layer:
+            lines.append(f"{h.name}: " + (h.layer_note or
+                                          "charter has not measured how this harness finds "
+                                          "an in-repo layer"))
+            continue
+        if h.trust_gate:
+            gated.append(h)
+        bits = []
+        for part in h.layer:
+            if _base.part_reaches(part, here, bound):
+                bits.append(f"{part.what} ✓")
+            else:
+                bits.append(f"{part.what} ✗ — {part.why}")
+        lines.append(f"{h.name}: " + "; ".join(bits))
+
+    # Said once, after the per-harness lines, and only where a harness has a MEASURED
+    # gate. Repeating it per harness would put a sentence about Claude Code's trust model
+    # under opencode's name, which is the kind of borrowed answer this row refuses above.
+    if own_repo and gated:
+        what = " / ".join(sorted({h.trust_gate for h in gated}))
+        lines.append(
+            f"trust: {bound} is a git root of its own, so it carries its own trust "
+            f"acceptance — until that is given, {what} do not run here whatever any "
+            f"settings file declares. `guard seen` cannot answer it: that state lives "
+            f"under {_config.STATE_DIR}, so it is per PLANE and a sighting there says "
+            f"nothing about this directory")
+
+    return Result(name, OK, detail=("\n        ↳ ".join(lines)))
 
 
 def check_guard_wired() -> Result:
@@ -2771,7 +2935,7 @@ def _checks():
         results.append(check_forge_cli(forge))
         results.append(check_forge_auth(forge))
     results += [check_ssh(), check_control_plane_config(), check_control_plane_schema(),
-                check_plane_root(), check_session_root(),
+                check_plane_root(), check_session_root(), check_session_layer(),
                 check_harness(), check_frame(), check_guard_wired(), check_guard_seen(), check_nested_plane(),
                 check_workspace_clones(), check_workspace_harness(), check_changes(),
                 check_inventory(), check_vaults(),
@@ -2811,7 +2975,8 @@ def _checks():
 _FIXED_CHECK_NAMES = (
     "python3", "git", "git identity",
     # ← the forge cli/auth pair is spliced in here, see `check_names`
-    "git auth", "charter.toml", "schema", "plane root", "session root", "harness", "frame",
+    "git auth", "charter.toml", "schema", "plane root", "session root", "session layer",
+    "harness", "frame",
     "plane-root guard", "guard seen", "nested plane", "workspace clones",
     "workspace layer", "changes",
     "inventory", "vaults", "vault registry", "version lock", "memory indexes",

--- a/charter/doctor.py
+++ b/charter/doctor.py
@@ -919,7 +919,8 @@ def check_session_layer() -> Result:
     * ``CLAUDE.md`` — walks up and is **not** git-bounded, so it arrives almost anywhere.
 
     That last rule is why such a chat reads as half-configured rather than as empty:
-    charter's prose reaches it and none of charter's machinery does. The row says so.
+    charter's prose reaches it and none of charter's machinery does. The row says so — in
+    the harness's own words, beside the walking rule it contrasts with.
 
     **About the LAYER, not the plugin, so `check_guard_wired`'s reasoning stays intact.**
     That check argues — rightly — that *"Whether the plane runs as a plugin is an

--- a/charter/doctor.py
+++ b/charter/doctor.py
@@ -1797,8 +1797,15 @@ def check_workspace_harness() -> Result:
     # A finished clause rather than a bare list of names, for `Deficit.detail`'s own
     # reason: the *why* is the harness's, and two names with no verb beside them read as
     # a failure.
-    aside = (f"  ({gaps}: config is machine-global, so a workspace cannot diverge — "
-             f"charter harness list)" if gaps else "")
+    # NOT "config is machine-global", which is what this said and is false of opencode:
+    # an `opencode.json` at the repository ROOT is read. What is true of both, and is the
+    # whole of what this aside claims, is that a workspace DIRECTORY is not a place either
+    # of them reads config from — so the conclusion survived the correction and only the
+    # reason had to go. The `why` belongs to the harness anyway (`Deficit.detail`,
+    # `charter harness list`); two names with no verb beside them read as a failure, and
+    # a verb charter invented for them read as a fact.
+    aside = (f"  ({gaps}: a workspace directory is not a config scope for them, so it "
+             f"cannot diverge — charter harness list)" if gaps else "")
 
     findings: list[str] = []
     foreign = False

--- a/charter/harness/base.py
+++ b/charter/harness/base.py
@@ -48,8 +48,12 @@ class Deficit(NamedTuple):
 
 
 #: The :attr:`Deficit.key` a harness uses to say it cannot hold per-workspace
-#: configuration at all — its config is machine-global, so two workspaces on one machine
-#: cannot be made to differ.
+#: configuration — a workspace directory is not a config scope for it, so two workspaces on
+#: one machine cannot be made to differ. NOT a claim that the harness ignores a project:
+#: opencode and Codex both declare this key and both read something from a repository
+#: (:attr:`Harness.layer_note` says what). Config scope and project scope are two things,
+#: and conflating them is what sent an earlier reading of this key into the docs as "no
+#: project-level config at all".
 #:
 #: A named constant rather than a string each side spells, because the two sides are far
 #: apart: the harness declares it, and `workspace.harness_layer` reads it to decide

--- a/charter/harness/base.py
+++ b/charter/harness/base.py
@@ -13,10 +13,20 @@ start one — what an operator types, and what argv to exec (ADR 0018, issue #34
 fact lives here, on the harness, for the same reason the first three do: anywhere else
 it is a hardcoded literal per harness, the exact failure `registry.py` iterating
 ``KINDS`` exists to end. A fifth member needs the same kind of argument, not just a use.
+
+:attr:`Harness.layer`, :attr:`Harness.layer_note` and :attr:`Harness.trust_gate` are that
+argument for a fifth, sixth and seventh, and it is the same one. `doctor`'s `session
+layer` row answers *"can a session started in this directory see charter's layer?"* (#869)
+— and the rules that decide differ per harness AND per artefact, measured rather than
+documented. Written in `doctor` they would be exactly the hardcoded literal per harness
+this file exists to stop: a harness added to ``KINDS`` would silently be reported under
+Claude Code's discovery rules, which is the "verified a proxy instead of the fact"
+failure #168, #177, #261 and #851 are each an instance of.
 """
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 from typing import NamedTuple
 
@@ -49,8 +59,122 @@ class Deficit(NamedTuple):
 WORKSPACE_SCOPE = "workspace-scope"
 
 
+class LayerPart(NamedTuple):
+    """One artefact of charter's IN-REPO layer, and the rule a harness discovers it by.
+
+    Data rather than a method, because the interesting thing about these is that **two
+    parts of one harness's layer follow different rules**. Claude Code reads
+    ``.claude/settings.json`` from the session's own directory and does not walk up, while
+    ``.claude/agents/`` and ``.claude/skills/`` walk up and stop at the git boundary — so
+    "charter is set up here" was never one fact, and an operator staring at a chat with no
+    skills could not infer it from any single row (#869).
+
+    ``paths`` are relative to the directory being asked about; **any** of them satisfies
+    the part. ``keys`` narrows that to a JSON document carrying one of the named top-level
+    keys, which is what makes the answer about *charter's* layer rather than about a file
+    that happens to share its name: a directory can hold a ``.claude/settings.json`` that
+    is entirely somebody else's.
+
+    ``why`` is printed only when the part does **not** reach, and it names the measured
+    rule rather than a remedy. A row that says "missing" without saying which rule decided
+    sends the reader to the wrong directory, which is the whole cost #851 recorded.
+    """
+
+    what: str
+    paths: tuple[str, ...]
+    #: Walk up from the directory, stopping at the git root — or read the directory alone.
+    #: A bool and not an enum because charter has measured exactly two rules; a third
+    #: belongs here the day something measures it, not before.
+    walks: bool
+    why: str
+    keys: tuple[str, ...] = ()
+
+
+def _search_dirs(here: Path, bound: Path | None) -> list[Path]:
+    """The directories a lookup from *here* covers, stopping at *bound* inclusive.
+
+    ``None`` bound means no walk at all — one directory. That is also the answer for a
+    walking part whose directory is in **no** repository: where the walk stops there has
+    not been measured, and a guess would put an unmeasured claim in the row whose entire
+    job is to report measured rules. Under-claiming is the direction that cannot mislead.
+    """
+    if bound is None or bound == here or bound not in here.parents:
+        return [here]
+    out = [here]
+    for parent in here.parents:
+        out.append(parent)
+        if parent == bound:
+            break
+    return out
+
+
+def _json_object(p: Path) -> dict | None:
+    try:
+        doc = json.loads(p.read_text())
+    except (OSError, ValueError, UnicodeDecodeError):
+        return None
+    return doc if isinstance(doc, dict) else None
+
+
+def part_reaches(part: LayerPart, here: Path, bound: Path | None) -> bool:
+    """Would a session started in *here* find *part*? *bound* is where a walk stops.
+
+    *bound* is handed in rather than derived, and that is deliberate: `doctor` already
+    asks git for the repository root, and a second spelling of "where does the walk stop"
+    is how two answers about one directory come to disagree.
+
+    A path that cannot be read is not found. Absent, unreadable and "not a JSON object"
+    are one answer here — the host would resolve nothing from it either way — and treating
+    a malformed file as a declaration would report a layer that is not there, which is the
+    only direction this row must never be wrong in.
+    """
+    for d in _search_dirs(here, bound if part.walks else None):
+        for rel in part.paths:
+            p = d / rel
+            if not part.keys:
+                try:
+                    if p.exists():
+                        return True
+                except OSError:
+                    pass
+                continue
+            doc = _json_object(p)
+            if doc is not None and any(k in doc for k in part.keys):
+                return True
+    return False
+
+
 class Harness:
     """One agent runtime charter can run inside."""
+
+    #: Every part of charter's in-repo layer, with the rule this harness finds each by.
+    #:
+    #: Empty means charter writes **no** in-repo layer for this harness — which is not the
+    #: same as the harness having no in-repo surface, and :attr:`layer_note` is where that
+    #: difference gets said. Empty with an empty note means charter has not measured this
+    #: harness at all, and `doctor` prints that rather than a clean row: "no known gaps"
+    #: and "no knowledge" read identically otherwise, the distinction `registry.deficits`
+    #: already draws.
+    layer: tuple[LayerPart, ...] = ()
+
+    #: Where charter's layer comes from on a harness whose :attr:`layer` is empty, and
+    #: which in-repo surfaces that harness reads that charter does not write.
+    #:
+    #: A sentence rather than a flag, for `Deficit.detail`'s reason: a capability that is
+    #: simply absent reads as a broken integration, and the person who reads it that way
+    #: files a bug. It is also the honest place for a measurement that has moved — what a
+    #: harness reads from a project is a fact about a binary version, and it changes.
+    layer_note: str = ""
+
+    #: What this harness refuses to run in a directory that has not been TRUSTED, or ``""``
+    #: when charter has not measured a trust gate here.
+    #:
+    #: The gate takes no argument saying which settings source declared the thing it is
+    #: gating, so *"a file this session reads declares `charter hook pretooluse`"* and
+    #: *"the guard will fire here"* are two different facts and an untrusted directory
+    #: answers yes to the first and no to the second (#859). A harness charter has not
+    #: measured says nothing, which is not a claim that it has no gate.
+    trust_gate: str = ""
 
     #: The value this harness puts in ``$CHARTER_HARNESS``. Its identity everywhere.
     name: str = ""

--- a/charter/harness/claude_code.py
+++ b/charter/harness/claude_code.py
@@ -69,7 +69,9 @@ LAYER = (
     LayerPart(
         "skills+agents", (".claude/skills", ".claude/agents"), True,
         "skills and agents DO walk up, but the walk stops at the git root — anything "
-        "charter wrote above that boundary is out of reach"),
+        "charter wrote above that boundary is out of reach, while CLAUDE.md walks up and "
+        "is NOT git-bounded, which is why a session like this reads as half-configured "
+        "rather than empty"),
     LayerPart(
         "status line", _PROJECT_SETTINGS, False,
         "`statusLine` is a key in that same settings file, so it is cwd-only too — a "

--- a/charter/harness/claude_code.py
+++ b/charter/harness/claude_code.py
@@ -11,7 +11,7 @@ import json
 import os
 from pathlib import Path
 
-from .base import Harness
+from .base import Harness, LayerPart
 
 NAME = "claude-code"
 
@@ -40,9 +40,56 @@ WORKSPACE_KEYS = ("enabledPlugins", "statusLine", "env")
 #: Where the mirrored document goes, relative to the workspace directory.
 WORKSPACE_SETTINGS = ".claude/settings.json"
 
+#: The settings files Claude Code resolves **from the session's own directory**, in the
+#: order it reads them. ``~/.claude/settings.json`` is deliberately not among them: it is
+#: machine-global state charter never writes, and this list answers what the REPO carries.
+_PROJECT_SETTINGS = (".claude/settings.json", ".claude/settings.local.json")
+
+#: Charter's layer, one part per discovery rule — every rule measured on binary 2.1.259.
+#:
+#: **Three parts and not one, because three rules.** `settings` is cwd-only; `skills+agents`
+#: walk up and stop at the git boundary; and the status line rides in the settings file, so
+#: it inherits that file's cwd-only rule rather than the walking one. `CLAUDE.md` is the
+#: fourth rule and is deliberately NOT a part here: it walks up and is **not** git-bounded,
+#: so it arrives almost everywhere — which is exactly why the reported chat read as
+#: half-configured rather than as absent, and `doctor` says so in the row instead of
+#: checking for a file that is always found.
+#:
+#: The status line is its own part rather than folded into `settings` for the correction
+#: :data:`WORKSPACE_KEYS` already records: *a workspace given only the plugin loads
+#: charter's skills and hooks and still renders no status line.* Two facts that go missing
+#: separately have to be reported separately, or the one that is present hides the one
+#: that is not.
+LAYER = (
+    LayerPart(
+        "settings", _PROJECT_SETTINGS, False,
+        "project settings are read from the session's OWN directory and the host does not "
+        "walk up, so nothing above it is in force",
+        keys=WORKSPACE_KEYS),
+    LayerPart(
+        "skills+agents", (".claude/skills", ".claude/agents"), True,
+        "skills and agents DO walk up, but the walk stops at the git root — anything "
+        "charter wrote above that boundary is out of reach"),
+    LayerPart(
+        "status line", _PROJECT_SETTINGS, False,
+        "`statusLine` is a key in that same settings file, so it is cwd-only too — a "
+        "directory can carry the plugin and still render nothing",
+        keys=("statusLine",)),
+)
+
 
 class ClaudeCodeHarness(Harness):
     name = NAME
+
+    layer = LAYER
+
+    #: Measured, and the reason `doctor` names a condition rather than a verdict (#859).
+    #: The gate is on the DIRECTORY and is global — it takes no argument saying which
+    #: settings source declared the hook — and it is inherited up to the git root. So
+    #: `workspaces/<ws>/` rides the plane's acceptance (it is inside the plane's own
+    #: repository) while a clone at `workspaces/<ws>/<repo>` or a linked worktree has a
+    #: git root of its own and needs its own.
+    trust_gate = "hooks or the status line"
 
     #: Empty on purpose. Claude Code carries every surface charter has — it is the
     #: runtime charter grew inside, so it is the reference ceiling rather than a harness

--- a/charter/harness/codex.py
+++ b/charter/harness/codex.py
@@ -53,9 +53,17 @@ PLUGIN_UPDATE_CMD = ("codex plugin marketplace upgrade charter && "
 
 
 def config_path() -> Path:
-    """Codex's config file. There is **no project-level one**: a `.codex/config.toml` or
-    `codex.toml` planted in a project directory is ignored, checked by putting a
+    """Codex's config file. There is no project-level **config**: a `.codex/config.toml`
+    or `codex.toml` planted in a project directory is ignored, checked by putting a
     deliberate type error in each and watching the config load anyway.
+
+    **That is a fact about config and not about the project**, and the wider reading it
+    used to carry was wrong. Codex reads a project `.codex/skills/`: a sentinel skill at
+    ``<repo>/.codex/skills/<name>/SKILL.md`` reaches a `codex exec` session's context with
+    **zero tool calls**, where a control repository without one does not. So Codex has an
+    in-repo surface; what it does not have is an in-repo place to put *this* file. The
+    original probe missed it by asking `codex mcp list` — a management CLI is not a
+    session, and it ignores project config, so it answers "no" with confidence.
 
     ``$CODEX_HOME`` is honoured — verified by pointing it at a throwaway directory and
     watching `codex mcp list` read that directory's config. Writing to `~/.codex`
@@ -139,33 +147,37 @@ class CodexHarness(Harness):
                 "the terminal-pane key. Hooks are unaffected — their payload carries "
                 "`session_id` directly."),
         # The sharpest of the three, and the one that is a fact about Codex rather than
-        # about a widget: it has NO project-level config at all. A `.codex/config.toml`
-        # or `codex.toml` beside a project is ignored — measured by planting a deliberate
-        # type error in each and watching the config load anyway (ADR 0015 records the
-        # same measurement for the hooks). So there is nowhere for a per-workspace answer
-        # to live, and charter says so rather than printing a tick beside Claude Code's.
+        # about a widget: there is nowhere in a project for its CONFIG to live. A
+        # `.codex/config.toml` or `codex.toml` beside a project is ignored — measured by
+        # planting a deliberate type error in each and watching the config load anyway
+        # (ADR 0015 records the same measurement for the hooks). So there is nowhere for a
+        # per-workspace answer to live, and charter says so rather than printing a tick
+        # beside Claude Code's.
+        #
+        # **Scoped to config, and it did not used to be.** This said "no project-level
+        # config exists at all", which reads as "Codex ignores the project" and is false:
+        # a project `.codex/skills/` IS read (see `config_path`). The conclusion survives
+        # the correction — a skills directory is not somewhere config can go — but the
+        # sentence that reached the operator would have stopped anyone looking for an
+        # in-repo surface Codex actually has.
         Deficit(WORKSPACE_SCOPE,
-                "no project-level config exists at all — a `.codex/config.toml` beside a "
+                "there is no project-level config file — a `.codex/config.toml` beside a "
                 "project is ignored, so `~/.codex/config.toml` is the only answer and "
-                "every workspace on this machine necessarily shares it."),
+                "every workspace on this machine necessarily shares it. A project "
+                "`.codex/skills/` IS read; that is a skills surface, not config, and "
+                "charter writes nothing there."),
     )
 
     #: Charter writes NO in-repo layer for Codex today, so there is nothing for `doctor`'s
     #: `session layer` row to look for and the row says where the layer does come from.
     #:
-    #: **And it narrows the deficit above, which is too broad as written.** *"No
-    #: project-level config exists at all"* is true of `config.toml` and false of the
-    #: project as a whole: measured against codex-cli 0.147.0 with a real `codex exec`
-    #: session, a sentinel skill at ``<repo>/.codex/skills/<name>/SKILL.md`` reaches the
-    #: model's context with **zero tool calls**, while a control repository without one
-    #: does not. A management CLI is not a session — `codex mcp list` ignores project
-    #: config and would have answered "no" with confidence — and a model asked whether it
-    #: can see a file will happily go and `sed` the file you just named, so the trace is
-    #: the evidence and not the answer.
-    #:
-    #: Said here rather than by rewriting the deficit: that wording also lives in
-    #: `docs/harnesses.md`, `docs/workspaces.md`, a staged news entry and
-    #: `test_codex_harness.py`, and moving all of them is a change of its own.
+    #: **The `.codex/skills/` half is the correction.** Measured against codex-cli 0.147.0
+    #: with a real `codex exec` session, a sentinel skill at
+    #: ``<repo>/.codex/skills/<name>/SKILL.md`` reaches the model's context with **zero
+    #: tool calls**, while a control repository without one does not. A management CLI is
+    #: not a session — `codex mcp list` ignores project config and would have answered
+    #: "no" with confidence — and a model asked whether it can see a file will happily go
+    #: and `sed` the file you just named, so the trace is the evidence and not the answer.
     layer_note = (
         "charter writes no in-repo layer for Codex — it arrives from "
         "`~/.codex/config.toml` and the plugin, and a project `.codex/config.toml` is "

--- a/charter/harness/codex.py
+++ b/charter/harness/codex.py
@@ -150,6 +150,28 @@ class CodexHarness(Harness):
                 "every workspace on this machine necessarily shares it."),
     )
 
+    #: Charter writes NO in-repo layer for Codex today, so there is nothing for `doctor`'s
+    #: `session layer` row to look for and the row says where the layer does come from.
+    #:
+    #: **And it narrows the deficit above, which is too broad as written.** *"No
+    #: project-level config exists at all"* is true of `config.toml` and false of the
+    #: project as a whole: measured against codex-cli 0.147.0 with a real `codex exec`
+    #: session, a sentinel skill at ``<repo>/.codex/skills/<name>/SKILL.md`` reaches the
+    #: model's context with **zero tool calls**, while a control repository without one
+    #: does not. A management CLI is not a session — `codex mcp list` ignores project
+    #: config and would have answered "no" with confidence — and a model asked whether it
+    #: can see a file will happily go and `sed` the file you just named, so the trace is
+    #: the evidence and not the answer.
+    #:
+    #: Said here rather than by rewriting the deficit: that wording also lives in
+    #: `docs/harnesses.md`, `docs/workspaces.md`, a staged news entry and
+    #: `test_codex_harness.py`, and moving all of them is a change of its own.
+    layer_note = (
+        "charter writes no in-repo layer for Codex — it arrives from "
+        "`~/.codex/config.toml` and the plugin, and a project `.codex/config.toml` is "
+        "ignored. Codex DOES read an in-repo `.codex/skills/` (measured, 0.147.0); "
+        "charter writes nothing there")
+
     cli_name = "codex"
     binary = "codex"
 

--- a/charter/harness/opencode.py
+++ b/charter/harness/opencode.py
@@ -697,27 +697,33 @@ class OpenCodeHarness(Harness):
         # printing a tick beside Claude Code's, because "already everywhere" and
         # "isolated per workspace" are different answers and only one of them was asked
         # for.
+        #
+        # **The REASON was rewritten, not the conclusion.** This said opencode's config is
+        # machine-global full stop, and that is false: an `opencode.json` at the
+        # REPOSITORY ROOT is read — a malformed one fails the run outright, `Error: Config
+        # file at <repo>/opencode.json is not valid JSON(C)` — and `.opencode/agent/` is
+        # read from the project (measured, 1.18.23, with a real session; `opencode agent
+        # list` alone is a management CLI and answers for the wrong thing). What is still
+        # true is what the ceiling claims: a workspace DIRECTORY is not a repository root,
+        # so every workspace under the plane resolves to the plane's own root and no two
+        # of them can be made to differ.
         Deficit(WORKSPACE_SCOPE,
-                "config is machine-global (`~/.config/opencode/`), so charter's layer is "
-                "already live in every workspace directory and cannot be made to DIFFER "
-                "between two of them — a workspace is not an isolation boundary here."),
+                "project config is keyed to the REPOSITORY ROOT (`opencode.json` there, "
+                "plus machine-global `~/.config/opencode/`), and a workspace directory is "
+                "not a repository root — every workspace under the plane resolves to the "
+                "plane's own root, so charter's layer is already live in all of them and "
+                "cannot be made to DIFFER between two."),
     )
 
     #: Charter writes NO in-repo layer for opencode today, so there is nothing for
     #: `doctor`'s `session layer` row to look for and the row says where the layer does
     #: come from instead.
     #:
-    #: **The second sentence is a correction, and it matters more than the first.** The
-    #: `WORKSPACE_SCOPE` deficit above says opencode's config is machine-global full stop.
-    #: Measured against opencode 1.18.23 with a real session — not `opencode agent list`
-    #: alone, since a management CLI is not a session — that is too broad: an
-    #: `opencode.json` at the REPOSITORY ROOT is read (a malformed one fails the run
-    #: outright, ``Error: Config file at <repo>/opencode.json is not valid JSON(C)``), and
-    #: `.opencode/agent/` is read from the project. So an in-repo surface exists and
-    #: charter simply does not use it yet. Stating that here rather than silently
-    #: contradicting the neighbour: correcting the deficit's own wording moves
-    #: `docs/harnesses.md`, `docs/workspaces.md` and a staged news entry with it, which is
-    #: a change of its own and not this row's to make.
+    #: **The second sentence is the one that matters.** An in-repo surface exists here and
+    #: charter simply does not use it yet — measured against opencode 1.18.23 with a real
+    #: session, not with `opencode agent list`, because a management CLI is not a session
+    #: and answers for the wrong thing. Naming the surface is what stops "charter writes
+    #: no layer here" from being read as "there is nowhere to write one".
     layer_note = (
         "charter writes no in-repo layer for opencode — it arrives from "
         "`~/.config/opencode/` and the plugin, which every directory on this machine "

--- a/charter/harness/opencode.py
+++ b/charter/harness/opencode.py
@@ -703,6 +703,27 @@ class OpenCodeHarness(Harness):
                 "between two of them — a workspace is not an isolation boundary here."),
     )
 
+    #: Charter writes NO in-repo layer for opencode today, so there is nothing for
+    #: `doctor`'s `session layer` row to look for and the row says where the layer does
+    #: come from instead.
+    #:
+    #: **The second sentence is a correction, and it matters more than the first.** The
+    #: `WORKSPACE_SCOPE` deficit above says opencode's config is machine-global full stop.
+    #: Measured against opencode 1.18.23 with a real session — not `opencode agent list`
+    #: alone, since a management CLI is not a session — that is too broad: an
+    #: `opencode.json` at the REPOSITORY ROOT is read (a malformed one fails the run
+    #: outright, ``Error: Config file at <repo>/opencode.json is not valid JSON(C)``), and
+    #: `.opencode/agent/` is read from the project. So an in-repo surface exists and
+    #: charter simply does not use it yet. Stating that here rather than silently
+    #: contradicting the neighbour: correcting the deficit's own wording moves
+    #: `docs/harnesses.md`, `docs/workspaces.md` and a staged news entry with it, which is
+    #: a change of its own and not this row's to make.
+    layer_note = (
+        "charter writes no in-repo layer for opencode — it arrives from "
+        "`~/.config/opencode/` and the plugin, which every directory on this machine "
+        "reads. opencode DOES read an in-repo `opencode.json` at the repository root and "
+        "`.opencode/agent/` from the project (measured, 1.18.23); charter writes neither")
+
     cli_name = "opencode"
     binary = "opencode"
 

--- a/charter/workspace.py
+++ b/charter/workspace.py
@@ -1175,8 +1175,10 @@ def is_workspace_dir(path) -> bool:
 def harness_deficits() -> list[tuple[str, object]]:
     """``(harness name, Deficit)`` for every registered harness that cannot isolate.
 
-    Their config is machine-global, so per-workspace divergence is not buildable for them
-    at all. Reported rather than skipped in silence: `base.Deficit` exists for exactly
+    A workspace DIRECTORY is not a config scope for them, so per-workspace divergence is
+    not buildable there — Codex reads no project config file at all, and opencode's is keyed
+    to the repository root, which every workspace under the plane shares. Reported rather
+    than skipped in silence: `base.Deficit` exists for exactly
     this — *"a capability that is simply missing reads as a broken integration"* — and a
     report showing one row for the harness that can and nothing for the two that cannot
     would be read as three ticks.

--- a/docs/harnesses.md
+++ b/docs/harnesses.md
@@ -39,7 +39,7 @@ offer**, and `charter doctor` prints the gap rather than leaving you to find it:
 | --- | --- | --- | --- | --- |
 | Claude Code | the plugin (`claude plugin install charter@charter`) | `claude plugin update charter@charter` | — | — |
 | opencode | `charter init` — one plugin under opencode's config dir, read by every project | charter moves it — its own file, compared byte for byte (`read_bytes`) with the one charter generates; anything else in that plugin directory is named too, and nothing charter did not write is ever overwritten | no status bar; no per-turn prompt hook; no ask at tool time; no per-workspace config; **no isolation from other plugins** | `charter statusline --watch`; mid-session notes ride tool output already; charter's own tool-time asks allow and are not shown — denials are unaffected; a second plugin in that directory shares charter's globals and can disable its guards, so `doctor` names it — charter reports the realm, it cannot contain it |
-| Codex | the same plugin (`codex plugin`), plus `charter harness install codex` to name the harness | `codex plugin marketplace upgrade charter && codex plugin add charter@charter` | no status bar; no command-pattern permissions; no project-level config at all, so no per-workspace config | `charter statusline --watch`; `guard ask` rules stay in charter's own hook |
+| Codex | the same plugin (`codex plugin`), plus `charter harness install codex` to name the harness | `codex plugin marketplace upgrade charter && codex plugin add charter@charter` | no status bar; no command-pattern permissions; no project-level config *file*, so no per-workspace config (a project `.codex/skills/` **is** read — a skills surface, not config) | `charter statusline --watch`; `guard ask` rules stay in charter's own hook |
 
 You never have to remember that third column — `charter update` asks the harness you are in
 and names its command (or, for opencode, just moves it). It is written down because a
@@ -75,9 +75,17 @@ fact, and the row names which part is missing and which rule decided. The rules 
 each harness (`Harness.layer`), so a harness added to the registry is answered for the day
 it is registered rather than reported under Claude Code's rules by default.
 
-opencode and Codex get nothing here and say why: their config is machine-global, so
-charter's layer is already live in every workspace and two workspaces on one machine
-cannot be made to differ. That ceiling is in `charter harness list` beside the others.
+opencode and Codex get nothing here and say why: a workspace **directory** is not a
+config scope for either, so charter's layer is already live in every workspace and two
+workspaces on one machine cannot be made to differ. That ceiling is in `charter harness
+list` beside the others.
+
+Both do read something from a project, and charter says which rather than implying the
+project carries nothing — measured with real sessions, because a management CLI is not one:
+opencode reads an `opencode.json` at the **repository root** and `.opencode/agent/`
+(1.18.23); Codex reads `.codex/skills/` and ignores a project `.codex/config.toml`
+(0.147.0). Charter writes into none of them today, and writes nothing machine-global on the
+operator's behalf either.
 
 Nothing is written into a **clone** — `workspaces/<ws>/<repo>/` is a repo charter does not
 own, and `git add -A` there would stage it. So a session inside a clone gets charter from

--- a/docs/harnesses.md
+++ b/docs/harnesses.md
@@ -66,6 +66,15 @@ the plane's `enabledPlugins`, `statusLine` and `env` into
 `charter doctor`'s `workspace layer` row reports staleness; `charter workspace reinit` is
 the repair.
 
+Beside it, the **`session layer`** row answers the other half — *can a session started in
+this directory see any of that?* Three artefacts, three discovery rules, all measured on
+Claude Code 2.1.259: `.claude/settings.json` is read from the session's own directory with
+no walk-up, `.claude/agents/` and `.claude/skills/` walk up but stop at the git root, and
+`CLAUDE.md` walks up and is not git-bounded. So "charter is set up here" was never one
+fact, and the row names which part is missing and which rule decided. The rules live on
+each harness (`Harness.layer`), so a harness added to the registry is answered for the day
+it is registered rather than reported under Claude Code's rules by default.
+
 opencode and Codex get nothing here and say why: their config is machine-global, so
 charter's layer is already live in every workspace and two workspaces on one machine
 cannot be made to differ. That ceiling is in `charter harness list` beside the others.

--- a/docs/news/unreleased-a-chat-in-a-workspace-gets-charters-layer.md
+++ b/docs/news/unreleased-a-chat-in-a-workspace-gets-charters-layer.md
@@ -69,11 +69,16 @@ root for a name that cannot be a workspace or a `workspaces/` charter cannot wri
 
 ## opencode and Codex are named, not skipped
 
-Their config is machine-global. opencode reads `~/.config/opencode/` for every project;
-Codex has **no project-level config at all** — a `.codex/config.toml` beside a project is
-ignored, measured by planting a deliberate type error in one and watching the config load
-anyway. So charter's layer is already live in a workspace on both, and there is nowhere for
-two workspaces on one machine to differ.
+A workspace **directory** is not a config scope for either. opencode reads
+`~/.config/opencode/` plus an `opencode.json` at the repository **root**; Codex has no
+project-level config **file** at all — a `.codex/config.toml` beside a project is ignored,
+measured by planting a deliberate type error in one and watching the config load anyway. So
+charter's layer is already live in a workspace on both, and there is nowhere for two
+workspaces on one machine to differ.
+
+(Both harnesses *do* read other things from a project — `.opencode/agent/` and
+`.codex/skills/` — which a later measurement established and this entry originally denied.
+Neither is a config scope, so the ceiling above is unchanged.)
 
 That is a ceiling, and each now declares it as a `Deficit` — visible in `charter harness
 list` and in the `workspace layer` row. Reporting one row for the harness that can and

--- a/docs/news/unreleased-doctor-says-which-of-charters-layer-reaches-here.md
+++ b/docs/news/unreleased-doctor-says-which-of-charters-layer-reaches-here.md
@@ -1,0 +1,115 @@
+---
+version: unreleased
+headline: `charter doctor` grows a `session layer` row that answers whether a session started in this directory can see charter's layer — naming which of settings, skills+agents or the status line is missing, which discovery rule decided, and whether the directory is trusted enough for any of it to run
+---
+
+An operator opened a chat in a workspace directory. **No skills, no agents, no plugin** —
+and nothing in `charter doctor` said why. Every row in that report was telling the truth.
+None of them could have carried the answer, because the answer is not one fact.
+
+Measured on Claude Code 2.1.259:
+
+| artefact | how it is found |
+| --- | --- |
+| `.claude/settings.json` | the session's **own** directory. No walk-up. |
+| `.claude/agents/`, `.claude/skills/` | walk **up**, stopping at the **git root**. |
+| `CLAUDE.md` | walks up, and is **not** git-bounded. |
+
+Three rules. So a chat can have charter's prose and none of charter's machinery, which is
+exactly what "it felt half-configured" meant, and no single row could say so.
+
+## The row
+
+```
+✓  session layer  /plane/workspaces/fleet/api — what a session started here would find in the repo
+      ↳ claude-code: settings ✗ — project settings are read from the session's OWN
+        directory and the host does not walk up, so nothing above it is in force;
+        skills+agents ✗ — skills and agents DO walk up, but the walk stops at the git
+        root — anything charter wrote above that boundary is out of reach, while
+        CLAUDE.md walks up and is NOT git-bounded, which is why a session like this reads
+        as half-configured rather than empty; status line ✗ — `statusLine` is a key in
+        that same settings file, so it is cwd-only too
+      ↳ trust: /plane/workspaces/fleet/api is a git root of its own, so it carries its own
+        trust acceptance — until that is given, hooks or the status line do not run here
+        whatever any settings file declares. `guard seen` cannot answer it: that state
+        lives under <plane>/.charter, so it is per PLANE and a sighting there says nothing
+        about this directory
+```
+
+**A fact, never a verdict — OK even when nothing reaches.** A chat rooted in a clone gets
+none of this and that is the designed workflow: charter deliberately writes nothing inside
+`workspaces/<ws>/<repo>/`. A row that warned there is a row operators learn to skip.
+Whatever is missing *and* fixable already warns where it can name its own remedy —
+`workspace layer` for a generated file gone stale, `plane-root guard` for the guard.
+
+It is about the **layer**, not the plugin, so it does not reopen `check_guard_wired`'s
+reasoning: *"Whether the plane runs as a plugin is an implementation detail. Whether the
+guard fires is the fact the operator needs."* That stands, in its own two rows.
+
+## Declared is not fired
+
+Claude Code gates hook execution **and** the status line on the directory being trusted,
+globally — the gate takes no argument saying which settings source declared them. So
+
+* *"a file this session reads declares `charter hook pretooluse`"*, and
+* *"charter's guard will fire here"*
+
+are two different facts, and an untrusted directory answers **yes** to the first and **no**
+to the second.
+
+Trust is inherited up to the git root. `workspaces/<ws>/` is inside the plane's own
+repository and rides its acceptance — the `+` button and every workspace tab are fine, and
+the row says nothing about them. A clone at `workspaces/<ws>/<repo>` and a linked worktree
+have a git root of their own and need their own.
+
+**Charter asks the question it owns.** `git rev-parse --show-toplevel`, and no
+host-private state. Reading `hasTrustDialogAccepted` out of `~/.claude.json` would need two
+things nobody has measured: that a *missing* project entry means "not trusted" rather than
+"never opened", and that the flag charter reads is the one the host actually gates on
+across versions. Reading absence as refusal warns at planes that are fine. Naming a
+condition is weaker than returning a verdict, and it cannot be wrong in the direction that
+matters.
+
+And it says why `guard seen` cannot stand in: `guardseen` state lives under
+`config.STATE_DIR`, so that row answers **per plane**. A guard that fired in the plane last
+week still shows a recent sighting for a session rooted in a clone where nothing has ever
+dispatched.
+
+## The rules live on the harness
+
+`Harness.layer` — a `LayerPart` per artefact, carrying its paths, whether it walks, and the
+measured sentence a miss is reported with. Written into `doctor` they would have been the
+hardcoded-literal-per-harness failure `harness/registry.py` exists to end: a fourth harness
+would be reported under Claude Code's discovery rules by default, which is *verifying a
+proxy instead of the fact* — #168, #177, #261 and #851 in one line. A test parses
+`check_session_layer` and fails if it names a harness or a harness path itself.
+
+## A retraction, measured
+
+Charter had recorded that opencode and Codex have **no project-level config at all**. That
+is too broad, and re-measuring against real sessions — not management CLIs — says so:
+
+* **Codex 0.147.0** ignores a project `.codex/config.toml`, as recorded. But it **does**
+  read `.codex/skills/` from the project: a sentinel skill at
+  `<repo>/.codex/skills/<name>/SKILL.md` reached the model's context with **zero tool
+  calls**, where a control repository without one did not.
+* **opencode 1.18.23** reads an `opencode.json` at the **repository root** — a malformed
+  one fails the run outright, `Error: Config file at <repo>/opencode.json is not valid
+  JSON(C)` — and reads `.opencode/agent/` from the project.
+
+The trap is worth writing down, because it caught the measurement three times: **a
+management CLI is not a session.** `codex mcp list` and `claude plugin marketplace list`
+both ignore project config, so probing with them yields a confident false negative. And a
+model asked whether it can see a file will cheerfully go and `sed` the file you just named
+— so the trace, not the answer, is the evidence.
+
+So all three harnesses have an in-repo surface. Charter writes one for Claude Code only,
+and the other two now say that in the row rather than implying the surface does not exist.
+Charter still writes **nothing** into `~/.config/opencode/` or `~/.codex/config.toml`: it
+writes no machine-global state on the operator's behalf, which is a decision and not an
+oversight.
+
+The `workspace-scope` deficits still carry the older, broader wording, and that wording
+also lives in `docs/harnesses.md`, `docs/workspaces.md` and an earlier staged entry.
+Correcting all of it is a change of its own; the harnesses' `layer_note` states the
+measured facts in the meantime rather than contradicting its neighbour in silence.

--- a/docs/news/unreleased-doctor-says-which-of-charters-layer-reaches-here.md
+++ b/docs/news/unreleased-doctor-says-which-of-charters-layer-reaches-here.md
@@ -109,7 +109,10 @@ Charter still writes **nothing** into `~/.config/opencode/` or `~/.codex/config.
 writes no machine-global state on the operator's behalf, which is a decision and not an
 oversight.
 
-The `workspace-scope` deficits still carry the older, broader wording, and that wording
-also lives in `docs/harnesses.md`, `docs/workspaces.md` and an earlier staged entry.
-Correcting all of it is a change of its own; the harnesses' `layer_note` states the
-measured facts in the meantime rather than contradicting its neighbour in silence.
+The two `workspace-scope` deficits kept their conclusion and lost their reason. Neither
+harness can hold **per-workspace** config, and that is still true — a workspace directory
+is not a config scope for either — but *"config is machine-global"* and *"no project-level
+config exists at all"* were the wrong grounds for it, and a reader following either
+sentence would have stopped looking for a surface that is there. `charter doctor`'s aside,
+`docs/harnesses.md`, `docs/workspaces.md` and the earlier entry that carried the same claim
+all say the narrower thing now.

--- a/docs/workspaces.md
+++ b/docs/workspaces.md
@@ -46,10 +46,12 @@ own, and `git add -A` there would stage whatever charter left behind. The limit 
 follows: a session inside a clone gets charter from the plugin, and **cannot delegate to a
 persona** — the plugin ships no `agents/`, and the clone's own git root stops the walk-up.
 
-Only Claude Code binds config to a project root. opencode and Codex read machine-global
-config, so charter's layer is already live in every workspace on those — and, by the same
-fact, cannot be made to differ between two of them. `charter harness list` names that
-ceiling.
+Only Claude Code binds config to the directory a session starts in. opencode's project
+config is keyed to the **repository root** (`opencode.json`) and Codex has no project config
+file at all, so on both, charter's layer is already live in every workspace — and, by the
+same fact, cannot be made to differ between two of them. `charter harness list` names that
+ceiling. Both still read *something* from a project — `.opencode/agent/` and
+`.codex/skills/`, measured with real sessions — and charter writes into neither today.
 
 ## Which workspace am I in
 

--- a/tests/test_a_workspace_carries_charters_layer.py
+++ b/tests/test_a_workspace_carries_charters_layer.py
@@ -163,7 +163,8 @@ class StalenessIsRegenerateAndCompare(WorkspaceLayer):
 
 class TheOtherHarnessesGetADeficit(WorkspaceLayer):
     def test_opencode_and_codex_declare_the_workspace_scope_ceiling(self):
-        """Their config is global — Codex has no project-level config at all — so
+        """Neither reads config from a workspace DIRECTORY — Codex reads no project
+        config file at all, and opencode's is keyed to the repository root — so
         per-workspace divergence is not buildable for them. Silence would read as three
         ticks."""
         keyed = {h.name: [d for d in h.deficits if d.key == base.WORKSPACE_SCOPE]
@@ -358,7 +359,7 @@ class TheCeilingReportedIsTheOneAboutWorkspaces(WorkspaceLayer):
 
     The consequence is a sentence rather than a crash, which is why it would have survived
     a reader too: `check_workspace_harness` renders the match as
-    *"(codex: config is machine-global, so a workspace cannot diverge)"*. Drop the filter
+    *"(codex: a workspace directory is not a config scope for them)"*. Drop the filter
     and that explanation is attached to Codex's **status bar** — a true fact about a
     different limitation, printed as the reason a workspace cannot hold its own config.
     """
@@ -559,8 +560,8 @@ class TheRowsQuietStates(WorkspaceLayer):
 
     def test_the_deficit_aside_names_the_harnesses_that_cannot_diverge(self):
         r = doctor.check_workspace_harness()
-        self.assertIn("config is machine-global, so a workspace cannot diverge — "
-                      "charter harness list", r.detail)
+        self.assertIn("a workspace directory is not a config scope for them, so it "
+                      "cannot diverge — charter harness list", r.detail)
 
     def test_a_plane_whose_harnesses_can_all_isolate_gets_no_aside(self):
         """The `else` half, which no registry this repository ships can reach: opencode and
@@ -570,7 +571,7 @@ class TheRowsQuietStates(WorkspaceLayer):
         between a clean row and one carrying a trailing parenthetical about nothing."""
         with mock.patch.object(workspace, "harness_deficits", return_value=[]):
             r = doctor.check_workspace_harness()
-        self.assertNotIn("machine-global", r.detail)
+        self.assertNotIn("not a config scope", r.detail)
         self.assertNotIn("  (", r.detail, "an empty aside still printed its brackets")
 
     def test_a_plane_with_nothing_to_mirror_says_so_rather_than_counting_zero(self):

--- a/tests/test_codex_harness.py
+++ b/tests/test_codex_harness.py
@@ -44,9 +44,11 @@ class CodexCeilings(unittest.TestCase):
 
 class CodexIsNotWiredYet(unittest.TestCase):
     def test_wiring_writes_nothing_until_it_is_consented_to(self):
-        """Codex reads no project-level config — `.codex/config.toml` and `codex.toml` in
-        a project directory are both ignored, verified by planting a type error in each
-        and watching the config load succeed anyway. Its hooks live only in
+        """Codex reads no project-level config FILE — `.codex/config.toml` and
+        `codex.toml` in a project directory are both ignored, verified by planting a type
+        error in each and watching the config load succeed anyway. (A project
+        `.codex/skills/` IS read; that is a skills surface, not config.) Its hooks live
+        only in
         `~/.codex/config.toml`, so wiring it is a MACHINE-WIDE act that would fire
         charter's hooks in every repo on the machine. `init` must not do that silently:
         it is the failure ADR 0014 already records, where a guard "fired in unrelated

--- a/tests/test_doctor_says_which_of_charters_layer_reaches_here.py
+++ b/tests/test_doctor_says_which_of_charters_layer_reaches_here.py
@@ -458,6 +458,24 @@ class TheHarnessesDeclareWhatWasMeasured(_isolation.PersonaIso):
             self.assertNotIn("no project-level config exists at all", h.layer_note)
             self.assertIn("DOES read an in-repo", h.layer_note)
 
+    def test_no_shipped_deficit_says_a_harness_ignores_the_project(self):
+        """The retraction, pinned where it can regress. The two `workspace-scope` deficits
+        kept their conclusion — a workspace **directory** is not a config scope for either
+        harness — and lost the grounds they had for it. *"Config is machine-global"* is
+        false of opencode (`opencode.json` at the repository root is read, and a malformed
+        one fails the run outright) and *"no project-level config exists at all"* was read
+        as "Codex ignores the project", which `.codex/skills/` refutes.
+
+        Both sentences reached `docs/harnesses.md`, `docs/workspaces.md`, a news entry and
+        `doctor`'s own aside before anybody re-measured. A wrong reason travels exactly as
+        far as a wrong conclusion, and costs the same: somebody stops looking."""
+        for h in registry.all():
+            for d in h.deficits:
+                self.assertNotIn("no project-level config exists at all", d.detail,
+                                 f"{h.name} still claims the project carries nothing")
+                self.assertNotIn("config is machine-global", d.detail,
+                                 f"{h.name}'s ceiling rests on a refuted measurement")
+
 
 class ThePartResolver(_isolation.PersonaIso):
     """`base.part_reaches` on its own, where the walk boundary can be stated exactly."""
@@ -680,84 +698,6 @@ class TheTrustClauseIsAssembledDeterministically(LayerCase):
     def test_one_gate_is_named_alone(self):
         self.rooted_at(self.clone())
         self.assertIn("hooks or the status line do not run here", self.detail())
-
-
-class GuardsThisBranchInheritedFromItsBase(LayerCase):
-    """Four survivors the sweep charged this branch that arrived with its base, #862.
-
-    Pinned **here** rather than in that branch's own test module, deliberately: #862 is
-    still open, and editing `tests/test_a_workspace_carries_charters_layer.py` from a
-    branch stacked on top of it buys a conflict for nothing. These assert behaviour, not
-    file layout, so they keep working after the rebase — and if #862 pins them itself, two
-    tests for one guard costs nothing. The fifth of the five was an equivalent mutant and
-    was deleted at the site (`commands_workspace._reinit`'s `or ()`).
-
-    A survivor is not somebody else's problem because it appeared on somebody else's line.
-    `tools/sweep.py` has no suppression list on purpose.
-    """
-
-    def _workspaces_missing_the_layer(self, n: int) -> None:
-        """Exactly *n* findings — counted, never assumed.
-
-        `setUp` leaves a bare `workspaces/fleet` behind, and it is a workspace as far as
-        `list_workspaces` is concerned, so "create four" quietly produced five and the
-        boundary case tested the wrong side of the boundary."""
-        import shutil
-
-        from charter import workspace as _workspace
-
-        shutil.rmtree(self.workspace, ignore_errors=True)
-        self.settings(self.plane)
-        for i in range(n):
-            name = f"ws{i}"
-            _workspace.ensure(name)
-            p = _workspace.workspace_dir(name) / ".claude" / "settings.json"
-            self.assertTrue(p.is_file(), "the fixture did not produce a layer to remove")
-            p.unlink()
-        self.assertEqual(_workspace.list_workspaces(), [f"ws{i}" for i in range(n)])
-
-    def test_more_findings_than_fit_are_marked_as_elided(self):
-        """`doctor` prints the first four. Without the marker a report of five reads as a
-        report of four, and the workspace nobody looked at is the one that stays broken."""
-        self._workspaces_missing_the_layer(5)
-        self.assertIn(", …", doctor.check_workspace_harness().detail)
-
-    def test_a_report_that_fits_is_not_marked_as_elided(self):
-        """The other half, and it is not reachable through the first: an ellipsis printed
-        unconditionally would say something was withheld from every complete report."""
-        self._workspaces_missing_the_layer(4)
-        self.assertNotIn(", …", doctor.check_workspace_harness().detail)
-
-    def test_a_tree_that_cannot_be_read_is_reported_as_not_checked(self):
-        """"Not checked" is the absence of information, not evidence of health — the
-        distinction `_NOT_CHECKED_HINT` exists to keep. Without the catch this is a
-        traceback out of the SessionStart preflight."""
-        from charter import workspace as _workspace
-
-        self.settings(self.plane)
-        _workspace.ensure("api")
-        with mock.patch.object(_workspace, "harness_layer",
-                               side_effect=OSError("permission denied")):
-            r = doctor.check_workspace_harness()
-        self.assertEqual(r.status, WARN)
-        self.assertIn("not checked", r.detail)
-
-    def test_the_layers_rows_come_back_in_a_stable_order(self):
-        """`harness_layer` feeds a report that prints only its first four rows, so which
-        four they are must not depend on the order a harness happened to build its dict
-        in. One file today; the guarantee is what makes a second one safe to add."""
-        from charter import workspace as _workspace
-
-        class _TwoFiles(base.Harness):
-            name = "two-files"
-
-            def workspace_files(self):
-                return {"z/second.json": "{}\n", "a/first.json": "{}\n"}
-
-        _workspace.ensure("api")
-        with mock.patch.object(registry, "all", return_value=[_TwoFiles()]):
-            rows = _workspace.harness_layer("api")
-        self.assertEqual([rel for rel, _st in rows], ["a/first.json", "z/second.json"])
 
 
 class TheRowIsInTheReport(LayerCase):

--- a/tests/test_doctor_says_which_of_charters_layer_reaches_here.py
+++ b/tests/test_doctor_says_which_of_charters_layer_reaches_here.py
@@ -532,11 +532,24 @@ class ThePartResolver(_isolation.PersonaIso):
             self.here, None))
 
     def test_a_json_document_that_is_not_an_object_carries_no_keys(self):
+        """The array **holds the key name**, and that is the whole test. `[]` proves
+        nothing: `"env" in []` is already False, so a check that had dropped the type
+        filter entirely would pass over it — the deletion sweep found exactly that and
+        was right. `["env"]` separates "this document declares env" from "this document
+        happens to contain the string"."""
         p = self.here / ".claude" / "settings.json"
         p.parent.mkdir(parents=True)
-        p.write_text("[]")
+        p.write_text(json.dumps(["env"]))
         self.assertFalse(base.part_reaches(
             self.part(False, ".claude/settings.json", keys=("env",)), self.here, None))
+
+    def test_a_path_that_cannot_be_read_is_not_found(self):
+        """`Path.exists` swallows ENOENT and ENOTDIR and does NOT swallow EACCES, so a
+        `.claude/` under an ancestor this process cannot traverse raises here. `doctor`
+        runs from the SessionStart hook: a row must render something."""
+        with mock.patch.object(Path, "exists", side_effect=PermissionError("nope")):
+            self.assertFalse(base.part_reaches(
+                self.part(False, ".claude/agents"), self.here, None))
 
     def test_an_unreadable_document_is_not_a_declaration(self):
         p = self.here / ".claude" / "settings.json"
@@ -550,6 +563,201 @@ class ThePartResolver(_isolation.PersonaIso):
         (self.here / ".claude" / "agents").mkdir(parents=True)
         self.assertTrue(base.part_reaches(
             self.part(False, ".claude/agents"), self.here, None))
+
+
+class WhereTheWalkStopsIsAskedOfGit(LayerCase):
+    """`_git_root_of` on its own. Everything above it — which directories the walk covers,
+    whether the trust condition fires — is decided by what this function answers, so its
+    refusals are stated here rather than inferred through a row."""
+
+    def _proc(self, returncode: int, stdout: str):
+        from types import SimpleNamespace
+
+        return SimpleNamespace(returncode=returncode, stdout=stdout, stderr="")
+
+    def test_a_directory_in_no_repository_has_no_git_root(self):
+        """git exits non-zero outside a repository. Read as an answer instead, `Path("")`
+        resolves to the CURRENT directory — so every loose directory would report itself
+        as its own git root and the trust condition would fire everywhere."""
+        with mock.patch.object(doctor, "_git_in", return_value=self._proc(128, "")):
+            self.assertIsNone(doctor._git_root_of(self.plane))
+
+    def test_an_empty_answer_is_not_a_root_either(self):
+        """The other half of the same refusal, and not reachable through the first: a
+        zero exit with nothing on stdout is what a git built without the subcommand, or
+        one whose output was swallowed, leaves behind."""
+        with mock.patch.object(doctor, "_git_in", return_value=self._proc(0, "  \n")):
+            self.assertIsNone(doctor._git_root_of(self.plane))
+
+    def test_a_real_repository_answers_with_itself(self):
+        self.assertEqual(doctor._git_root_of(self.plane), self.plane)
+
+    def test_a_clone_answers_with_the_clone_and_not_the_plane(self):
+        here = self.clone()
+        self.assertEqual(doctor._git_root_of(here), here)
+
+    def test_a_git_that_hangs_or_is_missing_does_not_take_the_row_with_it(self):
+        """`check_plane_root`'s two, for its reasons: a stalled network mount raises
+        `ProcTimeout`, and a missing git raises OSError out of the exec. This runs from
+        the SessionStart hook."""
+        from charter import util
+
+        for boom in (util.ProcTimeout(["git"], 5.0), OSError("no git")):
+            with self.subTest(boom=type(boom).__name__):
+                with mock.patch.object(doctor, "_git_in", side_effect=boom):
+                    self.assertIsNone(doctor._git_root_of(self.plane))
+
+
+class SettingsAreReadOnceAndDefensively(LayerCase):
+    """`_settings_docs` is the single reader every structured question about the session's
+    settings goes through, so what it refuses decides what several rows can claim."""
+
+    def test_a_settings_file_that_is_not_an_object_yields_no_plugin_ids(self):
+        """A JSON array parses fine and has no `.get`. Without the type filter this is an
+        `AttributeError` out of a preflight check — the row does not warn, it crashes."""
+        p = self.workspace / ".claude" / "settings.json"
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(json.dumps([{"enabledPlugins": {"charter@charter": True}}]))
+        self.rooted_at(self.workspace)
+        self.assertEqual(doctor._enabled_plugin_ids(), set())
+
+    def test_an_unreadable_settings_file_is_skipped_not_raised(self):
+        p = self.workspace / ".claude" / "settings.json"
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text("{ not json")
+        self.rooted_at(self.workspace)
+        self.assertEqual(doctor._settings_docs(), [])
+
+    def test_the_documents_come_back_in_the_order_the_host_reads_them(self):
+        self.settings(self.workspace, {"env": {"A": "1"}})
+        (self.workspace / ".claude" / "settings.local.json").write_text(
+            json.dumps({"env": {"B": "2"}}))
+        self.rooted_at(self.workspace)
+        self.assertEqual([d["env"] for d in doctor._settings_docs()],
+                         [{"A": "1"}, {"B": "2"}])
+
+
+class _StubHarness(base.Harness):
+    """A harness charter has never met, so the row's per-harness rendering can be driven
+    without waiting for a fourth real one to be registered."""
+
+    def __init__(self, name: str, gate: str) -> None:
+        self.name = name
+        self.trust_gate = gate
+        self.layer = (base.LayerPart("settings", (".nowhere",), False, "why"),)
+
+
+class TheTrustClauseIsAssembledDeterministically(LayerCase):
+    """Two harnesses can gate on two different things, and the sentence that joins them
+    must read the same on every run. A `set` has no order a reader or a test can rely on
+    — string hashing is randomised per process — so the row's own text would move between
+    runs, which is the defect this repo already pins column widths and roster order
+    against."""
+
+    def _detail_for(self, stubs) -> str:
+        with mock.patch.object(registry, "all", return_value=stubs):
+            os.environ.pop("CHARTER_HARNESS", None)
+            self.rooted_at(self.clone())
+            return self.detail()
+
+    def test_two_gates_are_named_in_registration_order(self):
+        detail = self._detail_for([_StubHarness("z-harness", "zeta"),
+                                   _StubHarness("a-harness", "alpha")])
+        self.assertIn("zeta / alpha", detail)
+
+    def test_registration_order_and_not_alphabetical_order(self):
+        """The same two, registered the other way round. Sorting would render both cases
+        identically and this pair is what tells them apart."""
+        detail = self._detail_for([_StubHarness("a-harness", "alpha"),
+                                   _StubHarness("z-harness", "zeta")])
+        self.assertIn("alpha / zeta", detail)
+
+    def test_two_harnesses_gating_on_the_same_thing_say_it_once(self):
+        detail = self._detail_for([_StubHarness("one", "hooks"),
+                                   _StubHarness("two", "hooks")])
+        self.assertIn("until that is given, hooks do not run", detail)
+
+    def test_one_gate_is_named_alone(self):
+        self.rooted_at(self.clone())
+        self.assertIn("hooks or the status line do not run here", self.detail())
+
+
+class GuardsThisBranchInheritedFromItsBase(LayerCase):
+    """Four survivors the sweep charged this branch that arrived with its base, #862.
+
+    Pinned **here** rather than in that branch's own test module, deliberately: #862 is
+    still open, and editing `tests/test_a_workspace_carries_charters_layer.py` from a
+    branch stacked on top of it buys a conflict for nothing. These assert behaviour, not
+    file layout, so they keep working after the rebase — and if #862 pins them itself, two
+    tests for one guard costs nothing. The fifth of the five was an equivalent mutant and
+    was deleted at the site (`commands_workspace._reinit`'s `or ()`).
+
+    A survivor is not somebody else's problem because it appeared on somebody else's line.
+    `tools/sweep.py` has no suppression list on purpose.
+    """
+
+    def _workspaces_missing_the_layer(self, n: int) -> None:
+        """Exactly *n* findings — counted, never assumed.
+
+        `setUp` leaves a bare `workspaces/fleet` behind, and it is a workspace as far as
+        `list_workspaces` is concerned, so "create four" quietly produced five and the
+        boundary case tested the wrong side of the boundary."""
+        import shutil
+
+        from charter import workspace as _workspace
+
+        shutil.rmtree(self.workspace, ignore_errors=True)
+        self.settings(self.plane)
+        for i in range(n):
+            name = f"ws{i}"
+            _workspace.ensure(name)
+            p = _workspace.workspace_dir(name) / ".claude" / "settings.json"
+            self.assertTrue(p.is_file(), "the fixture did not produce a layer to remove")
+            p.unlink()
+        self.assertEqual(_workspace.list_workspaces(), [f"ws{i}" for i in range(n)])
+
+    def test_more_findings_than_fit_are_marked_as_elided(self):
+        """`doctor` prints the first four. Without the marker a report of five reads as a
+        report of four, and the workspace nobody looked at is the one that stays broken."""
+        self._workspaces_missing_the_layer(5)
+        self.assertIn(", …", doctor.check_workspace_harness().detail)
+
+    def test_a_report_that_fits_is_not_marked_as_elided(self):
+        """The other half, and it is not reachable through the first: an ellipsis printed
+        unconditionally would say something was withheld from every complete report."""
+        self._workspaces_missing_the_layer(4)
+        self.assertNotIn(", …", doctor.check_workspace_harness().detail)
+
+    def test_a_tree_that_cannot_be_read_is_reported_as_not_checked(self):
+        """"Not checked" is the absence of information, not evidence of health — the
+        distinction `_NOT_CHECKED_HINT` exists to keep. Without the catch this is a
+        traceback out of the SessionStart preflight."""
+        from charter import workspace as _workspace
+
+        self.settings(self.plane)
+        _workspace.ensure("api")
+        with mock.patch.object(_workspace, "harness_layer",
+                               side_effect=OSError("permission denied")):
+            r = doctor.check_workspace_harness()
+        self.assertEqual(r.status, WARN)
+        self.assertIn("not checked", r.detail)
+
+    def test_the_layers_rows_come_back_in_a_stable_order(self):
+        """`harness_layer` feeds a report that prints only its first four rows, so which
+        four they are must not depend on the order a harness happened to build its dict
+        in. One file today; the guarantee is what makes a second one safe to add."""
+        from charter import workspace as _workspace
+
+        class _TwoFiles(base.Harness):
+            name = "two-files"
+
+            def workspace_files(self):
+                return {"z/second.json": "{}\n", "a/first.json": "{}\n"}
+
+        _workspace.ensure("api")
+        with mock.patch.object(registry, "all", return_value=[_TwoFiles()]):
+            rows = _workspace.harness_layer("api")
+        self.assertEqual([rel for rel, _st in rows], ["a/first.json", "z/second.json"])
 
 
 class TheRowIsInTheReport(LayerCase):

--- a/tests/test_doctor_says_which_of_charters_layer_reaches_here.py
+++ b/tests/test_doctor_says_which_of_charters_layer_reaches_here.py
@@ -1,0 +1,571 @@
+"""One row for the question no single row could answer — #869, and #859 beside it.
+
+An operator opened a chat in a workspace directory and found no skills, no agents and no
+plugin. Nothing in `charter doctor` said why, and every row in it was individually telling
+the truth: the artefacts are discovered by **different rules**, so *"charter is set up"*
+was never one fact. Measured on Claude Code 2.1.259:
+
+* `.claude/settings.json` — the session's own directory, **no walk-up**
+* `.claude/agents/`, `.claude/skills/` — walk up, **stopping at the git root**
+* `CLAUDE.md` — walks up and is **not** git-bounded
+
+Three rules, so three answers, and this file pins each of them separately: a test that
+asserted only "the row mentions the workspace" would pass over a check that got two of the
+three backwards.
+
+#859 rides along because it is the same question one level down. *"A file this session
+reads declares `charter hook pretooluse`"* and *"the guard will fire here"* are two facts,
+and an untrusted directory answers yes to the first and no to the second. Charter asks the
+half it owns — a directory with a git root of its own carries its own trust acceptance —
+and the cases below pin that it is asked of git and never of `~/.claude.json`, and that it
+is reported as a **condition** rather than as a verdict.
+
+Every case writes only into a `PersonaIso` tmp plane, and `setUp` asserts that before it
+writes anything. Nothing here may touch the developer's real plane.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import json
+import os
+import subprocess
+import textwrap
+from pathlib import Path
+from unittest import mock
+
+from charter import config, doctor
+from charter.harness import base, claude_code, codex, opencode, registry
+
+from tests import _isolation
+
+OK, WARN = doctor.OK, doctor.WARN
+
+#: The three keys charter's layer is made of, hand-spelled. Imported from
+#: `claude_code.WORKSPACE_KEYS` this would assert nothing: a check that stopped looking at
+#: any of them would still find the constant agreeing with itself.
+_LAYER_DOC = {
+    "enabledPlugins": {"charter@charter": True},
+    "statusLine": {"type": "command", "command": "charter statusline"},
+    "env": {"CHARTER_HARNESS": "claude-code"},
+}
+
+
+def _code(fn) -> str:
+    """*fn*'s executable body — no docstring, no comments.
+
+    Parsed rather than string-stripped, and both halves of that matter. `__doc__` is
+    **dedented** from 3.13 on, so `getsource().replace(fn.__doc__, "")` silently removes
+    nothing and every assertion built on it passes over the prose it meant to exclude —
+    measured here, not assumed. And dropping comments is the point rather than a side
+    effect: a comment naming Claude Code is exactly what a decision like this should carry,
+    while a *literal* naming it is the hardcoded-per-harness fact these tests refuse.
+    """
+    tree = ast.parse(textwrap.dedent(inspect.getsource(fn)))
+    node = tree.body[0]
+    body = getattr(node, "body", [])
+    if (body and isinstance(body[0], ast.Expr)
+            and isinstance(body[0].value, ast.Constant)
+            and isinstance(body[0].value.value, str)):
+        node.body = body[1:]
+    return ast.unparse(node)
+
+
+def _git_init(d: Path) -> None:
+    """A repository, so `git rev-parse --show-toplevel` answers with *d*.
+
+    No commit is made and none is needed: the boundary an upward search stops at, and the
+    unit trust is inherited to, both exist the moment `.git` does.
+    """
+    subprocess.run(["git", "init", "-q", str(d)], check=True,
+                   stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+
+
+class LayerCase(_isolation.PersonaIso):
+    """A plane wired the way `charter init` leaves one, with a workspace under it."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        # The tripwire every write below depends on.
+        self.assertIn("edm-test-", str(config.STATE_DIR))
+        (config.ROOT / "charter.toml").write_text("schema = 1\n")
+        self.enterContext(mock.patch.object(config, "HAS_CONTROL_PLANE", True))
+        # A HOME with no user-level settings, so nothing here can pass on the developer's
+        # own machine config and prove nothing on CI.
+        self.home = self.tmp / "home"
+        (self.home / ".claude").mkdir(parents=True, exist_ok=True)
+        self.enterContext(mock.patch.dict(os.environ, {"HOME": str(self.home)}))
+        os.environ.pop("CLAUDE_PLUGIN_ROOT", None)
+        # The plane is a git repository, which is what makes `workspaces/<ws>/` ride its
+        # trust and a clone under it not. `config.ROOT` is resolved because `os.getcwd()`
+        # is and because git answers with the physical path — macOS reaches its temp
+        # directory through `/var` → `/private/var`, and an unresolved fixture path fails
+        # on the developer's machine while passing on CI.
+        self.plane = Path(config.ROOT).resolve()
+        _git_init(self.plane)
+        self.workspace = self.plane / "workspaces" / "fleet"
+        self.workspace.mkdir(parents=True, exist_ok=True)
+        # Registered AFTER `PersonaIso`'s own cleanup, so it runs BEFORE it (LIFO): the
+        # tmp tree cannot be removed out from under the process's own cwd.
+        self.addCleanup(os.chdir, os.getcwd())
+        # Claude Code unless a case says otherwise. `_envguard` clears `$CHARTER_HARNESS`,
+        # and a row that answered for three harnesses would make every assertion below
+        # ambiguous about which one it caught.
+        self.enterContext(mock.patch.dict(os.environ, {"CHARTER_HARNESS": "claude-code"}))
+
+    def rooted_at(self, where: Path) -> None:
+        os.chdir(where)
+
+    def settings(self, where: Path, doc: dict | None = None) -> Path:
+        p = where / ".claude" / "settings.json"
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(json.dumps(doc if doc is not None else _LAYER_DOC))
+        return p
+
+    def agents(self, where: Path) -> Path:
+        d = where / ".claude" / "agents"
+        d.mkdir(parents=True, exist_ok=True)
+        return d
+
+    def clone(self, name: str = "api") -> Path:
+        """A repo checked out inside the workspace — a git root of its own."""
+        d = self.workspace / name
+        d.mkdir(parents=True, exist_ok=True)
+        _git_init(d)
+        return d.resolve()
+
+    def detail(self) -> str:
+        return doctor.check_session_layer().detail
+
+
+class TheThreeRulesAreThreeAnswers(LayerCase):
+    """#869: settings, skills+agents and the status line go missing separately."""
+
+    def test_settings_do_not_walk_up_from_a_workspace_directory(self):
+        """The reported chat, exactly. The plane is wired and the session is not."""
+        self.settings(self.plane)
+        self.rooted_at(self.workspace)
+        self.assertIn("settings ✗", self.detail())
+
+    def test_it_names_the_rule_that_decided_rather_than_only_the_miss(self):
+        """"missing" without the rule sends the reader to the plane's file, finds it
+        wired, and costs the investigation this row exists to end (#851's own lesson)."""
+        self.settings(self.plane)
+        self.rooted_at(self.workspace)
+        self.assertIn("does not walk up", self.detail())
+
+    def test_settings_written_into_the_workspace_do_reach_it(self):
+        """What #850 writes. The row has to go green on the fix or it is not measuring
+        the thing the fix changes."""
+        self.settings(self.workspace)
+        self.rooted_at(self.workspace)
+        self.assertIn("settings ✓", self.detail())
+
+    def test_agents_walk_up_to_a_workspace_inside_the_planes_repository(self):
+        """The rule that differs. `workspaces/<ws>/` is a plain directory inside the
+        plane's own git repo, so the walk reaches the plane's `.claude/agents/` — which
+        is why #850 deliberately copies no agents into a workspace."""
+        self.agents(self.plane)
+        self.rooted_at(self.workspace)
+        self.assertIn("skills+agents ✓", self.detail())
+
+    def test_the_walk_stops_at_the_git_root_of_a_clone(self):
+        """A clone under the workspace has a `.git` of its own, so the walk never reaches
+        the plane's agents however far above they are."""
+        self.agents(self.plane)
+        here = self.clone()
+        self.rooted_at(here)
+        self.assertIn("skills+agents ✗", self.detail())
+
+    def test_the_walk_that_stops_says_it_stopped_at_the_git_root(self):
+        self.agents(self.plane)
+        self.rooted_at(self.clone())
+        self.assertIn("stops at the git root", self.detail())
+
+    def test_skills_alone_satisfy_the_walking_part(self):
+        """Either directory answers it — a plane carrying skills and no agents is not a
+        plane whose walking artefacts are missing."""
+        (self.plane / ".claude" / "skills").mkdir(parents=True)
+        self.rooted_at(self.workspace)
+        self.assertIn("skills+agents ✓", self.detail())
+
+    def test_the_status_line_is_reported_apart_from_the_settings_that_carry_it(self):
+        """`WORKSPACE_KEYS`' own correction: a directory given only the plugin loads
+        charter's hooks and skills and still renders no status line. Folded into one
+        answer, the half that is present hides the half that is not."""
+        doc = {k: v for k, v in _LAYER_DOC.items() if k != "statusLine"}
+        self.settings(self.workspace, doc)
+        self.rooted_at(self.workspace)
+        detail = self.detail()
+        self.assertIn("settings ✓", detail)
+        self.assertIn("status line ✗", detail)
+
+    def test_claude_md_is_named_as_why_such_a_session_feels_half_configured(self):
+        """The fourth rule, and the one that explains the symptom: CLAUDE.md walks up and
+        is NOT git-bounded, so charter's prose arrives where none of its machinery does.
+        Without it the row reads as "nothing is here", which is not what the operator
+        saw."""
+        self.rooted_at(self.clone())
+        self.assertIn("CLAUDE.md", self.detail())
+
+    def test_a_settings_file_that_is_not_charters_is_not_charters_layer(self):
+        """A directory can hold somebody else's `.claude/settings.json`. Counting it
+        would report a layer that is not there — the one direction this row must never
+        be wrong in."""
+        self.settings(self.workspace, {"permissions": {"allow": ["Bash(ls:*)"]}})
+        self.rooted_at(self.workspace)
+        self.assertIn("settings ✗", self.detail())
+
+    def test_an_unparseable_settings_file_is_not_a_declaration(self):
+        p = self.workspace / ".claude" / "settings.json"
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text("{ not json")
+        self.rooted_at(self.workspace)
+        self.assertIn("settings ✗", self.detail())
+
+
+class ItIsAFactAndNeverAVerdict(LayerCase):
+    """`check_session_root`'s discipline, for its reason: a chat rooted in a clone reaches
+    none of this and that is the designed workflow — charter writes nothing inside
+    `workspaces/<ws>/<repo>/` on purpose. A row that warned there is a row operators learn
+    to skip, and the remedies belong to `workspace layer` and `plane-root guard`, which
+    have them."""
+
+    def test_a_clone_with_nothing_in_it_is_still_ok(self):
+        self.rooted_at(self.clone())
+        self.assertEqual(doctor.check_session_layer().status, OK)
+
+    def test_a_fully_wired_session_is_ok_too(self):
+        self.settings(self.plane)
+        self.agents(self.plane)
+        self.rooted_at(self.plane)
+        self.assertEqual(doctor.check_session_layer().status, OK)
+
+    def test_it_offers_no_hint_to_follow_into_the_wrong_directory(self):
+        """The row diagnoses; it does not send anybody anywhere. `charter reinit` writes
+        the PLANE's settings and would not change a session rooted in a clone — a remedy
+        that looks like a fix and is not is #851's own defect one level down."""
+        self.rooted_at(self.clone())
+        self.assertEqual(doctor.check_session_layer().hint, "")
+
+    def test_it_says_which_directory_answered(self):
+        here = self.clone()
+        self.rooted_at(here)
+        self.assertIn(str(here), self.detail())
+
+    def test_no_plane_no_row(self):
+        with mock.patch.object(config, "HAS_CONTROL_PLANE", False):
+            r = doctor.check_session_layer()
+        self.assertEqual(r.status, OK)
+        self.assertIn("no control plane", r.detail)
+
+
+class TrustIsAConditionNotAVerdict(LayerCase):
+    """#859. The gate is on the DIRECTORY and it is global — it takes no argument saying
+    which settings source declared the hook — so a declaration and a firing are two
+    facts."""
+
+    def test_a_workspace_inside_the_planes_repository_is_not_flagged(self):
+        """Trust is inherited up to the git root, and `workspaces/<ws>/` is inside the
+        plane's own repo. The `+` button and every workspace tab put a chat there, so a
+        trust clause on the common case would be the cry-wolf failure this file's
+        neighbours keep recording."""
+        self.rooted_at(self.workspace)
+        self.assertNotIn("trust:", self.detail())
+
+    def test_a_clone_with_its_own_git_root_is_flagged(self):
+        self.rooted_at(self.clone())
+        self.assertIn("trust:", self.detail())
+
+    def test_it_names_that_directorys_git_root(self):
+        here = self.clone()
+        self.rooted_at(here)
+        self.assertIn(str(here), self.detail())
+
+    def test_it_says_a_declaration_is_not_a_firing(self):
+        """The whole point. The clone can declare `charter hook pretooluse` in its own
+        settings and still run nothing, because the gate is on the directory."""
+        self.settings(self.clone(), _LAYER_DOC)
+        self.rooted_at(self.clone())
+        self.assertIn("whatever any settings file declares", self.detail())
+
+    def test_a_flagged_directory_is_still_reported_as_ok(self):
+        """It names a condition, not a verdict — charter cannot know the directory has
+        NOT been accepted, and warning as though it had not is exactly the guess #859
+        refuses to make."""
+        self.rooted_at(self.clone())
+        self.assertEqual(doctor.check_session_layer().status, OK)
+
+    def test_the_settings_being_present_does_not_suppress_the_condition(self):
+        """A clone that IS wired is the case the row most needs to qualify: everything
+        reads green and nothing runs."""
+        self.settings(self.clone(), _LAYER_DOC)
+        self.agents(self.clone())
+        self.rooted_at(self.clone())
+        detail = self.detail()
+        self.assertIn("settings ✓", detail)
+        self.assertIn("trust:", detail)
+
+    def test_it_says_guard_seen_answers_per_plane_and_cannot_stand_in(self):
+        """`guardseen` state lives under `config.STATE_DIR`, so a guard that fired in the
+        plane last week still shows a recent sighting for a session rooted in a clone
+        where nothing has ever dispatched."""
+        self.rooted_at(self.clone())
+        detail = self.detail()
+        self.assertIn("per PLANE", detail)
+        self.assertIn(str(config.STATE_DIR), detail)
+
+    def test_the_host_s_own_trust_record_is_never_read(self):
+        """The decision #859 argues for, pinned. Reading `hasTrustDialogAccepted` out of
+        `~/.claude.json` would need two things nobody has measured — that a MISSING entry
+        means "not trusted" rather than "never opened", and that the flag charter reads is
+        the one the host gates on across versions — and reading absence as refusal warns
+        at planes that are fine. A condition asked of git cannot be wrong that way."""
+        code = _code(doctor.check_session_layer)
+        self.assertNotIn("hasTrustDialogAccepted", code)
+        self.assertNotIn(".claude.json", code)
+
+    def test_a_directory_in_no_repository_at_all_says_nothing_about_trust(self):
+        """No git root, no claim. Where an unbounded walk stops has not been measured and
+        neither has what a trust boundary is without a repository."""
+        loose = self.tmp / "loose"
+        loose.mkdir()
+        with mock.patch.object(doctor, "_git_root_of", return_value=None):
+            self.rooted_at(loose)
+            self.assertNotIn("trust:", self.detail())
+
+
+class EveryHarnessAnswersForItself(LayerCase):
+    """The rules are per harness AND per artefact, so they live on the harness. Written
+    into `doctor` they would be the hardcoded-literal-per-harness failure
+    `harness/registry.py` exists to end."""
+
+    def as_harness(self, name: str) -> None:
+        self.enterContext(mock.patch.dict(os.environ, {"CHARTER_HARNESS": name}))
+
+    def test_opencode_gets_its_own_sentence_and_not_claude_codes_rules(self):
+        """charter writes no in-repo layer for opencode, so looking for `.claude/` there
+        and reporting it absent would be a confident answer to a question opencode was
+        never asked."""
+        self.as_harness("opencode")
+        self.rooted_at(self.clone())
+        detail = self.detail()
+        self.assertIn("opencode:", detail)
+        self.assertNotIn("skills+agents ✗", detail)
+
+    def test_opencodes_sentence_records_the_in_repo_surface_it_does_read(self):
+        """Measured against 1.18.23 with a real session: `opencode.json` at the repository
+        root IS read — a malformed one fails the run outright — and `.opencode/agent/` is
+        read from the project. A management CLI is not a session, and probing with one
+        yields a confident false negative."""
+        self.as_harness("opencode")
+        self.rooted_at(self.workspace)
+        detail = self.detail()
+        self.assertIn("opencode.json", detail)
+        self.assertIn(".opencode/agent", detail)
+
+    def test_codexs_sentence_records_the_in_repo_surface_it_does_read(self):
+        """Measured against 0.147.0 with `codex exec`: a project `.codex/config.toml` is
+        ignored, and `.codex/skills/` is NOT — a sentinel skill reaches the model's
+        context with zero tool calls."""
+        self.as_harness("codex")
+        self.rooted_at(self.workspace)
+        detail = self.detail()
+        self.assertIn(".codex/skills", detail)
+
+    def test_a_harness_with_no_measured_trust_gate_gets_no_trust_clause(self):
+        """Claude Code's gate is measured; opencode's is not. Printing the sentence under
+        opencode's name would be exactly the borrowed answer this row refuses."""
+        self.as_harness("opencode")
+        self.rooted_at(self.clone())
+        self.assertNotIn("trust:", self.detail())
+
+    def test_an_unregistered_harness_is_not_answered_for(self):
+        """"No known gaps" and "no knowledge" read identically otherwise — the
+        distinction `registry.deficits` already draws, one row over."""
+        self.as_harness("something-else")
+        self.rooted_at(self.workspace)
+        detail = self.detail()
+        self.assertIn("no record", detail)
+        self.assertNotIn("settings ✗", detail)
+
+    def test_with_no_harness_named_every_registered_one_answers(self):
+        """A `charter doctor` typed in a plain terminal has no harness to report for, and
+        picking one would be a guess."""
+        self.enterContext(mock.patch.dict(os.environ, {}, clear=False))
+        os.environ.pop("CHARTER_HARNESS", None)
+        self.rooted_at(self.workspace)
+        detail = self.detail()
+        for h in registry.all():
+            self.assertIn(f"{h.name}:", detail)
+
+    def test_doctor_names_no_harness_and_no_harness_path_of_its_own(self):
+        """The pin that keeps the rules on the harness. A fourth harness registered in
+        `KINDS` is covered the day it is registered, and cannot be silently reported under
+        Claude Code's discovery rules."""
+        code = _code(doctor.check_session_layer)
+        for literal in (".claude", "claude-code", "opencode", "codex", "CLAUDE.md"):
+            self.assertNotIn(literal, code,
+                             f"`check_session_layer` names {literal!r} itself; that fact "
+                             f"belongs on the harness")
+
+
+class TheHarnessesDeclareWhatWasMeasured(_isolation.PersonaIso):
+    """Properties of the declarations themselves, so a harness cannot be registered with a
+    layer nobody can render."""
+
+    def test_claude_code_declares_all_three_parts(self):
+        got = [p.what for p in claude_code.ClaudeCodeHarness().layer]
+        self.assertEqual(got, ["settings", "skills+agents", "status line"])
+
+    def test_the_two_rules_are_both_represented(self):
+        """One walking part and two that do not walk. A layer whose parts all shared a
+        rule would not have needed this row at all."""
+        parts = claude_code.ClaudeCodeHarness().layer
+        self.assertEqual([p.walks for p in parts], [False, True, False])
+
+    def test_every_part_says_why_it_would_be_missing(self):
+        for h in registry.all():
+            for part in h.layer:
+                self.assertTrue(part.why.strip(),
+                                f"{h.name}/{part.what} would print a bare 'missing'")
+
+    def test_a_harness_with_no_layer_says_where_its_layer_comes_from(self):
+        """Empty means charter writes no in-repo layer, NOT that the harness has no
+        in-repo surface — `Deficit.detail`'s reason: a capability that is simply absent
+        reads as a broken integration and gets filed as a bug."""
+        for h in registry.all():
+            if not h.layer:
+                self.assertTrue(h.layer_note.strip(),
+                                f"{h.name} declares neither a layer nor a note")
+
+    def test_only_claude_code_claims_a_measured_trust_gate(self):
+        gated = sorted(h.name for h in registry.all() if h.trust_gate)
+        self.assertEqual(gated, ["claude-code"])
+
+    def test_the_base_class_claims_nothing(self):
+        """A harness registered tomorrow inherits silence, not Claude Code's answers."""
+        h = base.Harness()
+        self.assertEqual((h.layer, h.layer_note, h.trust_gate), ((), "", ""))
+
+    def test_neither_note_claims_a_project_has_no_config_surface(self):
+        """The claim that had to be retracted. `.codex/skills/` and `opencode.json` are
+        both read from a project, measured with real sessions — so a note saying the
+        project carries nothing would be false in the direction that stops charter using
+        a surface it has."""
+        for h in (opencode.OpenCodeHarness(), codex.CodexHarness()):
+            self.assertNotIn("no project-level config exists at all", h.layer_note)
+            self.assertIn("DOES read an in-repo", h.layer_note)
+
+
+class ThePartResolver(_isolation.PersonaIso):
+    """`base.part_reaches` on its own, where the walk boundary can be stated exactly."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.top = (self.tmp / "repo").resolve()
+        self.here = self.top / "a" / "b"
+        self.here.mkdir(parents=True)
+
+    def part(self, walks: bool, *paths: str, keys=()) -> base.LayerPart:
+        return base.LayerPart("x", paths, walks, "why", keys=keys)
+
+    def test_a_walking_part_finds_a_directory_above_within_the_bound(self):
+        (self.top / ".claude" / "agents").mkdir(parents=True)
+        self.assertTrue(base.part_reaches(
+            self.part(True, ".claude/agents"), self.here, self.top))
+
+    def test_a_walking_part_stops_at_the_bound(self):
+        (self.top.parent / ".claude" / "agents").mkdir(parents=True)
+        self.assertFalse(base.part_reaches(
+            self.part(True, ".claude/agents"), self.here, self.top))
+
+    def test_a_non_walking_part_ignores_the_bound_entirely(self):
+        (self.top / ".claude").mkdir(parents=True)
+        (self.top / ".claude" / "settings.json").write_text("{}")
+        self.assertFalse(base.part_reaches(
+            self.part(False, ".claude/settings.json"), self.here, self.top))
+
+    def test_no_bound_means_no_walk(self):
+        """A directory in no repository at all. Where the walk would stop has not been
+        measured, so it covers that directory alone — under-claiming, which is the
+        direction that cannot mislead."""
+        (self.top / ".claude" / "agents").mkdir(parents=True)
+        self.assertFalse(base.part_reaches(
+            self.part(True, ".claude/agents"), self.here, None))
+
+    def test_a_bound_that_is_not_an_ancestor_is_not_walked_to(self):
+        """A caller handing in an unrelated root must not turn the walk loose on the
+        filesystem."""
+        (self.top / ".claude" / "agents").mkdir(parents=True)
+        elsewhere = (self.tmp / "elsewhere").resolve()
+        elsewhere.mkdir()
+        self.assertFalse(base.part_reaches(
+            self.part(True, ".claude/agents"), self.here, elsewhere))
+
+    def test_a_bound_equal_to_the_directory_is_that_directory(self):
+        (self.here / ".claude" / "agents").mkdir(parents=True)
+        self.assertTrue(base.part_reaches(
+            self.part(True, ".claude/agents"), self.here, self.here))
+
+    def test_any_of_the_paths_satisfies_a_part(self):
+        (self.here / ".claude" / "skills").mkdir(parents=True)
+        self.assertTrue(base.part_reaches(
+            self.part(False, ".claude/agents", ".claude/skills"), self.here, None))
+
+    def test_keys_narrow_presence_to_a_document_that_carries_one(self):
+        p = self.here / ".claude" / "settings.json"
+        p.parent.mkdir(parents=True)
+        p.write_text(json.dumps({"permissions": {}}))
+        part = self.part(False, ".claude/settings.json", keys=("statusLine",))
+        self.assertFalse(base.part_reaches(part, self.here, None))
+        p.write_text(json.dumps({"statusLine": {"command": "charter statusline"}}))
+        self.assertTrue(base.part_reaches(part, self.here, None))
+
+    def test_any_of_the_keys_satisfies_a_part(self):
+        p = self.here / ".claude" / "settings.json"
+        p.parent.mkdir(parents=True)
+        p.write_text(json.dumps({"env": {"CHARTER_HARNESS": "claude-code"}}))
+        self.assertTrue(base.part_reaches(
+            self.part(False, ".claude/settings.json", keys=("statusLine", "env")),
+            self.here, None))
+
+    def test_a_json_document_that_is_not_an_object_carries_no_keys(self):
+        p = self.here / ".claude" / "settings.json"
+        p.parent.mkdir(parents=True)
+        p.write_text("[]")
+        self.assertFalse(base.part_reaches(
+            self.part(False, ".claude/settings.json", keys=("env",)), self.here, None))
+
+    def test_an_unreadable_document_is_not_a_declaration(self):
+        p = self.here / ".claude" / "settings.json"
+        p.parent.mkdir(parents=True)
+        p.write_text("{ not json")
+        self.assertFalse(base.part_reaches(
+            self.part(False, ".claude/settings.json", keys=("env",)), self.here, None))
+
+    def test_a_keyless_part_asks_only_whether_the_path_is_there(self):
+        """Directories carry no keys, and `.claude/agents/` is a directory."""
+        (self.here / ".claude" / "agents").mkdir(parents=True)
+        self.assertTrue(base.part_reaches(
+            self.part(False, ".claude/agents"), self.here, None))
+
+
+class TheRowIsInTheReport(LayerCase):
+    def test_the_name_is_declared_before_the_run(self):
+        """`_FIXED_CHECK_NAMES` sizes the column without running a check, and is pinned by
+        equality against what `run_all` produces."""
+        self.assertIn("session layer", doctor.check_names())
+
+    def test_it_sits_beside_the_row_that_says_which_directory_answered(self):
+        """`session root` names the directory; this one says what that directory can
+        reach. Read in the other order the second row is trivia."""
+        names = doctor.check_names()
+        self.assertEqual(names[names.index("session root") + 1], "session layer")
+
+
+if __name__ == "__main__":
+    import unittest
+
+    unittest.main()


### PR DESCRIPTION
An operator opened a chat in a workspace directory. **No skills, no agents, no plugin** — and nothing in `charter doctor` said why. Every row in that report was individually telling the truth. None of them could have carried the answer, because the answer is not one fact.

Measured on Claude Code 2.1.259:

| artefact | how it is found |
| --- | --- |
| `.claude/settings.json` | the session's **own** directory. No walk-up. |
| `.claude/agents/`, `.claude/skills/` | walk **up**, stopping at the **git root**. |
| `CLAUDE.md` | walks up, and is **not** git-bounded. |

Three rules, so a chat can have charter's prose and none of charter's machinery — which is exactly what "it felt half-configured" meant.

## The row

`charter doctor` grows **`session layer`**, next to `session root`:

```
✓  session layer  /plane/workspaces/fleet/api — what a session started here would find in the repo
      ↳ claude-code: settings ✗ — project settings are read from the session's OWN directory and
        the host does not walk up, so nothing above it is in force; skills+agents ✗ — skills and
        agents DO walk up, but the walk stops at the git root — anything charter wrote above that
        boundary is out of reach, while CLAUDE.md walks up and is NOT git-bounded, which is why a
        session like this reads as half-configured rather than empty; status line ✗ — `statusLine`
        is a key in that same settings file, so it is cwd-only too
      ↳ trust: /plane/workspaces/fleet/api is a git root of its own, so it carries its own trust
        acceptance — until that is given, hooks or the status line do not run here whatever any
        settings file declares. `guard seen` cannot answer it: that state lives under
        <plane>/.charter, so it is per PLANE and a sighting there says nothing about this directory
```

**A fact, never a verdict — OK even when nothing reaches.** `check_session_root`'s discipline, for its reason: a chat rooted in a clone gets none of this and that is the designed workflow, so a row that warned there is a row operators learn to skip. Whatever is missing *and* fixable already warns where it can name its own remedy — `workspace layer`, `plane-root guard`.

**About the layer, not the plugin.** `doctor.py`'s *"Whether the plane runs as a plugin is an implementation detail. Whether the guard fires is the fact the operator needs"* stands untouched, in its own two rows, and the new docstring says so.

## Declared is not fired (#859)

Claude Code gates hook execution **and** the status line on the directory being trusted, globally — the gate takes no argument saying which settings source declared them. So *"a file this session reads declares `charter hook pretooluse`"* and *"the guard will fire here"* are two facts, and an untrusted directory answers **yes** to the first and **no** to the second.

Trust is inherited up to the git root. `workspaces/<ws>/` is inside the plane's own repository and rides its acceptance — the `+` button and every workspace tab are fine, and the row stays silent about them. A clone at `workspaces/<ws>/<repo>` and a linked worktree have a git root of their own.

**Charter asks the question it owns**: `git rev-parse --show-toplevel`, and no host-private state. `~/.claude.json` is deliberately not read — a missing project entry there means *never opened* as readily as *refused*, and reading absence as refusal warns at planes that are fine. A test parses the function and fails if `hasTrustDialogAccepted` ever appears in it.

And the row says why `guard seen` cannot stand in: `guardseen` lives under `config.STATE_DIR`, so it answers **per plane** — a guard that fired in the plane last week still shows a recent sighting for a session rooted in a clone where nothing has ever dispatched.

## The rules live on the harness

`Harness.layer` — a `LayerPart` per artefact carrying its paths, whether it walks, and the measured sentence a miss is reported with. Written into `doctor` they would be the hardcoded-literal-per-harness failure `harness/registry.py` exists to end: a fourth harness would be reported under Claude Code's discovery rules by default, which is *verifying a proxy instead of the fact* — #168, #177, #261 and #851 in one line. A test parses `check_session_layer` and fails if it names a harness or a harness path itself.

## A retraction, measured

This PR was briefed to record a `Deficit` saying opencode and Codex have **no project-level config at all**. Re-measuring against the installed binaries with **real sessions** refuted it, so no such `Deficit` was written and the ones already in the tree were corrected:

| harness | project config | project agents/skills |
|---|---|---|
| Claude Code | `.claude/settings.json` — cwd only, no walk-up | `.claude/skills`, `.claude/agents` — walk up, stop at the git boundary |
| opencode | `opencode.json` at repo root — **read** (malformed JSON fails the run outright) | `.opencode/agent/` — **read** |
| Codex | `.codex/config.toml` — NOT read | `.codex/skills/` — **read** (a sentinel SKILL.md reaches the session with zero tool calls) |

The trap, because it caught the measurement three times: **a management CLI is not a session.** `codex mcp list` and `claude plugin marketplace list` both ignore project config and answer "no" with confidence. And a model asked whether it can see a file will go and `sed` the file you just named — the trace is the evidence, not the answer.

So all three read something from a project. The two `workspace-scope` deficits **keep their conclusion and lose their grounds**: a workspace *directory* is not a config scope for either harness, so two workspaces on one machine still cannot be made to differ — but *"config is machine-global"* is false of opencode, and *"no project-level config exists at all"* was read as "Codex ignores the project". Both sentences had already reached `docs/harnesses.md`, `docs/workspaces.md`, a staged news entry and `doctor`'s own aside; all of them now say the narrower thing, and a test refuses either phrase in any shipped `Deficit`. A wrong reason travels as far as a wrong conclusion and costs the same: somebody stops looking for a surface that is there.

Charter still writes **nothing** into `~/.config/opencode/` or `~/.codex/config.toml` — no machine-global state on the operator's behalf, a decision rather than an oversight.

## The sweep

13 survivors on the pre-rebase run, every one answered:

- **7 pinned** in this diff — `_settings_docs`' type filter, `_json_object`'s, `part_reaches`' `OSError` catch, `_git_root_of`'s refusal and its narrow catch, the trust clause's ordering, and `live`'s branch.
- **2 deleted** as equivalent mutants, which is the sweep's own doctrine (*"equivalent mutant and dead code are the same finding"*): `registry.get` already answers `None` for a name that is `None`, so `if current else None` could never decide anything; `workspace.reinit` sets `layer` on every path it returns through, so `.get(...) or ()` defended against a shape its only producer cannot make. #862's merge made the second deletion independently.
- **4 belonged to #862's diff** — the sweep is scoped against `origin/main`, so a branch stacked on an unmerged one is charged for its base. #862's merge pinned all four itself; the duplicates written here were dropped in the rebase.

One method note worth keeping: `sorted` over a set is not an ordering guarantee a test can pin — with two elements a single assertion passes half the time by luck. The trust clause dedupes with `dict.fromkeys` in registration order instead, pinned by two cases asserting **opposite** orders for the same pair.

## Verification

`python3 -m unittest discover -s tests -q` → **Ran 11064 tests, OK (skipped=8)**, on the rebased branch. 67 of them are new, in `tests/test_doctor_says_which_of_charters_layer_reaches_here.py`.

Rebased onto `main` now that #862 has landed as `7d3beac`.

Closes #869
Closes #859

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Us4MbwkSCJCxwt1CjAd1sf
