### PR TITLE
A right click on a panel stays where it points, by wrapping tmux's own binding rather than replacing it (#848)

### DIFF
--- a/charter/commands_frame.py
+++ b/charter/commands_frame.py
@@ -725,6 +725,12 @@ def conf_text(*, hotkey: str, mouse: bool, history_limit: int, session: str,
     keys a component may not claim, for `HATCH_KEY`'s reason exactly — both are written
     here BEFORE the toggles, so tmux's last-wins would leave charter's mouse handling
     silently deleted and `list-keys` reading back one line where two were meant (#566).
+    `MouseDown3Pane` is in that same set and is NOT written here, which is #848: its
+    else-branch is not two commands charter can spell but a page of tmux's own
+    `display-menu` that differs between 3.2 and 3.7c, so charter reads the server's own
+    binding back and re-emits it wrapped, as its own `bind-key` argv — see
+    `_menu_button_argv` for the measurement that chose that over this bind's shape, and
+    `tmuxctl.CLICK_MENU_KEY` for why a third line here could not have carried it.
 
     **`focus-events` is the THIRD genuine server option here, and it is written `-g` for
     exactly `escape-time`'s reason.** Spec §4f closes the component event kinds at six,
@@ -769,7 +775,9 @@ def conf_text(*, hotkey: str, mouse: bool, history_limit: int, session: str,
 
     Neither `pane-died` hook lives here — see `_pane_died_write_hook_argv` and
     `_pane_died_teardown_hook_argv` for why they are issued as their own tmux commands
-    instead of text baked into this string.
+    instead of text baked into this string. Nor does the menu button's bind, for a third
+    reason of its own (`_menu_button_argv`): it is built out of what a `list-keys` READ
+    said, and this function has no server to ask.
 
     *session* is the frame id, which `state.frame_id` already sanitises (see
     `charter/frame/state.py`) before this function ever sees it — interpolated into
@@ -963,6 +971,139 @@ def conf_text(*, hotkey: str, mouse: bool, history_limit: int, session: str,
     lines.append(overlay.hatch_bind())
     lines.append("")
     return "\n".join(lines)
+
+
+#: One `list-keys -T root` line for :data:`tmuxctl.CLICK_MENU_KEY`, with the command it is
+#: bound to as the only group. What tmux prints is not one format across the versions
+#: charter supports, so this matches the parts that ARE stable and nothing else:
+#:
+#:     bind-key  -T root MouseDown3Pane            if-shell -F -t = "#{||:…}" { … } { … }
+#:     bind-key -T root MouseDown3Pane       if-shell -F -t = "#{||:…}" "…" "…"
+#:     bind-key -r -T root MouseDown3Pane          display-message hi
+#:
+#: The first is 3.7c, the second a 3.2 built from the release tarball, the third either
+#: version after `bind -n -r`. The column padding differs, the flag between `bind-key` and
+#: `-T` is the operator's, and `\s+` and the flag group absorb both. **`-N` is not a case
+#: this has to carry**: measured on 3.7c, a binding made with `bind -N 'my note'` reads
+#: back through a plain `list-keys` with no note at all — tmux prints notes only when
+#: asked with `-N`, which this read does not ask.
+#:
+#: `-T root` is spelled literally rather than captured, so a line from any OTHER key table
+#: cannot match: a `bind-key -T copy-mode MouseDown3Pane` is a real thing an operator can
+#: write, and wrapping it here would install a copy-mode binding into the root table.
+_MENU_BIND_RE = re.compile(r"^bind-key\s+(?:-\S+\s+)*-T root "
+                           + re.escape(tmuxctl.CLICK_MENU_KEY) + r"\s+(?P<cmd>\S.*?)\s*$")
+
+
+def _menu_button_default(listing: str) -> str | None:
+    """Whatever this server has bound to the menu button, out of a `list-keys -T root`.
+
+    ``None`` when there is nothing for charter to wrap, and all three of those readings
+    are benign rather than degraded — which is why this answers with one value and the
+    caller does not have to tell them apart:
+
+    * **the key is not in the table at all.** An operator who ran `unbind -n
+      MouseDown3Pane` has said this key does nothing, and a key that does nothing runs no
+      `select-pane`: there is no steal left to fix, and inventing a binding to fix it with
+      would be charter putting back what they removed.
+    * **charter already wrapped it**, which is every launch after the first on a shared
+      server. The bind is server-wide (`conf_text`'s own reason for leaving key tables
+      global), so it is already installed and correct. Wrapping it a SECOND time is not
+      merely wasteful: each pass nests another copy of a page-long `display-menu` inside
+      the last, so the ninth frame on a socket would carry a kilobyte of tmux config per
+      launch and the operator's own binding would be nine layers down.
+    * **tmux would not say.** A read that failed is reported by `tmuxctl.run` itself; what
+      is lost here is the fix, and what is left is exactly the behaviour every charter
+      before this one had.
+
+    The re-wrap test is for :data:`_PANEL_OPTION` in the command text, which is charter's
+    own marker and is in no default binding of tmux's on either version — the option name
+    itself, so a rename cannot leave this asking about a string nothing writes any more.
+    """
+    for line in listing.split("\n"):
+        found = _MENU_BIND_RE.match(line)
+        if found is None:
+            continue
+        cmd = found.group("cmd")
+        return None if _PANEL_OPTION in cmd else cmd
+    return None
+
+
+def _menu_button_argv(*, socket: str, default: str) -> list[str]:
+    """`bind-key -n MouseDown3Pane if-shell -F -t = '#{@charter_panel}' 'send-keys -M'
+    <whatever this server already had>` — as an ARGV, never as config text.
+
+    **An argv and not a `conf_text` line, and the difference is the whole safety of this
+    change.** *default* is a page of tmux's own config language — `{}` command blocks on
+    3.7c, backslash-escaped `"…"` on 3.2, `''` empty menu separators on both. Written into
+    the file `source-file` parses, it would have to survive a second round of quoting, and
+    a single unbalanced brace inside a quoted string (an operator's own binding is not
+    charter's to hold to any shape) would end the `bind` line early and take `mouse`,
+    `history-limit` and the palette's own hotkey down with it — the failure `conf_text`'s
+    docstring already names as the reason a refused toggle costs its key and nothing else.
+    As a separate argv element nothing re-lexes it: tmux hands it to `if-shell` verbatim
+    and parses it when the key fires, so the worst a malformed one can do is fail on a
+    right-click, on a pane charter does not own. Same reason both `pane-died` hooks are
+    their own commands rather than text in that string.
+
+    **The true branch is `send-keys -M` alone**, which is `conf_text`'s `CLICK_KEY` bind
+    one button over and for its reason exactly: forward the report to the panel, never
+    move the keyboard. **The false branch is what this server already had**, which is what
+    makes this a wrap rather than a replacement — measured on a real 3.7c and on a real
+    3.2, with a marked panel, the harness and a pane split by hand standing in for the
+    operator's own, SGR button-2 reports injected into a real client on a real pty::
+
+        bind                     right-click a panel   right-click harness  right-click own split
+        tmux's own default       delivered, MOVED      untouched            tmux's pane menu
+        `MouseDown1Pane`'s shape  delivered, unchanged untouched            MOVED, NO MENU
+        this one                 delivered, unchanged  untouched            tmux's pane menu
+
+    The middle row is the fix #634 shipped for button 1, applied verbatim to button 3, and
+    it is why this function reads the server instead: `select-pane -t =; send-keys -M` is
+    tmux's whole default for button 1 and only the FORWARDING half of its default for
+    button 3, so writing it out here would delete tmux's pane menu — Copy Line, Paste,
+    Horizontal Split, Kill, Zoom — from the harness and from every pane the operator split
+    themselves, inside charter's own window, to fix a focus steal that one click puts
+    right. That is a strictly worse trade than #634's and it is what #848 refused.
+
+    **An operator who rebound this key keeps their binding, and that is a property of
+    sourcing rather than a concession.** Whatever `list-keys` reported becomes the false
+    branch verbatim, so charter's panels stop stealing the keyboard and every pane that is
+    not charter's still does exactly what the operator's own `~/.tmux.conf` said — which a
+    hard-coded else-branch could not have promised at all. What is NOT carried across is a
+    `-r` on their binding and a `-N` note: this emits a plain `bind -n`, tmux's `list-keys`
+    does not report the note without being asked, and a repeat flag on a mouse button is
+    not a thing charter can honour by wrapping.
+
+    Every element is separate (`tmuxctl.server_argv`'s rule): nothing here is joined, so
+    nothing here is shell-interpreted.
+    """
+    return tmuxctl.server_argv(socket, "bind-key", "-n", tmuxctl.CLICK_MENU_KEY,
+                               "if-shell", "-F", "-t", "=", f"#{{{_PANEL_OPTION}}}",
+                               "send-keys -M", default)
+
+
+def _menu_button_bind_argv(*, socket: str, env: dict | None = None) -> list[str] | None:
+    """Read this server's menu button and build the bind that wraps it, or ``None``.
+
+    The one call that needs a running tmux, which is why it is not in `conf_text` and why
+    it happens where the launcher's other admin commands do — by then `new-session` has
+    started the harness, so there is a server to ask.
+
+    Ordered against charter's OWN write rather than against the clock: the read must land
+    before the `bind-key` this returns, and it does because the caller batches that write
+    and sends the batch afterwards. Two launchers racing each other both read tmux's
+    default and both write the same wrap, so the loser of the race installs what the
+    winner did.
+    """
+    said = tmuxctl.run("reading tmux's own binding for the menu button",
+                       tmuxctl.server_argv(socket, "list-keys", "-T", "root"), env=env)
+    if said.returncode != 0:
+        return None
+    default = _menu_button_default(said.stdout)
+    if default is None:
+        return None
+    return _menu_button_argv(socket=socket, default=default)
 
 
 def _charter_py_env_argv(*, socket: str, session: str) -> list[str]:
@@ -5276,6 +5417,22 @@ def _launch(args) -> int:
           tmuxctl.server_argv(SOCKET, "source-file", str(conf_path)),
           "charter frame: continuing without it — mouse/history-limit/hotkey "
           "settings may not be in effect for this frame")
+
+    # The third mouse key, and the only one charter cannot simply write out (#848). The
+    # file above carries the wheel's and the left click's binds as text; this one is a
+    # WRAP of whatever the server already had, so it needs a read before it can be built
+    # and it cannot be a line in a file built before the server was asked. `None` is the
+    # ordinary answer on every launch after the first on a shared socket — the bind is
+    # already there — and `_menu_button_default` says why the other two `None`s are
+    # benign too. Right here, beside `source-file`, so all three mouse keys are installed
+    # by the same batch and a reader looking for charter's mouse handling finds it in one
+    # place rather than two.
+    menu = _menu_button_bind_argv(socket=SOCKET, env=env)
+    if menu is not None:
+        _tell("binding the menu button off the panels",
+              menu,
+              "charter frame: continuing without it — a right-click on a panel may "
+              "move the keyboard off the harness")
 
     _tell("carrying the exit-status path",
           _exit_path_env_argv(socket=SOCKET, session=session,

--- a/charter/commands_frame.py
+++ b/charter/commands_frame.py
@@ -1053,10 +1053,10 @@ def _menu_button_argv(*, socket: str, default: str) -> list[str]:
     3.2, with a marked panel, the harness and a pane split by hand standing in for the
     operator's own, SGR button-2 reports injected into a real client on a real pty::
 
-        bind                     right-click a panel   right-click harness  right-click own split
-        tmux's own default       delivered, MOVED      untouched            tmux's pane menu
-        `MouseDown1Pane`'s shape  delivered, unchanged untouched            MOVED, NO MENU
-        this one                 delivered, unchanged  untouched            tmux's pane menu
+        bind                      right-click a panel   right-click harness  right-click own split
+        tmux's own default        delivered, MOVED      untouched            tmux's pane menu
+        `MouseDown1Pane`'s shape  delivered, unchanged  untouched            MOVED, and NO MENU
+        this one                  delivered, unchanged  untouched            tmux's pane menu
 
     The middle row is the fix #634 shipped for button 1, applied verbatim to button 3, and
     it is why this function reads the server instead: `select-pane -t =; send-keys -M` is

--- a/charter/frame/builtins.py
+++ b/charter/frame/builtins.py
@@ -266,8 +266,9 @@ _ACT_BUTTON = "left"
 #: not appear, because that binding tests `#{mouse_any_flag}` — which is 1 precisely
 #: because this pane asked for reporting — and takes its `send-keys -M` branch. **A custom
 #: `bind -n MouseDown3Pane` that omits `send -M` is the one thing that would swallow the
-#: press**, so charter binds nothing: `commands_frame.conf_text` names no mouse key, and
-#: adding one is what would break this rather than what would enable it.
+#: press**, which is the shape of every binding charter must not write for this key. The
+#: one it does write (#848, below) keeps `send-keys -M` as the branch a PANEL takes, so
+#: this row is unchanged by it.
 #:
 #: **It is deliberately NOT read by three of the four handlers below.** Right-click is a
 #: menu gesture and a menu needs something to be about; the repo table's rows, the two
@@ -275,23 +276,27 @@ _ACT_BUTTON = "left"
 #: and giving a second button a second one there would be inventing surfaces nobody asked
 #: for. `_bar_events` is the only reader, and only on the bar whose tabs are chats.
 #:
-#: **What the press DOES cost, measured here rather than assumed away.** tmux's default
-#: binding forwards the report, but it selects the pane first — read back off a real 3.7c
-#: with `list-keys -T root`, the forwarding branch is `{ select-pane -t = ; send-keys -M }`.
-#: So with `[frame] mouse = true` a right-click on any charter panel moves the keyboard to
-#: that panel before the byte arrives. **That is #634's defect one button over, it is
-#: pre-existing, and this change does not close it.** It costs nothing on the gesture this
-#: constant is for — a menu that opens takes the keyboard anyway, and
-#: `commands_frame._close_palette` selects the harness on the way out — and it costs a MISS
-#: one left click on the harness, or `overlay.HATCH_KEY`.
+#: **What the press USED to cost, and what closing it took** (#848). tmux's default binding
+#: forwards the report, but it selects the pane first — read back off a real 3.7c with
+#: `list-keys -T root`, the forwarding branch is `{ select-pane -t = ; send-keys -M }`. So
+#: with `[frame] mouse = true` a right-click on any charter panel moved the keyboard to
+#: that panel before the byte arrived: #634's defect one button over, and pre-existing.
+#: It cost nothing on the gesture this constant is for — a menu that opens takes the
+#: keyboard anyway, and `commands_frame._close_palette` selects the harness on the way out
+#: — and it cost a MISS one left click on the harness, or `overlay.HATCH_KEY`. The MISS is
+#: what made it worth closing, and it is the case the fix is pinned by
+#: (`tests/test_a_real_click_on_a_real_tab_bar_switches.py`'s heading press).
 #:
-#: Closing it is a change of its own and not a line here. `MouseDown1Pane`'s fix works
-#: because tmux's default for THAT key is two commands charter can write out verbatim in
+#: **It could not be closed the way `MouseDown1Pane` was, and that is the whole shape of
+#: the fix.** tmux's default for THAT key is two commands charter can write out verbatim in
 #: the else-branch (`commands_frame.conf_text`); button 3's else-branch is a `display-menu`
 #: a page long, built out of `#{mouse_word}`, `#{pane_marked}` and a dozen other formats,
 #: and it differs between the versions charter supports. A bind that dropped it would take
 #: tmux's own pane menu away from the harness and from the operator's own splits, inside
-#: charter's window, to fix a focus steal that a click puts right.
+#: charter's window, to fix a focus steal that a click puts right. So charter READS the
+#: server's own binding back and re-emits it as the else-branch of its own panel test,
+#: rather than writing one: `commands_frame._menu_button_bind_argv`, which is also why that
+#: bind is an argv issued at launch and not a line in `conf_text`.
 #:
 #: **And on a terminal that eats button 2 this constant simply never matches.** The
 #: measurement above injected bytes into a pty, which bypasses the terminal EMULATOR;

--- a/charter/frame/tmuxctl.py
+++ b/charter/frame/tmuxctl.py
@@ -182,21 +182,37 @@ WHEEL_KEY = "WheelUpPane"
 #: own default for it is `select-pane -t = \; send-keys -M`, which is the focus steal.
 CLICK_KEY = "MouseDown1Pane"
 
-#: Both of them, as the set of mouse keys charter binds for every frame on its own server.
+#: A RIGHT click on a pane, and the root-table key charter rebinds so a right click on a
+#: PANEL does not move the keyboard off the harness either (#848,
+#: `commands_frame._menu_button_bind_argv`). #634's defect, one button over.
+#:
+#: **The one mouse key whose rebind charter cannot WRITE, only wrap**, and that is what
+#: keeps it out of `conf_text` beside the other two. tmux's default for this key is a
+#: conditional whose forwarding branch is `select-pane -t = ; send-keys -M` — the steal —
+#: and whose other branch is a `display-menu` a page long that **differs between the tmux
+#: versions charter supports**: 1849 characters of `{}` blocks on 3.7c against 1378 of
+#: backslash-escaped quotes on 3.2, with rows for `#{mouse_hyperlink}` and
+#: `#{pane_floating_flag}` that the floor has never heard of. So charter reads the
+#: server's own binding back with `list-keys -T root` and re-emits it as the ELSE branch
+#: of its own panel test, rather than writing a replacement for it.
+CLICK_MENU_KEY = "MouseDown3Pane"
+
+#: All three, as the set of mouse keys charter binds for every frame on its own server.
 #:
 #: Defined HERE for :data:`CHARTER_PY_ENV`'s reason exactly — two modules need the same
 #: names for two different jobs and neither may spell them itself.
-#: `commands_frame.conf_text` WRITES a `bind -n` for each; `instance.component_tables`
-#: REFUSES each to a component's ``key``, because both lines are emitted before the toggle
+#: `commands_frame` BINDS each — the first two as `conf_text` lines, the third as its own
+#: `bind-key` argv (:data:`CLICK_MENU_KEY` says why); `instance.component_tables`
+#: REFUSES each to a component's ``key``, because all three are bound before the toggle
 #: binds and tmux's key tables have no notion of a conflict — a later `bind -n` simply
 #: replaces the earlier, so a component claiming one would delete charter's mouse handling
 #: for every frame on the socket and `list-keys` would read back one line where two were
 #: meant (#566). Two spellings of these names is that deletion waiting for the day they
 #: stop matching.
 #:
-#: Both names pass `instance._HOTKEY_RE` — they are alphanumerics under twenty characters —
-#: so this is a reachable claim rather than a theoretical one.
-MOUSE_KEYS = (WHEEL_KEY, CLICK_KEY)
+#: All three names pass `instance._HOTKEY_RE` — they are alphanumerics under twenty
+#: characters — so this is a reachable claim rather than a theoretical one.
+MOUSE_KEYS = (WHEEL_KEY, CLICK_KEY, CLICK_MENU_KEY)
 
 #: How long any one tmux ADMIN command may take before charter stops waiting for it.
 #: Every command the launcher issues is a local, in-process request to a server on a

--- a/charter/instance.py
+++ b/charter/instance.py
@@ -2367,8 +2367,8 @@ def component_arrangement(section, *,
     `frame/overlay.py`'s ``HATCH_KEY`` and `frame/tmuxctl.py`'s ``MOUSE_KEYS`` in the set
     of keys charter has already taken, and a component may have none of them. ``None``
     means the caller has no palette key to reserve, which is what resolving an arrangement
-    outside a `[frame]` section has; the hatch and the two mouse keys are reserved
-    regardless, because charter binds all three for every frame on its own server.
+    outside a `[frame]` section has; the hatch and the three mouse keys are reserved
+    regardless, because charter binds all four for every frame on its own server.
     """
     # **The absent key is the one branch that must never produce a reason**, and it is
     # asked before the value is looked at rather than inferred from the value being
@@ -2407,13 +2407,16 @@ def component_arrangement(section, *,
     # command, `charter --version` included, and must stay as cheap as it was.
     # `frame/tmuxctl.py` costs nothing extra: `frame/overlay.py` imports it already.
     #
-    # The two MOUSE keys are here for the hatch's reason with the sign flipped. `conf_text`
-    # writes them BEFORE the toggles, so tmux's last-wins leaves the COMPONENT's key alive
+    # The three MOUSE keys are here for the hatch's reason with the sign flipped. Charter
+    # binds them BEFORE the toggles, so tmux's last-wins leaves the COMPONENT's key alive
     # and charter's mouse handling silently gone — the wheel stops entering copy-mode and,
     # since #634, a click on a panel goes back to taking the keyboard off the harness. One
     # dead binding, nothing anywhere saying which, and the frame still launching at rc 0.
     # Named off `tmuxctl.MOUSE_KEYS` rather than spelled here, so the key this refuses is
-    # the same object `conf_text` binds.
+    # the same object charter binds. The third of them (`MouseDown3Pane`, #848) is the one
+    # where the loss is not charter's own line: that bind carries tmux's OWN pane menu as
+    # its else-branch, so a component claiming the key would replace the operator's Copy
+    # Line, Paste, Kill and Zoom with a panel toggle.
     #
     # `if k` drops a falsy *hotkey* — ``None`` for every caller with no palette key to
     # reserve — and it is the ONE place this set's invariant is established: `bound` holds

--- a/docs/frame.md
+++ b/docs/frame.md
@@ -160,7 +160,9 @@ still does not. Both measured on 3.7c and 3.2:
 |---|---|---|
 | does a click reach the panel? | only while the active pane is asking your terminal to report — your harness decides | always, from the moment you attach |
 | does a click on a panel move your keyboard? | **no** | **no** |
+| does a *right*-click on a panel move your keyboard? | **no** | **no** |
 | does a click on the harness, or a pane you split, move your keyboard? | no — with its mouse off tmux runs no mouse binding at all | yes — tmux's own behaviour, untouched |
+| does a right-click on the harness, or a pane you split, still open tmux's pane menu? | yes — with its mouse off tmux runs no mouse binding at all | yes — tmux's own menu, untouched |
 | does the wheel move your keyboard? | no | no |
 | do you keep native drag-select? | while no mouse-requesting pane is active | no |
 | a click on a pane border | reaches nobody — a border is a cell in neither pane | reaches nobody |
@@ -168,6 +170,17 @@ still does not. Both measured on 3.7c and 3.2:
 The drag-select row is the trade `mouse = true` makes, and it has not changed and will not:
 it is how tmux works, not a default charter chose. What went away was a second cost that was
 never part of that trade — one key's default behaviour, in a server charter owns.
+
+**The right button took a release longer, and the reason is worth one sentence** because it
+is what the last row of that table is about. tmux's default for the left button is two
+commands, so charter could write out the half it wanted to keep. Its default for the right
+button ends in tmux's own pane menu — Copy Line, Paste, Horizontal Split, Kill, Zoom — which
+is a page long and *different on different tmux versions*, so a charter that wrote its own
+replacement would have deleted that menu from your harness and from every pane you split
+yourself, inside charter's own window, to fix a focus steal one click puts right. Charter
+reads your server's binding back instead and puts its own panel test in front of it. If you
+rebound that key yourself, your binding is what every pane charter did not create still
+runs.
 
 One consequence of that first column worth knowing, because it is new: a panel whose
 component declares `click` or `scroll` asks *its own* terminal to report, so if you select
@@ -247,11 +260,14 @@ invisible until you try it, so it is a faster route to two things and never the 
 forwards it — measured on 3.2 and 3.7c, with `[frame] mouse` off and on, with no binding
 involved — but many terminal emulators serve their own context menu on button 2 instead of
 sending it to the application. iTerm2's default profile is one. If yours does, nothing
-breaks and nothing is refused: the menu simply never appears, and `F2` is unchanged. One
-cost worth knowing with `mouse = true`: tmux selects the pane under the pointer before
-forwarding a right-click, so a right-click that lands on a panel and opens nothing leaves
-your keyboard on that panel. A click on the harness, or `F12`, puts it back. (Left clicks
-have not done this since charter rebound `MouseDown1Pane` — see above.)
+breaks and nothing is refused: the menu simply never appears, and `F2` is unchanged.
+
+A right-click that lands on a panel and opens nothing now costs you nothing either: it
+leaves your keyboard on the harness, the same as a left click has since charter rebound
+`MouseDown1Pane`. It did not always — tmux selects the pane under the pointer before
+forwarding a right-click, so until charter wrapped that binding too a miss cost you one
+click on the harness or an `F12`. Right-clicking a pane charter did *not* create still
+opens tmux's own pane menu, exactly as it always did; see the mouse table above.
 
 **The `+N` counts are the exception, and they open the palette.** A `+9` stands for names
 that are not on the row, so there is nothing there to switch *to* — but it is the field

--- a/docs/news/unreleased-a-right-click-on-a-panel-stays-where-it-points.md
+++ b/docs/news/unreleased-a-right-click-on-a-panel-stays-where-it-points.md
@@ -1,0 +1,58 @@
+---
+version: unreleased
+headline: A right-click on a panel stays where it points too, and tmux's own pane menu is still there
+---
+
+**If you set `[frame] mouse = true`, right-clicking a panel no longer takes your keyboard
+with it. Right-clicking anything charter did not create — your harness, a pane you split
+yourself — still opens tmux's own pane menu, exactly as it always did.**
+
+Charter stopped left clicks moving the keyboard in 0.54.0. Right clicks still did, and
+right-clicking became something you would actually do the moment chat tabs grew a menu.
+The cause is the same one, one button over: tmux's default root binding for
+`MouseDown3Pane` forwards the report only *after* `select-pane -t =`, and a charter panel
+always takes that branch — a panel that declares `click` or `scroll` asks its own terminal
+to report, which is what makes it clickable, and that is exactly the condition tmux tests.
+
+On the gesture the menu is for this cost nothing: the menu takes the keyboard anyway. On a
+**miss** it cost you a click on the harness, or `F12` — and a miss is most of what a
+right-click on a bar is, because the heading and the padding are about no tab at all.
+
+## Why it is not the same fix as the left button's
+
+`MouseDown1Pane`'s default is two commands, so charter could write out the half worth
+keeping. This one's is not. Read back off a real tmux 3.7c, `MouseDown3Pane` is a
+conditional whose other branch is tmux's whole pane menu — Copy Line, Paste, Horizontal
+Split, Kill, Zoom — built out of `#{mouse_word}`, `#{mouse_hyperlink}`,
+`#{pane_floating_flag}` and a dozen more formats. **1849 characters on 3.7c, and 1378
+different characters on 3.2**, whose menu has no hyperlink rows and no floating panes and
+whose quoting is not even the same style.
+
+Applying the left button's fix here was measured, on a real server with a real client on a
+real pty, on both versions:
+
+```
+bind                      right-click a panel   right-click harness  right-click your own split
+tmux's own default        delivered, MOVED      untouched            tmux's pane menu
+the left button's shape   delivered, unchanged  untouched            MOVED, and NO MENU
+charter's (the wrap)      delivered, unchanged  untouched            tmux's pane menu
+```
+
+The middle row is the trade this release refused. It fixes a focus steal one click puts
+right by deleting a documented tmux affordance from panes charter has nothing to do with,
+inside charter's own window.
+
+## What charter does instead
+
+It reads your server's own binding back with `list-keys` at launch and re-emits it with its
+own panel test in front of it — so the branch that runs for every pane charter did not
+create is *whatever was already there*. **If you rebound that key yourself, your binding is
+what still runs.** A hard-coded else-branch could not have promised that at all.
+
+Two smaller things fell out of the measurement and are recorded in the code rather than
+here: `list-keys -T root MouseDown3Pane` prints the binding on tmux 3.2 and prints nothing
+at all, at rc 0, on 3.7c — so charter lists the whole root table and picks the line out of
+it. And the bind is issued as its own tmux command rather than written into the frame's
+config file: it carries a page of tmux's own config language as an argument, and one
+unbalanced brace in a binding charter did not write would otherwise have taken `mouse`,
+`history-limit` and the `F2` hotkey down with it.

--- a/docs/news/unreleased-right-click-a-chat-tab-to-act-on-that-chat.md
+++ b/docs/news/unreleased-right-click-a-chat-tab-to-act-on-that-chat.md
@@ -33,7 +33,12 @@ With tmux's own mouse off no mouse binding fires at all. With it on, tmux's *def
 `MouseDown3Pane` tests `#{mouse_any_flag}` — which is 1 precisely because the panel asked
 for reporting — and takes its `send-keys -M` branch, so tmux's own menu does not appear
 either. The third row is the trap: **a custom `bind -n MouseDown3Pane` that omits `send -M`
-swallows the press.** Binding is what would have broken this. Charter binds nothing.
+swallows the press.** Binding is what would have broken this; nothing here needed one.
+
+What that same default branch also does is select the pane before forwarding, so a
+right-click on a panel used to take your keyboard with it. Charter now wraps that binding
+rather than replacing it — see *a right-click on a panel stays where it points* in this
+same release, which keeps the `send-keys -M` this feature rides on and adds nothing to it.
 
 The events were already decoded, already delivered and already named `right`; they were
 dropped by one comparison.

--- a/tests/test_a_click_on_a_panel_stays_where_it_points.py
+++ b/tests/test_a_click_on_a_panel_stays_where_it_points.py
@@ -212,24 +212,32 @@ class NeitherMouseKeyIsAComponentsToTake(unittest.TestCase):
     """#566's hazard, in the mouse table.
 
     tmux key tables have no notion of a conflict — a later `bind -n` replaces the earlier
-    and `list-keys` reads back one line where two were meant. `conf_text` writes both mouse
-    binds BEFORE the toggles, so a component claiming either would leave its own key alive
-    and charter's mouse handling silently gone: the wheel would stop entering copy-mode,
-    and a click on a panel would go back to taking the keyboard off the harness.
+    and `list-keys` reads back one line where two were meant. `conf_text` writes two of the
+    three mouse binds BEFORE the toggles, so a component claiming either would leave its
+    own key alive and charter's mouse handling silently gone: the wheel would stop entering
+    copy-mode, and a click on a panel would go back to taking the keyboard off the harness.
 
-    Both names pass `instance._HOTKEY_RE` — they are alphanumerics under twenty characters
-    — so this is reachable rather than theoretical, and the guard is what closes it.
+    **The third is `MouseDown3Pane` and it is reserved for a sharper version of the same
+    reason** (#848). That one is not written by `conf_text` at all — it is a WRAP of
+    whatever the server already had, built from a `list-keys` read
+    (`_menu_button_bind_argv`) — so a component that claimed it would not merely replace
+    charter's binding: it would replace the operator's own pane menu with a toggle, having
+    been handed tmux's whole default `display-menu` to overwrite.
+
+    All three names pass `instance._HOTKEY_RE` — they are alphanumerics under twenty
+    characters — so this is reachable rather than theoretical, and the guard is what closes
+    it.
     """
 
     def _resolve(self, key: str) -> dict:
         return instance.frame_of(
             {"frame": {"hotkey": "M-x", "component": [{"use": "identity", "key": key}]}})
 
-    def test_both_names_are_keys_the_alphabet_would_otherwise_allow(self):
-        """Without this the two cases below could be passing for the wrong reason — a
+    def test_all_three_names_are_keys_the_alphabet_would_otherwise_allow(self):
+        """Without this the three cases below could be passing for the wrong reason — a
         component claiming a key `_HOTKEY_RE` rejects is refused by a different guard
         entirely, and the collision guard would never fire."""
-        for key in ("WheelUpPane", "MouseDown1Pane"):
+        for key in ("WheelUpPane", "MouseDown1Pane", "MouseDown3Pane"):
             with self.subTest(key=key):
                 self.assertEqual(instance.toggle_key(key), key)
 
@@ -240,6 +248,15 @@ class NeitherMouseKeyIsAComponentsToTake(unittest.TestCase):
 
     def test_a_component_may_not_take_the_click(self):
         frame = self._resolve("MouseDown1Pane")
+        self.assertEqual(frame["components"], [])
+        self.assertEqual(frame["slots"], instance.FRAME_DEFAULTS["slots"])
+
+    def test_a_component_may_not_take_the_menu_button(self):
+        """#848's key, held to the same rule the moment charter started binding it. It was
+        nobody's to claim before this — `MouseDown2Pane`'s control case below was true of
+        this name as well — and the reservation is what stops a plane's own toggle key
+        deleting the wrap that keeps a right-click off the keyboard."""
+        frame = self._resolve("MouseDown3Pane")
         self.assertEqual(frame["components"], [])
         self.assertEqual(frame["slots"], instance.FRAME_DEFAULTS["slots"])
 
@@ -280,12 +297,23 @@ class NeitherMouseKeyIsAComponentsToTake(unittest.TestCase):
 
     def test_the_reserved_names_are_the_ones_actually_bound(self):
         """The drift this reservation exists to prevent, asked directly: every key in
-        `tmuxctl.MOUSE_KEYS` must appear as a `bind -n` in `conf_text`'s output, and the
-        two spellings are pinned as literals so that renaming the constant alone is red."""
-        self.assertEqual(tuple(tmuxctl.MOUSE_KEYS), ("WheelUpPane", "MouseDown1Pane"))
+        `tmuxctl.MOUSE_KEYS` must really be bound somewhere, and the three spellings are
+        pinned as literals so that renaming a constant alone is red.
+
+        **Two of them are asked of `conf_text` and the third of the argv**, because that
+        is where they are: reserving a key charter does not bind is a refusal that costs a
+        plane its toggle and buys nothing, and the only way to notice is to ask each name
+        of the writer that actually emits it."""
+        self.assertEqual(tuple(tmuxctl.MOUSE_KEYS),
+                         ("WheelUpPane", "MouseDown1Pane", "MouseDown3Pane"))
         for key in ("WheelUpPane", "MouseDown1Pane"):
             with self.subTest(key=key):
                 self.assertIn(f"bind -n {key} ", _text())
+        self.assertNotIn("MouseDown3Pane", _text(),
+                         "the menu button is a WRAP of the server's own binding and "
+                         "cannot be a line in a file written before the server is asked")
+        argv = commands_frame._menu_button_argv(socket="charter", default="display-menu")
+        self.assertEqual(argv[3:6], ["bind-key", "-n", "MouseDown3Pane"])
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/tests/test_a_frame_sends_one_invocation_per_batch.py
+++ b/tests/test_a_frame_sends_one_invocation_per_batch.py
@@ -504,20 +504,27 @@ class ALaunchAndASwitchSpendWhatTheyMeasured(PersonaIso, unittest.TestCase):
     A count that has to be edited is a count somebody has to look at.
     """
 
-    def test_a_four_panel_launch_sends_fifteen_invocations_up_to_the_attach(self):
+    def test_a_four_panel_launch_sends_sixteen_invocations_up_to_the_attach(self):
         """The whole private-server launch, up to and including `attach`. It was 44.
 
         Against THIS MODULE'S fake, which is what makes the number assertable at all; a
-        real launch on a real server makes two more reads than the fake does (46 -> 17
-        measured), and the shape of the saving is the same one.
+        real launch on a real server makes two more reads than the fake does, and the
+        shape of the saving is the same one.
 
-        Five batches carry 33 of the 47 commands: the ten writes that tell the window and
-        session what they are, the window's own dressing, the four splits, every pane's
-        own options, and the four respawn hooks.
+        Five batches carry most of the commands: the eleven writes that tell the window
+        and session what they are, the window's own dressing, the four splits, every
+        pane's own options, and the four respawn hooks.
 
         Unbatched, and named here so a reader can see what is left rather than guess: two
         reaping reads, `new-session`, the eager death check, `list-panes`, the resize
-        hook, the window-seat read, `select-window`, `select-pane`, `attach`.
+        hook, the window-seat read, `list-keys`, `select-window`, `select-pane`, `attach`.
+
+        **`list-keys` is the sixteenth and it is a READ whose answer a later WRITE is
+        built out of** (#848: charter wraps tmux's own `MouseDown3Pane` rather than
+        replacing it). That is the one shape #780's batching cannot fold away — the bind
+        does not exist until the read has answered — so it is a round trip that was
+        chosen rather than one that was left behind. The bind itself costs nothing extra:
+        it rides in the batch that `source-file`s the config.
         """
         fake = _FakeTmux(panel_pane_ids={"top": "%11", "bottom": "%12",
                                          "right": "%13", "repos": "%14"},
@@ -525,8 +532,11 @@ class ALaunchAndASwitchSpendWhatTheyMeasured(PersonaIso, unittest.TestCase):
         with mock.patch.dict(config.FRAME, {"slots": list(_FOUR)}):
             self.assertEqual(_launch(fake, cols=200, rows=50), 0)
         attach = next(i for i, c in enumerate(fake.invocations) if "attach" in c)
-        self.assertEqual(attach + 1, 15,
+        self.assertEqual(attach + 1, 16,
                          [" ".join(c[3:])[:70] for c in fake.invocations[:attach + 1]])
+        self.assertEqual(
+            len([c for c in fake.invocations[:attach + 1] if "list-keys" in c]), 1,
+            "the menu button's read is one round trip and must not become one per key")
         # And every command is still issued — batching moved them, it did not drop them.
         self.assertEqual(len([c for c in fake.calls if "split-window" in c]), 4)
         self.assertEqual(sorted(state.panes(_the_chat(fake))),

--- a/tests/test_a_real_click_on_a_real_tab_bar_switches.py
+++ b/tests/test_a_real_click_on_a_real_tab_bar_switches.py
@@ -19,8 +19,9 @@ the panel process out of its own event handler. What that buys, link by link:
 * that the pane really asks (`overlay.MOUSE_ON` written to fd 1 by a process nobody in
   this test can monkey-patch);
 * that tmux routes the report to the pane under the pointer, in that pane's own cells, and
-  **leaves the keyboard on the harness** — #634's `MouseDown1Pane` rebind, which is what
-  makes a clickable bar something an operator can use rather than a trap;
+  **leaves the keyboard on the harness** — #634's `MouseDown1Pane` rebind for the left
+  button and #848's `MouseDown3Pane` wrap for the right, which is what makes a clickable
+  bar something an operator can use rather than a trap;
 * that the handler's `_spawn` really starts a charter that really performs the switch, in
   a plane the child resolves for itself — a link that is three processes long and whose
   failure mode (`No module named charter`, a plane resolved from a cwd) is silent.
@@ -201,12 +202,18 @@ class _ARealFrameWithBars(PersonaIso):
         return started.stdout.strip()
 
     def _source_conf(self, fid: str) -> None:
-        """charter's OWN frame config, `mouse = true`.
+        """charter's OWN frame config, `mouse = true`, and its own menu-button bind.
 
         Asking `conf_text` for the text rather than writing `set mouse on` by hand is what
         makes the `MouseDown1Pane` rebind (#634) part of what is under test — a
         hand-written config would leave tmux's default binding in place and the "keyboard
         stays on the harness" case below would be measuring a config this file invented.
+
+        `MouseDown3Pane` is the same rule for the same reason one button over (#848), and
+        it is a second call rather than a second line because that bind is not text at all:
+        it is a WRAP of whatever the server already had, so it needs a `list-keys` read
+        first and cannot exist before there is a server to ask. This is the launcher's own
+        call, made the way the launcher makes it.
         """
         conf = str(self.tmp / f"{fid}.conf")
         with open(conf, "w") as fh:
@@ -214,6 +221,11 @@ class _ARealFrameWithBars(PersonaIso):
                                               history_limit=100, session=fid))
         sourced = self._tmux("source-file", conf)
         self.assertEqual(sourced.returncode, 0, sourced.stderr)
+        wrap = commands_frame._menu_button_bind_argv(socket=self.socket, env=self.env)
+        if wrap is not None:
+            bound = subprocess.run(wrap, capture_output=True, text=True, timeout=20,
+                                   env=self.env)
+            self.assertEqual(bound.returncode, 0, bound.stderr)
 
     def _split_bar(self, harness: str, name: str, fid: str) -> str:
         """One real `charter panel <name>` pane, marked the way its launcher marks it.
@@ -744,34 +756,39 @@ class ARealRightClickOnTheChatBarOpensARealMenu(_ARealChatBarOverTwoChats,
         start — which is what makes the empty pane list below a real assertion rather than
         a race this case happened to win.
 
-        **What this case deliberately does NOT assert is where the keyboard ended up, and
-        that is a measurement rather than an omission.** tmux's own default binding for
-        this key, read back off a real 3.7c with `list-keys -T root`, is::
+        **And the keyboard stays on the harness, which is #848 and is the third line this
+        case could not assert when it was written.** tmux's own default binding for this
+        key, read back off a real 3.7c with `list-keys -T root`, is::
 
             MouseDown3Pane if-shell -F -t = "#{||:#{mouse_any_flag},…}"
                              { select-pane -t = ; send-keys -M }
                              { display-menu … }
 
-        The branch that forwards the report **selects the pane first**. That is #634's
-        defect, one button over and still open: with `[frame] mouse = true`, a right-click
-        on any charter panel moves the keyboard to it before the byte arrives. It is
-        pre-existing — it is what tmux has always done to button 3 — and it costs nothing
-        on the gesture this feature is for, because a menu that opens takes the keyboard
-        anyway and `commands_frame._close_palette` selects the harness on the way out. It
-        costs a MISS one left click, or `overlay.HATCH_KEY`.
+        The branch that forwards the report **selects the pane first**, and
+        `#{mouse_any_flag}` is 1 for this bar precisely because its component declared
+        `click` — so with `[frame] mouse = true` this press used to leave `#{pane_id}` on
+        the bar's pane rather than the harness's. It cost nothing on the gesture #846 is
+        for, because a menu that opens takes the keyboard anyway and
+        `commands_frame._close_palette` selects the harness on the way out; **a MISS is
+        exactly the case where it cost something**, which is why the missing assertion
+        belonged on this case and on no other.
 
-        Charter binds nothing here, which is `frame/builtins._MENU_BUTTON`'s own note:
-        `MouseDown1Pane`'s fix works because its else-branch is tmux's own two commands
-        written out, and button 3's else-branch is a `display-menu` a page long that
-        differs between versions. Asserting the steal here would enshrine it; asserting
-        its absence would be red. So this asserts what is contractual — nothing opened —
-        and says why the third line is missing.
+        Charter now wraps that binding rather than replacing it
+        (`commands_frame._menu_button_bind_argv`): its own `@charter_panel` test in front,
+        and whatever the server already had as the else-branch, so a right click on a pane
+        charter did not create still gets tmux's own pane menu. The bar is a panel, so this
+        press takes the forwarding branch without the `select-pane` — the report arrives,
+        `slots._Tabs.tab_at` answers nothing for a heading cell, and nothing at all
+        happens, which is what a miss should cost.
         """
         self._click(self.bar, col=self._column_of(self.bar, "chats"),
                     button=self.BUTTON)
         time.sleep(2.0)
         self.assertEqual(self._menu_pane(), "")
         self.assertIn(self.harness, self._panes(self.WS))
+        self.assertEqual(self._active(), self.harness,
+                         "a right click that opened nothing still took the keyboard off "
+                         "the harness — #848, and one left click or F12 to undo")
 
 
 @unittest.skipUnless(_HAS_TMUX, "no tmux on this machine")

--- a/tests/test_a_right_click_on_a_panel_stays_where_it_points.py
+++ b/tests/test_a_right_click_on_a_panel_stays_where_it_points.py
@@ -1,0 +1,317 @@
+"""`[frame] mouse = true` stops taking the keyboard off the harness on a RIGHT click (#848).
+
+#634 is this file's sibling and the difference between them is the whole reason this one
+exists. tmux's default `MouseDown1Pane` is two commands — `select-pane -t = \\; send-keys
+-M` — so charter could write them out verbatim in the else-branch of its own panel test and
+leave every pane it did not create exactly as tmux left it. Read back off a real 3.7c,
+tmux's default for the RIGHT button is not two commands::
+
+    MouseDown3Pane  if-shell -F -t = "#{||:#{mouse_any_flag},…}"
+                      { select-pane -t = ; send-keys -M }
+                      { display-menu -T "…" -t = -x M -y M … }
+
+The branch that FORWARDS the report selects the pane first, and `#{mouse_any_flag}` is 1
+for every charter panel that declared `click` or `scroll` — the panel asks its own terminal
+to report, which is what makes it clickable at all — so with `[frame] mouse = true` every
+right click on a panel takes the keyboard before the byte arrives. #846 made right-clicking
+a thing operators do, which is what turned a pre-existing tmux behaviour into a defect.
+
+**The else-branch cannot be written out, and that is measured rather than asserted.** It is
+a page-long `display-menu` built out of `#{mouse_word}`, `#{mouse_line}`,
+`#{mouse_hyperlink}`, `#{pane_marked}`, `#{pane_floating_flag}` and `#{pane_mode}`, and it
+**differs between the tmux versions charter supports**: 1849 characters of `{}` command
+blocks on 3.7c against 1378 of backslash-escaped `"…"` on a 3.2 built from the release
+tarball, the 3.7c one carrying hyperlink and floating-pane rows the floor has never heard
+of. A hard-coded copy would be wrong on one of them the day it was written.
+
+So charter **wraps rather than replaces**: it reads the server's own binding back with
+`list-keys -T root` and re-emits it as the else-branch of its own panel test. Three
+functions hold that and this file asks about all three — the parse
+(`commands_frame._menu_button_default`), the argv it feeds
+(`_menu_button_argv`), and the read that joins them (`_menu_button_bind_argv`).
+`tests/test_frame_input_reaches_a_component.py` is the real-tmux half: it can say what tmux
+does with a real right click and cannot say whether charter ever read the binding.
+
+**The measurement that chose the wrap over #634's own shape** — real server, real client on
+a real pty, `mouse on`, three panes (a marked panel, the harness, and one more split by
+hand standing in for the operator's), SGR button-2 reports injected as a reporting terminal
+sends them. **tmux 3.7c and tmux 3.2 answered identically in all nine cells**::
+
+    bind                       right-click a panel   right-click harness  right-click own split
+    tmux's own default         delivered, MOVED      untouched            tmux's pane menu
+    `MouseDown1Pane`'s shape   delivered, unchanged  untouched            MOVED, and NO MENU
+    charter's (the wrap)       delivered, unchanged  untouched            tmux's pane menu
+
+The middle row is #634's fix applied verbatim to this button, and it is the trade #848
+refused: `select-pane -t =; send-keys -M` is tmux's WHOLE default for button 1 and only the
+forwarding HALF of its default for button 3, so writing it out here deletes tmux's own pane
+menu — Copy Line, Paste, Horizontal Split, Kill, Zoom — from the harness and from every
+pane the operator split themselves, inside charter's own window, to fix a focus steal that
+one click puts right.
+
+**The issue's third open question, settled by measurement rather than by reasoning:
+`list-keys -T root MouseDown3Pane` cannot be the read.** Asking `list-keys` for one key by
+name prints the binding on a real 3.2 and prints **nothing at all, at rc 0**, on a real
+3.7c. So the whole root table is listed and the line is picked out of it, which is what
+:data:`commands_frame._MENU_BIND_RE` is for and why it has to carry two spellings.
+
+**And `M-MouseDown3Pane` is not an answer either.** It is tmux's unconditional
+`display-menu` and it is present on both versions, so it would be somewhere for the pane
+menu to go — but it is a documented affordance the operator would have to be told about, in
+exchange for a right-click that stopped doing what every other tmux does. The wrap costs
+them nothing and needs no doc line at all.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import unittest
+from unittest import mock
+
+from charter import commands_frame
+from charter.frame import tmuxctl
+
+#: One real `list-keys -T root` line off a real tmux 3.7c, its `display-menu` cut after the
+#: first two rows — the length is the one thing about it this file does not need, and the
+#: real-tmux half reads the whole thing off a real server rather than off a literal here.
+#: What IS verbatim is the shape: two spaces after `bind-key`, the column padding before
+#: the command, and `{}` command blocks.
+_LINE_37C = (
+    'bind-key  -T root MouseDown3Pane            if-shell -F -t = '
+    '"#{||:#{mouse_any_flag},#{&&:#{pane_in_mode},#{?#{m/r:(copy|view)-mode,'
+    '#{pane_mode}},0,1}}}" { select-pane -t = ; send-keys -M } '
+    '{ display-menu -T "#[align=centre]#{pane_index} (#{pane_id})" -t = -x M -y M '
+    "'' Kill X { kill-pane } Respawn R { respawn-pane -k } }")
+
+#: The same line off a 3.2 built from the release tarball — `tmuxctl.FLOOR`. One space
+#: after `bind-key`, different padding, and the branches are backslash-escaped `"…"`
+#: strings rather than `{}` blocks. **This is why the else-branch is sourced**: no single
+#: literal charter could hold is right on both machines.
+_LINE_32 = (
+    'bind-key -T root MouseDown3Pane       if-shell -F -t = '
+    '"#{||:#{mouse_any_flag},#{&&:#{pane_in_mode},#{?#{m/r:(copy|view)-mode,'
+    '#{pane_mode}},0,1}}}" "select-pane -t= ; send -M" '
+    '"display-menu -t= -xM -yM -T \\"#[align=centre]#{pane_index} (#{pane_id})\\" '
+    '\'\' Kill X kill-pane Respawn R \\"respawn-pane -k\\""')
+
+
+def _cmd(line: str) -> str:
+    """Everything the sample line says after the key — what the parse must hand back."""
+    return line.split("MouseDown3Pane", 1)[1].strip()
+
+
+class TheLineCharterPicksOutOfTmuxsOwnTable(unittest.TestCase):
+    """`_menu_button_default` against the two listings a supported tmux really prints."""
+
+    def test_the_command_comes_back_off_a_real_3_7c_listing(self):
+        self.assertEqual(commands_frame._menu_button_default(_LINE_37C), _cmd(_LINE_37C))
+
+    def test_the_command_comes_back_off_a_real_3_2_listing(self):
+        """The floor, whose padding and quoting are both different. A parse written
+        against one version's spacing alone passes the case above and fails here."""
+        self.assertEqual(commands_frame._menu_button_default(_LINE_32), _cmd(_LINE_32))
+
+    def test_it_is_found_among_the_whole_table_and_not_only_alone(self):
+        """The read lists the WHOLE root table (`list-keys -T root MouseDown3Pane` prints
+        nothing on 3.7c), so the line arrives with two dozen others around it."""
+        listing = "\n".join([
+            "bind-key  -T root MouseDown1Pane            select-pane -t = \\; send-keys -M",
+            _LINE_37C,
+            "bind-key  -T root WheelUpPane               if-shell -F \"#{x}\" { a } { b }",
+        ])
+        self.assertEqual(commands_frame._menu_button_default(listing), _cmd(_LINE_37C))
+
+    def test_an_operators_own_repeat_flag_does_not_hide_the_line(self):
+        """`bind -n -r MouseDown3Pane …` reads back with the flag between `bind-key` and
+        `-T`, measured on 3.7c. The flag is the operator's and the command after it is
+        still the thing to wrap."""
+        line = "bind-key -r -T root MouseDown3Pane          display-message hi"
+        self.assertEqual(commands_frame._menu_button_default(line), "display-message hi")
+
+    def test_a_binding_in_another_key_table_is_not_this_key(self):
+        """`bind -T copy-mode MouseDown3Pane …` is a real thing an operator can write, and
+        wrapping it here would install a copy-mode binding into the ROOT table — where it
+        would run against panes that are not in copy mode at all."""
+        line = "bind-key  -T copy-mode MouseDown3Pane       send-keys -X copy-pipe"
+        self.assertIsNone(commands_frame._menu_button_default(line))
+
+    def test_another_key_is_not_this_one(self):
+        """`M-MouseDown3Pane` ends with this key's name and is tmux's UNCONDITIONAL
+        `display-menu` — the one line in the table most likely to be mistaken for this one,
+        and wrapping it would leave the steal in place while charter reported success."""
+        line = ("bind-key  -T root M-MouseDown3Pane          display-menu -T \"x\" -t = "
+                "-x M -y M Kill X { kill-pane }")
+        self.assertIsNone(commands_frame._menu_button_default(line))
+
+    def test_a_key_the_operator_unbound_is_left_unbound(self):
+        """`unbind -n MouseDown3Pane` says this key does nothing, and a key that does
+        nothing runs no `select-pane`: there is no steal to fix. Inventing a binding here
+        would be charter putting back what the operator removed."""
+        self.assertIsNone(commands_frame._menu_button_default(
+            "bind-key  -T root MouseDown1Pane            select-pane -t =\n"))
+
+    def test_nothing_at_all_is_not_a_crash(self):
+        """A server that answered with an empty table — or with output charter could not
+        read (`tmuxctl.DECODE_ERRORS`) — degrades to the behaviour every charter before
+        this one had, rather than to a traceback out of a launcher that has already
+        started the harness."""
+        self.assertIsNone(commands_frame._menu_button_default(""))
+
+    def test_charters_own_wrap_is_never_wrapped_again(self):
+        """The second launch on a shared socket, which is the ordinary case rather than an
+        edge one — a root key table is server-wide, so frame two reads what frame one
+        installed.
+
+        Each pass would nest another copy of a page-long `display-menu` inside the last,
+        so the ninth frame on a socket would carry a kilobyte of tmux config per launch
+        and the operator's own binding would be nine layers down. The test is for
+        `_PANEL_OPTION` in the command text, which is in no default binding of tmux's on
+        either version.
+        """
+        wrapped = ("bind-key  -T root MouseDown3Pane            if-shell -F -t = "
+                   '"#{@charter_panel}" { send-keys -M } { ' + _cmd(_LINE_37C) + " }")
+        self.assertIsNone(commands_frame._menu_button_default(wrapped))
+
+    def test_the_marker_it_looks_for_is_the_one_charter_writes(self):
+        """Spelled out of the constant rather than as a literal, deliberately and against
+        this suite's usual rule: what the re-wrap guard has to agree with is the string
+        `_menu_button_argv` PUTS in the binding, so a rename that moved both together must
+        not be red — and a rename that moved only one must be."""
+        self.assertIn(commands_frame._PANEL_OPTION,
+                      " ".join(commands_frame._menu_button_argv(socket="charter",
+                                                                default="x")))
+
+
+class TheBindCharterBuilds(unittest.TestCase):
+    """`_menu_button_argv` — the whole argv, element by element."""
+
+    def test_the_argv_is_the_one_that_was_measured(self):
+        """Every element as a literal, which is this file's sibling's rule (#547): an
+        expectation assembled from the same constants the code assembles it from agrees
+        with any of them."""
+        self.assertEqual(
+            commands_frame._menu_button_argv(socket="charter", default="display-menu -T x"),
+            ["tmux", "-L", "charter", "bind-key", "-n", "MouseDown3Pane",
+             "if-shell", "-F", "-t", "=", "#{@charter_panel}",
+             "send-keys -M", "display-menu -T x"])
+
+    def test_a_panel_is_forwarded_to_and_never_selected(self):
+        """The true branch is `send-keys -M` ALONE. A `select-pane` that crept back into it
+        would restore the exact defect, and every other assertion here would still pass —
+        the bind would still be conditional, still carry the mark, still wrap the
+        default."""
+        argv = commands_frame._menu_button_argv(socket="charter", default="anything")
+        self.assertEqual(argv[-2], "send-keys -M")
+
+    def test_the_else_branch_is_what_the_server_already_had_byte_for_byte(self):
+        """The whole of the fix. A branch charter edited, trimmed or re-quoted is a branch
+        charter is now responsible for being right about on every tmux there will ever
+        be."""
+        default = _cmd(_LINE_37C)
+        argv = commands_frame._menu_button_argv(socket="charter", default=default)
+        self.assertEqual(argv[-1], default)
+
+    def test_nothing_is_joined(self):
+        """`tmuxctl.server_argv`'s rule, and here it is what makes the quoting question go
+        away entirely: a joined string is shell-interpreted by tmux and a separate argv is
+        not, so a page of `{}` blocks and `''` separators reaches `if-shell` verbatim with
+        nothing between it and tmux's own parser."""
+        argv = commands_frame._menu_button_argv(
+            socket="charter", default="a ; b 'c' \"d\" { e } $(f) `g`")
+        self.assertEqual(argv[-1], "a ; b 'c' \"d\" { e } $(f) `g`")
+        self.assertTrue(all(isinstance(part, str) for part in argv))
+
+    def test_it_reaches_the_server_it_was_asked_about(self):
+        """Charter talks to two servers and binds keys on exactly one of them
+        (`tmuxctl.server_argv`). A socket PATH is the operator's own tmux, and this is the
+        head that decides which one a `bind-key` lands on."""
+        argv = commands_frame._menu_button_argv(socket="/private/tmp/tmux-502/default",
+                                                default="x")
+        self.assertEqual(argv[:3], ["tmux", "-S", "/private/tmp/tmux-502/default"])
+
+
+class TheReadThatJoinsThem(unittest.TestCase):
+    """`_menu_button_bind_argv` — the one call that needs a running tmux."""
+
+    @staticmethod
+    def _answering(stdout: str, code: int = 0):
+        seen: list[list[str]] = []
+
+        def fake(action, argv, **kw):
+            seen.append(argv)
+            return subprocess.CompletedProcess(argv, code, stdout=stdout, stderr="")
+
+        return seen, mock.patch("charter.frame.tmuxctl.run", side_effect=fake)
+
+    def test_it_asks_for_the_whole_root_table(self):
+        """And not for the one key. `list-keys -T root MouseDown3Pane` prints nothing at
+        all on a real 3.7c — rc 0, no output — so a read narrowed to the key would answer
+        "nothing bound" on the version charter is developed against and leave the fix
+        silently off."""
+        seen, patched = self._answering(_LINE_37C)
+        with patched:
+            commands_frame._menu_button_bind_argv(socket="charter")
+        self.assertEqual(seen, [["tmux", "-L", "charter", "list-keys", "-T", "root"]])
+
+    def test_what_the_server_said_becomes_the_else_branch(self):
+        seen, patched = self._answering(_LINE_37C)
+        with patched:
+            argv = commands_frame._menu_button_bind_argv(socket="charter")
+        self.assertEqual(argv[-1], _cmd(_LINE_37C))
+        self.assertEqual(argv[3:6], ["bind-key", "-n", "MouseDown3Pane"])
+
+    def test_a_server_that_would_not_answer_binds_nothing(self):
+        """A wedged or gone server comes back as a return code (`tmuxctl.run` never
+        raises), and what is lost is the fix rather than the launch — every charter before
+        this one shipped with tmux's own binding in place."""
+        _seen, patched = self._answering("", code=1)
+        with patched:
+            self.assertIsNone(commands_frame._menu_button_bind_argv(socket="charter"))
+
+    def test_a_server_that_already_carries_the_wrap_binds_nothing(self):
+        """The second frame on a socket. Nothing to do is not a failure: the binding it
+        would install is already installed, by the frame that got there first."""
+        wrapped = ('bind-key  -T root MouseDown3Pane            if-shell -F -t = '
+                   '"#{@charter_panel}" { send-keys -M } { display-menu }')
+        _seen, patched = self._answering(wrapped)
+        with patched:
+            self.assertIsNone(commands_frame._menu_button_bind_argv(socket="charter"))
+
+    def test_the_environment_reaches_the_read(self):
+        """The launcher hands its own `_frame_env` to every tmux call it makes, and this
+        one is a read against the same server as the writes it is batched with."""
+        calls: list[dict] = []
+
+        def fake(action, argv, **kw):
+            calls.append(kw)
+            return subprocess.CompletedProcess(argv, 0, stdout=_LINE_37C, stderr="")
+
+        with mock.patch("charter.frame.tmuxctl.run", side_effect=fake):
+            commands_frame._menu_button_bind_argv(socket="charter", env={"A": "b"})
+        self.assertEqual([c.get("env") for c in calls], [{"A": "b"}])
+
+
+class TheKeyItself(unittest.TestCase):
+    """`tmuxctl.CLICK_MENU_KEY`, and where it may and may not appear."""
+
+    def test_the_key_is_the_one_tmux_calls_it(self):
+        self.assertEqual(tmuxctl.CLICK_MENU_KEY, "MouseDown3Pane")
+
+    def test_it_is_one_of_the_mouse_keys_a_component_may_not_claim(self):
+        """Reserved the moment charter started binding it — `tests/test_a_click_on_a_panel
+        _stays_where_it_points.py` holds the refusal itself; this is the membership the
+        refusal is built from."""
+        self.assertIn(tmuxctl.CLICK_MENU_KEY, tmuxctl.MOUSE_KEYS)
+
+    def test_it_is_not_a_line_in_the_config_file(self):
+        """The property that makes an unbalanced brace in an operator's own binding cost
+        one key instead of the frame. `conf_text`'s text is `source-file`d whole, and a
+        line that fails to parse there takes `mouse`, `history-limit` and the palette's own
+        hotkey with it."""
+        text = commands_frame.conf_text(hotkey="F2", mouse=True, history_limit=1,
+                                        session="fr-1")
+        self.assertNotIn(tmuxctl.CLICK_MENU_KEY, text)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()

--- a/tests/test_a_right_click_on_a_panel_stays_where_it_points.py
+++ b/tests/test_a_right_click_on_a_panel_stays_where_it_points.py
@@ -71,6 +71,8 @@ from unittest import mock
 from charter import commands_frame
 from charter.frame import tmuxctl
 
+from tests._tmuxsocket import OPERATOR_SOCKET
+
 #: One real `list-keys -T root` line off a real tmux 3.7c, its `display-menu` cut after the
 #: first two rows — the length is the one thing about it this file does not need, and the
 #: real-tmux half reads the whole thing off a real server rather than off a literal here.
@@ -225,9 +227,8 @@ class TheBindCharterBuilds(unittest.TestCase):
         """Charter talks to two servers and binds keys on exactly one of them
         (`tmuxctl.server_argv`). A socket PATH is the operator's own tmux, and this is the
         head that decides which one a `bind-key` lands on."""
-        argv = commands_frame._menu_button_argv(socket="/private/tmp/tmux-502/default",
-                                                default="x")
-        self.assertEqual(argv[:3], ["tmux", "-S", "/private/tmp/tmux-502/default"])
+        argv = commands_frame._menu_button_argv(socket=OPERATOR_SOCKET, default="x")
+        self.assertEqual(argv[:3], ["tmux", "-S", OPERATOR_SOCKET])
 
 
 class TheReadThatJoinsThem(unittest.TestCase):

--- a/tests/test_a_right_click_on_a_panel_stays_where_it_points.py
+++ b/tests/test_a_right_click_on_a_panel_stays_where_it_points.py
@@ -269,6 +269,18 @@ class TheReadThatJoinsThem(unittest.TestCase):
         with patched:
             self.assertIsNone(commands_frame._menu_button_bind_argv(socket="charter"))
 
+    def test_the_return_code_decides_and_not_the_bytes(self):
+        """**A non-zero return means charter did not read this table**, whatever came out
+        of it — the rule `tmuxctl.run`'s own docstring states for every other caller, said
+        here because this is the one place a half-answer would be *plausible*. A timeout
+        after partial output, or a `DECODE_ERRORS` replacement that made a line parse
+        anyway, would otherwise be wrapped into a `bind-key` built from a listing tmux
+        never finished printing.
+        """
+        _seen, patched = self._answering(_LINE_37C, code=1)
+        with patched:
+            self.assertIsNone(commands_frame._menu_button_bind_argv(socket="charter"))
+
     def test_a_server_that_already_carries_the_wrap_binds_nothing(self):
         """The second frame on a socket. Nothing to do is not a failure: the binding it
         would install is already installed, by the frame that got there first."""

--- a/tests/test_a_right_click_on_a_tab_acts_on_that_tab.py
+++ b/tests/test_a_right_click_on_a_tab_acts_on_that_tab.py
@@ -12,7 +12,13 @@ release, pane-relative, and no `bind -n` fires at all. With `mouse on`, tmux's *
 `MouseDown3Pane` tests `#{mouse_any_flag}`, which is 1 precisely because this pane asked
 for reporting, so it takes the `send-keys -M` branch and tmux's own menu never appears. A
 custom `bind -n MouseDown3Pane` that omitted `send -M` is the one thing that would swallow
-the press, so charter binds nothing.
+the press, so nothing here needed a bind to work.
+
+What that branch also does is `select-pane -t =` first, which took the keyboard off the
+harness on every right-click — #634's defect one button over, closed since by #848 with a
+binding that keeps the `send-keys -M` this file depends on and adds nothing to it. It is
+issued as its own `bind-key` argv (`commands_frame._menu_button_bind_argv`), never as a
+line in the config text, which is what the case below still asserts.
 
 **And exactly two palette rows are about a specific tab** — `chat: previous transcript`
 and `chat: close`. Everything else charter offers is about the frame (detach, the
@@ -596,18 +602,20 @@ class AnEmulatorThatEatsButtonTwoCostsNothing(_ABarThatWasDrawn, unittest.TestCa
                          (overlay.CLICK,))
         self.assertEqual(overlay.MOUSE_ON, "\x1b[?1006h\x1b[?1000h")
 
-    def test_charter_binds_no_mouse_key_for_the_menu_button(self):
-        """**Binding is what would break this, not what enables it.** tmux's own default
+    def test_the_menu_button_is_never_a_line_in_the_config_text(self):
+        """**A bind is what would break this, not what enables it.** tmux's own default
         `MouseDown3Pane` takes its `send -M` branch because `#{mouse_any_flag}` is 1 for a
         pane that asked for reporting; a custom `bind -n MouseDown3Pane` that omitted
-        `send -M` would swallow the press instead. charter's config text names no button-2
-        or button-3 key at all, and this is what would notice if one appeared.
+        `send -M` would swallow the press instead.
 
-        **The cost of binding nothing is measured and is not nothing** — tmux's forwarding
-        branch is `{ select-pane -t = ; send-keys -M }`, so with `[frame] mouse = true` a
-        right-click on a panel takes the keyboard before the byte arrives. That is #634 one
-        button over, it is pre-existing, and `frame/builtins._MENU_BUTTON` records why
-        closing it is a change of its own rather than a line in this one."""
+        **#848 added one, and the config text still names no button-2 or button-3 key** —
+        which is not an accident this case now tolerates but the property it now pins. That
+        bind wraps whatever the server already had, so it carries a page of tmux's own
+        `display-menu` as an argument; written into the text `source-file` parses, one
+        unbalanced brace in an operator's own binding would take `mouse`, `history-limit`
+        and the palette's hotkey down with it. It is issued as its own `bind-key` argv
+        instead (`commands_frame._menu_button_argv`), and this is what would notice a line
+        for it appearing here."""
         from charter import commands_frame
         text = commands_frame.conf_text(hotkey="F2", mouse=True, history_limit=2000,
                                         session=self.FID)

--- a/tests/test_frame_input_reaches_a_component.py
+++ b/tests/test_frame_input_reaches_a_component.py
@@ -740,9 +740,18 @@ class APointerWithTmuxsOwnMouseOn(_AFrameWithProviderPanels):
     those, measured on 3.7c and at the 3.2 floor — it takes away clicking back to any pane
     at all, the harness included, which is worse than the focus steal it fixes.
 
+    **The RIGHT button is the same defect and not the same fix** (#848). tmux's default
+    for `MouseDown3Pane` selects the pane before forwarding too, but its other branch is a
+    page-long `display-menu` that differs between the versions charter supports, so
+    charter cannot write it out — it reads the server's own binding back and re-emits it
+    as the else-branch (`_menu_button_bind_argv`). The last case in this class is the one
+    that tells the wrap apart from #634's shape applied to this button: a right-click on
+    the operator's own pane must still open **tmux's pane menu**, which the shape that
+    works for button 1 silently deletes.
+
     Nothing here is stubbed and nothing is set up by the test that the launcher does not
-    set up: the config is `conf_text`'s own text and the mark is `_panel_mark_argv`'s own
-    argv.
+    set up: the config is `conf_text`'s own text, the mark is `_panel_mark_argv`'s own
+    argv, and the menu button's bind is the launcher's own `_menu_button_bind_argv`.
     """
 
     #: The only difference from the fixture above, and the setting the whole class is about.
@@ -758,10 +767,64 @@ class APointerWithTmuxsOwnMouseOn(_AFrameWithProviderPanels):
                   "-P", "-F", "#{pane_id}", "--", "cat", env=self.env)
         self.assertEqual(r.returncode, 0, r.stderr)
         self.operator_pane = r.stdout.strip()
+        # What this server had for the menu button BEFORE charter touched it — read here
+        # rather than reconstructed, because it is what the wrap has to carry through
+        # unchanged and no literal charter could hold is right on every supported tmux.
+        self.menu_default = commands_frame._menu_button_default(
+            _tmux("list-keys", "-T", "root", env=self.env).stdout)
+        self.assertIsNotNone(self.menu_default,
+                             "this tmux binds nothing to the menu button, so there is no "
+                             "steal here to fix and nothing below is measured")
+        # The launcher's own call, made the way the launcher makes it (#547). A test that
+        # spelled the `bind-key` itself would be measuring its own copy of charter's
+        # answer, and the whole claim of #848 is *which* binding charter installs.
+        wrap = commands_frame._menu_button_bind_argv(socket=SOCKET, env=self.env)
+        self.assertIsNotNone(wrap, "charter read the table and found nothing to wrap")
+        bound = subprocess.run(wrap, capture_output=True, text=True, env=self.env)
+        self.assertEqual(bound.returncode, 0, bound.stderr)
         self._select(self.harness)
 
     def _pointed(self) -> str:
         return self._shown(POINT_CID)
+
+    def _menu_bind(self) -> str:
+        """The menu button's binding as this server now reads it back."""
+        listing = _tmux("list-keys", "-T", "root", env=self.env).stdout
+        return next(ln for ln in listing.split("\n")
+                    if f"-T root {tmuxctl.CLICK_MENU_KEY} " in ln)
+
+    def _press_right(self, pane: str, *, row: int = 0, col: int = 1) -> None:
+        """A right PRESS with no release — SGR button 2, which is what a real right-click
+        puts on the wire (`overlay._SGR_BUTTONS` maps 2 to `right`).
+
+        The release is deliberately not sent: tmux's own pane menu is modal, so a release
+        arriving after it opened would be delivered to the MENU rather than to the pane,
+        and the cases below would be measuring the menu's own key handling.
+        """
+        self._point(pane, row=row, col=col, button=2, release=False)
+
+    def _menu_opened(self) -> bool:
+        """Did tmux's own pane menu open on the client?
+
+        **Asked with a keypress, because a menu is not a pane.** `display-menu` draws on
+        the CLIENT — there is nothing for `capture-pane` to capture and no pane id for
+        `list-panes` to report — so the only observable is that the menu's own keys work.
+        `h` is `Horizontal Split` on tmux 3.7c and on the 3.2 floor alike, and a window
+        that grew a pane after one `h` had a menu open to receive it. Any pane it made is
+        killed again, so a case can ask this without changing the frame the next one runs
+        against.
+        """
+        before = set(self._panes())
+        self._inject(b"h")
+        grew = _await(lambda: set(self._panes()) - before, 6.0)
+        for extra in set(self._panes()) - before:
+            _tmux("kill-pane", "-t", extra, env=self.env)
+        self._inject(b"\x1b")
+        return bool(grew)
+
+    def _panes(self) -> list[str]:
+        return _tmux("list-panes", "-t", self.fid, "-F", "#{pane_id}",
+                     env=self.env).stdout.split()
 
     def test_tmuxs_own_mouse_really_is_on(self):
         """Without this every case below could be passing because tmux is ignoring the
@@ -848,6 +911,85 @@ class APointerWithTmuxsOwnMouseOn(_AFrameWithProviderPanels):
                         f"the wheel never reached it: {self._pointed()!r}")
         self.assertEqual(self._active(), self.harness,
                          "the wheel moved the keyboard")
+
+    # -- the right button (#848) -------------------------------------------- #
+
+    def test_the_menu_button_is_wrapped_and_not_replaced(self):
+        """What is actually in the root table, read back off the running server.
+
+        Both halves, because either alone is satisfied by a binding that is wrong:
+        charter's own condition must be in it (or nothing changed) **and** tmux's own
+        default must still be in it (or the pane menu was deleted, which is the trade #848
+        refused).
+
+        **Asked by token rather than byte for byte, and that is measured rather than
+        lax.** tmux re-quotes a command when it prints it back: on 3.7c the wrapped line
+        reads out as `{ … }` blocks, the same length it went in as, while a real 3.2
+        re-emits the same binding as backslash-escaped `"…"` — 1378 characters in, 1632
+        out. So the assertion is that the parts of tmux's own default that cannot be
+        re-quoted are all still there, and that the line did not get SHORTER, which is
+        what a trimmed else-branch would look like.
+        """
+        line = self._menu_bind()
+        self.assertIn(commands_frame._PANEL_OPTION, line)
+        for token in ("display-menu", "mouse_any_flag", "Horizontal Split", "Kill"):
+            with self.subTest(token=token):
+                self.assertIn(token, line,
+                              f"the wrap dropped {token!r} out of tmux's own binding")
+        self.assertGreater(len(line), len(self.menu_default),
+                           "the binding is shorter than the one it was built from, so "
+                           "something in tmux's own default was trimmed away")
+
+    def test_a_right_click_still_reaches_the_component_whose_pane_it_landed_on(self):
+        """Delivery first, as for the left button: a keyboard that did not move because
+        nothing arrived is not the property being claimed. `right` is the name
+        `overlay._SGR_BUTTONS` gives button 2, and it is the name #846's own chat-tab menu
+        is opened by."""
+        self._select(self.harness)
+        self._press_right(self.pane[POINT_CID], col=2)
+        self.assertTrue(_await(lambda: "POINT-click:right" in self._pointed()),
+                        f"a right press never reached it: {self._pointed()!r}")
+
+    def test_a_right_click_on_a_panel_does_not_move_the_keyboard(self):
+        """#848 itself. Before the wrap this assertion read `active pane: THE PANEL` on
+        3.7c and at the 3.2 floor identically, because tmux's default takes its forwarding
+        branch — `#{mouse_any_flag}` is 1 for this panel precisely because its component
+        declared `click` — and that branch is `select-pane -t = ; send-keys -M`."""
+        self._select(self.harness)
+        self._press_right(self.pane[POINT_CID], col=2)
+        self.assertTrue(_await(lambda: "POINT-click:right" in self._pointed()),
+                        "the press never arrived, so this proves nothing about focus")
+        self.assertEqual(self._active(), self.harness,
+                         "a right click on a panel took the keyboard off the harness")
+
+    def test_a_right_click_on_a_pane_the_operator_split_still_opens_tmuxs_menu(self):
+        """**The case that tells this fix apart from #634's shape applied to this button,
+        and the whole reason the else-branch is sourced rather than written.**
+
+        `select-pane -t =; send-keys -M` is tmux's WHOLE default for `MouseDown1Pane` and
+        only the forwarding HALF of its default for `MouseDown3Pane`. Written out here it
+        passes every case above and deletes tmux's own pane menu — Copy Line, Paste,
+        Horizontal Split, Kill, Zoom — from every pane charter did not create, inside
+        charter's own window. Measured on 3.7c and at the 3.2 floor: that shape leaves the
+        keyboard ON the operator's pane and opens nothing at all.
+        """
+        self._select(self.harness)
+        self._press_right(self.operator_pane)
+        self.assertTrue(self._menu_opened(),
+                        "a right click on a pane the operator split themselves no longer "
+                        "opens tmux's own pane menu — charter deleted a documented tmux "
+                        "affordance from a pane it has nothing to do with")
+
+    def test_the_menu_button_moves_nothing_when_it_opens_the_menu(self):
+        """tmux's own menu is drawn for the client and does not select the pane under it —
+        the branch that selects is the one that FORWARDS, and the operator's pane is not
+        asking for reports. So the keyboard is still on the harness while the menu is up,
+        which is what makes `Kill`/`Zoom` in it act on the pane that was pointed at rather
+        than on the one that was typed into."""
+        self._select(self.harness)
+        self._press_right(self.operator_pane)
+        self.assertEqual(self._active(), self.harness)
+        self._inject(b"\x1b")
 
 
 class APointerPastColumnTwoTwentyThreeLandsWhereItWasAimed(_AFrameWithProviderPanels):

--- a/tests/test_frame_launcher.py
+++ b/tests/test_frame_launcher.py
@@ -1808,6 +1808,13 @@ class _FakeTmux:
             # The one READ in the launcher's admin sequence whose answer another command
             # is built out of (#848) — see `_menu_button_bind_argv`. It cannot join the
             # batch below it for exactly that reason.
+            #
+            # **The stdout is the same whatever `keys_rc` says, deliberately.** A failing
+            # tmux usually prints nothing, but a timeout after partial output and a
+            # `tmuxctl.DECODE_ERRORS` replacement both leave readable bytes behind a
+            # non-zero code — so the claim under test is charter reading the RETURN CODE
+            # rather than the bytes, and a fake that emptied stdout here would make that
+            # claim unpinnable.
             return subprocess.CompletedProcess(cmd, self.keys_rc, stdout=self.root_keys,
                                                stderr="" if self.keys_rc == 0
                                                else "no server running")
@@ -2795,7 +2802,11 @@ class Launch(PersonaIso, unittest.TestCase):
     def test_a_read_that_fails_costs_the_bind_and_not_the_launch(self):
         """What is lost is the fix; what is left is what every charter before #848
         shipped. `tmuxctl.run` names the failed read itself, so this asserts the launch
-        continued rather than that it was silent about it."""
+        continued rather than that it was silent about it.
+
+        The fake still prints a readable table behind the non-zero code (see its
+        `list-keys` branch), so what this pins is that charter reads the RETURN CODE and
+        not the bytes."""
         fake = _FakeTmux(exit_code=0, keys_rc=1)
         self.assertEqual(_launch(fake), 0)
         self.assertEqual([c for c in fake.calls if "bind-key" in c], [])

--- a/tests/test_frame_launcher.py
+++ b/tests/test_frame_launcher.py
@@ -406,6 +406,18 @@ class Conf(unittest.TestCase):
 #: than today's five moves this with it instead of quietly leaving those cases short.
 _EVERY_CHROME_OPTION = max(floor for _n, _v, floor in commands_frame._CHROME)
 
+#: What `_FakeTmux` answers `list-keys -T root` with — tmux 3.7c's own `MouseDown3Pane`
+#: line, verbatim through the `select-pane` that is #848's defect and cut short of the
+#: page-long `display-menu` this suite has no use for. The launcher reads this and builds
+#: its wrap out of it (`commands_frame._menu_button_bind_argv`); a fake that answered with
+#: nothing would make every launch here take the "nothing to wrap" branch and no case
+#: below could tell the ordinary path from it.
+_ROOT_KEYS = (
+    "bind-key  -T root MouseDown1Pane            select-pane -t = \\; send-keys -M\n"
+    'bind-key  -T root MouseDown3Pane            if-shell -F -t = "#{||:'
+    '#{mouse_any_flag},#{pane_in_mode}}" { select-pane -t = ; send-keys -M } '
+    '{ display-menu -T "#{pane_index}" -t = -x M -y M Kill X { kill-pane } }\n')
+
 
 class Chrome(unittest.TestCase):
     """The frame's own pane-border settings (#514) — the builder alone; the launch paths
@@ -1511,6 +1523,7 @@ class _FakeTmux:
                 resize_hook_rc=0,
                 capture_rc=0,
                 respawn_hook_rc=0, chat_option_rc=0, plane_option_rc=0,
+                root_keys=None, keys_rc=0, menu_bind_rc=0,
                 resize_hook_stderr="bad resize hook target"):
         self.pane_id = pane_id
         self.exit_code = exit_code
@@ -1567,6 +1580,17 @@ class _FakeTmux:
         self.respawn_hook_rc = respawn_hook_rc
         self.chat_option_rc = chat_option_rc
         self.plane_option_rc = plane_option_rc
+        #: What `list-keys -T root` answers — the read #848's menu-button bind is built
+        #: out of. Defaults to tmux's own `MouseDown3Pane` line, cut short of its
+        #: page-long `display-menu`, so an ordinary launch here wraps something the way an
+        #: ordinary launch on a real server does. `""` is the server that binds nothing,
+        #: and a line already carrying `_PANEL_OPTION` is the second frame on a socket.
+        self.root_keys = _ROOT_KEYS if root_keys is None else root_keys
+        #: The read's own return code, and the bind's — separate knobs, because a server
+        #: that will not say what it has bound and one that refuses the bind are two
+        #: different degrades and each is warned about differently.
+        self.keys_rc = keys_rc
+        self.menu_bind_rc = menu_bind_rc
         #: Every value the launcher wrote to `@charter_plane`, in order — a list rather
         #: than a flag because "written once, by the launch that made the session" is a
         #: COUNT, and the case that would have caught a second write is a launch that
@@ -1780,6 +1804,20 @@ class _FakeTmux:
             if self.fid and self.still_live:
                 live.add(self.fid)
             return subprocess.CompletedProcess(cmd, 0, stdout="\n".join(live), stderr="")
+        if "list-keys" in cmd:
+            # The one READ in the launcher's admin sequence whose answer another command
+            # is built out of (#848) — see `_menu_button_bind_argv`. It cannot join the
+            # batch below it for exactly that reason.
+            return subprocess.CompletedProcess(cmd, self.keys_rc, stdout=self.root_keys,
+                                               stderr="" if self.keys_rc == 0
+                                               else "no server running")
+        if "bind-key" in cmd:
+            # And the write it produces. The only top-level `bind-key` the launcher makes:
+            # `conf_text`'s two mouse binds and the palette's hotkey travel inside the
+            # config file, and the hatch is a `set-option`.
+            return subprocess.CompletedProcess(cmd, self.menu_bind_rc, stdout="",
+                                               stderr="" if self.menu_bind_rc == 0
+                                               else "unknown key: MouseDown3Pane")
         raise AssertionError(f"unexpected tmux command in test: {cmd}")
 
     def _panes(self, harness: str) -> str:
@@ -2704,6 +2742,75 @@ class Launch(PersonaIso, unittest.TestCase):
         fake = _FakeTmux(exit_code=0)
         _launch(fake)
         self.assertNotIn("frame-toggle", fake.sourced_conf_text)
+
+    def test_the_menu_button_is_bound_out_of_what_the_server_already_had(self):
+        """#848, at the launcher. `conf_text` cannot carry this bind — it is built out of
+        a `list-keys` READ — so the launch is the only place the read and the write meet,
+        and a launcher that stopped making the read would leave every unit test in
+        `tests/test_a_right_click_on_a_panel_stays_where_it_points.py` green while no
+        frame anywhere had the binding."""
+        fake = _FakeTmux(exit_code=0)
+        _launch(fake)
+        bind = [c for c in fake.calls if "bind-key" in c]
+        self.assertEqual(len(bind), 1, "the menu button was not bound exactly once")
+        self.assertEqual(bind[0][3:11],
+                         ["bind-key", "-n", "MouseDown3Pane", "if-shell", "-F", "-t",
+                          "=", "#{@charter_panel}"])
+        self.assertEqual(bind[0][-2], "send-keys -M")
+        self.assertIn("display-menu", bind[0][-1],
+                      "the else-branch is not the binding this server already had")
+        # And NOT duplicated into the text file `source-file` loads, which is what keeps
+        # an operator's own binding out of a parse that would take `mouse`,
+        # `history-limit` and the palette's hotkey down with it.
+        self.assertNotIn("MouseDown3Pane", fake.sourced_conf_text or "")
+
+    def test_the_binding_is_read_before_it_is_written(self):
+        """Otherwise charter would read back its OWN wrap and nest another copy of a
+        page-long `display-menu` inside it on every launch."""
+        fake = _FakeTmux(exit_code=0)
+        _launch(fake)
+        read = next(i for i, c in enumerate(fake.calls) if "list-keys" in c)
+        wrote = next(i for i, c in enumerate(fake.calls) if "bind-key" in c)
+        self.assertLess(read, wrote)
+
+    def test_a_second_frame_on_the_socket_binds_nothing_again(self):
+        """The ordinary case after the first launch, since a root key table is
+        server-wide: the server answers with charter's own wrap, and there is nothing to
+        do. Silent rather than warned about — the binding this launch would have
+        installed is already installed."""
+        fake = _FakeTmux(exit_code=0, root_keys=(
+            'bind-key  -T root MouseDown3Pane            if-shell -F -t = '
+            '"#{@charter_panel}" { send-keys -M } { display-menu -T x }\n'))
+        _launch(fake)
+        self.assertEqual([c for c in fake.calls if "bind-key" in c], [])
+
+    def test_a_server_that_binds_the_key_to_nothing_is_left_alone(self):
+        """`unbind -n MouseDown3Pane` is a thing an operator can have written, and a key
+        that does nothing runs no `select-pane`: there is no steal to fix, and charter
+        putting a binding back would be charter undoing their config."""
+        fake = _FakeTmux(exit_code=0, root_keys="bind-key  -T root WheelUpPane  send -M\n")
+        _launch(fake)
+        self.assertEqual([c for c in fake.calls if "bind-key" in c], [])
+
+    def test_a_read_that_fails_costs_the_bind_and_not_the_launch(self):
+        """What is lost is the fix; what is left is what every charter before #848
+        shipped. `tmuxctl.run` names the failed read itself, so this asserts the launch
+        continued rather than that it was silent about it."""
+        fake = _FakeTmux(exit_code=0, keys_rc=1)
+        self.assertEqual(_launch(fake), 0)
+        self.assertEqual([c for c in fake.calls if "bind-key" in c], [])
+        self.assertTrue(any("source-file" in c for c in fake.calls),
+                        "a failed read took the rest of the launch with it")
+
+    def test_a_refused_bind_is_warned_about_and_the_launch_goes_on(self):
+        """One key, and a sentence naming what it cost. The frame still comes up: the
+        alternative is refusing a launch over a right-click."""
+        fake = _FakeTmux(exit_code=0, menu_bind_rc=1)
+        with mock.patch("charter.util.warn") as warned:
+            self.assertEqual(_launch(fake), 0)
+        said = " ".join(str(c) for c in warned.call_args_list)
+        self.assertIn("right-click", said)
+        self.assertIn("keyboard", said)
 
     def test_both_hooks_are_installed_as_their_own_commands(self):
         """Companion to the `source-file` test: neither hook is missing from BOTH

--- a/tests/test_the_end_of_a_name_is_the_end_of_the_string.py
+++ b/tests/test_the_end_of_a_name_is_the_end_of_the_string.py
@@ -244,6 +244,10 @@ DETECTORS: dict[str, str] = {
 LINE_SCANNERS: dict[str, str] = {
     "report._ATX_HEADING": "asked of `lines[0].strip()` — there is no newline left to match",
     "hooks._INDEX_LINE_RE": "asked of `.splitlines()` output — no trailing newline",
+    "commands_frame._MENU_BIND_RE":
+        "asked of one line of `list-keys -T root` at a time, off `.split(\"\\n\")` — no "
+        "trailing newline is left, and the `\\s*$` before the end absorbs a `\\r` from a "
+        "tmux whose output crossed a pty rather than leaving it in the bind text",
 }
 
 #: **Substitutions** — anchored patterns that never render a VERDICT. `.sub` asks where a


### PR DESCRIPTION
Closes #848

#634 stopped a LEFT click on a panel moving the keyboard off the harness. A right click still did, and #846 made right-clicking something operators will do.

## What was measured, before anything was written

The issue asked for three things to be established before an approach was chosen. All three were measured on a real tmux 3.7c and a real tmux 3.2 built from the release tarball (`tmuxctl.FLOOR`), with a real client on a real pty and SGR button-2 reports injected as a reporting terminal sends them.

**1. What the else-branch must be.** tmux's own default, and it cannot be written out. It is 1849 characters of `{}` command blocks on 3.7c against **1378 different characters** of backslash-escaped `"…"` on 3.2 — the 3.7c menu carries `#{mouse_hyperlink}` and `#{pane_floating_flag}` rows the floor has never heard of, and the quoting is not even the same style. No literal charter could hold is right on both machines.

**2. Whether it can be sourced.** Yes — but **not with `list-keys -T root MouseDown3Pane`**. Asking `list-keys` for one key by name prints the binding on 3.2 and prints **nothing at all, at rc 0**, on 3.7c. So charter lists the whole root table and picks the line out of it. And what sourcing costs when the operator rebound the key themselves is *nothing*: their binding becomes the else-branch verbatim, which a hard-coded one could not have promised at all.

**3. Whether `M-MouseDown3Pane` makes (1) unnecessary.** No. That option is "the same conditional as `MouseDown1Pane`'s", and it was run:

```
bind                      right-click a panel   right-click harness  right-click own split
tmux's own default        delivered, MOVED      untouched            tmux's pane menu
`MouseDown1Pane`'s shape  delivered, unchanged  untouched            MOVED, and NO MENU
this one (the wrap)       delivered, unchanged  untouched            tmux's pane menu
```

Identical on both versions. The middle row is the strictly worse trade the issue predicted: `select-pane -t =; send-keys -M` is tmux's *whole* default for button 1 and only the *forwarding half* of its default for button 3, so writing it out deletes tmux's pane menu — Copy Line, Paste, Horizontal Split, Kill, Zoom — from the harness and from every pane the operator split themselves, inside charter's own window, to fix a focus steal one click puts right.

## What charter does

`_menu_button_bind_argv` reads `list-keys -T root` at launch and re-emits what it found with charter's own panel test in front of it:

```
bind-key -n MouseDown3Pane if-shell -F -t = '#{@charter_panel}' 'send-keys -M' '<whatever was there>'
```

**As an argv, never as `conf_text` text.** The else-branch is a page of tmux's own config language; written into the file `source-file` parses it would face a second round of quoting, and one unbalanced brace in a binding charter did not write would take `mouse`, `history-limit` and the palette's `F2` down with it. As a separate argv element nothing re-lexes it — the same reason both `pane-died` hooks are their own commands.

Three `None`s, all benign and all pinned: the key is unbound (no `select-pane`, so no steal to fix), charter already wrapped it (every launch after the first on a shared socket — re-wrapping would nest another copy of the menu per launch), or the read failed (what is left is what every charter before this shipped).

`MouseDown3Pane` joins `tmuxctl.MOUSE_KEYS`, so a component may not claim it — sharper here than for the other two, because that bind carries the operator's own pane menu as its else-branch.

## Tests

The issue's own reproduction gets the third line it was written without: `test_a_right_press_on_the_heading_opens_nothing` now asserts the keyboard stayed on the harness. Without the wrap it reads `%2` for `%0`.

Both counterfactuals were run against the real-tmux half rather than argued about:

* charter binding nothing — the keyboard lands on the panel (`%4` for `%0`);
* `MouseDown1Pane`'s shape on button 3 — the operator's own pane opens nothing at all and takes the keyboard instead.

23 unit cases over the parse, the argv and the read (both versions' `list-keys` spellings, the operator's `-r`, a `-T copy-mode` binding, `M-MouseDown3Pane`, the re-wrap guard, and that the *return code* decides rather than the bytes); 5 real-tmux cases beside #634's; 6 launcher cases over the call site and its three degrades.

`test_a_frame_sends_one_invocation_per_batch` goes 15 → 16 up to the attach. The sixteenth is a READ whose answer a later WRITE is built out of, which is the one shape #780's batching cannot fold away; the bind itself rides in the batch that already `source-file`s the config.

Recorded where the issue asked: `frame/builtins._MENU_BUTTON`, `docs/frame.md` (two new rows in the mouse table), and a news entry.

Full suite: 10845 tests, OK, 9 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Us4MbwkSCJCxwt1CjAd1sf
