### PR TITLE
`_BODY_BUDGET` gets a legal value, and the session root row stops contradicting the one below it (#878, #879)

### DIFF
--- a/charter/commands.py
+++ b/charter/commands.py
@@ -2849,7 +2849,14 @@ def cmd_news(args) -> int:
         # redirects into and a character GitHub counts, and measuring the string rather than
         # the file is the off-by-one that would show up only at the ceiling — which is the
         # one place nobody gets a second try.
-        sent = len(body) + 1
+        #
+        # `news._sent_length` rather than `len`, and the same call `render_body` bounds
+        # itself with, so the number that decides an elision and the number that decides
+        # this refusal cannot disagree. It is the encoded length: never below the character
+        # count, so this refuses whichever unit GitHub's validator is really counting. The
+        # message says "characters" because that is the word in GitHub's own refusal and
+        # the reader is being told what GitHub will say.
+        sent = news._sent_length(body) + 1
         if sent > news.RELEASE_BODY_MAX:
             util.err(
                 f"the release notes for {version} come to {sent:,} characters and GitHub "

--- a/charter/commands.py
+++ b/charter/commands.py
@@ -2850,13 +2850,13 @@ def cmd_news(args) -> int:
         # the file is the off-by-one that would show up only at the ceiling — which is the
         # one place nobody gets a second try.
         #
-        # `news._sent_length` rather than `len`, and the same call `render_body` bounds
+        # `news.sent_length` rather than `len`, and the same call `render_body` bounds
         # itself with, so the number that decides an elision and the number that decides
         # this refusal cannot disagree. It is the encoded length: never below the character
         # count, so this refuses whichever unit GitHub's validator is really counting. The
         # message says "characters" because that is the word in GitHub's own refusal and
         # the reader is being told what GitHub will say.
-        sent = news._sent_length(body) + 1
+        sent = news.sent_length(body) + 1
         if sent > news.RELEASE_BODY_MAX:
             util.err(
                 f"the release notes for {version} come to {sent:,} characters and GitHub "

--- a/charter/doctor.py
+++ b/charter/doctor.py
@@ -890,7 +890,14 @@ def _discovery_rules() -> tuple[list[str], list[str]]:
     if current and live is None:
         return [], []
     harnesses = [live] if live else _registry.all()
-    parts = [p for h in harnesses for p in (h.layer or ())]
+    # `h.layer` and not `h.layer or ()`, and the distinction is which side of charter the
+    # value comes from. `Harness.layer` is a class attribute charter declares — `tuple[
+    # LayerPart, ...] = ()` on the base, a tuple on all three registered harnesses — so an
+    # `or ()` in front of it guards a shape charter itself guarantees one file away: a
+    # branch nothing can reach, which the deletion sweep charged as a survivor and was right
+    # to. A fallback in front of somebody ELSE's answer is a different thing and stays; this
+    # was one in front of charter's own. `check_session_layer` reads the attribute bare too.
+    parts = [p for h in harnesses for p in h.layer]
     return (list(dict.fromkeys(p.what for p in parts if not p.walks)),
             list(dict.fromkeys(p.what for p in parts if p.walks)))
 

--- a/charter/doctor.py
+++ b/charter/doctor.py
@@ -658,12 +658,21 @@ def session_root() -> Path:
     **Not the plane, and that is the whole point.** `config.ROOT` comes from
     `root.find_root`, which walks UP from the working directory until it finds a
     `charter.toml` — so it lands on the plane from anywhere inside it, which is exactly
-    right for identity. Claude Code does not walk up: project settings, agents, skills and
-    commands are read from the session's own directory and nowhere above it (only
-    `CLAUDE.md` walks). A chat launched at `workspaces/<ws>/` — where the `+` button and
-    every workspace tab put one — therefore reads none of the plane's `.claude/`, while
-    `doctor` read all of it and reported the plugin enabled and the guard wired over a
-    session that had neither.
+    right for identity. **Project settings do not walk up**: `.claude/settings.json` is read
+    from the session's own directory and nowhere above it, which is the rule this function
+    exists to serve — every settings row below reads what it returns. A chat launched at
+    `workspaces/<ws>/` — where the `+` button and every workspace tab put one — therefore
+    reads none of the plane's settings, while `doctor` read all of them and reported the
+    plugin enabled and the guard wired over a session that had neither.
+
+    This paragraph used to say agents, skills and commands were read the same way. They are
+    not: `.claude/agents/` and `.claude/skills/` walk up and stop at the git root, and
+    `CLAUDE.md` walks up and is not git-bounded at all — measured on Claude Code 2.1.259 and
+    declared on `Harness.layer`, which is where every part of that answer now lives (#879).
+    Charter has measured no rule for `.claude/commands` and this therefore claims none.
+    Settings are the only artefact this function answers for, and the only one it should:
+    which of the rest reach a directory is `check_session_layer`'s question, resolved
+    against that directory's real git root rather than stated in prose here.
 
     ``os.getcwd()`` is the evidence available, and it is the right evidence rather than a
     stand-in: doctor runs *inside* the session it is reporting on, so the directory this
@@ -834,6 +843,58 @@ def _plugin_declaring_guard(root: Path | None = None) -> str | None:
     return None
 
 
+def _named(items: list[str]) -> str:
+    """*items* as English — ``a``, ``a and b``, ``a, b and c``."""
+    if len(items) < 2:
+        return "".join(items)
+    return f"{', '.join(items[:-1])} and {items[-1]}"
+
+
+def _discovery_rules() -> tuple[list[str], list[str]]:
+    """Which parts of charter's layer are read from the session's own directory, and which
+    walk up — as the **harnesses** declare them, never as a sentence in this file.
+
+    Read from `Harness.layer` so that `session root` and `session layer` narrate one set of
+    rules from one source. They did not, and #879 is what that cost: this row said the host
+    reads "project settings, agents, skills and commands from the session's own directory
+    and does not walk up", while the row printed directly under it — added one pull request
+    later, from a measurement against Claude Code 2.1.259 — said `.claude/agents` and
+    `.claude/skills` **do** walk up and stop at the git boundary. Both rows described the
+    same binary; only one of them had measured it. An operator in a workspace clone reading
+    both was told their agents and skills were out of reach on the line above the line that
+    said they were not.
+
+    Prose was the wrong shape for it rather than merely the wrong words. Two rows narrating
+    one discovery rule from two independent sources is the drift this file already refuses
+    on the harness side — `check_session_layer` says the rules live on the harness *"and the
+    day a fourth harness is registered it would silently be reported under Claude Code's
+    rules"*. This row was that failure with the harness list of one.
+
+    ``commands`` is dropped rather than reworded. Charter has measured no discovery rule for
+    `.claude/commands`, so no `LayerPart` names it, so this row cannot: under-claiming is the
+    direction that cannot mislead, which is `_search_dirs`'s reasoning about an unmeasured
+    walk boundary.
+
+    **A harness charter has not met answers for nothing**, and both lists come back empty
+    for it. `check_session_layer` refuses to report an unregistered runtime under Claude
+    Code's rules; reporting it here instead would be the same borrowed answer one row up.
+
+    `dict.fromkeys` and not a set, for `check_session_layer`'s reason: string hashing is
+    randomised per process, so a set would order this sentence differently from one run to
+    the next.
+    """
+    from .harness import registry as _registry
+
+    current = _registry.current()
+    if current and _registry.get(current) is None:
+        return [], []
+    live = _registry.get(current)
+    harnesses = [live] if live else _registry.all()
+    parts = [p for h in harnesses for p in (h.layer or ())]
+    return (list(dict.fromkeys(p.what for p in parts if not p.walks)),
+            list(dict.fromkeys(p.what for p in parts if p.walks)))
+
+
 def check_session_root() -> Result:
     """Which directory answered for the settings rows — and whether it is the plane (#851).
 
@@ -843,6 +904,15 @@ def check_session_root() -> Result:
     up front, in the vocabulary charter already uses for it: **the plane is identity, the
     directory you are standing in is artifacts** (`config.in_tree`, `docs/control-plane.md`
     → *What follows the plane, and what follows the tree*).
+
+    **And the rules it names come from :func:`_discovery_rules`, not from a sentence here**
+    (#879). This row told an operator that agents and skills are read from the session's own
+    directory and do not walk up; the `session layer` row, printed on the very next line,
+    told them the opposite and was right. See `_discovery_rules` for why the fix is a shared
+    source rather than better words. What is left in this row's own voice is the one thing
+    it owns — which directory answered — and the walking half is handed to `session layer`
+    unanswered, because whether the walk arrives is a question about this directory's git
+    root and that row is the one that resolves it.
 
     **A fact, never a verdict — OK even when the two differ.** A chat rooted in a workspace
     is the designed workflow: the `+` button and every workspace tab put one there, and a
@@ -870,16 +940,27 @@ def check_session_root() -> Result:
         return Result(name, OK, detail=f"{here} — no control plane found")
     if session_is_the_plane():
         return Result(name, OK, detail=f"{here} — the plane")
-    return Result(
-        name, OK,
-        detail=(f"{here} — not the plane ({_config.ROOT})\n"
-                f"        ↳ the host reads project settings, agents, skills and commands "
-                f"from the session's own directory and does not walk up, so the plane's "
-                f".claude/ is not in force here — the rows below read {here}/.claude/ and "
-                f"~/.claude/\n"
-                f"        ↳ the plane is still this session's identity: personas, the "
-                f"vault, memory and workspaces resolve to {_config.ROOT} from anywhere "
-                f"inside it"))
+    cwd_only, walking = _discovery_rules()
+    lines = [f"{here} — not the plane ({_config.ROOT})"]
+    if cwd_only:
+        lines.append(f"the host reads {_named(cwd_only)} from the session's own directory "
+                     f"and does not walk up, so the plane's .claude/ is not in force for "
+                     f"them — the rows below read {here}/.claude/ and ~/.claude/")
+    else:
+        lines.append(f"the rows below read {here}/.claude/ and ~/.claude/, not the "
+                     f"plane's")
+    if walking:
+        # Said here, in the row that would otherwise be read as "none of it reaches",
+        # and said WITHOUT an answer: whether the walk actually delivers anything from
+        # this directory depends on where its git root is, and `session layer` is the row
+        # that resolves that against the real filesystem. Two rows answering it would be
+        # #879 again in the other direction.
+        lines.append(f"{_named(walking)} DO walk up, as far as the git root — which of "
+                     f"them reach here is the `session layer` row below, not this one")
+    lines.append(f"the plane is still this session's identity: personas, the vault, "
+                 f"memory and workspaces resolve to {_config.ROOT} from anywhere inside "
+                 f"it")
+    return Result(name, OK, detail="\n        ↳ ".join(lines))
 
 
 def _git_root_of(here: Path) -> Path | None:

--- a/charter/doctor.py
+++ b/charter/doctor.py
@@ -886,9 +886,9 @@ def _discovery_rules() -> tuple[list[str], list[str]]:
     from .harness import registry as _registry
 
     current = _registry.current()
-    if current and _registry.get(current) is None:
-        return [], []
     live = _registry.get(current)
+    if current and live is None:
+        return [], []
     harnesses = [live] if live else _registry.all()
     parts = [p for h in harnesses for p in (h.layer or ())]
     return (list(dict.fromkeys(p.what for p in parts if not p.walks)),

--- a/charter/harness/claude_code.py
+++ b/charter/harness/claude_code.py
@@ -93,7 +93,11 @@ LAYER = (
 #: Settings arrive by :meth:`ClaudeCodeHarness.workspace_files`, which every checkout gets
 #: through `_harness_files`; listing it here as well would mirror the plane's file over the
 #: generated one. `CLAUDE.md` is the project-instructions line `Harness.inherited_paths`
-#: draws — it walks up on the same rule as the two below and is left behind on purpose.
+#: draws, and it is left behind on purpose — but **not** on the rule the two below follow,
+#: which is what this comment used to say. :data:`LAYER` has the measurement: it walks up
+#: and is NOT git-bounded, so the plane's own copy already reaches a checkout inside the
+#: plane and there is no gap here for a mirror to close. What a mirror would add is the
+#: plane's instructions inside somebody else's repository, read there as that repository's.
 WALKUP_DIRS = (".claude/agents", ".claude/skills")
 
 

--- a/charter/news.py
+++ b/charter/news.py
@@ -673,8 +673,9 @@ def sent_length(body: str) -> int:
 #: held back, and it reshaped two releases GitHub would have taken whole: 0.52.0, whose
 #: published Release carries all 24 of its notes in full and none as a link, rendered here
 #: as 20 notes and four links — `charter news --for 0.52.0` printing a document GitHub does
-#: not hold — and 0.56.0, four notes short at 115,155 bytes against an allowance of 125,000.
-#: At 122,000 both render whole and the archive agrees with itself again.
+#: not hold — and the release this landed in, whose notes came to 115,155 bytes when #878 was
+#: filed, against an allowance of 125,000, and lost four of them for it. At 122,000 both
+#: render whole and the archive agrees with itself again.
 #:
 #: **A fraction of the limit was the other rejected shape** — `RELEASE_BODY_MAX * 0.85`, and
 #: the ceiling case used to compute one. A fraction re-derives itself whenever the limit

--- a/charter/news.py
+++ b/charter/news.py
@@ -610,69 +610,101 @@ def for_version(version: str) -> list[Entry]:
 #: rather than trimming to fit — so a version whose notes render past it does not publish
 #: shorter notes, it publishes **none**.
 #:
-#: Characters, not bytes, and the distinction is load-bearing in both directions. The API
-#: counts code points and charter's entries are not ASCII — they carry ``—``, ``✗``, ``⬢``
-#: — so ``len(body.encode())`` reports a bigger number than the one GitHub applies and
-#: would refuse a release GitHub would have accepted. 0.54.0's 86 notes differ by 438
-#: between the two measures in the body that shipped, and by 3,603 rendered whole.
+#: **Whether it counts characters or bytes charter does not know, and no longer has to.**
+#: The refusal says "characters" and charter's entries are not ASCII — they carry ``—``,
+#: ``✗``, ``⬢`` — so the two measures differ, by 793 on the body 0.56.0 publishes and by
+#: 3,603 on 0.54.0's 86 notes rendered whole. This line used to resolve that by taking the
+#: message at its word and measuring code points, which is a guess about somebody else's
+#: validator standing between an irreversible upload and a release body. :func:`_sent_length`
+#: measures the larger of the two instead, so the question stops mattering: what it costs is
+#: under 1% of the limit and it is measured on the string rather than reserved for.
 RELEASE_BODY_MAX = 125_000
 
-#: How much of :data:`RELEASE_BODY_MAX` :func:`render_body` will actually spend. **Charter's
-#: number, and deliberately well below GitHub's**, for three reasons that are not one
-#: reason said three ways:
+
+def _sent_length(body: str) -> int:
+    """How long *body* is by the more conservative of the two measures GitHub might apply.
+
+    The encoded length, which for UTF-8 is never below the character count and is above it
+    for every entry charter has published — so a body under this number is under
+    :data:`RELEASE_BODY_MAX` whichever unit the API's validator is actually counting.
+
+    **Measuring code points was the alternative and it was a guess.** The refusal reads
+    ``body is too long (maximum is 125000 characters)``, which is evidence and not proof:
+    the word in an error message is not the expression that produced it, and the one place
+    the difference shows up is a body within 1% of the limit — i.e. exactly the bodies this
+    module exists for. Charter cannot run that validator, so it satisfies both readings.
+
+    **And the cost of doing so is measured rather than reserved for**, which is the trade
+    that makes this cheap. Across every version charter has stamped, the encoded body runs
+    between 0.25% and 1.22% longer than the character count (worst: 0.47.0, at 1.22%; the
+    two largest releases, 0.54.0 and 0.55.0, at 0.85%). Taking the conservative measure
+    therefore spends about a thousand characters of a 125,000-character allowance. The
+    reserve it replaces — a flat 15% of the limit, held back in case the units differed —
+    cost 0.52.0 four notes and 0.56.0 another four, for a hazard under a hundredth of it.
+
+    Used by :func:`render_body` to bound what it renders and by
+    :func:`commands.cmd_news` to decide what it refuses to print, so the number that
+    decides an elision and the number that decides a refusal are the same number.
+    """
+    return len(body.encode())
+
+
+#: How much of :data:`RELEASE_BODY_MAX` :func:`render_body` will actually spend, measured
+#: by :func:`_sent_length`. **Charter's number, and the 3,000 it leaves unspent is what the
+#: number is actually about.**
 #:
-#: *The string charter measures is not quite the string GitHub counts.* `charter news --for`
-#: ``print``s this body, so the file `announce` redirects into is one character longer than
-#: what was measured here, and nothing downstream re-measures. One character is enough at a
-#: bound set exactly at the ceiling, and that is the smallest of the three.
+#: **What the reserve still holds.** One thing: something added to the body that charter did
+#: not render. `announce` writes the file `gh release create` uploads, and a preamble, a
+#: footer or a wrapper added to that step lands on a body already at this budget — after the
+#: PyPI upload, which is the failure this whole mechanism exists to move to the cheap end.
+#: The largest block charter itself adds to a body no entry wrote is :func:`_elision`'s
+#: notice, at 443 bytes; 3,000 is seven of those.
 #:
-#: *A ceiling reached is a ceiling with nothing left for the next change.* A preamble, a
-#: footer, a wrapper someone adds to the announce step — any of them lands on a body already
-#: at the limit, and lands there **after** the PyPI upload, which is the failure this whole
-#: mechanism exists to move to the cheap end.
+#: **What it no longer holds, and this is the change.** It used to hold the gap between the
+#: string charter measured and the string GitHub counts — code points here, possibly bytes
+#: there — which was a guess about somebody else's validator, sized at a fifth of the
+#: allowance. :func:`_sent_length` settles that on the string instead, at a measured cost
+#: under 1%. It also used to hold slack against "just under is a state nobody notices", and
+#: that reason retired when the bound landed: a release over this budget is not refused, it
+#: is *reshaped*, and the only cliff is at :data:`RELEASE_BODY_MAX` — where
+#: :func:`commands.cmd_news` counts the newline `print` adds and refuses.
 #:
-#: *And "just under" is a state nobody notices.* 0.52.0 published at 111,723 characters —
-#: 3,277 short of the refusal — and nothing in the repository remarked on it, because
-#: nothing was looking. Entries accumulate one pull request at a time and each author sees
-#: only their own.
+#: **100,000 was the rejected value and it cost real notes.** A round fifth of the limit
+#: held back, and it reshaped two releases GitHub would have taken whole: 0.52.0, whose
+#: published Release carries all 24 of its notes in full and none as a link, rendered here
+#: as 20 notes and four links — `charter news --for 0.52.0` printing a document GitHub does
+#: not hold — and 0.56.0, four notes short at 115,155 bytes against an allowance of 125,000.
+#: At 122,000 both render whole and the archive agrees with itself again.
 #:
-#: 100,000 rather than a fraction of the limit, because a fraction invites re-deriving it:
-#: this is a round number a human holds, and it leaves a fifth of the API's allowance
-#: unspent.
+#: **A fraction of the limit was the other rejected shape** — `RELEASE_BODY_MAX * 0.85`, and
+#: the ceiling case used to compute one. A fraction re-derives itself whenever the limit
+#: moves and never says what the remainder is *for*, which is how a 15% reserve came to be
+#: guarding a 1% hazard. The remainder is the whole content of this number, so it is written
+#: as a subtraction a reader can check: 125,000 − 3,000.
 #:
-#: **It reaches for one release GitHub would have taken whole, and that is still 0.52.0, at
-#: 111,723.** This line used to say "above every release charter has ever cut but one",
-#: which counted elided releases rather than the thing the number decides — and 0.54.0
-#: retired that phrasing rather than merely dating it: 86 notes, 423,196 characters rendered
-#: whole, 3.4× the ceiling in :data:`RELEASE_BODY_MAX`. No value of this budget publishes
-#: that body, so eliding it is the bound doing the job it was added for and not the dial
-#: creeping down. The set this dial governs is the releases GitHub *would* have accepted
-#: whole, and there 0.52.0 is still the only one it reshapes.
+#: **The window is pinned from both ends, and both ends now read one number.**
+#: `tests/test_release_notes_fit_the_release.py` declares `RESERVE` beside its own copy of
+#: GitHub's limit and derives `CEILING` from them.
+#: `test_the_budget_keeps_the_reserve_it_declares` holds this line at or below that
+#: ceiling, and `test_the_bound_is_an_exception_rather_than_the_normal_path` requires
+#: every version whose whole body fits **under that same ceiling** to render whole.
+#: The floor's set is bounded by the ceiling, so its demand can never rise past it — which
+#: is the defect #878 reported: a floor counting all of history against a fixed fraction of
+#: the limit, growing every release until the two crossed and no value of this line was
+#: legal.
 #:
-#: **The deletion sweep reports this line as unpinned, and it is right to.** `retune-constant`
-#: rewrites it as ``100_001`` and the suite stays green, because it must: this is a dial, and
-#: one character of it changes no output anyone can name. What IS pinned is the *window* the
-#: dial has to sit in, from both ends and for different reasons —
-#: `test_the_staged_release_has_headroom` from above, so GitHub keeps real slack, and
-#: `test_the_bound_is_an_exception_rather_than_the_normal_path` from below, so a budget small
-#: enough to turn ordinary releases into a table of contents cannot pass while every length
-#: assertion still does. 100,001 is inside that window, which is exactly why it survives.
+#: **The deletion sweep used to report this line as unpinned and no longer can.** With the
+#: budget at the ceiling, `retune-constant`'s ``122_001`` reddens the case above. The floor
+#: is what a ``120_000`` or a ``90_000`` reddens, so the dial is held from both sides by
+#: cases that measure rendered bodies rather than read the literal back at itself.
 #:
-#: **The upper half of that window is open on a release branch, and that is where raising
-#: this number would be proposed.** `test_the_staged_release_has_headroom` measures
-#: ``render_body(UNRELEASED)`` and skips when nothing is staged — which is precisely the
-#: tree `charter news stamp` leaves behind, i.e. every release commit. So on the one commit
-#: where this number decides a body that is about to be published, the case that objects to
-#: raising it does not run, and a skipped case reports success. The floor below is the only
-#: half still speaking there. Treat a proposal to raise `_BODY_BUDGET` on a stamped tree as
-#: unguarded: measure it by hand, or make the case on a branch that still has entries
-#: staged — the alternative is discovering it in `announce`, after the upload.
-#:
-#: This is the "explained equivalent" the sweep's own docstring reserves, not a suppression:
-#: there is no suppression list and this needs none. The only test that would redden on
-#: ``100_001`` is one asserting the literal back at itself, and a test that reads the source
-#: it is checking is the assertion this file has watched fail more than once.
-_BODY_BUDGET = 100_000
+#: **Neither end skips on a release commit.** The ceiling case reads two constants, and the
+#: floor reads the stamped versions *and* the staged one — so it gives the same answer on a
+#: branch with entries staged and on the tree `charter news stamp` leaves behind. The old
+#: ceiling read `render_body(UNRELEASED)` and skipped when nothing was staged, which is
+#: every release commit: the one place this number decides a body about to be published was
+#: the one place the case objecting to raising it did not run.
+_BODY_BUDGET = 122_000
 
 
 def _part(e: Entry) -> str:
@@ -772,10 +804,16 @@ def render_body(version: str) -> str:
     The label comes from :func:`marker`, which the offline view calls too.
 
     **And the result is bounded, because the far end of it refuses a long one.** The whole
-    body is returned whenever it fits :data:`_BODY_BUDGET`, which is what sixteen of the
-    seventeen stamped versions do, and what keeps this function's output byte-identical to
-    what it has always been for them. Past that, the notes that fit are rendered whole and the rest become a headline
-    and a link, with :func:`_elision` between them saying so.
+    body is returned whenever it fits :data:`_BODY_BUDGET`, which is what eighteen of the
+    twenty stamped versions do. Past that, the notes that fit are rendered whole and the
+    rest become a headline and a link, with :func:`_elision` between them saying so.
+
+    **Measured by :func:`_sent_length`, not by :func:`len`.** The two differ by under 1% and
+    the difference is entirely in charter's favour: a body under the budget by the encoded
+    measure is under it by the character measure too, so the bound holds whichever unit
+    GitHub's validator is counting. What that costs is a note's worth of allowance on the
+    largest releases; what it replaces was a fifth of the allowance held back for the same
+    uncertainty. `_sent_length`'s docstring carries the measurements.
 
     Three properties decide the shape, and each of them rules out an easier one:
 
@@ -812,14 +850,14 @@ def render_body(version: str) -> str:
     entries = for_version(version)
     whole = [_part(e) for e in entries]
     body = "\n\n".join(whole)
-    if len(body) <= _BODY_BUDGET:
+    if _sent_length(body) <= _BODY_BUDGET:
         return body
     brief = [_brief(e) for e in entries]
     smallest = ""
     for k in range(len(entries) - 1, -1, -1):
         candidate = "\n\n".join([*whole[:k], _elision(k, len(entries), len(body)),
                                  *brief[k:]])
-        if len(candidate) <= _BODY_BUDGET:
+        if _sent_length(candidate) <= _BODY_BUDGET:
             return candidate
         smallest = candidate
     return smallest

--- a/charter/news.py
+++ b/charter/news.py
@@ -615,13 +615,13 @@ def for_version(version: str) -> list[Entry]:
 #: ``✗``, ``⬢`` — so the two measures differ, by 793 on the body 0.56.0 publishes and by
 #: 3,603 on 0.54.0's 86 notes rendered whole. This line used to resolve that by taking the
 #: message at its word and measuring code points, which is a guess about somebody else's
-#: validator standing between an irreversible upload and a release body. :func:`_sent_length`
+#: validator standing between an irreversible upload and a release body. :func:`sent_length`
 #: measures the larger of the two instead, so the question stops mattering: what it costs is
 #: under 1% of the limit and it is measured on the string rather than reserved for.
 RELEASE_BODY_MAX = 125_000
 
 
-def _sent_length(body: str) -> int:
+def sent_length(body: str) -> int:
     """How long *body* is by the more conservative of the two measures GitHub might apply.
 
     The encoded length, which for UTF-8 is never below the character count and is above it
@@ -650,7 +650,7 @@ def _sent_length(body: str) -> int:
 
 
 #: How much of :data:`RELEASE_BODY_MAX` :func:`render_body` will actually spend, measured
-#: by :func:`_sent_length`. **Charter's number, and the 3,000 it leaves unspent is what the
+#: by :func:`sent_length`. **Charter's number, and the 3,000 it leaves unspent is what the
 #: number is actually about.**
 #:
 #: **What the reserve still holds.** One thing: something added to the body that charter did
@@ -663,7 +663,7 @@ def _sent_length(body: str) -> int:
 #: **What it no longer holds, and this is the change.** It used to hold the gap between the
 #: string charter measured and the string GitHub counts — code points here, possibly bytes
 #: there — which was a guess about somebody else's validator, sized at a fifth of the
-#: allowance. :func:`_sent_length` settles that on the string instead, at a measured cost
+#: allowance. :func:`sent_length` settles that on the string instead, at a measured cost
 #: under 1%. It also used to hold slack against "just under is a state nobody notices", and
 #: that reason retired when the bound landed: a release over this budget is not refused, it
 #: is *reshaped*, and the only cliff is at :data:`RELEASE_BODY_MAX` — where
@@ -808,12 +808,12 @@ def render_body(version: str) -> str:
     twenty stamped versions do. Past that, the notes that fit are rendered whole and the
     rest become a headline and a link, with :func:`_elision` between them saying so.
 
-    **Measured by :func:`_sent_length`, not by :func:`len`.** The two differ by under 1% and
+    **Measured by :func:`sent_length`, not by :func:`len`.** The two differ by under 1% and
     the difference is entirely in charter's favour: a body under the budget by the encoded
     measure is under it by the character measure too, so the bound holds whichever unit
     GitHub's validator is counting. What that costs is a note's worth of allowance on the
     largest releases; what it replaces was a fifth of the allowance held back for the same
-    uncertainty. `_sent_length`'s docstring carries the measurements.
+    uncertainty. `sent_length`'s docstring carries the measurements.
 
     Three properties decide the shape, and each of them rules out an easier one:
 
@@ -850,14 +850,14 @@ def render_body(version: str) -> str:
     entries = for_version(version)
     whole = [_part(e) for e in entries]
     body = "\n\n".join(whole)
-    if _sent_length(body) <= _BODY_BUDGET:
+    if sent_length(body) <= _BODY_BUDGET:
         return body
     brief = [_brief(e) for e in entries]
     smallest = ""
     for k in range(len(entries) - 1, -1, -1):
         candidate = "\n\n".join([*whole[:k], _elision(k, len(entries), len(body)),
                                  *brief[k:]])
-        if _sent_length(candidate) <= _BODY_BUDGET:
+        if sent_length(candidate) <= _BODY_BUDGET:
             return candidate
         smallest = candidate
     return smallest

--- a/charter/news.py
+++ b/charter/news.py
@@ -612,8 +612,8 @@ def for_version(version: str) -> list[Entry]:
 #:
 #: **Whether it counts characters or bytes charter does not know, and no longer has to.**
 #: The refusal says "characters" and charter's entries are not ASCII — they carry ``—``,
-#: ``✗``, ``⬢`` — so the two measures differ, by 793 on the body 0.56.0 publishes and by
-#: 3,603 on 0.54.0's 86 notes rendered whole. This line used to resolve that by taking the
+#: ``✗``, ``⬢`` — so the two measures differ, by 3,603 on 0.54.0's 86 notes rendered whole
+#: and by 2,468 on 0.55.0's 54. This line used to resolve that by taking the
 #: message at its word and measuring code points, which is a guess about somebody else's
 #: validator standing between an irreversible upload and a release body. :func:`sent_length`
 #: measures the larger of the two instead, so the question stops mattering: what it costs is

--- a/docs/news/unreleased-a-chat-in-a-workspace-gets-charters-layer.md
+++ b/docs/news/unreleased-a-chat-in-a-workspace-gets-charters-layer.md
@@ -14,9 +14,10 @@ workspaces/*/   nothing — not one had a .claude
 ```
 
 Claude Code reads project settings from the session's working directory and **does not walk
-up**. Agents, skills and CLAUDE.md *do* walk up and stop at a git boundary, and a workspace
-directory is not one — it is a plain directory inside the plane's own repo — so those
-already arrived. What did not was everything that comes from a settings file: no plugin, no
+up**. Agents and skills *do* walk up and stop at a git boundary, and a workspace directory
+is not one — it is a plain directory inside the plane's own repo — so those already arrived.
+`CLAUDE.md` walks up too and, measured later in this release, is not git-bounded at all, so
+it arrives from further still. What did not was everything that comes from a settings file: no plugin, no
 status line, no `$CHARTER_HARNESS`. On this plane `fleet.1` and `opencode-integration.1`
 had been running that way all along.
 
@@ -98,7 +99,7 @@ differ per workspace, into a directory charter itself creates.
 The staleness bookkeeping comes back, and is paid for by the `doctor` row above. The
 `.git/info/exclude` entry per checkout does not arrive **for the workspace directory**:
 `/workspaces/*/*` is already in the plane's `.gitignore` and the managed LIVE block
-un-ignores four named paths, none of them `.claude/`. Nothing generated there can reach a
+un-ignores five named paths, none of them `.claude/`. Nothing generated there can reach a
 commit. One directory deeper it does arrive, and #870 is the entry that argues for it.
 
 ## To adopt

--- a/docs/news/unreleased-a-chat-tab-shows-when-its-harness-is-working.md
+++ b/docs/news/unreleased-a-chat-tab-shows-when-its-harness-is-working.md
@@ -136,7 +136,7 @@ The strip does not tick unless a chat is actually working, and learning that cos
 | `slots.chats_bar`, 3 chats, two working | 454.1 µs | **0.227% of a core** |
 | `inflight.turn_bump()`, one hook | 11.5 µs | per tool call |
 
-An idle plane pays the 4.8 µs and nothing else, forever — and only on the pane that draws
+An idle plane pays the 4.6 µs and nothing else, forever — and only on the pane that draws
 the strip. Against `slots.ANIMATED`'s own recorded budget, *"one `render("right")` costs
 4 816 µs … at 5Hz that one pane alone is ~2.4% of a core"*, an animated chat strip is a
 tenth of what this frame already animates.

--- a/docs/news/unreleased-a-clone-carries-every-harnesss-layer.md
+++ b/docs/news/unreleased-a-clone-carries-every-harnesss-layer.md
@@ -92,10 +92,14 @@ The paths are new; the restraints are not, and each is re-asked of them:
   `foreign`, and a stale copy is refreshed rather than left for the next upgrade;
 - removing the workspace removes them, pruning the directories that emptied.
 
-**`CLAUDE.md` is still deliberately left behind**, and so is any equivalent. It walks up on
-the same rule, so the gap is real for it too — and it is the one file a repo of its own is
-most likely to have opinions about. A guest hides its own files; it does not narrate the
-host's.
+**`CLAUDE.md` is still deliberately left behind**, and so is any equivalent — and the reason
+is not the one that applies to the directories above. It walks up on a **different** rule:
+measured on Claude Code 2.1.259 it is not git-bounded at all, so the plane's own copy
+already reaches a clone inside it and there is no gap here to fill. Copying it in would put
+the plane's project instructions inside somebody else's repository, to be read there as that
+repository's own — which is a claim of a different size from mirroring a settings key, and
+it is the one file a repo of its own is most likely to have opinions about. A guest hides
+its own files; it does not narrate the host's.
 
 A workspace **directory** gets none of this and needs none of it: every one of these paths
 is resolved from inside the plane's own repository, so the plane's copies already reach it

--- a/docs/news/unreleased-a-clone-gets-the-layer-and-hides-it.md
+++ b/docs/news/unreleased-a-clone-gets-the-layer-and-hides-it.md
@@ -72,11 +72,10 @@ measured against the installed binaries — `.claude/agents` and `.claude/skills
 `.opencode/agent` (1.18.23), `.codex/skills` (0.147.0). See *a clone carries every harness's
 layer*, in this same release.
 
-**CLAUDE.md is deliberately not carried in.** It walks up on the same rule, so the gap is
-real for it too — and it is the one file a repo of its own is most likely to have opinions
-about. Dropping the plane's project instructions into somebody else's repo, to be read
-there as that repo's instructions, is a claim of a different size from mirroring a settings
-key. A guest may hide its own files; it does not narrate the host's.
+**CLAUDE.md is deliberately not carried in**, on grounds of its own rather than the ones
+above — it walks up and is not git-bounded, so it already arrives here. The argument is in
+*a clone carries every harness's in-repo surface*, in this same release, beside the paths
+that are carried.
 
 ## Removal, and why it is not `rm -rf`
 

--- a/docs/news/unreleased-a-release-body-spends-what-github-allows.md
+++ b/docs/news/unreleased-a-release-body-spends-what-github-allows.md
@@ -15,7 +15,7 @@ was a fixed fraction of the limit and never moved.
 Most of that fraction was the units. GitHub refuses with `body is too long (maximum is
 125000 characters)`, and whether the validator behind it counts code points or bytes is not
 something charter can run and find out — so 15% was held back in case they differed.
-`news._sent_length` settles it on the string: it measures the encoded body, which is never
+`news.sent_length` settles it on the string: it measures the encoded body, which is never
 below the character count, so the bound holds either way. Measured across every version
 charter has cut, that costs between 0.25% and 1.22%.
 

--- a/docs/news/unreleased-a-release-body-spends-what-github-allows.md
+++ b/docs/news/unreleased-a-release-body-spends-what-github-allows.md
@@ -13,11 +13,10 @@ history, and required all but one to render whole — a demand that only grows. 
 was a fixed fraction of the limit and never moved.
 
 Most of that fraction was the units. GitHub refuses with `body is too long (maximum is
-125000 characters)`, and whether the validator behind it counts code points or bytes is not
-something charter can run and find out — so 15% was held back in case they differed.
-`news.sent_length` settles it on the string: it measures the encoded body, which is never
-below the character count, so the bound holds either way. Measured across every version
-charter has cut, that costs between 0.25% and 1.22%.
+125000 characters)`, and whether the validator counts code points or bytes is not something
+charter can run and find out — so 15% was held back in case they differed. `news.sent_length`
+measures the encoded body, never below the character count, so the bound holds either way.
+Across every version charter has cut, that costs 0.25%–1.22%.
 
 What is left to reserve for is one thing — something added to the body that charter did not
 render, landing after the PyPI upload. It is 3,000 now, a subtraction rather than a

--- a/docs/news/unreleased-a-release-body-spends-what-github-allows.md
+++ b/docs/news/unreleased-a-release-body-spends-what-github-allows.md
@@ -1,0 +1,30 @@
+---
+version: unreleased
+headline: 'Release notes stop being shortened for headroom that was not needed — the budget is measured in the units GitHub might count, and its two guards read one window instead of two that could cross'
+---
+
+**Four notes of this release were about to publish as a headline and a link, and GitHub
+would have taken the whole body.** So were four of 0.52.0's, whose published Release carries
+all 24 in full.
+
+The bound had a floor and a ceiling and they had crossed: no value of `news._BODY_BUDGET`
+satisfied both. The floor counted every release GitHub would have accepted whole, across all
+history, and required all but one to render whole — a demand that only grows. The ceiling
+was a fixed fraction of the limit and never moved.
+
+Most of that fraction was the units. GitHub refuses with `body is too long (maximum is
+125000 characters)`, and whether the validator behind it counts code points or bytes is not
+something charter can run and find out — so 15% was held back in case they differed.
+`news._sent_length` settles it on the string: it measures the encoded body, which is never
+below the character count, so the bound holds either way. Measured across every version
+charter has cut, that costs between 0.25% and 1.22%.
+
+What is left to reserve for is one thing — something added to the body that charter did not
+render, landing after the PyPI upload. It is 3,000 now, a subtraction rather than a
+percentage, and the budget is 122,000.
+
+Both guards read one `CEILING`, and the floor asks only about releases that fit *under it*,
+so the most it can demand is the ceiling itself. The ceiling reads no entries at all: it used
+to measure the staged body and skip when nothing was staged, which is the tree `charter news
+stamp` leaves behind — so the case objecting to a raise sat out every commit where a raise
+would be proposed.

--- a/docs/news/unreleased-a-renamed-workspace-keeps-its-chats-and-a-deleted-one-says-so.md
+++ b/docs/news/unreleased-a-renamed-workspace-keeps-its-chats-and-a-deleted-one-says-so.md
@@ -119,7 +119,7 @@ true; you decide.
 **The cold-start line is untouched.** `⋯ gathering this workspace's repos…` still appears
 for the seconds it was always right for, in a workspace that exists.
 
-**One predicate, three surfaces.** `charter quit` already recorded a chat whose workspace had
+**One predicate, three surfaces.** `charter: quit` already recorded a chat whose workspace had
 gone (`homeless`) and `charter reopen` already noted it on that chat's line. Both spelled the
 question inline; all three now ask `workspace.exists`, so the frame and the quit path cannot
 come to disagree about whether a workspace is there.

--- a/docs/news/unreleased-charter-records-the-plane-as-it-changes.md
+++ b/docs/news/unreleased-charter-records-the-plane-as-it-changes.md
@@ -77,9 +77,9 @@ offer a quit made.
 
 ## What the restore says: one line, and never silence
 
-`charter reopen` is a deliberate act, so its per-chat report is read and is unchanged. The
-automatic restore happens because you typed `charter` and wanted a terminal, so it is one
-line — and when part of the plane cannot come back, the rest is named on that same line:
+`charter reopen` is a deliberate act, so its per-chat report is read — and it grew a line
+later in this release, in *a restored chat comes back in its workspace*. The automatic
+restore happens because you typed `charter` and wanted a terminal, so it is one line — and when part of the plane cannot come back, the rest is named on that same line:
 
 ```
 ✓ charter: restored 3 of the 4 chats this plane last recorded — beta.1 did not come back

--- a/docs/news/unreleased-charter-save-refuses-from-a-workspace-clone-that-is-a-plane.md
+++ b/docs/news/unreleased-charter-save-refuses-from-a-workspace-clone-that-is-a-plane.md
@@ -65,7 +65,7 @@ manifest all follow `config.ROOT` outward — and split the plane in two.
 ## What still works from inside a clone
 
 Only the **unbounded** stage refuses. `charter save` is the sole caller that stages the whole
-tree; reactive memory, the dispatch tally, the workspace manifest and `version pin --push`
+tree; reactive memory, the dispatch tally, the workspace manifest and `version bump --push`
 all name plane-state files, and those keep committing to the plane from anywhere. Working
 inside a clone is the ordinary way work happens on a charter plane, and every agent doing it
 writes memory — refusing that would have been a larger harm than the one being fixed.

--- a/docs/news/unreleased-doctor-answers-for-the-directory-it-is-running-in.md
+++ b/docs/news/unreleased-doctor-answers-for-the-directory-it-is-running-in.md
@@ -33,10 +33,17 @@ comes from `root.find_root`, which **walks up** from the working directory until
 `charter.toml`. That is exactly right for identity — the plane is who you are, from anywhere
 inside it.
 
-The host does not walk up. Claude Code reads project settings, agents, skills and commands
-from the session's own directory and nowhere above it; only `CLAUDE.md` walks. So the two
-answers differ for every chat that is not rooted at the plane, and doctor reported the one
-the operator was not in.
+The host does not walk up for **settings**. Claude Code reads `.claude/settings.json` from
+the session's own directory and nowhere above it, and `statusLine` is a key in that file, so
+it inherits the rule. So the two answers differ for every chat that is not rooted at the
+plane, and doctor reported the one the operator was not in.
+
+(This paragraph, and the row below it, once said agents, skills and commands were read the
+same way and that only `CLAUDE.md` walks. Measured later in this release, that is wrong on
+both halves: `.claude/agents/` and `.claude/skills/` walk up and stop at the git root, and
+`CLAUDE.md` walks up and is not git-bounded at all. See *doctor answers whether a session
+started here can see charter's layer*. Charter has measured no rule for `.claude/commands`,
+so the row no longer claims one.)
 
 **That is the shape of the defect, not the shape of one plane.** Doctor is what an operator
 runs *because something felt wrong in that chat*, and a checker that reports on a different
@@ -49,9 +56,11 @@ A new `session root` row, and every row that reads settings answers for that dir
 
 ```
   ✓  session root     /…/plane/workspaces/fleet — not the plane (/…/plane)
-        ↳ the host reads project settings, agents, skills and commands from the session's
-          own directory and does not walk up, so the plane's .claude/ is not in force here
-          — the rows below read /…/plane/workspaces/fleet/.claude/ and ~/.claude/
+        ↳ the host reads settings and status line from the session's own directory and
+          does not walk up, so the plane's .claude/ is not in force for them — the rows
+          below read /…/plane/workspaces/fleet/.claude/ and ~/.claude/
+        ↳ skills+agents DO walk up, as far as the git root — which of them reach here is
+          the `session layer` row below, not this one
         ↳ the plane is still this session's identity: personas, the vault, memory and
           workspaces resolve to /…/plane from anywhere inside it
   !  plane-root guard  pretooluse is not wired — branch moves in the plane root are NOT

--- a/docs/news/unreleased-doctor-says-which-of-charters-layer-reaches-here.md
+++ b/docs/news/unreleased-doctor-says-which-of-charters-layer-reaches-here.md
@@ -36,11 +36,19 @@ exactly what "it felt half-configured" meant, and no single row could say so.
         about this directory
 ```
 
-**A fact, never a verdict — OK even when nothing reaches.** A chat rooted in a clone gets
-none of this and that is the designed workflow: charter deliberately writes nothing inside
-`workspaces/<ws>/<repo>/`. A row that warned there is a row operators learn to skip.
-Whatever is missing *and* fixable already warns where it can name its own remedy —
-`workspace layer` for a generated file gone stale, `plane-root guard` for the guard.
+**A fact, never a verdict — OK even when nothing reaches.** A chat can be rooted in a
+directory that reaches none of this and be exactly where it belongs — a clone charter has
+not wired yet, or one whose harness declares no layer parts. A row that warned there is a
+row operators learn to skip. Whatever is missing *and* fixable already warns where it can
+name its own remedy — `workspace layer` for a generated file gone stale, `plane-root guard`
+for the guard.
+
+This paragraph read *"charter deliberately writes nothing inside `workspaces/<ws>/<repo>/`"*
+and that is no longer the reason, in this same release: *a clone inside a workspace gets the
+layer, and hides it in the clone's `info/exclude`* writes it there, and *a clone inside a
+workspace carries every harness's in-repo surface* decides what it carries. The argument is
+unchanged — a row that warns on the designed workflow teaches operators to skip it — and it
+now rests on what a session would find rather than on charter having written nothing.
 
 It is about the **layer**, not the plugin, so it does not reopen `check_guard_wired`'s
 reasoning: *"Whether the plane runs as a plugin is an implementation detail. Whether the
@@ -103,9 +111,15 @@ both ignore project config, so probing with them yields a confident false negati
 model asked whether it can see a file will cheerfully go and `sed` the file you just named
 — so the trace, not the answer, is the evidence.
 
-So all three harnesses have an in-repo surface. Charter writes one for Claude Code only,
-and the other two now say that in the row rather than implying the surface does not exist.
-Charter still writes **nothing** into `~/.config/opencode/` or `~/.codex/config.toml`: it
+So all three harnesses have an in-repo surface, and the row says so for each of them rather
+than implying the surface does not exist. This entry went on to say charter *writes* one for
+Claude Code only, and by the end of this release that is no longer true either: every
+harness declares its own `inherited_paths` — `.claude/agents` and `.claude/skills`,
+`.opencode/agent`, `.codex/skills` — and a clone inside a workspace carries all of them (*a
+clone inside a workspace carries every harness's in-repo surface*). What is still Claude
+Code's alone is the generated `.claude/settings.json` per workspace **directory**, because
+the other two have no per-workspace config scope to hold one. Charter still writes
+**nothing** into `~/.config/opencode/` or `~/.codex/config.toml`: it
 writes no machine-global state on the operator's behalf, which is a decision and not an
 oversight.
 

--- a/docs/news/unreleased-doctor-says-which-of-charters-layer-reaches-here.md
+++ b/docs/news/unreleased-doctor-says-which-of-charters-layer-reaches-here.md
@@ -43,12 +43,11 @@ row operators learn to skip. Whatever is missing *and* fixable already warns whe
 name its own remedy — `workspace layer` for a generated file gone stale, `plane-root guard`
 for the guard.
 
-This paragraph read *"charter deliberately writes nothing inside `workspaces/<ws>/<repo>/`"*
-and that is no longer the reason, in this same release: *a clone inside a workspace gets the
-layer, and hides it in the clone's `info/exclude`* writes it there, and *a clone inside a
-workspace carries every harness's in-repo surface* decides what it carries. The argument is
-unchanged — a row that warns on the designed workflow teaches operators to skip it — and it
-now rests on what a session would find rather than on charter having written nothing.
+This paragraph read *"charter deliberately writes nothing inside `workspaces/<ws>/<repo>/`"*.
+Two entries in this same release retract it: *a clone inside a workspace gets the layer*
+writes it there, and *a clone inside a workspace carries every harness's in-repo surface*
+decides what it carries. The argument is unchanged; it now rests on what a session would
+find rather than on charter having written nothing.
 
 It is about the **layer**, not the plugin, so it does not reopen `check_guard_wired`'s
 reasoning: *"Whether the plane runs as a plugin is an implementation detail. Whether the

--- a/docs/news/unreleased-hooks-are-plane-gated.md
+++ b/docs/news/unreleased-hooks-are-plane-gated.md
@@ -7,8 +7,11 @@ headline: charter's hooks stop writing into repositories that are not control pl
 denials inside `pretooluse` and `_state_write_reason`. ADR 0015 raises the objection this
 answers — *"a plugin installed for every project does run charter's hooks in repos with no
 control plane"* — and answers it with a promise: *"the guards gate on
-`config.HAS_CONTROL_PLANE` and stay silent outside a plane."* Six of the eleven handlers in
-`hooks._HANDLERS` had never heard of the flag.
+`config.HAS_CONTROL_PLANE` and stay silent outside a plane."* Six of the handlers in
+`hooks._HANDLERS` had never heard of the flag. (Eleven of them when this was written;
+twelve by the end of the release, because *a chat tab shows when its harness is working*
+adds one — and it arrives gated, since the property below is driven off `_HANDLERS` rather
+than written out per handler.)
 
 Outside a plane `config.STATE_DIR` is `<cwd>/.charter`, so what those handlers wrote, they
 wrote into whatever repository you happened to be standing in. Measured on 0.55.0, each

--- a/docs/news/unreleased-right-click-a-chat-tab-to-act-on-that-chat.md
+++ b/docs/news/unreleased-right-click-a-chat-tab-to-act-on-that-chat.md
@@ -91,19 +91,19 @@ So every path degrades to *never fires*: an absent or unspellable tab is not an 
 the ordinary palette opening instead. Nothing is refused, nothing is half-drawn, and `F2`
 still reaches both rows.
 
-## One cost, measured and left open
+## One cost, measured — and closed later in this release
 
 With `[frame] mouse = true`, tmux's forwarding branch for button 3 is
 `{ select-pane -t = ; send-keys -M }` — it **selects the pane before forwarding**. That is
-the focus steal charter already fixed for the left button, one button over, and it is not
-closed here: a right-click that lands on a panel and opens nothing leaves the keyboard on
-that panel until you click the harness or press `F12`. It costs the gesture this change is
-for nothing, because a menu that opens takes the keyboard anyway and gives it back on the way
-out.
+the focus steal charter already fixed for the left button, one button over: a right-click
+that lands on a panel and opens nothing left the keyboard on that panel until you clicked
+the harness or pressed `F12`. It costs the gesture this change is for nothing, because a
+menu that opens takes the keyboard anyway and gives it back on the way out — which is why it
+was written up here rather than fixed in passing.
 
-The left button's fix works because tmux's default for that key is two commands charter can
-write out verbatim in the else-branch. Button 3's else-branch is a `display-menu` a page long
-built out of a dozen formats, and it differs between the tmux versions charter supports — so
-replacing it would take tmux's own pane menu away from the harness and from panes you split
-yourself, inside charter's window, to fix a steal that one click puts right. It is written up
-where it lives rather than fixed in passing.
+It was then fixed in passing, in this same release, and not by the shape that was rejected
+here: see *a right-click on a panel stays where it points*. Replacing tmux's own
+`MouseDown3Pane` would have taken its pane menu away from the harness and from panes you
+split yourself; charter **wraps** the binding instead, keeping the `send-keys -M` this
+feature rides on and dropping only the `select-pane`. That entry carries the measurement on
+tmux 3.2 and 3.7c.

--- a/docs/news/unreleased-the-plane-init-creates-is-one-init-can-see.md
+++ b/docs/news/unreleased-the-plane-init-creates-is-one-init-can-see.md
@@ -23,8 +23,10 @@ That made it a trap rather than a fault: correct until somebody adds a code path
 
 Somebody did. Gating `hooks.context_block` on `HAS_CONTROL_PLANE` (#852/#857) broke a fresh
 `charter init` — the gate asked during `init`, the answer was `False`, and the generated
-opencode context file came out empty. That gate was reverted rather than shipped, and this
-is why it can be written now.
+opencode context file came out empty. That half was reverted; the rest of #857 shipped,
+gating every handler in `hooks._HANDLERS`. And with this fix in, the gate still stays out —
+it no longer breaks a fresh `init`, so what it would add is a branch nothing can reach.
+`hooks.context_block` carries both halves of that.
 
 ## What init does differently
 

--- a/docs/news/unreleased-the-session-root-row-stops-contradicting-the-row-below-it.md
+++ b/docs/news/unreleased-the-session-root-row-stops-contradicting-the-row-below-it.md
@@ -1,7 +1,6 @@
 ---
 version: unreleased
 headline: '`charter doctor`''s `session root` row stops telling you agents and skills do not walk up, one line above the row that correctly says they do'
-check: doctor
 ---
 
 Two rows, printed one under the other, about the same directory. `session root` said *"the

--- a/docs/news/unreleased-the-session-root-row-stops-contradicting-the-row-below-it.md
+++ b/docs/news/unreleased-the-session-root-row-stops-contradicting-the-row-below-it.md
@@ -1,0 +1,34 @@
+---
+version: unreleased
+headline: '`charter doctor`''s `session root` row stops telling you agents and skills do not walk up, one line above the row that correctly says they do'
+check: doctor
+---
+
+Two rows, printed one under the other, about the same directory. `session root` said *"the
+host reads project settings, agents, skills and commands from the session's own directory
+and does not walk up"*. `session layer`, directly below it, said *"skills and agents DO walk
+up, but the walk stops at the git root"*.
+
+The second one is right. It was added in this same release from a measurement against Claude
+Code 2.1.259; the first kept the wording it had from before anyone measured. An operator in a
+workspace clone was told their agents were out of reach on the line above the line that said
+they were not.
+
+Two rows restating one discovery rule from two independent sources drift by default, and
+nothing renders them together, so nobody sees it. `session root` now reads the rules off
+`Harness.layer` — the declaration `session layer` already renders:
+
+```
+        ↳ the host reads settings and status line from the session's own directory and
+          does not walk up, so the plane's .claude/ is not in force for them
+        ↳ skills+agents DO walk up, as far as the git root — which of them reach here is
+          the `session layer` row below, not this one
+```
+
+It says nothing about whether the walk *arrives*: that depends on this directory's git root,
+and the row below is the one that resolves it. `commands` is dropped rather than reworded —
+charter has measured no rule for `.claude/commands`, so no `LayerPart` names it and this row
+cannot claim one. A harness charter has never met gets no rule sentence at all, because
+reporting it under Claude Code's rules would be a borrowed answer in the row read first.
+
+No artefact name is spelled into the row's code any more, and a test holds that.

--- a/docs/news/unreleased-the-session-root-row-stops-contradicting-the-row-below-it.md
+++ b/docs/news/unreleased-the-session-root-row-stops-contradicting-the-row-below-it.md
@@ -26,9 +26,8 @@ nothing renders them together, so nobody sees it. `session root` now reads the r
 ```
 
 It says nothing about whether the walk *arrives*: that depends on this directory's git root,
-and the row below is the one that resolves it. `commands` is dropped rather than reworded —
-charter has measured no rule for `.claude/commands`, so no `LayerPart` names it and this row
-cannot claim one. A harness charter has never met gets no rule sentence at all, because
-reporting it under Claude Code's rules would be a borrowed answer in the row read first.
-
-No artefact name is spelled into the row's code any more, and a test holds that.
+and the row below resolves it. `commands` is dropped rather than reworded — charter has
+measured no rule for `.claude/commands`, so no `LayerPart` names it. A harness charter has
+never met gets no rule sentence at all: reporting it under Claude Code's rules would be a
+borrowed answer in the row read first. No artefact name is spelled into this row's code any
+more, and a test holds that.

--- a/tests/test_doctor_says_which_of_charters_layer_reaches_here.py
+++ b/tests/test_doctor_says_which_of_charters_layer_reaches_here.py
@@ -713,6 +713,103 @@ class TheRowIsInTheReport(LayerCase):
         self.assertEqual(names[names.index("session root") + 1], "session layer")
 
 
+class TheTwoRowsNarrateOneSetOfRules(LayerCase):
+    """#879: `session root` and `session layer` are printed one under the other and told an
+    operator opposite things about the same directory.
+
+    The older row said the host reads *"project settings, agents, skills and commands from
+    the session's own directory and does not walk up"*. The newer one — added in the same
+    release, from the measurement — said `.claude/agents` and `.claude/skills` walk up and
+    stop at the git boundary. Both were describing Claude Code 2.1.259, and an operator in a
+    workspace clone was told on one line that their agents were out of reach and on the next
+    that they were not.
+
+    The words were fixable; the shape was the defect. Two rows restating one discovery rule
+    from two independent sources drift by default, and nothing renders them together, so
+    nobody sees it. These cases hold both rows to `Harness.layer` — the source
+    `check_session_layer` already reads — and to each other.
+    """
+
+    def root(self) -> str:
+        self.rooted_at(self.workspace)
+        return doctor.check_session_root().detail
+
+    def parts(self) -> tuple[list[str], list[str]]:
+        """What the harness declares, split by rule. Hand-spelling these would be a second
+        copy of the thing under test; `TheHarnessesDeclareWhatWasMeasured` is where the
+        declaration itself is pinned against the measurement."""
+        layer = claude_code.ClaudeCodeHarness().layer
+        return ([p.what for p in layer if not p.walks],
+                [p.what for p in layer if p.walks])
+
+    def test_no_walking_part_is_named_in_the_clause_that_says_the_host_does_not_walk_up(self):
+        """The defect itself, in the one direction it did harm. `agents` and `skills` stood
+        inside the sentence ending "and does not walk up"."""
+        cwd_only, walking = self.parts()
+        clause = next(ln for ln in self.root().splitlines() if "does not walk up" in ln)
+        for what in walking:
+            self.assertNotIn(
+                what, clause,
+                f"`{what}` walks up per the harness and this row says it does not: "
+                f"{clause.strip()}")
+        for what in cwd_only:
+            self.assertIn(what, clause,
+                          f"`{what}` is cwd-only per the harness and the row that explains "
+                          f"why the plane's .claude/ is not in force does not name it")
+
+    def test_the_walking_parts_are_named_as_walking_and_handed_to_the_row_below(self):
+        """Naming only the cwd-only half would leave "the plane's .claude/ is not in force"
+        reading as "none of it reaches", which is the same wrong answer with the false
+        sentence removed rather than corrected. The row says what walks and then declines to
+        say whether the walk arrives — that is a fact about this directory's git root, and
+        `session layer` is the row that resolves it."""
+        detail = self.root()
+        for what in self.parts()[1]:
+            self.assertIn(what, detail)
+        self.assertIn("DO walk up", detail)
+        self.assertIn("git root", detail)
+        self.assertIn("session layer", detail)
+
+    def test_the_two_rows_name_the_same_parts(self):
+        """Whatever a harness declares, both rows account for all of it. A part added to
+        `Harness.layer` and rendered by only one of them is how they came apart."""
+        self.rooted_at(self.workspace)
+        root, layer = doctor.check_session_root().detail, self.detail()
+        for what in sum(self.parts(), []):
+            with self.subTest(what=what):
+                self.assertIn(what, root)
+                self.assertIn(what, layer)
+
+    def test_the_row_restates_no_discovery_rule_of_its_own(self):
+        """The structural half, and the reason the words above stay fixed. No artefact is
+        named in this row's code — the names come from the harness — so there is no second
+        copy of the rules here to drift from the measurement again.
+
+        Comments are stripped, deliberately, per `_code`: a comment naming `agents` is
+        exactly what a decision like this should carry, while a literal is the thing being
+        refused.
+        """
+        code = _code(doctor.check_session_root) + _code(doctor._discovery_rules)
+        for artefact in ("agents", "skills", "commands", "CLAUDE.md", "settings.json"):
+            self.assertNotIn(
+                artefact, code,
+                f"`{artefact}` is spelled into the session root row rather than read from "
+                f"the harness, which is how the two rows disagreed")
+
+    def test_a_harness_charter_has_not_met_borrows_no_rules_from_one_it_has(self):
+        """`check_session_layer` refuses to report an unregistered runtime under Claude
+        Code's rules. Reporting it one row up would be the same borrowed answer, in the row
+        an operator reads first."""
+        with mock.patch.dict(os.environ, {"CHARTER_HARNESS": "somethingelse"}):
+            detail = self.root()
+        self.assertNotIn("walk up", detail)
+        for what in sum(self.parts(), []):
+            self.assertNotIn(what, detail)
+        self.assertIn("not the plane", detail)
+        self.assertIn("identity", detail,
+                      "the row dropped the half that is true of every harness")
+
+
 if __name__ == "__main__":
     import unittest
 

--- a/tests/test_doctor_says_which_of_charters_layer_reaches_here.py
+++ b/tests/test_doctor_says_which_of_charters_layer_reaches_here.py
@@ -770,6 +770,25 @@ class TheTwoRowsNarrateOneSetOfRules(LayerCase):
         self.assertIn("git root", detail)
         self.assertIn("session layer", detail)
 
+    def test_the_parts_are_named_in_the_order_the_harness_declares_them(self):
+        """`dict.fromkeys` and not a `set`, and declaration order and not `sorted`, for the
+        reason the trust clause below uses the same call: string hashing is randomised per
+        process, so a set would render this sentence one way on one run and another way on
+        the next — a row whose text moves between runs of an unchanged tree.
+
+        Driven off a stub declaring five cwd-only parts rather than off the shipped layer's
+        two. With two there is one wrong order and a set finds it half the time, which is a
+        pin that passes by luck; with five, declaration order is also neither alphabetical
+        nor its reverse, so `sorted` is caught outright.
+        """
+        names = ("delta", "alpha", "echo", "charlie", "bravo")
+        stub = _StubHarness("many", "gate")
+        stub.layer = tuple(base.LayerPart(n, (".nowhere",), False, "why") for n in names)
+        with mock.patch.object(registry, "all", return_value=[stub]):
+            os.environ.pop("CHARTER_HARNESS", None)
+            self.assertEqual(doctor._discovery_rules(), (list(names), []))
+            self.assertIn("delta, alpha, echo, charlie and bravo", self.root())
+
     def test_the_two_rows_name_the_same_parts(self):
         """Whatever a harness declares, both rows account for all of it. A part added to
         `Harness.layer` and rendered by only one of them is how they came apart."""

--- a/tests/test_doctor_says_which_of_charters_layer_reaches_here.py
+++ b/tests/test_doctor_says_which_of_charters_layer_reaches_here.py
@@ -809,6 +809,59 @@ class TheTwoRowsNarrateOneSetOfRules(LayerCase):
         self.assertIn("identity", detail,
                       "the row dropped the half that is true of every harness")
 
+    def test_the_running_harness_answers_alone_and_not_every_registered_one(self):
+        """The rules named are the rules of the harness this session is in.
+
+        Every registered harness answering would be right only while one of them declares a
+        layer — which is true today and is exactly why it needs a case. Register a second
+        one with a part of its own and the row must still name Claude Code's, or a session
+        under one harness is told another's discovery rules in the row it reads first.
+        """
+        other = _StubHarness("second", "gate")
+        other.layer = (base.LayerPart("elsewhere", (".nowhere",), True, "why"),)
+        with mock.patch.object(
+                registry, "all",
+                return_value=[claude_code.ClaudeCodeHarness(), other]):
+            detail = self.root()
+        self.assertNotIn("elsewhere", detail,
+                         "a harness this session is not running answered for it")
+        for what in sum(self.parts(), []):
+            self.assertIn(what, detail)
+
+    def test_no_harness_named_and_every_registered_one_answers(self):
+        """The other branch, and the reason it is not `[live]` unconditionally: a `charter
+        doctor` typed in a plain terminal has no harness to report for, and picking one
+        would be a guess — the same answer `check_session_layer` gives."""
+        other = _StubHarness("second", "gate")
+        other.layer = (base.LayerPart("elsewhere", (".nowhere",), True, "why"),)
+        with mock.patch.object(
+                registry, "all",
+                return_value=[claude_code.ClaudeCodeHarness(), other]):
+            os.environ.pop("CHARTER_HARNESS", None)
+            detail = self.root()
+        self.assertIn("elsewhere", detail,
+                      "with no harness named, a registered one went unanswered for")
+
+
+class TheRulesAreJoinedIntoASentence(_isolation.PersonaIso):
+    """`doctor._named`, alone. Its branches are reachable from the row only while the
+    shipped layer happens to have two cwd-only parts and one walking one — so a harness
+    declaring one of each, or three, would move the row's grammar with nothing watching."""
+
+    def test_nothing_is_nothing(self):
+        self.assertEqual(doctor._named([]), "")
+
+    def test_one_stands_alone_with_no_conjunction(self):
+        """The branch the row takes for `skills+agents` today. Falling through to the join
+        below would write `" and skills+agents"`, leading space and all."""
+        self.assertEqual(doctor._named(["a"]), "a")
+
+    def test_two_are_joined_by_and_with_no_comma(self):
+        self.assertEqual(doctor._named(["a", "b"]), "a and b")
+
+    def test_three_take_a_comma_and_then_the_and(self):
+        self.assertEqual(doctor._named(["a", "b", "c"]), "a, b and c")
+
 
 if __name__ == "__main__":
     import unittest

--- a/tests/test_release_notes_fit_the_release.py
+++ b/tests/test_release_notes_fit_the_release.py
@@ -77,10 +77,10 @@ from unittest import mock
 from charter import commands, news
 from tests.test_workflows import _release
 
-#: GitHub's documented maximum for a release body, in characters — not bytes. The API
-#: counts characters, and charter's entries are not ASCII (they carry `—`, `✗`, `⬢`), so
-#: measuring `len(body.encode())` would report a larger number than the one GitHub
-#: applies and would fail a release that would in fact have been accepted.
+#: GitHub's documented maximum for a release body. The refusal reads `body is too long
+#: (maximum is 125000 characters)`, and whether the validator behind it counts code points
+#: or bytes is not something charter can run and find out — so `news._sent_length` measures
+#: the larger of the two and this file compares against it in that measure.
 #:
 #: **Written out here rather than imported from `news`**, and that duplication is the
 #: point: this is GitHub's number, and a test that read charter's copy of it would agree
@@ -88,17 +88,68 @@ from tests.test_workflows import _release
 #: that matters — charter may be more conservative, never less.
 GITHUB_RELEASE_BODY_MAX = 125_000
 
-#: How close to the ceiling a version may come before this suite says so. A release that
-#: fits with 200 characters to spare is not a release that is safe — the next entry lands
-#: on main without anyone re-rendering the body, and the version after it is the one that
-#: cannot publish. 0.52.0 sat at 89% of the limit and read as fine.
-HEADROOM = 0.85
+#: What charter keeps back from that limit rather than spending on notes — **and the one
+#: number both guards on `_BODY_BUDGET` read**, from opposite sides.
+#:
+#: A flat count and not a fraction, and the replacement of `HEADROOM = 0.85`, which is what
+#: #878 was. A fraction says how much is left over without ever saying what it is *for*, so
+#: nothing about it can be checked and it drifts against whatever else is measuring the same
+#: hazard: 0.85 reserved a fifth of the allowance against a chars-vs-bytes gap measured, on
+#: the tree, at under 1.3%. What is actually left to reserve for is one thing — something
+#: added to the body that charter did not render, a preamble or a footer or a wrapper on the
+#: `announce` step, landing on a body already at the budget and after the PyPI upload. The
+#: largest block charter itself adds to a body no entry wrote is `news._elision`'s notice,
+#: at 443 bytes. This is seven of those.
+#:
+#: The gap between the string charter measures and the string GitHub counts is deliberately
+#: NOT in here: `news._sent_length` closes it on the string, and the newline `print` adds is
+#: counted by `commands.cmd_news` where it happens. A reserve holding hazards that are
+#: measured elsewhere is a reserve nobody can size.
+RESERVE = 3_000
+
+#: The most `_BODY_BUDGET` may be — and, read from the other end, the size above which a
+#: release may be reshaped at all.
+#:
+#: **One number for both guards, which is the structural half of #878.** The ceiling case
+#: holds `_BODY_BUDGET` at or below this. The floor case asks whether charter reshaped any
+#: release whose whole body fits *under this same line* — so the largest thing the floor can
+#: ever demand is this number, and the two cannot cross however much history accumulates.
+#: The old pair could: the floor counted every release GitHub would have accepted whole
+#: across all of history and its demand grew monotonically, while the ceiling was pinned to
+#: a fixed fraction and never moved. 0.56.0 was the release that landed between them, and no
+#: value of `_BODY_BUDGET` was green.
+CEILING = GITHUB_RELEASE_BODY_MAX - RESERVE
 
 _V = "0.60.0"
 
 
 def _versions() -> set[str]:
     return {e.version for e in news.all() if e.version != news.UNRELEASED}
+
+
+def _whole(version: str) -> str:
+    """*version*'s entries rendered whole — the body before the bound has any say in it."""
+    return "\n\n".join(news._part(e) for e in news.for_version(version))
+
+
+def _within_the_reserve() -> dict[str, int]:
+    """Every version charter could publish whole without spending :data:`RESERVE`, and how
+    long its whole body is.
+
+    **Stamped versions and the staged one together**, because the question they are asked
+    below is the same question and the answer must not change when `charter news stamp`
+    renames the files. The old floor read only stamped versions and the old ceiling read
+    only the staged ones, so on a release commit — where the staged entries have just become
+    a stamped version — one of them changed its mind and the other went silent.
+
+    Filtered by :data:`CEILING` rather than by GitHub's raw limit, which is what stops the
+    demand ratcheting past what the ceiling allows. A release whose notes come to more than
+    charter will spend is one charter is *supposed* to reshape; asking it to render whole
+    would be asking for the reserve back.
+    """
+    sizes = {v: news._sent_length(_whole(v))
+             for v in [*sorted(_versions()), news.UNRELEASED] if news.for_version(v)}
+    return {v: n for v, n in sizes.items() if n <= CEILING}
 
 
 class ReleaseBodyFits(unittest.TestCase):
@@ -130,12 +181,13 @@ class ReleaseBodyFits(unittest.TestCase):
         """
         for version in sorted(_versions()):
             with self.subTest(version=version):
-                size = len(news.render_body(version))
+                size = news._sent_length(news.render_body(version)) + 1
                 self.assertLessEqual(
                     size, GITHUB_RELEASE_BODY_MAX,
-                    f"the rendered notes for {version} are {size:,} characters and "
-                    f"GitHub refuses a release body over {GITHUB_RELEASE_BODY_MAX:,} — "
-                    f"`gh release create` would fail with `body is too long`",
+                    f"the notes file announce would write for {version} is {size:,} "
+                    f"long and GitHub refuses a release body over "
+                    f"{GITHUB_RELEASE_BODY_MAX:,} — `gh release create` would fail with "
+                    f"`body is too long`",
                 )
 
     def test_the_staged_release_fits(self) -> None:
@@ -149,7 +201,7 @@ class ReleaseBodyFits(unittest.TestCase):
         staged = news.for_version(news.UNRELEASED)
         if not staged:
             self.skipTest("no entries staged for the next release")
-        size = len(news.render_body(news.UNRELEASED))
+        size = news._sent_length(news.render_body(news.UNRELEASED)) + 1
         self.assertLessEqual(
             size, GITHUB_RELEASE_BODY_MAX,
             f"{len(staged)} entries are staged for the next release and they render to "
@@ -160,76 +212,148 @@ class ReleaseBodyFits(unittest.TestCase):
             f"fails on a version PyPI already has.",
         )
 
-    def test_the_staged_release_has_headroom(self) -> None:
-        """And it is not merely under the limit, but under it with room to spare.
+    def test_the_budget_keeps_the_reserve_it_declares(self) -> None:
+        """`_BODY_BUDGET`'s value, pinned from above — the half that objects to raising it.
 
-        Separate from the case above because the two say different things. "Would this
-        release publish?" is a fact about today. "Is the next one going to?" is the one
-        0.52.0 could have answered and was never asked.
+        **It reads no entries, and that is the fix rather than a weakening.** The case this
+        replaces measured `render_body(UNRELEASED)` and skipped when nothing was staged,
+        which is exactly the tree `charter news stamp` leaves behind — so on every release
+        commit, the one place this number decides a body about to be uploaded, the objection
+        did not run and a skipped case reported success. It could not have had teeth anyway:
+        `render_body` bounds its own output at `_BODY_BUDGET`, so no rendered body can ever
+        exceed it and no measurement of one can constrain it. The constant is the only thing
+        there is to hold, so this holds the constant, in the open, against a limit written
+        out independently a few lines above.
 
-        With the bound in place this is also the end-to-end guard on `_BODY_BUDGET`:
-        raise it toward the ceiling and this goes red, measured through the real render
-        rather than by reading the constant back.
+        Two assertions because there are two different failures, and only the first of them
+        is the one this suite was founded on:
+
+        **The hard edge.** A body at the budget, plus the newline `print` adds, must fit
+        GitHub's limit. Past that line a release is *refused* — after the PyPI upload, out
+        of reach of the documented retry.
+
+        **And the declared reserve.** Between the hard edge and :data:`CEILING` a release
+        still publishes, so this half is policy rather than catastrophe: it is the promise
+        that :data:`RESERVE` is actually left over for something charter does not render.
+        Spending it is allowed and takes an edit to `RESERVE` here, in a file charter does
+        not own, next to the sentence saying what it was being kept for.
         """
-        staged = news.for_version(news.UNRELEASED)
-        if not staged:
-            self.skipTest("no entries staged for the next release")
-        size = len(news.render_body(news.UNRELEASED))
-        ceiling = int(GITHUB_RELEASE_BODY_MAX * HEADROOM)
         self.assertLessEqual(
-            size, ceiling,
-            f"the staged notes are {size:,} characters, which is "
-            f"{size / GITHUB_RELEASE_BODY_MAX:.0%} of GitHub's "
-            f"{GITHUB_RELEASE_BODY_MAX:,}-character limit. Under the limit is not the "
-            f"same as safe: the next entry to land is not re-measured by anything.",
-        )
+            news._BODY_BUDGET + 1, GITHUB_RELEASE_BODY_MAX,
+            f"render_body will spend up to {news._BODY_BUDGET:,} and `print` adds a "
+            f"newline, so the file announce writes can reach "
+            f"{news._BODY_BUDGET + 1:,} — past GitHub's {GITHUB_RELEASE_BODY_MAX:,}. "
+            f"`gh release create` fails with `body is too long`, in `announce`, after "
+            f"the PyPI upload that cannot be taken back.")
+        self.assertLessEqual(
+            news._BODY_BUDGET, CEILING,
+            f"_BODY_BUDGET is {news._BODY_BUDGET:,}, which leaves "
+            f"{GITHUB_RELEASE_BODY_MAX - news._BODY_BUDGET:,} of GitHub's "
+            f"{GITHUB_RELEASE_BODY_MAX:,} for anything charter did not render — a "
+            f"preamble, a footer, a wrapper on the announce step. RESERVE says that "
+            f"should be {RESERVE:,}. Lower RESERVE here if the reserve is what you mean "
+            f"to spend; do not raise the budget past it silently.")
+
+    def test_the_floor_can_never_ask_for_more_than_the_ceiling_allows(self) -> None:
+        """#878 itself, asserted rather than argued — the two guards cannot cross.
+
+        The floor below requires every version in :func:`_within_the_reserve` to render
+        whole, so the largest budget it can ever demand is the largest whole body in that
+        set. The set is filtered by :data:`CEILING`, so that demand is bounded by the
+        ceiling by construction and the window between them is never empty.
+
+        The version of this suite that reported #878 had no such bound. Its floor counted
+        every release GitHub would have accepted whole, across all history, and required all
+        but one of them to render whole — a demand that only ever grows as releases land in
+        the band below the limit — while its ceiling was a fixed fraction of that limit and
+        never moved. They crossed on 0.56.0, and `_BODY_BUDGET` had no legal value.
+
+        Written as a case rather than left as a property of the code because it is a
+        property of the code that one deleted filter removes: drop the `<= CEILING` from
+        `_within_the_reserve` and this reddens immediately, on 0.54.0's 426,799.
+        """
+        demand = max(_within_the_reserve().values(), default=0)
+        self.assertLessEqual(
+            demand, CEILING,
+            f"the floor demands a budget of at least {demand:,} and the ceiling forbids "
+            f"anything over {CEILING:,}, so no value of _BODY_BUDGET is green. The two "
+            f"guards are reading different windows again, which is #878.")
 
     def test_the_bound_is_an_exception_rather_than_the_normal_path(self):
-        """`_BODY_BUDGET`'s value, pinned from below — and on a release branch, the only
-        half of its window still being asserted at all. The caveat at the end is why.
+        """`_BODY_BUDGET`'s value, pinned from below, and the half with something to
+        measure. Too high is a constant compared against a limit; too low is a fact about
+        the notes this repository is carrying, and only reading them answers it.
 
-        Between them the number is in a window rather than free, and each side says
-        something different. Too high and a release is refused after the upload, which is
-        the whole finding. **Too low and every release becomes a table of contents** —
-        every length assertion in this file still passes, and the notes stop being notes.
-        Nothing else in the suite would notice: a smaller budget is *safer* in the only
-        direction the other cases measure.
+        **Too low and every release becomes a table of contents** — every length assertion
+        in this file still passes, and the notes stop being notes. Nothing else in the suite
+        would notice: a smaller budget is *safer* in the only direction the other cases
+        measure.
 
-        **What is counted is releases GitHub would have accepted whole, and it used to be
-        every elided release.** That was the wrong set, and 0.54.0 is what showed it: 86
-        notes, 423,196 characters rendered whole, 3.4× the 125,000 the API takes. No value
-        of `_BODY_BUDGET` publishes that body — its elision is the bound doing the job it
-        was added for — so counting it here charged the number for an outcome the number
-        cannot change, and reddened this case on a release where nothing was wrong. Asking
-        only about bodies GitHub *would* have taken asks what this case is actually for:
-        **is charter shortening notes it did not have to shorten?**
+        **The set is every version charter could have published whole with the reserve
+        intact — stamped and staged — and none of them may be reshaped.** Two corrections
+        are folded into that sentence, and they are the two halves of #878.
 
-        Which keeps the teeth, and keeps them without reading a literal from `news.py` back
-        at itself. Measured on the shipped tree, 100,000 reshapes exactly one such release
-        (0.52.0, 111,723 whole). 90,000 reshapes two — 0.53.0, at 98,265, joins it. A budget
-        squeezed down toward a table of contents still fails here.
+        *It used to be every elided release*, which charged the budget for outcomes the
+        budget cannot change: 0.54.0's 86 notes come to 423,196 characters whole, 3.4× the
+        125,000 the API takes, and no value of `_BODY_BUDGET` publishes that body. Its
+        elision is the bound working.
 
-        **And the pin from above is not watching on the commit that matters.**
-        `test_the_staged_release_has_headroom` reads `render_body(UNRELEASED)` and skips
-        when nothing is staged, which is exactly what a stamped release branch looks like —
-        so on the commit where raising `_BODY_BUDGET` would decide a body about to be
-        published, the case that objects to raising it does not run, and a skipped case
-        reports success. This one is what is left. That is a reason to keep it honest
-        rather than to widen it until it is quiet.
+        *And then it was every release GitHub would have accepted whole*, which is the
+        ratchet #878 reported: a demand growing with history, against a ceiling that never
+        moved. Filtering by :data:`CEILING` instead asks the question the reserve makes
+        sense of — **is charter shortening notes it did not have to shorten, given what it
+        said it would keep back?** — and bounds the demand by the ceiling in the same
+        breath.
+
+        *And it now reads the staged release too.* The staged entries are the next stamped
+        version; leaving them out meant this case gave one answer on a branch and another on
+        the release commit cut from it, which is the tree where the answer is published.
+
+        Teeth, measured on the shipped tree rather than by reading a literal from `news.py`
+        back at itself: at 122,000 nothing in the set is reshaped. At 115,000 the staged
+        release is. At 100,000 — the value #878 was filed against — 0.52.0 joins it, four of
+        its 24 notes reduced to links though the Release GitHub actually holds for v0.52.0
+        carries all 24 whole. At 90,000, 0.53.0 joins them.
         """
-        whole = {v: "\n\n".join(news._part(e) for e in news.for_version(v))
-                 for v in sorted(_versions())}
-        reshaped = [v for v, text in whole.items()
-                    if news.render_body(v) != text
-                    and len(text) <= GITHUB_RELEASE_BODY_MAX]
-        self.assertLessEqual(
-            len(reshaped), 1,
-            f"charter's own budget now reshapes {len(reshaped)} releases GitHub would "
-            f"have accepted whole ({', '.join(reshaped)}) — so _BODY_BUDGET is too small: "
-            f"it is eliding notes to buy headroom that was not needed. Raising it is the "
-            f"fix, and `test_the_staged_release_has_headroom` is the case that bounds how "
-            f"far — but it SKIPS on a stamped tree, so measure the raise by hand if this "
-            f"is a release branch.")
+        reshaped = sorted(v for v in _within_the_reserve()
+                          if news.render_body(v) != _whole(v))
+        self.assertFalse(
+            reshaped,
+            f"charter's own budget reshapes {len(reshaped)} release(s) it had the room to "
+            f"publish whole ({', '.join(reshaped)}) — so _BODY_BUDGET is too small: it is "
+            f"eliding notes to buy headroom RESERVE has already accounted for. Raising it "
+            f"is the fix and `test_the_budget_keeps_the_reserve_it_declares` says how far, "
+            f"on this tree and every other — it reads no entries, so it does not go quiet "
+            f"on a stamped release branch the way its predecessor did.")
+
+    def test_the_number_charter_bounds_by_is_the_size_of_the_file_announce_writes(self):
+        """What `news._sent_length` claims to be, checked against the thing itself.
+
+        `announce` redirects `charter news --for` into a file and hands GitHub the file, so
+        the length that decides an elision and a refusal has to be the length of that file —
+        the body, encoded, plus the newline `print` writes. Asserted as an equality against
+        the encoded string, which is the one construction of it that does not go through
+        `_sent_length`.
+
+        **And the two measures really do differ here**, or the equality above would hold for
+        `len` as well and this would pin nothing. The second assertion says so on real
+        entries: charter's notes carry `—`, `✗` and `⬢`, and the encoded body of every
+        version charter has cut runs between 0.25% and 1.22% longer than its character count.
+        """
+        differ = 0
+        for version in [*sorted(_versions()), news.UNRELEASED]:
+            if not news.for_version(version):
+                continue
+            body = news.render_body(version)
+            with self.subTest(version=version):
+                self.assertEqual(
+                    news._sent_length(body) + 1, len((body + "\n").encode()),
+                    "the number charter bounds and refuses on is not the size of the "
+                    "file announce writes")
+            differ += news._sent_length(body) > len(body)
+        self.assertTrue(
+            differ, "no version's encoded body is longer than its character count, so "
+                    "the case above cannot tell the two measures apart")
 
     def test_every_note_the_staged_release_carries_is_in_the_body(self):
         """The half that makes the case above worth passing.
@@ -346,16 +470,20 @@ class ABodyThatFitsIsUntouched(NewsDir):
         `TheGateRefusesABodyItCannotBound` does: `_BODY_BUDGET` is charter's own policy
         number and the claim under test is what the comparison means by it, not what the
         number is.
+
+        Measured with `news._sent_length` and not `len`, because that is what the budget is
+        denominated in — an ASCII fixture makes the two agree, and a case that only holds
+        while the fixture stays ASCII is one a `—` in a headline would silently retire.
         """
         for slug in ("a-one", "b-two", "c-three"):
             self.write(f"{_V}-{slug}.md", _entry(_V, slug, self.filler(f"BODY-{slug}")))
         whole = "\n\n".join(news._part(e) for e in news.for_version(_V))
-        with mock.patch.object(news, "_BODY_BUDGET", len(whole)):
+        with mock.patch.object(news, "_BODY_BUDGET", news._sent_length(whole)):
             self.assertEqual(
                 news.render_body(_V), whole,
                 "a body of exactly the budget went through the elision path, so the "
                 "budget is being read as exclusive")
-        with mock.patch.object(news, "_BODY_BUDGET", len(whole) - 1):
+        with mock.patch.object(news, "_BODY_BUDGET", news._sent_length(whole) - 1):
             self.assertIn(
                 "listed by headline only", news.render_body(_V),
                 "one character under the budget changed nothing, so the case above is "
@@ -407,7 +535,7 @@ class NothingIsDroppedToMakeItFit(NewsDir):
 
     def test_the_bound_holds(self):
         self.oversized()
-        self.assertLessEqual(len(news.render_body(_V)), news._BODY_BUDGET)
+        self.assertLessEqual(news._sent_length(news.render_body(_V)), news._BODY_BUDGET)
 
     def test_every_entry_still_has_its_own_heading(self):
         """In its own place in the order. Twelve entries in, twelve headings out."""
@@ -724,6 +852,31 @@ class TheGateRefusesABodyItCannotBound(NewsDir):
         self.assertEqual(out, "")
         self.assertIn("too long", err)
 
+    def test_a_body_under_the_limit_in_characters_and_over_it_encoded_is_refused(self):
+        """The other off-by-one at the ceiling, and the one that needed a decision.
+
+        GitHub's refusal says `characters`. Whether the validator behind it counts code
+        points or bytes charter cannot run and find out, and the only bodies where the
+        answer changes anything are the ones within a percent of the limit — which is every
+        body this gate exists for. So the gate takes the larger of the two measures and the
+        question stops mattering.
+
+        The fixture is the shape that separates them: 124,999 characters, one of which is an
+        em dash, so the file `announce` writes is 125,002 bytes. Counted as characters it is
+        exactly at the limit once `print`'s newline is added and would have been published.
+        """
+        self.write(f"{_V}-a.md", _entry(_V, "a"))
+        body = "x" * (news.RELEASE_BODY_MAX - 2) + "—"
+        self.assertEqual(len(body) + 1, news.RELEASE_BODY_MAX,
+                         "the fixture is not at the limit by the character measure, so it "
+                         "would be refused whichever measure the gate uses")
+        with mock.patch.object(news, "render_body", return_value=body):
+            code, out, err = self._run(_V)
+        self.assertEqual(code, 1, "a body GitHub refuses on any byte-counting reading of "
+                                  "its own limit was printed for announce to upload")
+        self.assertEqual(out, "")
+        self.assertIn("too long", err)
+
     def test_and_one_character_under_it_is_printed(self):
         """The other direction, and it is not decoration: a gate that refused everything
         would pass every case above and take the release path with it."""
@@ -742,10 +895,16 @@ class TheGateRefusesABodyItCannotBound(NewsDir):
         Reached by moving the budget to the length of a real candidate rather than by
         sizing a fixture to the character: the number is charter's own policy dial and the
         claim under test is what the comparison means by it, so the dial is what moves.
+
+        `news._sent_length` and not `len`, and here the two genuinely differ: the fixture is
+        ASCII but `news._elision`'s notice — which only an elided body carries — has an em
+        dash in it. A budget set from the character count would be two under the byte count
+        the render is comparing, and this case would be measuring an off-by-two instead of
+        the boundary it names.
         """
         self.oversized()
         body = news.render_body(_V)
-        exact = len(body)
+        exact = news._sent_length(body)
         with mock.patch.object(news, "_BODY_BUDGET", exact):
             self.assertEqual(
                 news.render_body(_V), body,
@@ -753,7 +912,7 @@ class TheGateRefusesABodyItCannotBound(NewsDir):
                 "being read as exclusive")
         with mock.patch.object(news, "_BODY_BUDGET", exact - 1):
             self.assertLess(
-                len(news.render_body(_V)), exact,
+                news._sent_length(news.render_body(_V)), exact,
                 "one character under the budget changed nothing, so the case above is "
                 "not measuring the boundary it claims to")
 

--- a/tests/test_release_notes_fit_the_release.py
+++ b/tests/test_release_notes_fit_the_release.py
@@ -37,7 +37,15 @@ bound below from insurance into the ordinary path.
 
 ## What this suite holds, and why it is not one assertion
 
-Three groups, and they fail for different reasons at different times.
+Four groups, and they fail for different reasons at different times.
+
+**The budget sits in a window, and the window is one number read from both ends.**
+`_BODY_BUDGET` too high is a release refused after the PyPI upload; too low is every release
+becoming a table of contents, which every length assertion below still passes. `RESERVE` and
+the `CEILING` derived from it are what both guards read — and reading one number is not
+decoration: the two used to read different ones, the floor's demand grew with history while
+the ceiling never moved, and #878 is what happened when they crossed. Neither end depends on
+entries being staged, so neither goes quiet on a release commit.
 
 **It fits.** `news.render_body` bounds what it returns, so every version — shipped or
 staged — renders a body `gh release create` will accept. Asserted against the *shipped

--- a/tests/test_release_notes_fit_the_release.py
+++ b/tests/test_release_notes_fit_the_release.py
@@ -479,13 +479,22 @@ class ABodyThatFitsIsUntouched(NewsDir):
         number and the claim under test is what the comparison means by it, not what the
         number is.
 
-        Measured with `news.sent_length` and not `len`, because that is what the budget is
-        denominated in — an ASCII fixture makes the two agree, and a case that only holds
-        while the fixture stays ASCII is one a `—` in a headline would silently retire.
+        **And the fixture carries an em dash on purpose.** This is the only case that
+        reaches `render_body`'s early return — the branch that hands back the whole body
+        untouched — so it is the only case that can say what that comparison measures.
+        With an ASCII fixture the two measures agree, `len` and `sent_length` are
+        interchangeable there, and the release path's most-taken branch is denominated in
+        whichever one somebody last typed. Measured: the mutation survives an ASCII
+        fixture and reddens this one.
         """
         for slug in ("a-one", "b-two", "c-three"):
-            self.write(f"{_V}-{slug}.md", _entry(_V, slug, self.filler(f"BODY-{slug}")))
+            self.write(f"{_V}-{slug}.md",
+                       _entry(_V, slug, self.filler(f"BODY-{slug} — not ASCII")))
         whole = "\n\n".join(news._part(e) for e in news.for_version(_V))
+        self.assertGreater(
+            news.sent_length(whole), len(whole),
+            "the fixture is pure ASCII, so this case cannot tell the budget's two "
+            "candidate measures apart and the early return is unpinned")
         with mock.patch.object(news, "_BODY_BUDGET", news.sent_length(whole)):
             self.assertEqual(
                 news.render_body(_V), whole,

--- a/tests/test_release_notes_fit_the_release.py
+++ b/tests/test_release_notes_fit_the_release.py
@@ -79,7 +79,7 @@ from tests.test_workflows import _release
 
 #: GitHub's documented maximum for a release body. The refusal reads `body is too long
 #: (maximum is 125000 characters)`, and whether the validator behind it counts code points
-#: or bytes is not something charter can run and find out — so `news._sent_length` measures
+#: or bytes is not something charter can run and find out — so `news.sent_length` measures
 #: the larger of the two and this file compares against it in that measure.
 #:
 #: **Written out here rather than imported from `news`**, and that duplication is the
@@ -102,7 +102,7 @@ GITHUB_RELEASE_BODY_MAX = 125_000
 #: at 443 bytes. This is seven of those.
 #:
 #: The gap between the string charter measures and the string GitHub counts is deliberately
-#: NOT in here: `news._sent_length` closes it on the string, and the newline `print` adds is
+#: NOT in here: `news.sent_length` closes it on the string, and the newline `print` adds is
 #: counted by `commands.cmd_news` where it happens. A reserve holding hazards that are
 #: measured elsewhere is a reserve nobody can size.
 RESERVE = 3_000
@@ -147,7 +147,7 @@ def _within_the_reserve() -> dict[str, int]:
     charter will spend is one charter is *supposed* to reshape; asking it to render whole
     would be asking for the reserve back.
     """
-    sizes = {v: news._sent_length(_whole(v))
+    sizes = {v: news.sent_length(_whole(v))
              for v in [*sorted(_versions()), news.UNRELEASED] if news.for_version(v)}
     return {v: n for v, n in sizes.items() if n <= CEILING}
 
@@ -181,7 +181,7 @@ class ReleaseBodyFits(unittest.TestCase):
         """
         for version in sorted(_versions()):
             with self.subTest(version=version):
-                size = news._sent_length(news.render_body(version)) + 1
+                size = news.sent_length(news.render_body(version)) + 1
                 self.assertLessEqual(
                     size, GITHUB_RELEASE_BODY_MAX,
                     f"the notes file announce would write for {version} is {size:,} "
@@ -201,7 +201,7 @@ class ReleaseBodyFits(unittest.TestCase):
         staged = news.for_version(news.UNRELEASED)
         if not staged:
             self.skipTest("no entries staged for the next release")
-        size = news._sent_length(news.render_body(news.UNRELEASED)) + 1
+        size = news.sent_length(news.render_body(news.UNRELEASED)) + 1
         self.assertLessEqual(
             size, GITHUB_RELEASE_BODY_MAX,
             f"{len(staged)} entries are staged for the next release and they render to "
@@ -327,13 +327,13 @@ class ReleaseBodyFits(unittest.TestCase):
             f"on a stamped release branch the way its predecessor did.")
 
     def test_the_number_charter_bounds_by_is_the_size_of_the_file_announce_writes(self):
-        """What `news._sent_length` claims to be, checked against the thing itself.
+        """What `news.sent_length` claims to be, checked against the thing itself.
 
         `announce` redirects `charter news --for` into a file and hands GitHub the file, so
         the length that decides an elision and a refusal has to be the length of that file —
         the body, encoded, plus the newline `print` writes. Asserted as an equality against
         the encoded string, which is the one construction of it that does not go through
-        `_sent_length`.
+        `sent_length`.
 
         **And the two measures really do differ here**, or the equality above would hold for
         `len` as well and this would pin nothing. The second assertion says so on real
@@ -347,10 +347,10 @@ class ReleaseBodyFits(unittest.TestCase):
             body = news.render_body(version)
             with self.subTest(version=version):
                 self.assertEqual(
-                    news._sent_length(body) + 1, len((body + "\n").encode()),
+                    news.sent_length(body) + 1, len((body + "\n").encode()),
                     "the number charter bounds and refuses on is not the size of the "
                     "file announce writes")
-            differ += news._sent_length(body) > len(body)
+            differ += news.sent_length(body) > len(body)
         self.assertTrue(
             differ, "no version's encoded body is longer than its character count, so "
                     "the case above cannot tell the two measures apart")
@@ -471,19 +471,19 @@ class ABodyThatFitsIsUntouched(NewsDir):
         number and the claim under test is what the comparison means by it, not what the
         number is.
 
-        Measured with `news._sent_length` and not `len`, because that is what the budget is
+        Measured with `news.sent_length` and not `len`, because that is what the budget is
         denominated in — an ASCII fixture makes the two agree, and a case that only holds
         while the fixture stays ASCII is one a `—` in a headline would silently retire.
         """
         for slug in ("a-one", "b-two", "c-three"):
             self.write(f"{_V}-{slug}.md", _entry(_V, slug, self.filler(f"BODY-{slug}")))
         whole = "\n\n".join(news._part(e) for e in news.for_version(_V))
-        with mock.patch.object(news, "_BODY_BUDGET", news._sent_length(whole)):
+        with mock.patch.object(news, "_BODY_BUDGET", news.sent_length(whole)):
             self.assertEqual(
                 news.render_body(_V), whole,
                 "a body of exactly the budget went through the elision path, so the "
                 "budget is being read as exclusive")
-        with mock.patch.object(news, "_BODY_BUDGET", news._sent_length(whole) - 1):
+        with mock.patch.object(news, "_BODY_BUDGET", news.sent_length(whole) - 1):
             self.assertIn(
                 "listed by headline only", news.render_body(_V),
                 "one character under the budget changed nothing, so the case above is "
@@ -535,7 +535,7 @@ class NothingIsDroppedToMakeItFit(NewsDir):
 
     def test_the_bound_holds(self):
         self.oversized()
-        self.assertLessEqual(news._sent_length(news.render_body(_V)), news._BODY_BUDGET)
+        self.assertLessEqual(news.sent_length(news.render_body(_V)), news._BODY_BUDGET)
 
     def test_every_entry_still_has_its_own_heading(self):
         """In its own place in the order. Twelve entries in, twelve headings out."""
@@ -896,7 +896,7 @@ class TheGateRefusesABodyItCannotBound(NewsDir):
         sizing a fixture to the character: the number is charter's own policy dial and the
         claim under test is what the comparison means by it, so the dial is what moves.
 
-        `news._sent_length` and not `len`, and here the two genuinely differ: the fixture is
+        `news.sent_length` and not `len`, and here the two genuinely differ: the fixture is
         ASCII but `news._elision`'s notice — which only an elided body carries — has an em
         dash in it. A budget set from the character count would be two under the byte count
         the render is comparing, and this case would be measuring an off-by-two instead of
@@ -904,7 +904,7 @@ class TheGateRefusesABodyItCannotBound(NewsDir):
         """
         self.oversized()
         body = news.render_body(_V)
-        exact = news._sent_length(body)
+        exact = news.sent_length(body)
         with mock.patch.object(news, "_BODY_BUDGET", exact):
             self.assertEqual(
                 news.render_body(_V), body,
@@ -912,7 +912,7 @@ class TheGateRefusesABodyItCannotBound(NewsDir):
                 "being read as exclusive")
         with mock.patch.object(news, "_BODY_BUDGET", exact - 1):
             self.assertLess(
-                news._sent_length(news.render_body(_V)), exact,
+                news.sent_length(news.render_body(_V)), exact,
                 "one character under the budget changed nothing, so the case above is "
                 "not measuring the boundary it claims to")
 


### PR DESCRIPTION
Unblocks 0.56.0 (#877), which fails on #878 alone. This lands on `main`; #877 rebases on top.

## #878 — `_BODY_BUDGET` had no legal value

The floor counted every release GitHub would have accepted whole, across all history, and required all but one of them to render whole — a demand that only grows. The ceiling was `125,000 × 0.85` and never moved. They crossed on 0.56.0 and no value of the constant was green.

**The units were most of the reserve, and they did not have to be a guess.** GitHub refuses with `body is too long (maximum is 125000 characters)`. Whether the validator behind that counts code points or bytes is not something charter can run and find out, and the only bodies where the answer changes anything are within a percent of the limit — which is every body this module is for. `news._sent_length` measures the encoded body, never below the character count, so the bound holds under either reading. Measured on every stamped version, that conservatism costs 0.25%–1.22% (worst 0.47.0, at 1.22%; 0.54.0 and 0.55.0 at 0.85%). It replaces a 15% reserve held back for the same uncertainty.

| | before | after |
| --- | --- | --- |
| `_BODY_BUDGET` | 100,000 characters | **122,000**, measured by `_sent_length` |
| reserve | `HEADROOM = 0.85` (18,750) | `RESERVE = 3_000`, a subtraction with a stated purpose |
| 0.56.0 | 4 notes elided, 114,362 chars whole | **renders whole**, 121,271 bytes of a 122,000 budget |
| 0.52.0 | 4 notes elided | renders whole — matching the Release GitHub actually holds, which carries all 24 |

**The two guards now read one number and cannot cross.** `CEILING = GITHUB_RELEASE_BODY_MAX - RESERVE`. The ceiling holds `_BODY_BUDGET` at or below it; the floor requires every version whose whole body fits *under that same ceiling* to render whole — so the floor's demand is bounded by the ceiling by construction, and `test_the_floor_can_never_ask_for_more_than_the_ceiling_allows` asserts that rather than leaving it as a property of the code.

**And neither end goes quiet on a release commit.** The ceiling reads no entries at all, where it used to measure `render_body(UNRELEASED)` and skip when nothing was staged — the tree `charter news stamp` leaves behind. That was the reason the dangerous direction was unwatched on exactly the commit where it matters. It could not have had teeth there anyway: `render_body` bounds its own output, so no rendered body can constrain the constant. The floor reads the staged release alongside the stamped ones, so it gives the same answer before and after the stamp.

Verified by hand: `122_001` reddens the ceiling case, `115_000` and `90_000` redden the floor, and `_sent_length` returning `len(body)` reddens 22 subtests.

## #879 — a doctor row contradicting the row below it

`session root` said the host reads *"project settings, agents, skills and commands from the session's own directory and does not walk up"*. `session layer`, printed directly under it and added one PR later from a measurement, said `.claude/agents` and `.claude/skills` **do** walk up and stop at the git boundary.

`_discovery_rules` reads `Harness.layer` — the same declaration `session layer` renders — and splits it by rule. The row names what is cwd-only, names what walks, and hands the question of whether the walk *arrives* to the row below, where it is resolved against the directory's real git root. `commands` is dropped rather than reworded: charter has measured no rule for `.claude/commands`. An unregistered harness gets no rule sentence, for the reason `check_session_layer` already refuses one.

`session_root`'s own docstring carried the same stale claim and now answers only for settings. `TheTwoRowsNarrateOneSetOfRules` holds both rows to the harness and to each other, including a source-level case that no artefact name is spelled into this row's code at all.

## The 0.56.0 notes that described retracted behaviour

Release notes are the one document nobody re-derives. Eight entries described code a later PR in the same release changed — see the third commit for each. The largest: *doctor says which of charter's layer reaches here* rested its "fact, never a verdict" argument on charter writing nothing inside `workspaces/<ws>/<repo>/` (#870 writes the layer there) and on charter writing an in-repo layer for Claude Code only (all three harnesses declare `inherited_paths`); *Right-click a chat tab* left the button-3 focus steal open in a section headed "left open", four paragraphs after pointing at the entry that closes it; and three entries said `CLAUDE.md` walks up on the same rule as agents and skills, where it is not git-bounded at all — so the plane's copy already reaches a clone and there is no gap for a mirror to close. `claude_code.WALKUP_DIRS` said the same and is corrected too.

Closes #878
Closes #879

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Us4MbwkSCJCxwt1CjAd1sf
