### PR TITLE
0.56.0 — a chat gets charter's layer wherever it runs

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "charter",
   "description": "Personas, workspaces and memory for coding agents across many repos \u2014 Claude Code, opencode and Codex",
-  "version": "0.55.0",
+  "version": "0.56.0",
   "author": {
     "name": "Aaron Yordanyan"
   },

--- a/charter/__init__.py
+++ b/charter/__init__.py
@@ -7,4 +7,4 @@ Run it as ``python3 -m charter`` (from the control plane root) or via the
 installed ``charter`` console script.
 """
 
-__version__ = "0.55.0"
+__version__ = "0.56.0"

--- a/docs/news/0.56.0-a-chat-in-a-workspace-gets-charters-layer.md
+++ b/docs/news/0.56.0-a-chat-in-a-workspace-gets-charters-layer.md
@@ -1,5 +1,6 @@
 ---
-version: unreleased
+version: 0.56.0
+lead: true
 headline: a chat launched in `workspaces/<ws>/` gets charter's layer there — the status line, the plugin and `$CHARTER_HARNESS` — and the two harnesses that cannot hold one say so instead of showing a tick
 ---
 

--- a/docs/news/0.56.0-a-chat-tab-shows-when-its-harness-is-working.md
+++ b/docs/news/0.56.0-a-chat-tab-shows-when-its-harness-is-working.md
@@ -1,5 +1,5 @@
 ---
-version: unreleased
+version: 0.56.0
 headline: a chat tab spins while that chat's harness is working — the turn's start was already on disk, the Stop hook that ends it was not
 ---
 

--- a/docs/news/0.56.0-a-clone-carries-every-harnesss-layer.md
+++ b/docs/news/0.56.0-a-clone-carries-every-harnesss-layer.md
@@ -1,5 +1,5 @@
 ---
-version: unreleased
+version: 0.56.0
 headline: a clone inside a workspace now carries **every** harness's in-repo surface, not Claude Code's — `.opencode/agent/` for opencode and `.codex/skills/` for Codex, each spelled by the harness rather than by charter
 ---
 

--- a/docs/news/0.56.0-a-clone-gets-the-layer-and-hides-it.md
+++ b/docs/news/0.56.0-a-clone-gets-the-layer-and-hides-it.md
@@ -1,5 +1,5 @@
 ---
-version: unreleased
+version: 0.56.0
 headline: a clone inside a workspace gets charter's layer too — written into the clone and hidden in that checkout's own `.git/info/exclude`, so your repo's `git status` never sees it
 ---
 

--- a/docs/news/0.56.0-a-green-doctor-row-keeps-nothing-back.md
+++ b/docs/news/0.56.0-a-green-doctor-row-keeps-nothing-back.md
@@ -1,5 +1,5 @@
 ---
-version: unreleased
+version: 0.56.0
 headline: 'The `frame` row says a blank status line is deliberate on a healthy machine too, instead of only on an old tmux'
 ---
 

--- a/docs/news/0.56.0-a-published-version-cannot-quietly-gain-a-file.md
+++ b/docs/news/0.56.0-a-published-version-cannot-quietly-gain-a-file.md
@@ -1,5 +1,5 @@
 ---
-version: unreleased
+version: 0.56.0
 headline: A release refuses a build whose artefact set a retry could add to a version PyPI already published
 ---
 

--- a/docs/news/0.56.0-a-random-directory-name-is-not-a-charter-spawn.md
+++ b/docs/news/0.56.0-a-random-directory-name-is-not-a-charter-spawn.md
@@ -1,5 +1,5 @@
 ---
-version: unreleased
+version: 0.56.0
 headline: charter's own suite stops refusing a `bash -c printf` because `tempfile` happened to spell `edm` in a random directory name — the plane tripwire now says which plane it objected to and where that value came from
 ---
 

--- a/docs/news/0.56.0-a-release-body-spends-what-github-allows.md
+++ b/docs/news/0.56.0-a-release-body-spends-what-github-allows.md
@@ -1,5 +1,5 @@
 ---
-version: unreleased
+version: 0.56.0
 headline: 'Release notes stop being shortened for headroom that was not needed — the budget is measured in the units GitHub might count, and its two guards read one window instead of two that could cross'
 ---
 

--- a/docs/news/0.56.0-a-renamed-workspace-keeps-its-chats-and-a-deleted-one-says-so.md
+++ b/docs/news/0.56.0-a-renamed-workspace-keeps-its-chats-and-a-deleted-one-says-so.md
@@ -1,5 +1,5 @@
 ---
-version: unreleased
+version: 0.56.0
 headline: A renamed workspace keeps its chats, and one that is gone stops being drawn as an empty one
 ---
 

--- a/docs/news/0.56.0-a-restored-chat-comes-back-in-its-workspace.md
+++ b/docs/news/0.56.0-a-restored-chat-comes-back-in-its-workspace.md
@@ -1,5 +1,5 @@
 ---
-version: unreleased
+version: 0.56.0
 headline: a restored chat comes back in its workspace, and says where it had been
 ---
 

--- a/docs/news/0.56.0-a-right-click-on-a-panel-stays-where-it-points.md
+++ b/docs/news/0.56.0-a-right-click-on-a-panel-stays-where-it-points.md
@@ -1,5 +1,5 @@
 ---
-version: unreleased
+version: 0.56.0
 headline: A right-click on a panel stays where it points too, and tmux's own pane menu is still there
 ---
 

--- a/docs/news/0.56.0-a-switch-dresses-where-you-are-going-first.md
+++ b/docs/news/0.56.0-a-switch-dresses-where-you-are-going-first.md
@@ -1,5 +1,5 @@
 ---
-version: unreleased
+version: 0.56.0
 headline: A switch draws the chat you are arriving at before it tidies the one you left, so the wait on a bare harness pane roughly halves
 ---
 

--- a/docs/news/0.56.0-a-tab-strip-grows-a-row-when-its-tabs-overflow.md
+++ b/docs/news/0.56.0-a-tab-strip-grows-a-row-when-its-tabs-overflow.md
@@ -1,5 +1,5 @@
 ---
-version: unreleased
+version: 0.56.0
 headline: a tab strip whose names will not fit on one row is given another one — and gives it back when the pane is widened again
 ---
 

--- a/docs/news/0.56.0-charter-records-the-plane-as-it-changes.md
+++ b/docs/news/0.56.0-charter-records-the-plane-as-it-changes.md
@@ -1,5 +1,5 @@
 ---
-version: unreleased
+version: 0.56.0
 headline: the plane is recorded as it changes, not only when you quit — and bare `charter` puts it back
 ---
 

--- a/docs/news/0.56.0-charter-save-refuses-from-a-workspace-clone-that-is-a-plane.md
+++ b/docs/news/0.56.0-charter-save-refuses-from-a-workspace-clone-that-is-a-plane.md
@@ -1,5 +1,5 @@
 ---
-version: unreleased
+version: 0.56.0
 headline: '`charter save` from a workspace clone that is itself a plane refuses, instead of committing the outer plane'
 ---
 

--- a/docs/news/0.56.0-doctor-answers-for-the-directory-it-is-running-in.md
+++ b/docs/news/0.56.0-doctor-answers-for-the-directory-it-is-running-in.md
@@ -1,5 +1,5 @@
 ---
-version: unreleased
+version: 0.56.0
 headline: '`charter doctor` reports the directory the session is rooted in, and says when that is not the plane'
 ---
 

--- a/docs/news/0.56.0-doctor-says-which-of-charters-layer-reaches-here.md
+++ b/docs/news/0.56.0-doctor-says-which-of-charters-layer-reaches-here.md
@@ -1,5 +1,5 @@
 ---
-version: unreleased
+version: 0.56.0
 headline: `charter doctor` grows a `session layer` row that answers whether a session started in this directory can see charter's layer — naming which of settings, skills+agents or the status line is missing, which discovery rule decided, and whether the directory is trusted enough for any of it to run
 ---
 

--- a/docs/news/0.56.0-hooks-are-plane-gated.md
+++ b/docs/news/0.56.0-hooks-are-plane-gated.md
@@ -1,5 +1,5 @@
 ---
-version: unreleased
+version: 0.56.0
 headline: charter's hooks stop writing into repositories that are not control planes — outside a plane the plugin now says nothing, writes nothing and grants nothing, while the vault-leak and live-substitution guards keep refusing
 ---
 

--- a/docs/news/0.56.0-right-click-a-chat-tab-to-act-on-that-chat.md
+++ b/docs/news/0.56.0-right-click-a-chat-tab-to-act-on-that-chat.md
@@ -1,5 +1,5 @@
 ---
-version: unreleased
+version: 0.56.0
 headline: right-click a chat tab and charter draws a menu about that tab — its transcript, and closing it
 ---
 

--- a/docs/news/0.56.0-the-plane-init-creates-is-one-init-can-see.md
+++ b/docs/news/0.56.0-the-plane-init-creates-is-one-init-can-see.md
@@ -1,5 +1,5 @@
 ---
-version: unreleased
+version: 0.56.0
 headline: '`charter init` re-derives config where the marker lands, so the plane it just built is one it can see'
 ---
 

--- a/docs/news/0.56.0-the-session-root-row-stops-contradicting-the-row-below-it.md
+++ b/docs/news/0.56.0-the-session-root-row-stops-contradicting-the-row-below-it.md
@@ -1,5 +1,5 @@
 ---
-version: unreleased
+version: 0.56.0
 headline: '`charter doctor`''s `session root` row stops telling you agents and skills do not walk up, one line above the row that correctly says they do'
 ---
 

--- a/docs/news/0.56.0-the-tmux-integration-tests-stop-waiting-for-the-next-look.md
+++ b/docs/news/0.56.0-the-tmux-integration-tests-stop-waiting-for-the-next-look.md
@@ -1,5 +1,5 @@
 ---
-version: unreleased
+version: 0.56.0
 headline: The tmux integration tests stop waiting for the next look, so the suite's slowest module costs a third less on every run and every mutation
 ---
 

--- a/docs/news/0.56.0-the-workspace-tab-tests-stop-rebuilding-the-tmux-server-between-them.md
+++ b/docs/news/0.56.0-the-workspace-tab-tests-stop-rebuilding-the-tmux-server-between-them.md
@@ -1,5 +1,5 @@
 ---
-version: unreleased
+version: 0.56.0
 headline: The workspace-tab tests stop rebuilding the tmux server between themselves, so a red pull request stops meaning "the runner was busy"
 ---
 

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -14,7 +14,7 @@
           },
           {
             "type": "command",
-            "command": "charter hook sessionstart --plugin-version 0.55.0",
+            "command": "charter hook sessionstart --plugin-version 0.56.0",
             "timeout": 5
           },
           {
@@ -35,7 +35,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook userpromptsubmit --plugin-version 0.55.0",
+            "command": "charter hook userpromptsubmit --plugin-version 0.56.0",
             "timeout": 5
           }
         ]
@@ -47,7 +47,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse --plugin-version 0.55.0",
+            "command": "charter hook pretooluse --plugin-version 0.56.0",
             "timeout": 10
           }
         ]
@@ -57,7 +57,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse-read --plugin-version 0.55.0",
+            "command": "charter hook pretooluse-read --plugin-version 0.56.0",
             "timeout": 5
           }
         ]
@@ -67,7 +67,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse-dispatch --plugin-version 0.55.0"
+            "command": "charter hook pretooluse-dispatch --plugin-version 0.56.0"
           }
         ]
       },
@@ -76,7 +76,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse-edit --plugin-version 0.55.0",
+            "command": "charter hook pretooluse-edit --plugin-version 0.56.0",
             "timeout": 5
           }
         ]
@@ -88,7 +88,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse-bash --plugin-version 0.55.0",
+            "command": "charter hook posttooluse-bash --plugin-version 0.56.0",
             "timeout": 5
           }
         ]
@@ -98,7 +98,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse --plugin-version 0.55.0",
+            "command": "charter hook posttooluse --plugin-version 0.56.0",
             "timeout": 5
           }
         ]
@@ -108,7 +108,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse-skill --plugin-version 0.55.0",
+            "command": "charter hook posttooluse-skill --plugin-version 0.56.0",
             "timeout": 5
           }
         ]
@@ -118,7 +118,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse-dispatch --plugin-version 0.55.0",
+            "command": "charter hook posttooluse-dispatch --plugin-version 0.56.0",
             "timeout": 5
           }
         ]
@@ -128,7 +128,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse-message --plugin-version 0.55.0",
+            "command": "charter hook posttooluse-message --plugin-version 0.56.0",
             "timeout": 5
           }
         ]
@@ -139,7 +139,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook stop --plugin-version 0.55.0",
+            "command": "charter hook stop --plugin-version 0.56.0",
             "timeout": 5
           },
           {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "charter-cp"
-version = "0.55.0"
+version = "0.56.0"
 description = "Personas, workspaces and memory for coding agents across many repos — Claude Code, opencode and Codex"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Cuts **0.56.0**. Version bump and news stamp only — no behaviour change.

Rebuilt on top of #883, which unblocked this. **Replayed onto `main` rather than rebased**: the previous head stamped the same entries #883 was correcting, so a rebase would have resolved into a stamped copy of the stale prose. Resetting to `main` and re-running the bump and stamp guarantees every entry carries #883's corrected text.

## The four version sites move together

| file | 0.55.0 → 0.56.0 |
| --- | --- |
| `pyproject.toml` | `version` |
| `charter/__init__.py` | `__version__` |
| `.claude-plugin/plugin.json` | `version` |
| `hooks/hooks.json` | all **12** `--plugin-version` flags |

Re-grepped for the old version afterwards: every remaining `0.55.0` is historical prose, a test fixture, or a persona memory. `TestVersionsMoveInLockstep` passes.

## The news is stamped, not written

`news.stamp("0.56.0")` moved **23** staged entries — the 21 from the first cut plus the two #883 brought — atomically, nothing blocked, read-back found 23, and nothing is left staged.

`lead: true` goes to **a chat launched in `workspaces/<ws>/` gets charter's layer there**. The release's through-line is that a chat gets charter's layer wherever it runs; the clone entries and the `doctor` row read as its consequences. No entry declares `security:`, so the other 22 sort alphabetically beneath it.

## The body fits whole — with 729 bytes to spare

Measured with `news.sent_length`, the larger of code points and encoded bytes, which is what #883's guards use:

| | |
| --- | --- |
| entries | 23 |
| characters | 120,436 |
| UTF-8 bytes | **121,271** |
| `sent_length` | **121,271** |
| `_BODY_BUDGET` | 122,000 |
| headroom to budget | **729 bytes** |
| headroom to `RELEASE_BODY_MAX` | 3,729 bytes |
| **notes elided** | **none — renders whole** |

All four of the notes 0.56.0 previously lost to elision are back. `test_release_notes_fit_the_release` passes in full, including #883's new `test_the_floor_can_never_ask_for_more_than_the_ceiling_allows`.

**729 bytes is thin, and it is worth naming.** `news._elision`'s own notice is 443 bytes, so the slack here is under two of those. Any entry added to 0.56.0 before the tag — a correction that lengthens prose, or a note for #885 — pushes the body past the budget and restarts elision; a typical entry in this release is several thousand bytes, which would also clear `RELEASE_BODY_MAX`. That is the bound working as designed rather than a fault, but it means **this release has room for no further notes**.

This does not put 0.57.0 in trouble: each release renders only its own entries, so 0.57.0 starts from zero and grows. The pressure is on *this* body, now.

## The asset-freshness gate

Still nothing to regenerate. `docs/assets/captured.json` stamps all three captures at 0.55.0, so at 0.56.0 the lag is exactly 1 and `MAX_MINOR_LAG` allows it. 0.57.0 will need them regenerated.

## One gap, for a maintainer to decide

**#885 (the persona switcher, #882) shipped with no news entry.** Its file list contains no `docs/news/` path and nothing staged mentions the switcher, so re-running the stamp cannot pick it up — there is nothing to pick up. It is a user-visible change: it reorders the `F2` picker and the sidebar persona column. Deliberately not written here, both because authoring another PR's note is not the release engineer's call and because, as measured above, this body has no room for it without forcing elision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Us4MbwkSCJCxwt1CjAd1sf
