### PR TITLE
A clone inside a workspace carries every harness's in-repo surface, not Claude Code's (#868)

### DIFF
--- a/charter/doctor.py
+++ b/charter/doctor.py
@@ -941,10 +941,14 @@ def check_session_layer() -> Result:
     one charter has never measured says exactly that rather than borrowing an answer.
 
     **A fact, never a verdict.** `check_session_root`'s discipline, for its reason: a chat
-    rooted in a clone reaches none of this and that is the designed workflow — charter
-    deliberately writes nothing inside `workspaces/<ws>/<repo>/` — so a row that warned
-    there is a row operators learn to skip, the cry-wolf failure `check_memory_indexes`
-    and `check_harness` each record. Whatever is genuinely missing AND fixable warns on
+    can be rooted in a directory that reaches none of this and be exactly where it belongs
+    — a clone charter has not wired yet, or one whose harness charter declares no layer
+    parts for — so a row that warned there is a row operators learn to skip, the cry-wolf
+    failure `check_memory_indexes` and `check_harness` each record. (This used to say
+    charter writes nothing inside `workspaces/<ws>/<repo>/`. It does now: #870 writes the
+    layer there and #868 made what it carries every harness's own. The argument is
+    unchanged — the row reports what a session would find, and it is `workspace layer` that
+    warns when what charter wrote has gone stale or vanished.) Whatever is genuinely missing AND fixable warns on
     its own row, where it can name its own remedy: `workspace layer` for a generated file
     that has gone stale or vanished, `plane-root guard` for the guard.
 

--- a/charter/harness/base.py
+++ b/charter/harness/base.py
@@ -209,15 +209,29 @@ class Harness:
     #: in-repo paths does a nested checkout stop seeing. A harness may declare this without
     #: declaring a rule it has not measured.
     #:
-    #: Directories and single files both, because harnesses spell it both ways — Claude
-    #: Code's ``.claude/agents`` is a tree and opencode's ``opencode.json`` is one file at
-    #: the root — and the mirror reads whichever it finds.
+    #: Directories and single files both. Every shipped harness spells this as a
+    #: directory today, and the mirror still reads a plain file first, because half the
+    #: in-repo surfaces charter has measured ARE single files at a repository root
+    #: (opencode's ``opencode.json``, Codex's ignored ``.codex/config.toml``). The whole
+    #: point of the member is that a harness charter has not met declares its own spelling,
+    #: and a mirror that answered "nothing" for a file would be silently wrong for the next
+    #: one — `rglob` on a file yields nothing at all.
     #:
-    #: A path here is a claim that the plane's copy is safe to place in a repo charter does
-    #: not own. Project INSTRUCTIONS are the line: ``CLAUDE.md`` and any equivalent are
-    #: deliberately absent, because dropping the plane's instructions into somebody else's
-    #: repo, to be read there as that repo's, is a claim of a different size from mirroring
-    #: a settings key. A guest hides its own files; it does not narrate the host's.
+    #: **A path here is a claim that the plane's copy is safe to place in a repository
+    #: charter does not own**, and two kinds of thing are deliberately not:
+    #:
+    #: * **Grants.** Charter mirrors CAPABILITY — agents, skills, commands — never
+    #:   permission. `charter guard` writes this plane's rules into a harness's own config
+    #:   file, so mirroring that file would put an ``allow`` in force in a repository
+    #:   nobody granted it in. :data:`claude_code.WORKSPACE_KEYS` already refuses exactly
+    #:   this for Claude Code, and this mechanism writing into the same directory must not
+    #:   answer it two opposite ways for two harnesses. Where a harness's config file mixes
+    #:   the two, a mirror is the wrong instrument — it cannot drop a key — and
+    #:   :meth:`workspace_files` is the one that can.
+    #: * **Project instructions.** ``CLAUDE.md`` and any equivalent: dropping the plane's
+    #:   instructions into somebody else's repo, to be read there as that repo's, is a
+    #:   claim of a different size from mirroring a settings key. A guest hides its own
+    #:   files; it does not narrate the host's.
     inherited_paths: tuple[str, ...] = ()
 
     #: The value this harness puts in ``$CHARTER_HARNESS``. Its identity everywhere.

--- a/charter/harness/base.py
+++ b/charter/harness/base.py
@@ -22,6 +22,12 @@ documented. Written in `doctor` they would be exactly the hardcoded literal per 
 this file exists to stop: a harness added to ``KINDS`` would silently be reported under
 Claude Code's discovery rules, which is the "verified a proxy instead of the fact"
 failure #168, #177, #261 and #851 are each an instance of.
+
+:attr:`Harness.inherited_paths` is the eighth and the same argument again, one verb over:
+`workspace.py` held two Claude Code paths as a literal and mirrored them into every guest
+checkout, so an operator on opencode or Codex got a workspace with none of the plane's
+agents or skills (#868). Reporting a harness under another's rules and *writing* another
+harness's files are the same mistake; only the second one lands on disk.
 """
 
 from __future__ import annotations
@@ -179,6 +185,40 @@ class Harness:
     #: answers yes to the first and no to the second (#859). A harness charter has not
     #: measured says nothing, which is not a claim that it has no gate.
     trust_gate: str = ""
+
+    #: The paths, relative to a REPOSITORY ROOT, that this harness reads for a session
+    #: anywhere inside that repository — and which a checkout with a git root of its own
+    #: therefore cuts off from the plane's copies.
+    #:
+    #: This is what `workspace._inherited_files` mirrors into a guest checkout at
+    #: ``workspaces/<ws>/<repo>/``. It names the PLANE's own directories in this harness's
+    #: spelling, which is why it has to live here: charter has to know the names to find
+    #: them on disk, and a list of them in `workspace.py` is a list every new harness makes
+    #: wrong — the hardcoded-literal-per-harness failure `registry.py` exists to end. Until
+    #: #868 that list was exactly two Claude Code paths, and an operator on opencode or
+    #: Codex got a workspace with none of the plane's agents or skills.
+    #:
+    #: **A separate member from :attr:`layer`, and the reason is what each can be measured
+    #: to say.** `layer` answers *"would a session started HERE find it, by which discovery
+    #: rule"*, and :class:`LayerPart` has exactly two measured rules — cwd-only, and walk
+    #: up to the git root. opencode resolves ``opencode.json`` at the repository ROOT,
+    #: which is neither; declaring it as a walking part would report a layer as reachable
+    #: from an intermediate directory that opencode never reads there, and `part_reaches`
+    #: says over-claiming is the one direction that row must never be wrong in. The
+    #: question here is narrower and IS answered for all three: which of the plane's
+    #: in-repo paths does a nested checkout stop seeing. A harness may declare this without
+    #: declaring a rule it has not measured.
+    #:
+    #: Directories and single files both, because harnesses spell it both ways — Claude
+    #: Code's ``.claude/agents`` is a tree and opencode's ``opencode.json`` is one file at
+    #: the root — and the mirror reads whichever it finds.
+    #:
+    #: A path here is a claim that the plane's copy is safe to place in a repo charter does
+    #: not own. Project INSTRUCTIONS are the line: ``CLAUDE.md`` and any equivalent are
+    #: deliberately absent, because dropping the plane's instructions into somebody else's
+    #: repo, to be read there as that repo's, is a claim of a different size from mirroring
+    #: a settings key. A guest hides its own files; it does not narrate the host's.
+    inherited_paths: tuple[str, ...] = ()
 
     #: The value this harness puts in ``$CHARTER_HARNESS``. Its identity everywhere.
     name: str = ""

--- a/charter/harness/claude_code.py
+++ b/charter/harness/claude_code.py
@@ -80,10 +80,29 @@ LAYER = (
 )
 
 
+#: The plane-root paths a checkout of its own cuts a Claude Code session off from.
+#:
+#: The same two directories :data:`LAYER`'s walking part is about, said for a different
+#: purpose: that part answers whether a session HERE finds them, this one is the spelling
+#: charter mirrors into `workspaces/<ws>/<repo>/`. Not derived from `LAYER` because the two
+#: only coincide for this harness — opencode's in-repo surface is resolved by a rule
+#: `LayerPart` cannot express, so deriving one from the other would have kept opencode's
+#: paths out of a clone for as long as its discovery rule went unmeasured.
+#:
+#: **`.claude/settings.json` is deliberately not here**, and neither is `CLAUDE.md`.
+#: Settings arrive by :meth:`ClaudeCodeHarness.workspace_files`, which every checkout gets
+#: through `_harness_files`; listing it here as well would mirror the plane's file over the
+#: generated one. `CLAUDE.md` is the project-instructions line `Harness.inherited_paths`
+#: draws — it walks up on the same rule as the two below and is left behind on purpose.
+WALKUP_DIRS = (".claude/agents", ".claude/skills")
+
+
 class ClaudeCodeHarness(Harness):
     name = NAME
 
     layer = LAYER
+
+    inherited_paths = WALKUP_DIRS
 
     #: Measured, and the reason `doctor` names a condition rather than a verdict (#859).
     #: The gate is on the DIRECTORY and is global — it takes no argument saying which

--- a/charter/harness/codex.py
+++ b/charter/harness/codex.py
@@ -182,7 +182,20 @@ class CodexHarness(Harness):
         "charter writes no in-repo layer for Codex — it arrives from "
         "`~/.codex/config.toml` and the plugin, and a project `.codex/config.toml` is "
         "ignored. Codex DOES read an in-repo `.codex/skills/` (measured, 0.147.0); "
-        "charter writes nothing there")
+        "charter mirrors the plane's copy of that into a workspace's checkouts and "
+        "writes nothing here")
+
+    #: What a checkout inside a workspace stops seeing, in Codex's spelling (#868).
+    #:
+    #: One entry and not two, and the missing one is the point: a project
+    #: `.codex/config.toml` is IGNORED (see :func:`config_path`), so mirroring it would put
+    #: a file in somebody's repo that nothing ever reads — charter's own writing looking
+    #: exactly like wiring and being inert, the "looks wired and is not" shape #177 and
+    #: #433 already cost this repo twice. `.codex/skills/` is the half that was measured to
+    #: reach a session: a sentinel at ``<repo>/.codex/skills/<name>/SKILL.md`` arrives in a
+    #: `codex exec` session's context with **zero tool calls**, where a control repository
+    #: answers NONE.
+    inherited_paths = (".codex/skills",)
 
     cli_name = "codex"
     binary = "codex"

--- a/charter/harness/codex.py
+++ b/charter/harness/codex.py
@@ -164,12 +164,20 @@ class CodexHarness(Harness):
                 "there is no project-level config file — a `.codex/config.toml` beside a "
                 "project is ignored, so `~/.codex/config.toml` is the only answer and "
                 "every workspace on this machine necessarily shares it. A project "
-                "`.codex/skills/` IS read; that is a skills surface, not config, and "
-                "charter writes nothing there."),
+                "`.codex/skills/` IS read; that is a skills surface, not config — charter "
+                "mirrors the plane's copy of it into a workspace's checkouts, which "
+                "carries capability there and still cannot make two workspaces differ."),
     )
 
-    #: Charter writes NO in-repo layer for Codex today, so there is nothing for `doctor`'s
+    #: Charter declares NO :class:`LayerPart` for Codex, so there is nothing for `doctor`'s
     #: `session layer` row to look for and the row says where the layer does come from.
+    #:
+    #: Empty because charter has not measured Codex's DISCOVERY rules — where a lookup for
+    #: `.codex/skills/` starts and where it stops — not because charter writes nothing in a
+    #: repo. Since #868 it mirrors the plane's `.codex/skills/` into a workspace's
+    #: checkouts (:attr:`inherited_paths`); what it cannot yet do is say which of the two
+    #: measured rules finds it, and reporting it under Claude Code's would be the borrowed
+    #: answer this whole member exists to refuse.
     #:
     #: **The `.codex/skills/` half is the correction.** Measured against codex-cli 0.147.0
     #: with a real `codex exec` session, a sentinel skill at

--- a/charter/harness/codex.py
+++ b/charter/harness/codex.py
@@ -187,11 +187,11 @@ class CodexHarness(Harness):
     #: "no" with confidence — and a model asked whether it can see a file will happily go
     #: and `sed` the file you just named, so the trace is the evidence and not the answer.
     layer_note = (
-        "charter writes no in-repo layer for Codex — it arrives from "
+        "charter has not measured Codex's discovery rules, so this row cannot say "
+        "what a session here would find — the layer arrives from "
         "`~/.codex/config.toml` and the plugin, and a project `.codex/config.toml` is "
         "ignored. Codex DOES read an in-repo `.codex/skills/` (measured, 0.147.0); "
-        "charter mirrors the plane's copy of that into a workspace's checkouts and "
-        "writes nothing here")
+        "charter mirrors the plane's copy of that into a workspace's checkouts")
 
     #: What a checkout inside a workspace stops seeing, in Codex's spelling (#868).
     #:

--- a/charter/harness/opencode.py
+++ b/charter/harness/opencode.py
@@ -732,13 +732,14 @@ class OpenCodeHarness(Harness):
     #: Naming the surface is what stops "charter declares no layer here" from being read as
     #: "there is nowhere to write one".
     layer_note = (
-        "charter writes no in-repo layer for opencode — it arrives from "
+        "charter has not measured opencode's discovery rules, so this row cannot say "
+        "what a session here would find — the layer arrives from "
         "`~/.config/opencode/` and the plugin, which every directory on this machine "
         "reads. opencode DOES read an in-repo `opencode.json` at the repository root and "
         "`.opencode/agent/` from the project (measured, 1.18.23); charter mirrors the "
-        "plane's `.opencode/agent/` into a workspace's checkouts, and neither writes nor "
-        "mirrors `opencode.json` — that is where `charter guard` keeps this plane's own "
-        "permission grants")
+        "plane's `.opencode/agent/` into a workspace's checkouts and leaves "
+        "`opencode.json` alone — that file is where `charter guard` keeps this plane's "
+        "own permission grants")
 
     #: What a checkout inside a workspace stops seeing, in opencode's spelling (#868).
     #:

--- a/charter/harness/opencode.py
+++ b/charter/harness/opencode.py
@@ -729,15 +729,38 @@ class OpenCodeHarness(Harness):
         "`~/.config/opencode/` and the plugin, which every directory on this machine "
         "reads. opencode DOES read an in-repo `opencode.json` at the repository root and "
         "`.opencode/agent/` from the project (measured, 1.18.23); charter mirrors the "
-        "plane's copies of those into a workspace's checkouts and writes neither here")
+        "plane's `.opencode/agent/` into a workspace's checkouts, and neither writes nor "
+        "mirrors `opencode.json` — that is where `charter guard` keeps this plane's own "
+        "permission grants")
 
     #: What a checkout inside a workspace stops seeing, in opencode's spelling (#868).
     #:
-    #: Both measured against opencode 1.18.23 with a real session: malformed JSON at
-    #: ``<repo>/opencode.json`` fails the run outright (`Error: Config file at
-    #: <repo>/opencode.json is not valid JSON(C)`), and a sentinel at
+    #: Measured against opencode 1.18.23 with a real session: a sentinel at
     #: ``<repo>/.opencode/agent/probe.md`` is a project agent where a control repository
-    #: has none.
+    #: has none. That is the surface #868 is about — the plane's agents, which a clone's
+    #: own git root cuts off exactly as it cuts off Claude Code's.
+    #:
+    #: **`opencode.json` is measured, is read, and is deliberately NOT here.** opencode
+    #: does read it at a repository root — malformed JSON at ``<repo>/opencode.json`` fails
+    #: the run outright — so a clone genuinely stops seeing the plane's copy, and #868's
+    #: own table lists it. Charter still does not mirror it, because of what is in it:
+    #: :meth:`_apply_rule` writes `charter guard`'s rules there, so a plane's copy holds
+    #: `permission` — and ``charter guard allow "npm test *"`` puts
+    #: ``{"bash": {"npm test *": "allow"}}`` in that file. Copying it into a checkout would
+    #: put an ALLOW in force in a repository nobody granted it in.
+    #:
+    #: Charter already answered this question one harness over and answered it the other
+    #: way: :data:`claude_code.WORKSPACE_KEYS` mirrors three keys of the plane's settings
+    #: into a checkout and refuses `permissions`, *"because copying a grant sideways into a
+    #: directory nobody granted it in puts a permission in force where no one clicked for
+    #: it"*. The same mechanism writing into the same directory must not answer it two
+    #: opposite ways for two harnesses.
+    #:
+    #: The split is capability versus grant, and it is why `inherited_paths` mirrors while
+    #: `workspace_files` generates: a mirror cannot drop a key. A generated guest
+    #: `opencode.json` carrying the safe half is the honest way to close the rest, and it
+    #: is a separate piece of work — charter's own opencode layer is machine-global and
+    #: already reaches a checkout, so nothing of CHARTER's is missing there today.
     #:
     #: **This does not touch the ceiling in :data:`WORKSPACE_SCOPE` above and does not
     #: contradict it.** That ceiling is about a workspace DIRECTORY, which is not a
@@ -745,7 +768,7 @@ class OpenCodeHarness(Harness):
     #: is already live there and cannot be made to DIFFER between two. A clone at
     #: `workspaces/<ws>/<repo>/` is a repository root, which is exactly why it was getting
     #: nothing, and exactly why charter can write here.
-    inherited_paths = (".opencode/agent", "opencode.json")
+    inherited_paths = (".opencode/agent",)
 
     cli_name = "opencode"
     binary = "opencode"

--- a/charter/harness/opencode.py
+++ b/charter/harness/opencode.py
@@ -728,7 +728,24 @@ class OpenCodeHarness(Harness):
         "charter writes no in-repo layer for opencode — it arrives from "
         "`~/.config/opencode/` and the plugin, which every directory on this machine "
         "reads. opencode DOES read an in-repo `opencode.json` at the repository root and "
-        "`.opencode/agent/` from the project (measured, 1.18.23); charter writes neither")
+        "`.opencode/agent/` from the project (measured, 1.18.23); charter mirrors the "
+        "plane's copies of those into a workspace's checkouts and writes neither here")
+
+    #: What a checkout inside a workspace stops seeing, in opencode's spelling (#868).
+    #:
+    #: Both measured against opencode 1.18.23 with a real session: malformed JSON at
+    #: ``<repo>/opencode.json`` fails the run outright (`Error: Config file at
+    #: <repo>/opencode.json is not valid JSON(C)`), and a sentinel at
+    #: ``<repo>/.opencode/agent/probe.md`` is a project agent where a control repository
+    #: has none.
+    #:
+    #: **This does not touch the ceiling in :data:`WORKSPACE_SCOPE` above and does not
+    #: contradict it.** That ceiling is about a workspace DIRECTORY, which is not a
+    #: repository root — every one of them resolves to the plane's own root, so the layer
+    #: is already live there and cannot be made to DIFFER between two. A clone at
+    #: `workspaces/<ws>/<repo>/` is a repository root, which is exactly why it was getting
+    #: nothing, and exactly why charter can write here.
+    inherited_paths = (".opencode/agent", "opencode.json")
 
     cli_name = "opencode"
     binary = "opencode"

--- a/charter/harness/opencode.py
+++ b/charter/harness/opencode.py
@@ -715,15 +715,22 @@ class OpenCodeHarness(Harness):
                 "cannot be made to DIFFER between two."),
     )
 
-    #: Charter writes NO in-repo layer for opencode today, so there is nothing for
+    #: Charter declares NO :class:`LayerPart` for opencode, so there is nothing for
     #: `doctor`'s `session layer` row to look for and the row says where the layer does
     #: come from instead.
     #:
-    #: **The second sentence is the one that matters.** An in-repo surface exists here and
-    #: charter simply does not use it yet — measured against opencode 1.18.23 with a real
-    #: session, not with `opencode agent list`, because a management CLI is not a session
-    #: and answers for the wrong thing. Naming the surface is what stops "charter writes
-    #: no layer here" from being read as "there is nowhere to write one".
+    #: **Empty because the discovery RULE is unmeasured, not because nothing is written.**
+    #: Since #868 charter mirrors the plane's `.opencode/agent/` into a workspace's
+    #: checkouts (:attr:`inherited_paths`). What `LayerPart` cannot yet say is by which
+    #: rule opencode finds it: its project config is keyed to the repository ROOT, which is
+    #: neither of the two rules charter has measured, and declaring it as a walking part
+    #: would report a layer as reachable from an intermediate directory opencode never
+    #: reads there — the one direction `part_reaches` says that row must never be wrong in.
+    #:
+    #: Measured against opencode 1.18.23 with a real session, not with `opencode agent
+    #: list`, because a management CLI is not a session and answers for the wrong thing.
+    #: Naming the surface is what stops "charter declares no layer here" from being read as
+    #: "there is nowhere to write one".
     layer_note = (
         "charter writes no in-repo layer for opencode — it arrives from "
         "`~/.config/opencode/` and the plugin, which every directory on this machine "

--- a/charter/harness/registry.py
+++ b/charter/harness/registry.py
@@ -52,6 +52,23 @@ def current() -> str | None:
     return None
 
 
+def inherited_paths() -> tuple[str, ...]:
+    """Every registered harness's :attr:`Harness.inherited_paths`, once each.
+
+    The plane-root paths a checkout with a git root of its own cuts a session off from —
+    what `workspace._inherited_files` mirrors into a guest checkout. Asked of the registry
+    rather than listed in `workspace.py`, so a harness registered in :data:`KINDS` has its
+    in-repo surface carried into a clone the day it declares one (#868).
+
+    Deduplicated with ``dict.fromkeys`` rather than a set, and both halves of that are
+    deliberate. Two harnesses naming the same path must not mirror it twice — the second
+    pass would be a second key for one file — and the order has to be the registration
+    order, not whatever a hash gives: an answer that comes out of a set is right about half
+    the time by luck, which is a guarantee nothing can pin.
+    """
+    return tuple(dict.fromkeys(p for h in all() for p in h.inherited_paths))
+
+
 def deficits(name: str | None) -> tuple[Deficit, ...]:
     """What *name* cannot carry.
 

--- a/charter/workspace.py
+++ b/charter/workspace.py
@@ -1310,8 +1310,8 @@ def _inherited_files() -> dict[str, str]:
 
     Which paths those are is every registered harness's own
     :attr:`harness.base.Harness.inherited_paths` — Claude Code's `.claude/agents` and
-    `.claude/skills`, opencode's `.opencode/agent` and `opencode.json`, Codex's
-    `.codex/skills`. **Nothing here names any of them**, and that is the whole of #868.
+    `.claude/skills`, opencode's `.opencode/agent`, Codex's `.codex/skills`. **Nothing here
+    names any of them**, and that is the whole of #868.
     This function held Claude Code's two as a literal, under a comment stating the limit
     honestly, and an honest limit is still a limit: an operator on opencode or Codex got a
     workspace with none of the plane's agents or skills. The registry answers now, so a
@@ -1336,9 +1336,11 @@ def _inherited_files() -> dict[str, str]:
     for sub in _registry.inherited_paths():
         d = config.ROOT / sub
         # `(d, *d.rglob("*"))` — the path ITSELF, then everything under it, because a
-        # harness spells this both ways: `.claude/agents` is a tree and opencode's
-        # `opencode.json` is one file at the repository root. `rglob` on a file yields
-        # nothing, so a file would silently mirror as nothing at all without `d` in front.
+        # harness may spell this as one FILE at a repository root rather than as a tree.
+        # Every shipped harness spells it as a tree today; half the in-repo surfaces
+        # charter has measured are single files, and `rglob` on a file yields nothing at
+        # all — so without `d` in front, the next harness to spell it that way would mirror
+        # as nothing, silently and with no row anywhere saying so.
         #
         # No `is_dir()` guard and no `is_file()` filter. Reading a directory raises
         # `IsADirectoryError`, reading a path that is not there raises `FileNotFoundError`,
@@ -1354,8 +1356,9 @@ def _inherited_files() -> dict[str, str]:
             except (OSError, UnicodeDecodeError):
                 continue
             rel = f.relative_to(d).as_posix()
-            # `d.relative_to(d)` is `.`, which would mirror `opencode.json` to the key
-            # `opencode.json/.` — a path that names nothing and hides nothing.
+            # `d.relative_to(d)` is `.`, so a declared FILE would land at the key
+            # `<path>/.` — a path that names nothing, hides nothing, and turns the file
+            # into a directory on the way in.
             out[sub if rel == "." else f"{sub}/{rel}"] = text
     return out
 

--- a/charter/workspace.py
+++ b/charter/workspace.py
@@ -1305,86 +1305,75 @@ def _layer_files(name: str) -> dict[str, str]:
     return _harness_files(workspace_dir(name))
 
 
-#: The plane-root directories Claude Code WALKS UP for, and where that walk stops.
-#:
-#: Agents and skills are found by searching the session's cwd and its parents, and the
-#: search stops at a git boundary. `workspaces/<ws>/` sits inside the plane's own repo, so
-#: both already arrive there untouched — which is why `claude_code.WORKSPACE_KEYS` is
-#: right not to copy them and `test_nothing_else_is_materialised_into_the_workspace` is
-#: right to forbid it. `workspaces/<ws>/<repo>/` is a repo of its own, so the walk stops
-#: at its root and NEITHER arrives. That is the whole of #870: the same layer, one
-#: directory deeper, is missing the half that a workspace directory got for free.
-#:
-#: `enabledPlugins` alone does not close it. The plugin brings charter's own skills, and
-#: it cannot bring this plane's `.claude/agents/` — those are generated from `personas/`
-#: by `persona sync-agents` and are as local to a plane as its personas are. Without them
-#: a chat in a clone loads charter and still cannot delegate to a persona, which is
-#: exactly the limit this module used to record as permanent.
-#:
-#: **CLAUDE.md is deliberately not here.** It walks up on the same rule, so the gap is
-#: real for it too — and it is the one file a repo of its own is most likely to have
-#: opinions about. Dropping the plane's project instructions into a repo charter does not
-#: own, to be read as that repo's instructions, is a claim of a different size from
-#: mirroring a settings key; a guest may hide its own files, not narrate the host's.
-#:
-#: **These two paths are Claude Code's spelling, and that is a stated LIMIT rather than
-#: an assumption that it is the only harness.** Everything else on this path is
-#: harness-agnostic: the mechanism below writes, marks, hides and removes whatever
-#: :func:`_harness_files` returns, which is every registered harness's own
-#: `workspace_files()` — so a harness that answers with files gets them into a clone the
-#: day it answers, with no change here. Only this list is hard-coded, because it is not
-#: any harness's answer: it is the plane's OWN directories, and charter has to know their
-#: names to find them.
-#:
-#: The other two harnesses do read project-level surfaces, measured against the installed
-#: binaries (codex-cli 0.147.0, opencode 1.18.23): opencode reads `opencode.json` and
-#: `.opencode/agent/` at a project root, and Codex reads `.codex/skills/` (though not a
-#: project `.codex/config.toml`). So the same cut-off exists for them in a clone and is
-#: NOT closed here. It is not closed by adding their directory names to this tuple
-#: either: what a harness needs in a tree is `workspace_files()`'s question, and
-#: answering it for them from this module is the mistake `harness/registry.py` exists to
-#: stop — charter naming a harness's files on its behalf, in a file that has to be
-#: edited every time another harness is added.
-WALKUP_DIRS = (".claude/agents", ".claude/skills")
+def _inherited_files() -> dict[str, str]:
+    """``{relative path: text}`` for the plane paths a guest checkout cuts a session off from.
 
+    Which paths those are is every registered harness's own
+    :attr:`harness.base.Harness.inherited_paths` — Claude Code's `.claude/agents` and
+    `.claude/skills`, opencode's `.opencode/agent` and `opencode.json`, Codex's
+    `.codex/skills`. **Nothing here names any of them**, and that is the whole of #868.
+    This function held Claude Code's two as a literal, under a comment stating the limit
+    honestly, and an honest limit is still a limit: an operator on opencode or Codex got a
+    workspace with none of the plane's agents or skills. The registry answers now, so a
+    harness registered tomorrow is carried the day it declares a surface.
 
-def _walkup_files() -> dict[str, str]:
-    """``{relative path: text}`` for the plane directories a guest checkout cuts off.
+    `workspaces/<ws>/` needs none of this and gets none of it. Every one of those paths is
+    resolved from a directory inside the plane's own repository — by a walk that stops at
+    the git root, or by resolving the repository root itself — so a workspace directory
+    already reads the plane's copies, and a second copy would shadow the first
+    non-deterministically. `workspaces/<ws>/<repo>/` is a repository of its own, which is
+    where all of them stop.
 
-    A 1:1 mirror of what is on disk, for `workspace_files`' reason: these are generated
-    from `personas/` by somebody else's generator, so re-deriving them here would be a
-    second generator that drifts. Read as text and skipped when that fails — a binary or
-    unreadable file in `.claude/agents/` is not something charter can copy, and it must
-    not take the whole layer down with it.
+    A 1:1 mirror of what is on disk, for `workspace_files`' reason: `.claude/agents/` is
+    generated from `personas/` by somebody else's generator, so re-deriving it here would
+    be a second generator that drifts. Read as text and skipped when that fails — a binary
+    or unreadable file is not something charter can copy, and it must not take the whole
+    layer down with it.
     """
+    from .harness import registry as _registry
+
     out: dict[str, str] = {}
-    for sub in WALKUP_DIRS:
+    for sub in _registry.inherited_paths():
         d = config.ROOT / sub
-        # No `is_dir()` guard and no `is_file()` filter. `rglob` on a directory that is
-        # not there yields nothing, and a directory entry, a dangling symlink and a
-        # binary file are one answer here — "not text charter can mirror" — which the
-        # read already gives. A predicate in front of it is a branch the deletion sweep
-        # can remove without changing a single answer, which is what makes it noise —
-        # and so was the `sorted()` that used to wrap this, for the same reason: every
-        # entry is an independent key in a dict, and `_layer_status` sorts what it
-        # reports anyway. The sweep found it as a survivor and was right.
-        for f in d.rglob("*"):
+        # `(d, *d.rglob("*"))` — the path ITSELF, then everything under it, because a
+        # harness spells this both ways: `.claude/agents` is a tree and opencode's
+        # `opencode.json` is one file at the repository root. `rglob` on a file yields
+        # nothing, so a file would silently mirror as nothing at all without `d` in front.
+        #
+        # No `is_dir()` guard and no `is_file()` filter. Reading a directory raises
+        # `IsADirectoryError`, reading a path that is not there raises `FileNotFoundError`,
+        # and a dangling symlink and a binary file raise too — all of them one answer here,
+        # "not text charter can mirror", which the read already gives. A predicate in front
+        # of it is a branch the deletion sweep can remove without changing a single answer,
+        # which is what makes it noise — and so was the `sorted()` that used to wrap this,
+        # for the same reason: every entry is an independent key in a dict, and
+        # `_layer_status` sorts what it reports anyway. The sweep found it and was right.
+        for f in (d, *d.rglob("*")):
             try:
                 text = f.read_text()
             except (OSError, UnicodeDecodeError):
                 continue
-            out[f"{sub}/{f.relative_to(d).as_posix()}"] = text
+            rel = f.relative_to(d).as_posix()
+            # `d.relative_to(d)` is `.`, which would mirror `opencode.json` to the key
+            # `opencode.json/.` — a path that names nothing and hides nothing.
+            out[sub if rel == "." else f"{sub}/{rel}"] = text
     return out
 
 
 def _guest_files(tree: Path) -> dict[str, str]:
     """Everything charter generates inside the guest checkout *tree*.
 
-    The harness layer the workspace directory gets, PLUS the walk-up directories that
-    directory did not need — see :data:`WALKUP_DIRS`.
+    The harness layer the workspace directory gets, PLUS the in-repo paths that directory
+    did not need — see :func:`_inherited_files`.
+
+    Two questions, deliberately kept apart. `_harness_files` asks each harness what it
+    needs in a directory charter OWNS, and the answer is generated content. This asks which
+    of the PLANE's own paths a git boundary cuts off, and the answer is a copy of what is
+    on disk. A harness declares both, and neither can be derived from the other: charter
+    cannot generate a plane's personas, and it must not mirror a file it generated.
     """
     out = _harness_files(tree)
-    out.update(_walkup_files())
+    out.update(_inherited_files())
     return out
 
 
@@ -1726,7 +1715,7 @@ def unwire_guest(tree: Path) -> list[str]:
     for rel in sorted(marker):
         p = tree / rel
         try:
-            # No `is_file()` in front of the read, for `_walkup_files`' reason: a path
+            # No `is_file()` in front of the read, for `_inherited_files`' reason: a path
             # already gone and a path that is a directory both raise here, and both mean
             # the same thing — charter has nothing of its own to take away.
             if marker[rel] != content_digest(p.read_text()):

--- a/docs/harnesses.md
+++ b/docs/harnesses.md
@@ -84,8 +84,8 @@ Both do read something from a project, and charter says which rather than implyi
 project carries nothing — measured with real sessions, because a management CLI is not one:
 opencode reads an `opencode.json` at the **repository root** and `.opencode/agent/`
 (1.18.23); Codex reads `.codex/skills/` and ignores a project `.codex/config.toml`
-(0.147.0). Charter writes into none of them today, and writes nothing machine-global on the
-operator's behalf either.
+(0.147.0). Charter writes nothing machine-global on the operator's behalf, and inside a
+workspace's checkouts it writes to exactly those surfaces — see below.
 
 **A clone gets the same layer, plus what the walk-up could not carry there.**
 `workspaces/<ws>/<repo>/` is a repo of its own, so a session inside it loses the settings
@@ -99,11 +99,20 @@ repo is unaffected, and nothing charter wrote can be staged. Linked worktrees in
 their `info/exclude` is the main repo's, which is also why removal is not just a
 `rm -rf`.
 
-The *mechanism* is harness-agnostic: whatever a harness declares it needs in a tree is
-written, marked, hidden and removed the same way. The two mirrored directories are Claude
-Code's, and that is a limit rather than a claim about the others — opencode reads
-`opencode.json` and `.opencode/agent/` at a project root, and Codex reads
-`.codex/skills/`, so a clone cuts those off too and charter does not yet carry them in.
+**And it is every harness's layer.** What a git boundary cuts off is spelled by each
+harness — `Harness.inherited_paths`, beside `layer` and `layer_note` — so charter's own code
+names none of it:
+
+| harness | carried into a checkout | binary |
+|---|---|---|
+| Claude Code | `.claude/agents`, `.claude/skills` | 2.1.259 |
+| opencode | `.opencode/agent`, `opencode.json` | 1.18.23 |
+| Codex | `.codex/skills` | 0.147.0 |
+
+A harness registered tomorrow is carried the day it declares a surface. Two things are
+deliberately absent from every row: a project `.codex/config.toml`, because Codex ignores
+it and writing it would look like wiring while being inert; and `CLAUDE.md` or any
+equivalent, because a guest hides its own files and does not narrate the host's.
 
 ## `charter statusline --watch`
 

--- a/docs/harnesses.md
+++ b/docs/harnesses.md
@@ -84,8 +84,9 @@ Both do read something from a project, and charter says which rather than implyi
 project carries nothing — measured with real sessions, because a management CLI is not one:
 opencode reads an `opencode.json` at the **repository root** and `.opencode/agent/`
 (1.18.23); Codex reads `.codex/skills/` and ignores a project `.codex/config.toml`
-(0.147.0). Charter writes nothing machine-global on the operator's behalf, and inside a
-workspace's checkouts it writes to exactly those surfaces — see below.
+(0.147.0). Charter writes nothing machine-global on the operator's behalf. Inside a
+workspace's checkouts it mirrors the plane's copy of each *capability* surface, and of the
+config files above it mirrors none — see below.
 
 **A clone gets the same layer, plus what the walk-up could not carry there.**
 `workspaces/<ws>/<repo>/` is a repo of its own, so a session inside it loses the settings
@@ -106,13 +107,21 @@ names none of it:
 | harness | carried into a checkout | binary |
 |---|---|---|
 | Claude Code | `.claude/agents`, `.claude/skills` | 2.1.259 |
-| opencode | `.opencode/agent`, `opencode.json` | 1.18.23 |
+| opencode | `.opencode/agent` | 1.18.23 |
 | Codex | `.codex/skills` | 0.147.0 |
 
-A harness registered tomorrow is carried the day it declares a surface. Two things are
-deliberately absent from every row: a project `.codex/config.toml`, because Codex ignores
-it and writing it would look like wiring while being inert; and `CLAUDE.md` or any
-equivalent, because a guest hides its own files and does not narrate the host's.
+A harness registered tomorrow is carried the day it declares a surface. What charter mirrors
+is **capability** — agents, skills, commands — and three things are deliberately absent:
+
+- **A harness's config file.** `opencode.json` is read at a repository root, so a clone does
+  stop seeing the plane's copy — and `charter guard` keeps this plane's `permission` grants
+  in that same file. Copying it would put an `allow` in force in a repository nobody granted
+  it in, which is what `.claude/settings.json`'s three mirrored keys already refuse for
+  Claude Code. A mirror cannot drop a key; that is the difference between the two lists.
+- **A project `.codex/config.toml`**, because Codex ignores it — writing it would look like
+  wiring while being inert.
+- **`CLAUDE.md` or any equivalent**, because a guest hides its own files and does not
+  narrate the host's.
 
 ## `charter statusline --watch`
 

--- a/docs/news/unreleased-a-clone-carries-every-harnesss-layer.md
+++ b/docs/news/unreleased-a-clone-carries-every-harnesss-layer.md
@@ -1,0 +1,81 @@
+---
+version: unreleased
+headline: a clone inside a workspace now carries **every** harness's in-repo surface, not Claude Code's — `.opencode/agent/` and `opencode.json` for opencode, `.codex/skills/` for Codex, each spelled by the harness rather than by charter
+---
+
+The entry above gave a clone at `workspaces/<ws>/<repo>/` the plane's layer. What it
+carried was two paths, spelled out in `workspace.py`:
+
+```python
+WALKUP_DIRS = (".claude/agents", ".claude/skills")
+```
+
+That was recorded as a **stated limit** with the measured facts beside it, which is honest.
+An honest limit is still a limit: an operator on opencode or Codex got a workspace with
+none of the plane's agents or skills, and no row anywhere said so.
+
+## The three surfaces, each measured against the installed binary
+
+| harness | carried into a checkout | binary |
+|---|---|---|
+| Claude Code | `.claude/agents`, `.claude/skills` | 2.1.259 |
+| opencode | `.opencode/agent`, `opencode.json` | 1.18.23 |
+| Codex | `.codex/skills` | 0.147.0 |
+
+Measured with real sessions, because a **management CLI is not a session** and answers for
+the wrong thing — the trap that made the first survey of this conclude Codex had no in-repo
+surface at all:
+
+- **opencode's config.** Malformed JSON at `<repo>/opencode.json` fails the run outright —
+  `Error: Config file at <repo>/opencode.json is not valid JSON(C)` — and a control repo
+  without one runs clean.
+- **opencode's agents.** A sentinel at `<repo>/.opencode/agent/probe.md` is a project
+  agent; the control repo has none.
+- **Codex's skills.** A sentinel at `<repo>/.codex/skills/<name>/SKILL.md` reaches a
+  `codex exec` session's context with **zero tool calls**; the control repo answers `NONE`.
+- **Codex's config, which is the one that is NOT carried.** A malformed project
+  `.codex/config.toml` causes no error at all — Codex ignores it. Mirroring it would put a
+  file in somebody's repo that nothing reads: charter's writing looking exactly like wiring
+  and being inert, which is the failure shape this repo has already paid for twice.
+
+## The spelling belongs to the harness
+
+`Harness.inherited_paths` sits beside `layer` and `layer_note`, which the `session layer`
+row added for exactly this shape, and `workspace.py` asks the registry. A test parses
+`_inherited_files` and `_guest_files` with `ast` and fails if their **code** names any
+harness or any harness path — the same pin `check_session_layer` already carries, one verb
+over. Reporting a harness under another's discovery rules and *writing* another harness's
+files are the same mistake; only the second one lands on disk.
+
+It is a separate member from `layer` rather than derived from it, and the reason is what
+each can honestly say. `layer` answers *"would a session started here find it, by which
+rule"*, and charter has measured exactly two rules — cwd-only, and walk up to the git root.
+opencode resolves `opencode.json` at the repository **root**, which is neither; declaring it
+as a walking part would report a layer as reachable from an intermediate directory opencode
+never reads there. This member answers something narrower that *is* measured for all three:
+which of the plane's in-repo paths a nested checkout stops seeing.
+
+## Everything the guest contract already promised still holds
+
+The paths are new; the restraints are not, and each is re-asked of them:
+
+- exact paths in the checkout's `.git/info/exclude`, never a directory glob — your own
+  `.codex/` or `opencode.json` stays visible in your own `git status`;
+- idempotent re-wiring, so the block never doubles;
+- a file charter did not generate is never overwritten — and not hidden either. The guest's
+  own `opencode.json` is the sharpest case in the set: a file at the repository root that a
+  repo is quite likely to have, and rewriting it would change how their opencode runs;
+- `.charter-generated` records a hash of each, so `charter doctor` still tells `stale` from
+  `foreign`, and a stale copy is refreshed rather than left for the next upgrade;
+- removing the workspace removes them, pruning the directories that emptied.
+
+**`CLAUDE.md` is still deliberately left behind**, and so is any equivalent. It walks up on
+the same rule, so the gap is real for it too — and it is the one file a repo of its own is
+most likely to have opinions about. A guest hides its own files; it does not narrate the
+host's.
+
+A workspace **directory** gets none of this and needs none of it: every one of these paths
+is resolved from inside the plane's own repository, so the plane's copies already reach it
+and a second copy would shadow the first. The ceiling `charter harness list` names for
+opencode and Codex — that a workspace directory is not a config scope, so two workspaces on
+one machine cannot be made to differ — is untouched and still true.

--- a/docs/news/unreleased-a-clone-carries-every-harnesss-layer.md
+++ b/docs/news/unreleased-a-clone-carries-every-harnesss-layer.md
@@ -1,6 +1,6 @@
 ---
 version: unreleased
-headline: a clone inside a workspace now carries **every** harness's in-repo surface, not Claude Code's — `.opencode/agent/` and `opencode.json` for opencode, `.codex/skills/` for Codex, each spelled by the harness rather than by charter
+headline: a clone inside a workspace now carries **every** harness's in-repo surface, not Claude Code's — `.opencode/agent/` for opencode and `.codex/skills/` for Codex, each spelled by the harness rather than by charter
 ---
 
 The entry above gave a clone at `workspaces/<ws>/<repo>/` the plane's layer. What it
@@ -19,24 +19,48 @@ none of the plane's agents or skills, and no row anywhere said so.
 | harness | carried into a checkout | binary |
 |---|---|---|
 | Claude Code | `.claude/agents`, `.claude/skills` | 2.1.259 |
-| opencode | `.opencode/agent`, `opencode.json` | 1.18.23 |
+| opencode | `.opencode/agent` | 1.18.23 |
 | Codex | `.codex/skills` | 0.147.0 |
 
 Measured with real sessions, because a **management CLI is not a session** and answers for
 the wrong thing — the trap that made the first survey of this conclude Codex had no in-repo
 surface at all:
 
-- **opencode's config.** Malformed JSON at `<repo>/opencode.json` fails the run outright —
-  `Error: Config file at <repo>/opencode.json is not valid JSON(C)` — and a control repo
-  without one runs clean.
 - **opencode's agents.** A sentinel at `<repo>/.opencode/agent/probe.md` is a project
   agent; the control repo has none.
 - **Codex's skills.** A sentinel at `<repo>/.codex/skills/<name>/SKILL.md` reaches a
   `codex exec` session's context with **zero tool calls**; the control repo answers `NONE`.
-- **Codex's config, which is the one that is NOT carried.** A malformed project
-  `.codex/config.toml` causes no error at all — Codex ignores it. Mirroring it would put a
-  file in somebody's repo that nothing reads: charter's writing looking exactly like wiring
-  and being inert, which is the failure shape this repo has already paid for twice.
+- **Codex's config, which is NOT carried.** A malformed project `.codex/config.toml` causes
+  no error at all — Codex ignores it. Mirroring it would put a file in somebody's repo that
+  nothing reads: charter's writing looking exactly like wiring and being inert, which is the
+  failure shape this repo has already paid for twice.
+- **opencode's config, which is NOT carried either — and this one IS read.** Malformed JSON
+  at `<repo>/opencode.json` fails the run outright (`Error: Config file at
+  <repo>/opencode.json is not valid JSON(C)`), so a clone genuinely stops seeing the plane's
+  copy. It stays behind anyway, because of the next section.
+
+## Charter mirrors capability, never a grant
+
+`charter guard allow "npm test *"` writes `{"permission": {"bash": {"npm test *": "allow"}}}`
+into the plane's own `opencode.json`. Copying that file into a workspace's checkout would put
+an **allow in force in a repository nobody granted it in**.
+
+Charter answered this exact question one harness over and answered it the other way: what a
+checkout receives for Claude Code is a *generated* `.claude/settings.json` holding three keys
+— `enabledPlugins`, `statusLine`, `env` — and explicitly not `permissions`, "*because copying
+a grant sideways into a directory nobody granted it in puts a permission in force where no
+one clicked for it*". The same mechanism, writing into the same directory, must not answer it
+two opposite ways for two harnesses.
+
+That is the difference between the two lists on a harness. `inherited_paths` **mirrors**, and
+a mirror cannot drop a key; `workspace_files` **generates**, and can. Where a harness's config
+file mixes capability and grant, only the second is the right instrument — and nothing of
+*charter's* is missing from a checkout meanwhile, because charter's opencode layer is
+machine-global and already reaches every directory on the box.
+
+A test pins it without naming a filename: it asks each registered harness to write an allow
+rule into a throwaway root, then refuses any harness that mirrors a file its own guard just
+wrote to. A harness registered tomorrow is covered by it.
 
 ## The spelling belongs to the harness
 
@@ -50,21 +74,20 @@ files are the same mistake; only the second one lands on disk.
 It is a separate member from `layer` rather than derived from it, and the reason is what
 each can honestly say. `layer` answers *"would a session started here find it, by which
 rule"*, and charter has measured exactly two rules — cwd-only, and walk up to the git root.
-opencode resolves `opencode.json` at the repository **root**, which is neither; declaring it
-as a walking part would report a layer as reachable from an intermediate directory opencode
-never reads there. This member answers something narrower that *is* measured for all three:
-which of the plane's in-repo paths a nested checkout stops seeing.
+opencode resolves its project config at the repository **root**, which is neither; declaring
+it as a walking part would report a layer as reachable from an intermediate directory
+opencode never reads there. This member answers something narrower that *is* measured for
+all three: which of the plane's in-repo paths a nested checkout stops seeing.
 
 ## Everything the guest contract already promised still holds
 
 The paths are new; the restraints are not, and each is re-asked of them:
 
 - exact paths in the checkout's `.git/info/exclude`, never a directory glob — your own
-  `.codex/` or `opencode.json` stays visible in your own `git status`;
+  `.codex/` and `.opencode/` stay visible in your own `git status`;
 - idempotent re-wiring, so the block never doubles;
-- a file charter did not generate is never overwritten — and not hidden either. The guest's
-  own `opencode.json` is the sharpest case in the set: a file at the repository root that a
-  repo is quite likely to have, and rewriting it would change how their opencode runs;
+- a file charter did not generate is never overwritten — and not hidden either. A guest repo
+  with a skill of its own at the same path keeps it, untouched and unhidden;
 - `.charter-generated` records a hash of each, so `charter doctor` still tells `stale` from
   `foreign`, and a stale copy is refreshed rather than left for the next upgrade;
 - removing the workspace removes them, pruning the directories that emptied.

--- a/docs/news/unreleased-a-clone-gets-the-layer-and-hides-it.md
+++ b/docs/news/unreleased-a-clone-gets-the-layer-and-hides-it.md
@@ -64,15 +64,13 @@ is byte-identical.
   this design guards against: every file can be current and your status still full of
   charter. A row nothing reports is a guarantee nothing keeps.
 
-**The two mirrored directories are Claude Code's, and the rest is not.** Everything that
-writes, marks, hides and removes works from whatever a harness declares it needs in a
-tree, so a harness that answers with files gets them into a clone the day it answers. Only
-the walk-up list is spelled out, because it names the *plane's* own directories rather
-than any harness's answer. Measured against the installed binaries: opencode reads
-`opencode.json` and `.opencode/agent/` at a project root, and Codex reads `.codex/skills/`
-— so a clone cuts those off too, and this release does not carry them in. That belongs in
-each harness's own answer, not in a list in `workspace.py` that has to be edited every
-time another harness arrives.
+**Every harness's surface is carried, not Claude Code's.** Everything that writes, marks,
+hides and removes works from whatever a harness declares, so a harness registered tomorrow
+is covered the day it declares one. The list of *what a git boundary cuts off* used to be
+two Claude Code paths spelled out in `workspace.py`; it is now `Harness.inherited_paths`,
+measured against the installed binaries — `.claude/agents` and `.claude/skills` (2.1.259),
+`.opencode/agent` and `opencode.json` (1.18.23), `.codex/skills` (0.147.0). See *a clone
+carries every harness's layer*, in this same release.
 
 **CLAUDE.md is deliberately not carried in.** It walks up on the same rule, so the gap is
 real for it too — and it is the one file a repo of its own is most likely to have opinions

--- a/docs/news/unreleased-a-clone-gets-the-layer-and-hides-it.md
+++ b/docs/news/unreleased-a-clone-gets-the-layer-and-hides-it.md
@@ -69,8 +69,8 @@ hides and removes works from whatever a harness declares, so a harness registere
 is covered the day it declares one. The list of *what a git boundary cuts off* used to be
 two Claude Code paths spelled out in `workspace.py`; it is now `Harness.inherited_paths`,
 measured against the installed binaries — `.claude/agents` and `.claude/skills` (2.1.259),
-`.opencode/agent` and `opencode.json` (1.18.23), `.codex/skills` (0.147.0). See *a clone
-carries every harness's layer*, in this same release.
+`.opencode/agent` (1.18.23), `.codex/skills` (0.147.0). See *a clone carries every harness's
+layer*, in this same release.
 
 **CLAUDE.md is deliberately not carried in.** It walks up on the same rule, so the gap is
 real for it too — and it is the one file a repo of its own is most likely to have opinions

--- a/docs/workspaces.md
+++ b/docs/workspaces.md
@@ -41,17 +41,32 @@ plane's settings move; one that does not is yours — left completely untouched,
 repaired, and named by `charter doctor`'s `workspace layer` row. `charter workspace reinit`
 (or `--all`) is the repair.
 
-**Nothing is written into a clone.** `workspaces/<name>/<repo>/` is a repo charter does not
-own, and `git add -A` there would stage whatever charter left behind. The limit that
-follows: a session inside a clone gets charter from the plugin, and **cannot delegate to a
-persona** — the plugin ships no `agents/`, and the clone's own git root stops the walk-up.
+**A clone gets the layer too, and pays a cost this directory does not.**
+`workspaces/<name>/<repo>/` is a repo of its own, so the walk-up that carries agents and
+skills into a workspace directory stops at its root and a session there got none of the
+layer — not the settings, and not the personas either. Charter writes both, and registers
+every path it generated in that checkout's **`.git/info/exclude`**: per-checkout, never
+committed, not itself tracked, and the one file a guest may write. Charter never edits the
+clone's `.gitignore`, hides only the exact paths it wrote (never a `.claude/` glob, which
+would take your own untracked files with it), never touches a file it did not generate, and
+removes its files and its exclude block when the workspace goes. `git status` in your repo
+is unaffected. Linked worktrees included — their `info/exclude` is the main repo's, which is
+also why removal is not just a `rm -rf`. **`CLAUDE.md` is deliberately left behind**: a guest
+hides its own files, it does not narrate the host's.
 
-Only Claude Code binds config to the directory a session starts in. opencode's project
-config is keyed to the **repository root** (`opencode.json`) and Codex has no project config
-file at all, so on both, charter's layer is already live in every workspace — and, by the
+**And it is every harness's layer, not Claude Code's.** What a clone cuts off is spelled by
+each harness, measured against the installed binary: `.claude/agents/` and `.claude/skills/`
+(Claude Code 2.1.259), `.opencode/agent/` and `opencode.json` at the repository root
+(opencode 1.18.23), `.codex/skills/` (codex-cli 0.147.0 — a project `.codex/config.toml` is
+ignored, so charter writes none). A harness registered tomorrow is carried the day it
+declares a surface.
+
+That is about a **clone**. A workspace **directory** is a different question, and there the
+ceiling stands: only Claude Code binds config to the directory a session starts in.
+opencode's project config is keyed to the repository root, and Codex has no project config
+file at all — so on both, charter's layer is already live in every workspace and, by the
 same fact, cannot be made to differ between two of them. `charter harness list` names that
-ceiling. Both still read *something* from a project — `.opencode/agent/` and
-`.codex/skills/`, measured with real sessions — and charter writes into neither today.
+ceiling.
 
 ## Which workspace am I in
 

--- a/docs/workspaces.md
+++ b/docs/workspaces.md
@@ -56,10 +56,12 @@ hides its own files, it does not narrate the host's.
 
 **And it is every harness's layer, not Claude Code's.** What a clone cuts off is spelled by
 each harness, measured against the installed binary: `.claude/agents/` and `.claude/skills/`
-(Claude Code 2.1.259), `.opencode/agent/` and `opencode.json` at the repository root
-(opencode 1.18.23), `.codex/skills/` (codex-cli 0.147.0 — a project `.codex/config.toml` is
-ignored, so charter writes none). A harness registered tomorrow is carried the day it
-declares a surface.
+(Claude Code 2.1.259), `.opencode/agent/` (opencode 1.18.23), `.codex/skills/` (codex-cli
+0.147.0). A harness registered tomorrow is carried the day it declares a surface. What
+travels is **capability**, never a grant: `opencode.json` is read at a repository root and is
+carried by nothing, because `charter guard` keeps this plane's permission rules in it and
+copying those sideways would put an `allow` in force in a repo nobody granted it in — the
+same reason `.claude/settings.json`'s mirror is three keys and not the file.
 
 That is about a **clone**. A workspace **directory** is a different question, and there the
 ceiling stands: only Claude Code binds config to the directory a session starts in.

--- a/tests/test_a_clone_gets_the_layer_and_hides_it.py
+++ b/tests/test_a_clone_gets_the_layer_and_hides_it.py
@@ -191,7 +191,13 @@ class APathThatWouldEscapeTheCheckout(CloneLayer):
     """
 
     def files(self, rel: str) -> dict:
-        rogue = SimpleNamespace(workspace_files=lambda: {rel: "not charter's to place\n"})
+        # `inherited_paths=()` because the rogue stands in for a HARNESS, and a harness
+        # answers both questions `_guest_files` asks — what it needs generated in a tree,
+        # and which of the plane's own paths a git boundary cuts off (#868). The rogue's
+        # answer to the second is "nothing", so the containment refusal below is measured
+        # against the first and only the first.
+        rogue = SimpleNamespace(workspace_files=lambda: {rel: "not charter's to place\n"},
+                                inherited_paths=())
         with mock.patch.object(registry, "all",
                                return_value=[rogue, claude_code.ClaudeCodeHarness()]):
             return dict(workspace._guest_files(self.clone))
@@ -210,7 +216,8 @@ class APathThatWouldEscapeTheCheckout(CloneLayer):
 
     def test_nothing_is_written_outside_the_checkout(self):
         rogue = SimpleNamespace(
-            workspace_files=lambda: {"../escaped.json": "not charter's to place\n"})
+            workspace_files=lambda: {"../escaped.json": "not charter's to place\n"},
+            inherited_paths=())
         with mock.patch.object(registry, "all",
                                return_value=[rogue, claude_code.ClaudeCodeHarness()]):
             workspace.wire_guest(self.clone)

--- a/tests/test_every_harness_carries_its_own_paths_into_a_clone.py
+++ b/tests/test_every_harness_carries_its_own_paths_into_a_clone.py
@@ -12,18 +12,27 @@ and an honest limit is still a limit: an operator on opencode or Codex got a wor
 none of the plane's agents or skills. The three surfaces, each measured against the
 installed binary rather than its documentation:
 
-| harness      | in-repo surface                      | binary   |
-|--------------|--------------------------------------|----------|
-| Claude Code  | `.claude/agents`, `.claude/skills`    | 2.1.259  |
-| opencode     | `.opencode/agent`, `opencode.json`    | 1.18.23  |
-| Codex        | `.codex/skills`                       | 0.147.0  |
+| harness      | carried                            | binary   |
+|--------------|------------------------------------|----------|
+| Claude Code  | `.claude/agents`, `.claude/skills`  | 2.1.259  |
+| opencode     | `.opencode/agent`                   | 1.18.23  |
+| Codex        | `.codex/skills`                     | 0.147.0  |
 
 So the spelling moved onto the harness, beside `Harness.layer` and `layer_note`, and
 `workspace._inherited_files` asks the registry. Two things that makes true are what this
 file is about — `workspace.py` names no harness and no harness path of its own, and a
 surface a harness declares reaches a real clone — plus the invariants that keep the new
-member from being used for the wrong thing: it is not where a harness's GENERATED files
-go, and it is not where the plane's project instructions go.
+member from being used for the wrong thing.
+
+**`opencode.json` is measured, is read, and is carried by nothing**, which is the sharpest
+of those invariants and the one #868's own table would have got wrong. opencode reads it at
+a repository root, so a clone genuinely stops seeing the plane's copy — and
+`charter guard allow` writes this plane's `permission` grants into that very file, so
+mirroring it would put an allow in force in a repository nobody granted it in. Charter
+answered the same question one harness over and answered it the other way
+(`claude_code.WORKSPACE_KEYS` mirrors three keys and refuses `permissions`), and the same
+mechanism writing into the same directory must not answer it two ways for two harnesses.
+The test below asks each harness where its OWN grants go rather than naming a filename.
 
 Every case writes only into a `PersonaIso` tmp plane, and the fixture asserts that before
 it writes anything. Nothing here touches the developer's real `workspaces/`.
@@ -38,6 +47,7 @@ from unittest import mock
 from charter import config, workspace
 from charter.harness import base, claude_code, codex, opencode, registry
 
+from tests import _isolation
 from tests.test_a_clone_gets_the_layer_and_hides_it import CloneLayer
 from tests.test_doctor_says_which_of_charters_layer_reaches_here import _code
 
@@ -53,7 +63,7 @@ def _harness(name: str, *paths: str) -> base.Harness:
     return type("Fake", (base.Harness,), {"name": name, "inherited_paths": paths})()
 
 
-class TheSpellingIsTheHarnesses(unittest.TestCase):
+class TheSpellingIsTheHarnesses(_isolation.PersonaIso):
     """Properties of the declarations, so a harness cannot be registered with a surface
     nothing carries — or with one carrying something it must not."""
 
@@ -88,8 +98,7 @@ class TheSpellingIsTheHarnesses(unittest.TestCase):
         harness had quietly stopped declaring anything."""
         self.assertEqual(claude_code.ClaudeCodeHarness().inherited_paths,
                          (".claude/agents", ".claude/skills"))
-        self.assertEqual(opencode.OpenCodeHarness().inherited_paths,
-                         (".opencode/agent", "opencode.json"))
+        self.assertEqual(opencode.OpenCodeHarness().inherited_paths, (".opencode/agent",))
         self.assertEqual(codex.CodexHarness().inherited_paths, (".codex/skills",))
 
     def test_the_base_class_declares_nothing(self):
@@ -109,6 +118,40 @@ class TheSpellingIsTheHarnesses(unittest.TestCase):
                                  ("CLAUDE.md", "AGENTS.md", "AGENT.md", ".cursorrules"),
                                  f"{h.name} would narrate the host's repo with {p}")
 
+    def test_no_harness_mirrors_the_file_its_own_guard_writes_grants_into(self):
+        """Charter mirrors CAPABILITY, never a grant — and this asks each harness where
+        its grants go rather than naming a filename, so it holds for a harness registered
+        tomorrow.
+
+        `charter guard allow "npm test *"` writes into the PLANE root:
+        `.claude/settings.json` for Claude Code, `opencode.json` for opencode (Codex has no
+        command-pattern permissions and writes nothing). Mirroring either into a checkout
+        would put an allow in force in a repository nobody granted it in — which
+        `claude_code.WORKSPACE_KEYS` already refuses in so many words, and the same
+        mechanism writing into the same directory must not answer it two ways for two
+        harnesses. #868's own table listed `opencode.json` as a surface to carry; it is
+        read by opencode, it is genuinely cut off in a clone, and this is why it is
+        carried by nothing.
+        """
+        wrote_something = False
+        for h in registry.all():
+            root = self.tmp / "grants" / h.name
+            root.mkdir(parents=True)
+            status, _detail = h.apply_allow_rule(root, "npm test *")
+            if status != "added":
+                continue
+            wrote_something = True
+            for p in root.rglob("*"):
+                if not p.is_file():
+                    continue
+                rel = p.relative_to(root).as_posix()
+                for got in h.inherited_paths:
+                    self.assertFalse(rel == got or rel.startswith(f"{got}/"),
+                                     f"{h.name} mirrors {rel}, where `charter guard` "
+                                     f"keeps this plane's grants")
+        self.assertTrue(wrote_something,
+                        "no harness wrote a grant, so this asserted nothing at all")
+
     def test_no_harness_mirrors_a_file_it_also_generates(self):
         """The two questions `_guest_files` asks must not overlap. `.claude/settings.json`
         is GENERATED for a checkout — the plane's three keys, composed — and a harness that
@@ -127,9 +170,11 @@ class TheRegistryAnswersForAllOfThem(unittest.TestCase):
 
     def test_every_harnesss_surface_is_in_the_answer(self):
         got = registry.inherited_paths()
-        for p in (".claude/agents", ".claude/skills", ".opencode/agent", "opencode.json",
-                  ".codex/skills"):
+        for p in (".claude/agents", ".claude/skills", ".opencode/agent", ".codex/skills"):
             self.assertIn(p, got)
+        # And the one that is READ but deliberately not carried — see the module docstring
+        # and `TheSpellingIsTheHarnesses`.
+        self.assertNotIn("opencode.json", got)
 
     def test_a_path_two_harnesses_name_is_carried_once(self):
         """Two harnesses can agree on a directory — nothing stops a future one adopting
@@ -187,21 +232,15 @@ class EveryHarnessesSurfaceReachesTheClone(CloneLayer):
         self.assertEqual((self.clone / ".opencode/agent/steward.md").read_text(),
                          "---\nname: steward\n---\nroute it\n")
 
-    def test_the_opencode_project_config_reaches_the_clone_as_ONE_file(self):
-        """The path that is a FILE and not a directory, which is why the mirror reads the
-        declared path itself before it reads anything under it. `rglob` on a file yields
-        nothing, so before #868 this would have been carried as nothing at all — and a
-        mirror that used the relative path unconditionally would have written it to the key
-        `opencode.json/.`, a path that names nothing and hides nothing.
-
-        It is load-bearing rather than an example: malformed JSON at `<repo>/opencode.json`
-        fails the run OUTRIGHT (`Error: Config file at <repo>/opencode.json is not valid
-        JSON(C)`), so this is the file that proves opencode reads a project at all."""
-        self.plane("opencode.json", '{"instructions": ["AGENTS.md"]}\n')
+    def test_the_planes_opencode_config_is_carried_by_nothing(self):
+        """opencode reads it at a repository root, a clone genuinely stops seeing the
+        plane's copy, and #868's table listed it — and it stays behind, because
+        `charter guard allow` keeps this plane's `permission` grants in that same file.
+        `TheSpellingIsTheHarnesses` pins the rule mechanically; this pins that the rule
+        reaches disk."""
+        self.plane("opencode.json", '{"permission": {"bash": {"npm test *": "allow"}}}\n')
         self.wire()
-        self.assertEqual((self.clone / "opencode.json").read_text(),
-                         '{"instructions": ["AGENTS.md"]}\n')
-        self.assertFalse((self.clone / "opencode.json.").exists())
+        self.assertFalse((self.clone / "opencode.json").exists())
 
     def test_the_three_surfaces_arrive_together(self):
         """One `wire`, not one per harness. A workspace is not a harness's workspace."""
@@ -220,10 +259,9 @@ class EveryHarnessesSurfaceReachesTheClone(CloneLayer):
         and a second copy would shadow the first."""
         self.plane(".opencode/agent/steward.md", "oc\n")
         self.plane(".codex/skills/s/SKILL.md", "cx\n")
-        self.plane("opencode.json", "{}\n")
         workspace.wire_harnesses(self.ws)
         wd = workspace.workspace_dir(self.ws)
-        for unwanted in (".opencode", ".codex", "opencode.json"):
+        for unwanted in (".opencode", ".codex"):
             self.assertFalse((wd / unwanted).exists(), f"{unwanted} should not be written")
 
     def test_the_plane_charter_file_is_still_left_behind(self):
@@ -234,6 +272,53 @@ class EveryHarnessesSurfaceReachesTheClone(CloneLayer):
         self.wire()
         self.assertFalse((self.clone / "CLAUDE.md").exists())
         self.assertFalse((self.clone / "AGENTS.md").exists())
+
+
+class ADeclaredPathThatIsAFileAndNotADirectory(CloneLayer):
+    """A harness may spell its surface as ONE file at a repository root, and every shipped
+    harness spells it as a directory — so this is asked with a harness of its own.
+
+    Not speculative generality. Half the in-repo surfaces charter has measured are single
+    files at a repository root: opencode's `opencode.json` (read; left behind for a reason
+    of its own) and Codex's `.codex/config.toml` (ignored, so never carried). The mirror
+    walks a declared path with `rglob`, which yields **nothing at all** for a file — so a
+    mirror that did not read the path itself would answer "nothing" for the next harness
+    that spells it that way, silently and with no row anywhere saying so. That is the
+    failure this member exists to end, one harness later.
+    """
+
+    def wire_with(self, *paths: str) -> dict:
+        """The generated rows, without `info/exclude`'s — that row is about the checkout,
+        not about a mirrored path, and it is `TheGuestContractHoldsForAllOfThem`'s."""
+        with mock.patch.object(registry, "all", return_value=[_harness("fake", *paths)]):
+            rows = dict(workspace.wire_guest(self.clone))
+        rows.pop(".git/info/exclude", None)
+        return rows
+
+    def test_the_file_itself_is_mirrored_under_its_own_name(self):
+        (config.ROOT / "fake.json").write_text('{"model": "big"}\n')
+        rows = self.wire_with("fake.json")
+        self.assertEqual(rows["fake.json"], "created")
+        self.assertEqual((self.clone / "fake.json").read_text(), '{"model": "big"}\n')
+
+    def test_it_is_not_mirrored_to_a_path_naming_a_directory_entry(self):
+        """`Path.relative_to` itself is `.`, so a mirror that spelled the key from the
+        relative path unconditionally would write `fake.json/.` — a path that names
+        nothing, hides nothing, and turns the file into a directory on the way."""
+        (config.ROOT / "fake.json").write_text("{}\n")
+        rows = self.wire_with("fake.json")
+        self.assertEqual(sorted(rows), ["fake.json"])
+        self.assertTrue((self.clone / "fake.json").is_file())
+
+    def test_a_declared_file_that_is_not_there_carries_nothing(self):
+        self.assertEqual(self.wire_with("fake.json"), {})
+
+    def test_a_directory_and_a_file_are_both_carried_in_one_pass(self):
+        (config.ROOT / "fake.json").write_text("{}\n")
+        (config.ROOT / ".fake" / "agent").mkdir(parents=True)
+        (config.ROOT / ".fake" / "agent" / "one.md").write_text("one\n")
+        rows = self.wire_with(".fake/agent", "fake.json")
+        self.assertEqual(sorted(rows), [".fake/agent/one.md", "fake.json"])
 
 
 class TheGuestContractHoldsForAllOfThem(CloneLayer):
@@ -248,17 +333,15 @@ class TheGuestContractHoldsForAllOfThem(CloneLayer):
     def seed(self) -> None:
         self.plane(".opencode/agent/steward.md", "oc\n")
         self.plane(".codex/skills/s/SKILL.md", "cx\n")
-        self.plane("opencode.json", "{}\n")
 
     def test_the_exact_paths_are_hidden_never_a_directory(self):
-        """A guest repo may have its own `.codex/` and its own `opencode.json`. Hiding a
+        """A guest repo may have a `.codex/` and an `.opencode/` of its own. Hiding a
         directory would hide the operator's files inside it from their own `git status`,
         which is a worse failure than the noise this prevents."""
         self.seed()
         self.wire()
         lines = self.excludes().splitlines()
-        for rel in ("/.opencode/agent/steward.md", "/.codex/skills/s/SKILL.md",
-                    "/opencode.json"):
+        for rel in ("/.opencode/agent/steward.md", "/.codex/skills/s/SKILL.md"):
             self.assertIn(rel, lines)
         for glob in ("/.opencode/", "/.codex/", "/.opencode", "/.codex"):
             self.assertNotIn(glob, lines)
@@ -276,28 +359,28 @@ class TheGuestContractHoldsForAllOfThem(CloneLayer):
         self.wire()
         self.wire()
         text = self.excludes()
-        self.assertEqual(text.count("/opencode.json"), 1)
+        self.assertEqual(text.count("/.codex/skills/s/SKILL.md"), 1)
         self.assertEqual(text.count("# <<< charter <<<"), 1)
 
     def test_a_file_the_operator_already_owns_is_never_overwritten(self):
-        """The guest's own `opencode.json` is the sharpest case in the set: it is a file at
-        the repository root that a repo is quite likely to have, and overwriting it would
-        change how their opencode runs."""
+        """A guest repo with a skill of its own at the same path is the sharpest case in
+        the set: charter cannot vouch for it, so it neither rewrites it nor hides it."""
         self.seed()
-        (self.clone / "opencode.json").write_text('{"theirs": true}\n')
+        p = self.clone / ".codex/skills/s/SKILL.md"
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text("# theirs\n")
         rows = self.wire()
-        self.assertEqual(rows["opencode.json"], "foreign")
-        self.assertEqual((self.clone / "opencode.json").read_text(), '{"theirs": true}\n')
+        self.assertEqual(rows[".codex/skills/s/SKILL.md"], "foreign")
+        self.assertEqual(p.read_text(), "# theirs\n")
         # And not hidden either — the quieter half of the same restraint.
-        self.assertNotIn("/opencode.json", self.excludes().splitlines())
+        self.assertNotIn("/.codex/skills/s/SKILL.md", self.excludes().splitlines())
 
     def test_the_marker_vouches_for_every_one_of_them(self):
         """`doctor` tells `stale` from `foreign` by this file and nothing else."""
         self.seed()
         self.wire()
         marker = json.loads((self.clone / workspace.GENERATED_MARKER).read_text())
-        for rel in (".opencode/agent/steward.md", ".codex/skills/s/SKILL.md",
-                    "opencode.json"):
+        for rel in (".opencode/agent/steward.md", ".codex/skills/s/SKILL.md"):
             self.assertEqual(marker[rel],
                              workspace.content_digest((self.clone / rel).read_text()))
 
@@ -308,14 +391,15 @@ class TheGuestContractHoldsForAllOfThem(CloneLayer):
         get the create-once bug the `.claude/` ones already lost."""
         self.seed()
         self.wire()
-        self.plane("opencode.json", '{"moved": true}\n')
+        self.plane(".opencode/agent/steward.md", "oc moved\n")
         self.plane(".codex/skills/s/SKILL.md", "cx moved\n")
         # The operator's now. Charter cannot vouch for it, so it never rewrites it — even
         # though the plane's copy moved in exactly the same way.
         (self.clone / ".codex/skills/s/SKILL.md").write_text("theirs\n")
         rows = self.wire()
-        self.assertEqual(rows["opencode.json"], "refreshed")
-        self.assertEqual((self.clone / "opencode.json").read_text(), '{"moved": true}\n')
+        self.assertEqual(rows[".opencode/agent/steward.md"], "refreshed")
+        self.assertEqual((self.clone / ".opencode/agent/steward.md").read_text(),
+                         "oc moved\n")
         self.assertEqual(rows[".codex/skills/s/SKILL.md"], "foreign")
         self.assertEqual((self.clone / ".codex/skills/s/SKILL.md").read_text(), "theirs\n")
 
@@ -327,8 +411,7 @@ class TheGuestContractHoldsForAllOfThem(CloneLayer):
         self.seed()
         self.wire()
         removed = workspace.unwire_guest(self.clone)
-        for rel in (".opencode/agent/steward.md", ".codex/skills/s/SKILL.md",
-                    "opencode.json"):
+        for rel in (".opencode/agent/steward.md", ".codex/skills/s/SKILL.md"):
             self.assertIn(rel, removed)
             self.assertFalse((self.clone / rel).exists())
         self.assertFalse((self.clone / ".codex").exists())
@@ -337,7 +420,7 @@ class TheGuestContractHoldsForAllOfThem(CloneLayer):
         # file is EMPTY would pass for a charter that had truncated somebody else's file.
         left = self.excludes()
         self.assertNotIn("charter", left)
-        self.assertNotIn("opencode.json", left)
+        self.assertNotIn(".codex", left)
 
     def test_a_binary_in_one_surface_does_not_empty_the_others(self):
         """One unreadable file must not take the layer down with it — the restraint
@@ -347,7 +430,7 @@ class TheGuestContractHoldsForAllOfThem(CloneLayer):
         self.wire()
         self.assertFalse((self.clone / ".codex/skills/s/logo.png").exists())
         self.assertTrue((self.clone / ".opencode/agent/steward.md").is_file())
-        self.assertTrue((self.clone / "opencode.json").is_file())
+        self.assertTrue((self.clone / ".codex/skills/s/SKILL.md").is_file())
 
 
 if __name__ == "__main__":

--- a/tests/test_every_harness_carries_its_own_paths_into_a_clone.py
+++ b/tests/test_every_harness_carries_its_own_paths_into_a_clone.py
@@ -188,11 +188,14 @@ class TheRegistryAnswersForAllOfThem(unittest.TestCase):
                              (".shared/skills", ".a/agents", ".b/agents"))
 
     def test_the_order_is_registration_order_and_not_a_hash(self):
-        """Two opposite registrations of the SAME pair, because one assertion would pass
+        """Two opposite registrations of the SAME pair, because ONE of them would pass
         about half the time by luck: `sorted` over a set, or a set at all, orders by hash,
-        and a guarantee that holds by coincidence is one nothing can pin. Order is what
-        decides which harness's copy wins when two name one path and the plane holds a file
-        at it, so it is a real answer rather than cosmetics."""
+        and a guarantee that holds by coincidence is one nothing can pin.
+
+        It is a real answer rather than cosmetics. `_inherited_files` walks these in order
+        into one dict, so where two declared paths overlap — a harness naming `.a` and
+        another `.a/sub` — the later write is the one a checkout gets. An order that came
+        out of a hash would make two `wire`s of an unchanged tree disagree."""
         first, second = _harness("a", ".a/x"), _harness("b", ".b/x")
         with mock.patch.object(registry, "all", return_value=[first, second]):
             self.assertEqual(registry.inherited_paths(), (".a/x", ".b/x"))

--- a/tests/test_every_harness_carries_its_own_paths_into_a_clone.py
+++ b/tests/test_every_harness_carries_its_own_paths_into_a_clone.py
@@ -1,0 +1,354 @@
+"""A clone gets EVERY harness's in-repo surface, in that harness's own spelling — #868.
+
+#870 gave a guest checkout at `workspaces/<ws>/<repo>/` the plane's layer, and the list of
+what to carry was two literals in `workspace.py`:
+
+```python
+WALKUP_DIRS = (".claude/agents", ".claude/skills")
+```
+
+#872 recorded that as a stated limit with the measured facts beside it, which is honest,
+and an honest limit is still a limit: an operator on opencode or Codex got a workspace with
+none of the plane's agents or skills. The three surfaces, each measured against the
+installed binary rather than its documentation:
+
+| harness      | in-repo surface                      | binary   |
+|--------------|--------------------------------------|----------|
+| Claude Code  | `.claude/agents`, `.claude/skills`    | 2.1.259  |
+| opencode     | `.opencode/agent`, `opencode.json`    | 1.18.23  |
+| Codex        | `.codex/skills`                       | 0.147.0  |
+
+So the spelling moved onto the harness, beside `Harness.layer` and `layer_note`, and
+`workspace._inherited_files` asks the registry. Two things that makes true are what this
+file is about — `workspace.py` names no harness and no harness path of its own, and a
+surface a harness declares reaches a real clone — plus the invariants that keep the new
+member from being used for the wrong thing: it is not where a harness's GENERATED files
+go, and it is not where the plane's project instructions go.
+
+Every case writes only into a `PersonaIso` tmp plane, and the fixture asserts that before
+it writes anything. Nothing here touches the developer's real `workspaces/`.
+"""
+
+from __future__ import annotations
+
+import json
+import unittest
+from unittest import mock
+
+from charter import config, workspace
+from charter.harness import base, claude_code, codex, opencode, registry
+
+from tests.test_a_clone_gets_the_layer_and_hides_it import CloneLayer
+from tests.test_doctor_says_which_of_charters_layer_reaches_here import _code
+
+
+def _harness(name: str, *paths: str) -> base.Harness:
+    """A registered-looking harness that declares *paths* and generates nothing.
+
+    A real :class:`base.Harness` subclass rather than a `SimpleNamespace`, because these
+    are handed to `registry.all()`'s callers and every one of them asks a harness more than
+    one question. A stub that answers only the question a test happens to ask is how a
+    fake drifts from the interface it stands for.
+    """
+    return type("Fake", (base.Harness,), {"name": name, "inherited_paths": paths})()
+
+
+class TheSpellingIsTheHarnesses(unittest.TestCase):
+    """Properties of the declarations, so a harness cannot be registered with a surface
+    nothing carries — or with one carrying something it must not."""
+
+    def test_workspace_names_no_harness_and_no_harness_path_of_its_own(self):
+        """The pin that keeps the spelling on the harness, and the same pin
+        `check_session_layer` already carries one module over: reporting a harness under
+        another's rules and WRITING another harness's files are the same mistake, and only
+        the second one lands on disk.
+
+        Docstrings and comments are stripped, so the prose above `_inherited_files` may go
+        on naming what was measured. A *literal* is the thing refused.
+        """
+        for fn in (workspace._inherited_files, workspace._guest_files):
+            code = _code(fn)
+            for literal in (".claude", "claude-code", "opencode", "codex", "CLAUDE.md"):
+                self.assertNotIn(literal, code,
+                                 f"`{fn.__name__}` names {literal!r} itself; that fact "
+                                 f"belongs on the harness")
+
+    def test_every_shipped_harness_declares_what_a_clone_cuts_it_off_from(self):
+        """All three were measured to read something from a project. A harness left at the
+        default here is one whose operator gets a workspace with none of the plane's
+        agents or skills, which is the whole of #868."""
+        for h in registry.all():
+            self.assertTrue(h.inherited_paths,
+                            f"{h.name} declares no in-repo surface, so a clone carries "
+                            f"nothing for it")
+
+    def test_each_harness_declares_the_surface_that_was_measured(self):
+        """Spelled out per harness rather than compared to the registry's own answer: a
+        test that asked the registry what it holds would agree with itself no matter which
+        harness had quietly stopped declaring anything."""
+        self.assertEqual(claude_code.ClaudeCodeHarness().inherited_paths,
+                         (".claude/agents", ".claude/skills"))
+        self.assertEqual(opencode.OpenCodeHarness().inherited_paths,
+                         (".opencode/agent", "opencode.json"))
+        self.assertEqual(codex.CodexHarness().inherited_paths, (".codex/skills",))
+
+    def test_the_base_class_declares_nothing(self):
+        """A harness registered tomorrow inherits silence, not Claude Code's paths — the
+        restraint `layer`, `layer_note` and `trust_gate` already keep."""
+        self.assertEqual(base.Harness().inherited_paths, ())
+
+    def test_no_harness_carries_the_planes_project_instructions(self):
+        """The line `Harness.inherited_paths` draws. `CLAUDE.md` walks up on the same rule
+        as `.claude/agents/`, so the gap is real for it too — and it is the one file a repo
+        of its own is most likely to have opinions about. Dropping the plane's instructions
+        into somebody else's repo, to be read there as that repo's, is a claim of a
+        different size from mirroring a settings key."""
+        for h in registry.all():
+            for p in h.inherited_paths:
+                self.assertNotIn(p.rsplit("/", 1)[-1],
+                                 ("CLAUDE.md", "AGENTS.md", "AGENT.md", ".cursorrules"),
+                                 f"{h.name} would narrate the host's repo with {p}")
+
+    def test_no_harness_mirrors_a_file_it_also_generates(self):
+        """The two questions `_guest_files` asks must not overlap. `.claude/settings.json`
+        is GENERATED for a checkout — the plane's three keys, composed — and a harness that
+        also listed `.claude` here would mirror the plane's whole settings file over the
+        generated one, silently putting the plane's `permissions` in force in a repo
+        charter is a guest in."""
+        for h in registry.all():
+            for gen in h.workspace_files():
+                for got in h.inherited_paths:
+                    self.assertFalse(gen == got or gen.startswith(f"{got}/"),
+                                     f"{h.name} both generates and mirrors {gen}")
+
+
+class TheRegistryAnswersForAllOfThem(unittest.TestCase):
+    """`registry.inherited_paths()` — the one place `workspace.py` asks."""
+
+    def test_every_harnesss_surface_is_in_the_answer(self):
+        got = registry.inherited_paths()
+        for p in (".claude/agents", ".claude/skills", ".opencode/agent", "opencode.json",
+                  ".codex/skills"):
+            self.assertIn(p, got)
+
+    def test_a_path_two_harnesses_name_is_carried_once(self):
+        """Two harnesses can agree on a directory — nothing stops a future one adopting
+        `.claude/skills`. Carried twice it is two keys for one file, and the second pass
+        would overwrite the first's marker entry with an identical digest for a path the
+        exclude block then lists twice."""
+        with mock.patch.object(registry, "all", return_value=[
+                _harness("a", ".shared/skills", ".a/agents"),
+                _harness("b", ".shared/skills", ".b/agents")]):
+            self.assertEqual(registry.inherited_paths(),
+                             (".shared/skills", ".a/agents", ".b/agents"))
+
+    def test_the_order_is_registration_order_and_not_a_hash(self):
+        """Two opposite registrations of the SAME pair, because one assertion would pass
+        about half the time by luck: `sorted` over a set, or a set at all, orders by hash,
+        and a guarantee that holds by coincidence is one nothing can pin. Order is what
+        decides which harness's copy wins when two name one path and the plane holds a file
+        at it, so it is a real answer rather than cosmetics."""
+        first, second = _harness("a", ".a/x"), _harness("b", ".b/x")
+        with mock.patch.object(registry, "all", return_value=[first, second]):
+            self.assertEqual(registry.inherited_paths(), (".a/x", ".b/x"))
+        with mock.patch.object(registry, "all", return_value=[second, first]):
+            self.assertEqual(registry.inherited_paths(), (".b/x", ".a/x"))
+
+    def test_a_harness_that_declares_nothing_removes_nobody_elses(self):
+        with mock.patch.object(registry, "all",
+                               return_value=[_harness("quiet"), _harness("loud", ".l/x")]):
+            self.assertEqual(registry.inherited_paths(), (".l/x",))
+
+
+class EveryHarnessesSurfaceReachesTheClone(CloneLayer):
+    """The behaviour, in a real clone inside a real workspace."""
+
+    def plane(self, rel: str, text: str) -> None:
+        p = config.ROOT / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(text)
+
+    def test_a_codex_skill_reaches_the_clone(self):
+        """Measured against codex-cli 0.147.0 with a real `codex exec` session: a sentinel
+        at `<repo>/.codex/skills/<name>/SKILL.md` reaches the model's context with zero
+        tool calls, where a control repository answers NONE. So this is the file that
+        decides whether a Codex chat in a clone has the plane's skills."""
+        self.plane(".codex/skills/deploy/SKILL.md", "# deploy\n")
+        self.wire()
+        self.assertEqual((self.clone / ".codex/skills/deploy/SKILL.md").read_text(),
+                         "# deploy\n")
+
+    def test_an_opencode_project_agent_reaches_the_clone(self):
+        """Measured against opencode 1.18.23: a sentinel at
+        `<repo>/.opencode/agent/probe.md` is a project agent that a control repository does
+        not have."""
+        self.plane(".opencode/agent/steward.md", "---\nname: steward\n---\nroute it\n")
+        self.wire()
+        self.assertEqual((self.clone / ".opencode/agent/steward.md").read_text(),
+                         "---\nname: steward\n---\nroute it\n")
+
+    def test_the_opencode_project_config_reaches_the_clone_as_ONE_file(self):
+        """The path that is a FILE and not a directory, which is why the mirror reads the
+        declared path itself before it reads anything under it. `rglob` on a file yields
+        nothing, so before #868 this would have been carried as nothing at all — and a
+        mirror that used the relative path unconditionally would have written it to the key
+        `opencode.json/.`, a path that names nothing and hides nothing.
+
+        It is load-bearing rather than an example: malformed JSON at `<repo>/opencode.json`
+        fails the run OUTRIGHT (`Error: Config file at <repo>/opencode.json is not valid
+        JSON(C)`), so this is the file that proves opencode reads a project at all."""
+        self.plane("opencode.json", '{"instructions": ["AGENTS.md"]}\n')
+        self.wire()
+        self.assertEqual((self.clone / "opencode.json").read_text(),
+                         '{"instructions": ["AGENTS.md"]}\n')
+        self.assertFalse((self.clone / "opencode.json.").exists())
+
+    def test_the_three_surfaces_arrive_together(self):
+        """One `wire`, not one per harness. A workspace is not a harness's workspace."""
+        self.plane(".claude/agents/steward.md", "cc\n")
+        self.plane(".opencode/agent/steward.md", "oc\n")
+        self.plane(".codex/skills/s/SKILL.md", "cx\n")
+        rows = self.wire()
+        for rel in (".claude/agents/steward.md", ".opencode/agent/steward.md",
+                    ".codex/skills/s/SKILL.md"):
+            self.assertEqual(rows[rel], "created", rel)
+
+    def test_the_workspace_directory_still_gets_none_of_them(self):
+        """The boundary did not move. Every one of these paths is resolved from inside the
+        plane's own repository — by a walk that stops at the git root, or by resolving the
+        repository root itself — so a workspace directory already reads the plane's copies
+        and a second copy would shadow the first."""
+        self.plane(".opencode/agent/steward.md", "oc\n")
+        self.plane(".codex/skills/s/SKILL.md", "cx\n")
+        self.plane("opencode.json", "{}\n")
+        workspace.wire_harnesses(self.ws)
+        wd = workspace.workspace_dir(self.ws)
+        for unwanted in (".opencode", ".codex", "opencode.json"):
+            self.assertFalse((wd / unwanted).exists(), f"{unwanted} should not be written")
+
+    def test_the_plane_charter_file_is_still_left_behind(self):
+        """Carried in the same pass as everything else if any harness had declared it.
+        None does, and this is where that stays true."""
+        self.plane("CLAUDE.md", "the plane's instructions\n")
+        self.plane("AGENTS.md", "also the plane's\n")
+        self.wire()
+        self.assertFalse((self.clone / "CLAUDE.md").exists())
+        self.assertFalse((self.clone / "AGENTS.md").exists())
+
+
+class TheGuestContractHoldsForAllOfThem(CloneLayer):
+    """The four restraints #870 bought, asked of the paths #868 added. A mechanism that
+    held only for `.claude/` would be a mechanism that never held."""
+
+    def plane(self, rel: str, text: str) -> None:
+        p = config.ROOT / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(text)
+
+    def seed(self) -> None:
+        self.plane(".opencode/agent/steward.md", "oc\n")
+        self.plane(".codex/skills/s/SKILL.md", "cx\n")
+        self.plane("opencode.json", "{}\n")
+
+    def test_the_exact_paths_are_hidden_never_a_directory(self):
+        """A guest repo may have its own `.codex/` and its own `opencode.json`. Hiding a
+        directory would hide the operator's files inside it from their own `git status`,
+        which is a worse failure than the noise this prevents."""
+        self.seed()
+        self.wire()
+        lines = self.excludes().splitlines()
+        for rel in ("/.opencode/agent/steward.md", "/.codex/skills/s/SKILL.md",
+                    "/opencode.json"):
+            self.assertIn(rel, lines)
+        for glob in ("/.opencode/", "/.codex/", "/.opencode", "/.codex"):
+            self.assertNotIn(glob, lines)
+
+    def test_the_status_stays_clean_and_nothing_can_be_staged(self):
+        """Against real `git`, not against charter's model of it."""
+        self.seed()
+        self.wire()
+        self.assertEqual(self.status(), "")
+
+    def test_re_wiring_does_not_duplicate_the_block(self):
+        """An `ensure` runs on every launch. Appending would leave `git status` clean while
+        `info/exclude` grew without bound — the failure nobody would ever look for."""
+        self.seed()
+        self.wire()
+        self.wire()
+        text = self.excludes()
+        self.assertEqual(text.count("/opencode.json"), 1)
+        self.assertEqual(text.count("# <<< charter <<<"), 1)
+
+    def test_a_file_the_operator_already_owns_is_never_overwritten(self):
+        """The guest's own `opencode.json` is the sharpest case in the set: it is a file at
+        the repository root that a repo is quite likely to have, and overwriting it would
+        change how their opencode runs."""
+        self.seed()
+        (self.clone / "opencode.json").write_text('{"theirs": true}\n')
+        rows = self.wire()
+        self.assertEqual(rows["opencode.json"], "foreign")
+        self.assertEqual((self.clone / "opencode.json").read_text(), '{"theirs": true}\n')
+        # And not hidden either — the quieter half of the same restraint.
+        self.assertNotIn("/opencode.json", self.excludes().splitlines())
+
+    def test_the_marker_vouches_for_every_one_of_them(self):
+        """`doctor` tells `stale` from `foreign` by this file and nothing else."""
+        self.seed()
+        self.wire()
+        marker = json.loads((self.clone / workspace.GENERATED_MARKER).read_text())
+        for rel in (".opencode/agent/steward.md", ".codex/skills/s/SKILL.md",
+                    "opencode.json"):
+            self.assertEqual(marker[rel],
+                             workspace.content_digest((self.clone / rel).read_text()))
+
+    def test_a_stale_copy_is_refreshed_and_a_taken_over_one_is_not(self):
+        """Refresh, not create-once — a copy an older charter wrote must not survive every
+        upgrade while `doctor` reports the checkout wired (ADR 0015). The distinction is
+        the marker's, and it has to hold for the paths #868 added or those two harnesses
+        get the create-once bug the `.claude/` ones already lost."""
+        self.seed()
+        self.wire()
+        self.plane("opencode.json", '{"moved": true}\n')
+        self.plane(".codex/skills/s/SKILL.md", "cx moved\n")
+        # The operator's now. Charter cannot vouch for it, so it never rewrites it — even
+        # though the plane's copy moved in exactly the same way.
+        (self.clone / ".codex/skills/s/SKILL.md").write_text("theirs\n")
+        rows = self.wire()
+        self.assertEqual(rows["opencode.json"], "refreshed")
+        self.assertEqual((self.clone / "opencode.json").read_text(), '{"moved": true}\n')
+        self.assertEqual(rows[".codex/skills/s/SKILL.md"], "foreign")
+        self.assertEqual((self.clone / ".codex/skills/s/SKILL.md").read_text(), "theirs\n")
+
+    def test_unwiring_takes_them_back_out_and_leaves_no_empty_directories(self):
+        """`workspace remove` unwires before the `rmtree`, because a linked worktree's
+        exclude lives in a main repo outside the directory. A `.codex/skills/s/` left
+        standing after its last generated file is charter still visible in a repo it no
+        longer has anything in."""
+        self.seed()
+        self.wire()
+        removed = workspace.unwire_guest(self.clone)
+        for rel in (".opencode/agent/steward.md", ".codex/skills/s/SKILL.md",
+                    "opencode.json"):
+            self.assertIn(rel, removed)
+            self.assertFalse((self.clone / rel).exists())
+        self.assertFalse((self.clone / ".codex").exists())
+        self.assertFalse((self.clone / ".opencode").exists())
+        # git's own commented header stays; charter's block is what goes. Asserting the
+        # file is EMPTY would pass for a charter that had truncated somebody else's file.
+        left = self.excludes()
+        self.assertNotIn("charter", left)
+        self.assertNotIn("opencode.json", left)
+
+    def test_a_binary_in_one_surface_does_not_empty_the_others(self):
+        """One unreadable file must not take the layer down with it — the restraint
+        `_inherited_files` records, now across three harnesses rather than one."""
+        self.seed()
+        (config.ROOT / ".codex/skills/s/logo.png").write_bytes(b"\x89PNG\r\n\x1a\n\xff\xfe")
+        self.wire()
+        self.assertFalse((self.clone / ".codex/skills/s/logo.png").exists())
+        self.assertTrue((self.clone / ".opencode/agent/steward.md").is_file())
+        self.assertTrue((self.clone / "opencode.json").is_file())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #868 — the one item left after #872 and #873. Items (1), (3) and (4) landed there; this is (2).

## The limit

`charter/workspace.py` held what a git boundary cuts a session off from as two literals:

```python
WALKUP_DIRS = (".claude/agents", ".claude/skills")
```

so a guest checkout at `workspaces/<ws>/<repo>/` received Claude Code's walk-up directories and nothing else. #872 recorded that as a **stated limit** with the measured facts beside it, which is honest. An honest limit is still a limit: an operator on opencode or Codex got a workspace with none of the plane's agents or skills.

## The shape

The spelling moves onto the harness — `Harness.inherited_paths`, beside `layer` and `layer_note`, which #873 added for exactly this — and `workspace._inherited_files` (was `_walkup_files`) asks `registry.inherited_paths()`.

| harness | carried into a checkout | binary |
|---|---|---|
| Claude Code | `.claude/agents`, `.claude/skills` | 2.1.259 |
| opencode | `.opencode/agent` | 1.18.23 |
| Codex | `.codex/skills` | 0.147.0 |

## One item on #868's table is measured right and still not carried

The issue lists `opencode.json` at the project root, and the measurement behind it holds: opencode reads it there, a malformed one fails the run outright, so a clone genuinely stops seeing the plane's copy. Charter still does not mirror it, and the reason is one command:

```
$ charter guard allow "npm test *"
opencode: allowing permission.bash."npm test *" → <plane>/opencode.json
```

That file is where `charter guard` keeps **this plane's permission grants**. Copying it into `workspaces/<ws>/<repo>/` would put an `allow` in force in a repository nobody granted it in — and charter answered the same question one harness over and answered it the other way: a checkout gets a *generated* `.claude/settings.json` of three keys, explicitly not `permissions`, "*because copying a grant sideways into a directory nobody granted it in puts a permission in force where no one clicked for it*". The same mechanism writing into the same directory must not answer it two opposite ways for two harnesses.

So `inherited_paths` carries **capability** — agents, skills, commands. Where a harness's config file mixes capability and grant, a mirror is the wrong instrument (it cannot drop a key) and `workspace_files` is the one that can. That is separate work, and nothing of *charter's* is missing from a checkout meanwhile: charter's opencode layer is machine-global and already reaches every directory on the box.

Pinned without naming a filename — each registered harness is asked to write an allow rule into a throwaway root, and any harness that mirrors a file its own guard just wrote to fails. Happy to carry `opencode.json` instead if you'd rather; it needs the grant question answered first, and that answer is a change to `charter guard`'s scope, not to this mechanism.

**A separate member from `layer`, not derived from it.** `layer` answers *"would a session started here find it, by which rule"*, and `LayerPart` has exactly two measured rules — cwd-only, and walk up to the git root. opencode resolves `opencode.json` at the repository **root**, which is neither; declaring it as a walking part would report a layer as reachable from an intermediate directory opencode never reads there, and `part_reaches` says over-claiming is the one direction that row must never be wrong in. This member answers something narrower that *is* measured for all three: which of the plane's in-repo paths a nested checkout stops seeing. Deriving one from the other would have kept opencode's paths out of a clone for as long as its discovery rule went unmeasured.

**A path that is a FILE.** Every shipped harness spells its surface as a directory today, and the mirror still reads a plain file first — `rglob` on a file yields nothing at all, so a mirror that skipped that would answer "nothing" for the next harness that spells it as one file at a repository root, silently. Half the in-repo surfaces charter has measured are exactly that shape. Pinned with a harness of its own.

**Two more things are deliberately absent.** A project `.codex/config.toml`, because Codex ignores it (measured: a malformed one causes no error) and writing it would be charter's own output looking exactly like wiring while being inert. And `CLAUDE.md` or any equivalent: a guest hides its own files, it does not narrate the host's.

## What still holds

Every restraint #870 bought is re-asked of the paths this adds, in a real clone in a real workspace: exact paths in `.git/info/exclude` and never a directory glob, idempotent re-wiring, a foreign file neither rewritten nor hidden (the guest's own `opencode.json` is the sharpest case in the set), `.charter-generated` vouching for each so `doctor` still tells `stale` from `foreign`, a stale copy refreshed rather than left for the next upgrade, and removal that prunes the directories it emptied. `workspaces/<ws>/` gets none of it and needs none of it — every one of these paths resolves from inside the plane's own repository, so a second copy would shadow the first.

The workspace-**directory** ceiling in `charter harness list` is untouched and still true: a workspace directory is not a config scope for opencode or Codex, so two workspaces on one machine cannot be made to differ. That is a different question from a clone, and `docs/workspaces.md` now keeps them apart — it was still saying "nothing is written into a clone", which #870 closed and nobody updated.

## Guards

- `_inherited_files` and `_guest_files` are parsed with `ast` and refused if their **code** names any harness or harness path — the same pin `check_session_layer` carries, one verb over. Reporting a harness under another's rules and writing another harness's files are the same mistake; only the second lands on disk.
- The registry's answer is pinned for dedupe and for **order**, with two opposite registrations of one pair — an order that comes out of a set is right about half the time by luck.
- No harness may both generate and mirror a path, none may mirror the file its own guard writes grants into, and none may carry the plane's project instructions.

Three claims elsewhere in the tree said charter writes nothing in a repository and are corrected in passing — `codex.py`'s `workspace-scope` deficit, and `doctor.check_session_layer`, which had been saying charter *"deliberately writes nothing inside `workspaces/<ws>/<repo>/`"* since #870 landed and made that false. Both keep the argument they were making.

The two empty `layer` declarations stay empty, and their notes now give the honest reason: charter has not measured those harnesses' **discovery rules**, not that it writes nothing in a repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Us4MbwkSCJCxwt1CjAd1sf
