### PR TITLE
The persona switcher stops lifting the selected persona, and sorts by use (#882)

### DIFF
--- a/charter/frame/slots.py
+++ b/charter/frame/slots.py
@@ -1847,10 +1847,18 @@ def _cap_personas(cells: list, keep: int) -> list:
     personas survive" is one question, and answering it in two places is how the two
     answers come to disagree; a short pane at `terse` asks it once here.
 
-    `_persona_chip_cells` is already ordered (the active persona first, then anything
-    carrying a health mark), so what survives is the top of an order rather than an
-    arbitrary handful, and a row that was ALREADY standing for hidden personas folds its
-    count into the new row rather than losing it.
+    `_persona_chip_cells` is already ordered — `persona.by_use`: the plane's declared
+    default, then most-dispatched first (#882) — so what survives is the top of an order
+    rather than an arbitrary handful, and a row that was ALREADY standing for hidden
+    personas folds its count into the new row rather than losing it.
+
+    **That order used to be "the active persona first", and the trim reads no worse for
+    the change.** Both orders put something worth seeing at the top; this one puts the
+    same thing there on every frame, so a sidebar shortened by a density key drops the
+    persona nobody dispatches rather than whichever name happened to be next after the one
+    the operator was standing on. The active persona can now be among what is dropped —
+    it is still named on the top bar (`identity`, `◆ <name>`), which is the row that
+    answers "who am I being" when the column cannot.
     """
     from .. import statusline as sl
     if keep <= 0 or len(cells) <= keep:

--- a/charter/frame/switch.py
+++ b/charter/frame/switch.py
@@ -106,15 +106,30 @@ def workspaces() -> list[str]:
 
 
 def personas() -> list[str]:
-    """Every persona a switcher may offer, name-checked on the way out.
+    """Every persona a switcher may offer, name-checked on the way out and **ordered by
+    use**: the plane's declared default first, then most-dispatched first, ties broken by
+    the larger memory count, then by name.
 
-    Same reasoning as :func:`workspaces`, one noun over — `persona.list_personas` globs
+    Same name-check as :func:`workspaces`, one noun over — `persona.list_personas` globs
     the plane's `personas/` directory, and `persona.valid_name` is the rule
     `persona.dir_of`'s own join depends on. No fold-in here: there is no always-present
     persona, and "no personas" is a real and ordinary answer for a plane that has none.
+
+    **The order is not this function's, and that is deliberate** (#882). `persona.by_use`
+    owns it and states the whole argument — why dispatches rather than memories, why the
+    default is pinned, why the memory count is read only where dispatch counts tie. The
+    other switcher onto the same names is the frame's sidebar persona column
+    (`statusline._persona_chip_cells`, clickable through `frame/builtins._persona_events`),
+    which used to lift the ACTIVE persona to the top; both ask one function now, so a
+    picker and the column beside it cannot draw the same roster in two orders.
+
+    **The name-check is applied BEFORE the ordering, not after.** `by_use` reads a
+    dispatch tally and, on a tie, a memory directory per name; handing it a name
+    `valid_name` refuses would be spending those reads on a row no switcher may draw, and
+    `persona.memory_dir`'s join is the very thing that check stands in front of (#442).
     """
     from .. import persona as p_mod
-    return sorted(n for n in p_mod.list_personas() if p_mod.valid_name(n))
+    return p_mod.by_use([n for n in p_mod.list_personas() if p_mod.valid_name(n)])
 
 
 #: How many names an "I do not have that one, here is what I have" message lists. A

--- a/charter/persona.py
+++ b/charter/persona.py
@@ -31,6 +31,7 @@ import os
 import re
 import shutil
 import time
+from itertools import groupby as _groupby
 from pathlib import Path
 
 from . import config, contain, mcpseen
@@ -970,6 +971,122 @@ def declared_default() -> str | None:
     # the wrong question — a reference climbing out of `personas/` named a file the plane
     # does not contain, and `resolve()` merged its `vault:`, `role:` and `tools:` (#337).
     return val if val and reference_ok(val) and def_path(val).exists() else None
+
+
+def plane_default() -> str | None:
+    """The default persona this PLANE declares, or ``None`` — the two committed rungs of
+    :func:`_resolved` and neither of the four session ones.
+
+    That exclusion is the whole point of the function existing. :func:`resolve_active`
+    answers *who am I being right now*, which moves with a `$CHARTER_PERSONA`, a session
+    pointer or a `charter persona use`; this answers *who does this plane put first*,
+    which is a committed fact and the same for every frame, every session and every
+    teammate on the plane. :func:`by_use` pins the answer to the top of every switcher,
+    and a pin that moved with the session would be the defect #882 is about wearing a
+    different name.
+
+    ``charter.toml`` before ``personas/.default`` for :func:`declared_default`'s own
+    reason, and both are already validated against what exists, so a declaration naming a
+    persona that was renamed resolves to nothing rather than pinning a name no switcher
+    can offer.
+    """
+    return declared_default() or default_persona()
+
+
+def _dispatches() -> dict:
+    """agent → how many times it has been dispatched, ever. ``{}`` on any failure.
+
+    One read of `personas/_dispatch/` per call and never one per persona — the store is a
+    handful of month-and-host jsonl files, so the whole tally is a directory glob and a
+    line walk (measured on this plane at 0.4 ms for 449 rows), while asking it per name
+    would re-walk the same files once for each. Swallowed like every other number a
+    switcher draws: an unreadable log is a roster in alphabetical order, never a frame
+    that will not paint.
+    """
+    from . import dispatch
+    try:
+        return dict(dispatch.tally())
+    except Exception:
+        return {}
+
+
+def by_use(names: list[str] | None = None) -> list[str]:
+    """*names* (default: every persona) in the order a switcher offers them.
+
+        **The declared default first, then most-dispatched first, ties broken by the
+        larger memory count, then by name.**
+
+    **Nothing here depends on which persona you are currently on**, and that is the whole
+    of #882. The sidebar column used to lift the ACTIVE persona to the top
+    (`statusline._persona_chip_cells`), so choosing a persona re-laid the list that had
+    just been chosen from: every other row moved, and where a name sat depended on where
+    the operator already was. A list whose rows reorder with state is a list nobody
+    learns — `frame/slots._change_rows` settled the identical question for changes, and
+    this is that rule arriving on the noun it was first broken for. The active persona is
+    still MARKED, on every surface that draws it; being marked costs no other row its
+    position.
+
+    **Dispatch count and not memory count, and the two genuinely disagree.** Measured on
+    this plane the day #882 was written: by memory it is `release 51`, `steward 47`,
+    `statusline 14`, `forge 13`, `reddit 7`; by dispatch it is `release 26`, `forge 18`,
+    `steward 11`, `statusline 8`, `reddit 4` — `forge` is second on one and fourth on the
+    other. **A memory count only ever grows**, so it ossifies: a persona worked heavily
+    one month outranks one used daily the next, permanently, because nothing ever takes a
+    memory back. A dispatch count measures *use*, which is what makes a persona worth
+    reaching for, and it is the same number `charter persona stats` retires personas on.
+
+    **"Last dispatched" was considered and rejected**, and it is the sharper signal of the
+    two — `dispatch.last_seen` already computes it. It is refused because it makes the
+    list reorder far more often than a count does: every dispatch would be able to move a
+    row, where a count only moves one past a neighbour it has overtaken. That is the same
+    defect as lifting the selected item, one cause over, and a fix that reintroduces the
+    thing it removes is not a fix.
+
+    **The memory count is read only where dispatch counts TIE**, which is why the tie-break
+    is a second pass rather than a second term in one sort key. `memory_count` is a
+    directory glob per persona (`memstore.files`), a switcher opens on a keypress, and a
+    key function is called once per element — so a single key would pay one glob per
+    persona on every open, to decide an order the first term almost always decides alone.
+    On this plane's five personas the dispatch counts are all distinct and this reads no
+    memory directory at all. `groupby` over the already-sorted list is what makes "almost
+    always" free rather than merely cheap.
+
+    The name is the last term on both passes so the answer is TOTAL: two personas with the
+    same dispatch count and the same memory count still have one order, the same one every
+    time, on every machine. `sorted` over a set would have been an ordering that is right
+    about half the time by luck.
+    """
+    names = sorted(list_personas() if names is None else names)
+    if not names:
+        return []
+    default = plane_default()
+    rest = [n for n in names if n != default]
+    disp = _dispatches()
+    rest.sort(key=lambda n: (-disp.get(n, 0), n))
+    out = []
+    for _, grp in _groupby(rest, key=lambda n: disp.get(n, 0)):
+        run = list(grp)
+        # One name in the run is one order already, and asking for its memory count would
+        # be a directory glob spent on a comparison with nobody.
+        out.extend(run if len(run) == 1
+                   else sorted(run, key=lambda n: (-memory_count(n), n)))
+    return ([default] if default in names else []) + out
+
+
+def memory_count(name: str) -> int:
+    """How many persistent memories *name* holds — :func:`by_use`'s tie-break, and 0 for a
+    persona whose directory cannot be read.
+
+    Its own function rather than a `len(memories(...))` inside the sort, because the tie-
+    break is exactly what a mutation sweep attacks and a named thing can be measured
+    directly. The 0 is the same fail-toward-no-change every other number on a switcher
+    takes: an unreadable memory directory demotes a persona within its tie group, and does
+    not raise out of a repaint.
+    """
+    try:
+        return len(memories(name))
+    except Exception:
+        return 0
 
 
 def _pointer_files(session_id: str | None = None,

--- a/charter/persona.py
+++ b/charter/persona.py
@@ -1054,11 +1054,16 @@ def by_use(names: list[str] | None = None) -> list[str]:
     The name is the last term on both passes so the answer is TOTAL: two personas with the
     same dispatch count and the same memory count still have one order, the same one every
     time, on every machine. `sorted` over a set would have been an ordering that is right
-    about half the time by luck.
+    about half the time by luck — and that totality is also why *names* is not pre-sorted
+    here: both passes below already end in the name, so a `sorted()` in front of them
+    would be a line no test could go red without.
+
+    **No early return for an empty roster either**, for the same rule one step further.
+    Every line below is a no-op on `[]` — the two store reads answer for a plane, not for
+    a name, and neither of them is reached per persona — so a guard would only save a
+    directory glob on the one plane whose switcher has nothing to offer anyway.
     """
-    names = sorted(list_personas() if names is None else names)
-    if not names:
-        return []
+    names = list(list_personas() if names is None else names)
     default = plane_default()
     rest = [n for n in names if n != default]
     disp = _dispatches()

--- a/charter/statusline.py
+++ b/charter/statusline.py
@@ -1875,9 +1875,9 @@ class PersonaChip(NamedTuple):
 
 
 def _persona_chips(session: str | None = None) -> list[str]:
-    """One chip per persona (active first) for the status-line right column, each
-    tagged with its memory counts (``✎`` persistent + ``◌`` ephemeral). Every
-    persona is also dispatchable as a sub-agent.
+    """One chip per persona, **ordered by use** (`persona.by_use`), for the status-line
+    right column, each tagged with its memory counts (``✎`` persistent + ``◌`` ephemeral).
+    Every persona is also dispatchable as a sub-agent.
 
     Composed from :func:`_persona_chip_cells` rather than built alongside it — one
     builder, two shapes. See :class:`PersonaChip`.
@@ -1892,6 +1892,16 @@ def _persona_chip_cells(session: str | None = None) -> list[PersonaChip]:
     order, capped at :data:`_MAX_PERSONA_LINES` with a row that says how many were
     dropped, and never raising. See :class:`PersonaChip` for where the split falls and
     why the vault dot sits on the name's side of it.
+
+    **The order no longer depends on which persona the session is on** (#882). This column
+    is a switcher — `frame/slots.persona_section` draws it and `frame/builtins._persona_events`
+    turns a click on a name into `frame-switch --persona` — and it used to put the ACTIVE
+    persona first, so choosing a name re-laid the very list it had been chosen from and
+    where every other row sat depended on where the operator already was. `persona.by_use`
+    is the order now, it is the same one `frame/switch.personas` gives the F2 picker, and
+    it states the whole argument for itself. The active persona is still marked, in
+    magenta with `_MARK_ACTIVE`, and carried as `PersonaChip.active` for the frame's
+    full-row highlight; being marked costs no other row its position.
     """
     try:
         from . import persona
@@ -1899,7 +1909,7 @@ def _persona_chip_cells(session: str | None = None) -> list[PersonaChip]:
         if not names:
             return []
         active = persona.resolve_active()
-        order = ([active] if active in names else []) + [n for n in names if n != active]
+        order = persona.by_use(names)
         known = set(names)   # computed once for the whole column, not once per persona
         flying = _inflight_by_persona()   # one glob for the column, not one per chip
         chips = []
@@ -1937,9 +1947,18 @@ def _persona_chip_cells(session: str | None = None) -> list[PersonaChip]:
             # a health mark (`_health_mark` speaks only when something is wrong), then the
             # rest. The count of what is hidden is shown rather than implied — the same
             # contract `_repo_rows` keeps with its own "(+N more)".
+            #
+            # **The active persona is lifted HERE and nowhere else, and #882 does not
+            # reach this branch.** That issue is about what the list READS like, and the
+            # answer is `by_use`'s: no row's position depends on where the operator is
+            # standing. This asks a different question — which rows FIT — and "the persona
+            # you are being is not one a column may drop" is identity, the same reason
+            # `frame/slots._cap_personas` keeps it. It is also unobservable on a plane
+            # under `_MAX_PERSONA_LINES` personas, which is nearly all of them, where the
+            # order on screen is `by_use`'s untouched.
             keep = _MAX_PERSONA_LINES - 1          # one row spent saying what was dropped
             by_name = dict(zip(order, chips))
-            lead = [n for n in order[:1] if n == active]
+            lead = [n for n in order if n == active][:1]
             rest = [n for n in order if n not in lead]
             ordered = lead + [n for n in rest if n in flagged_names] \
                            + [n for n in rest if n not in flagged_names]

--- a/charter/statusline.py
+++ b/charter/statusline.py
@@ -1958,7 +1958,7 @@ def _persona_chip_cells(session: str | None = None) -> list[PersonaChip]:
             # order on screen is `by_use`'s untouched.
             keep = _MAX_PERSONA_LINES - 1          # one row spent saying what was dropped
             by_name = dict(zip(order, chips))
-            lead = [n for n in order if n == active][:1]
+            lead = [active] if active in by_name else []
             rest = [n for n in order if n not in lead]
             ordered = lead + [n for n in rest if n in flagged_names] \
                            + [n for n in rest if n not in flagged_names]

--- a/docs/frame.md
+++ b/docs/frame.md
@@ -285,6 +285,21 @@ is what makes a double-click harmless: the second press lands on the tab you jus
 and that one does nothing. It also means the names a click can reach are the ones on your
 page; `F2` is what reaches the other pages.
 
+**The persona column does not move when you switch either, and it is ordered by use.** The
+plane's declared default (`charter.toml`'s `[persona] default`) is the first row, always;
+under it the personas come most-dispatched first, and two with the same dispatch count are
+separated by the one holding more memories, then by name. Nothing in that depends on which
+persona you are being — the one you are on is *marked* (`▸`, in magenta), and being marked
+costs no other row its position. So the name you reach for is in the same place every time
+you look, and adopting it does not re-lay the column you just chose from.
+
+It is a **dispatch** count and not a memory count because the two rank differently and only
+one of them measures use: a memory count never goes down, so a persona worked heavily one
+month would outrank one used daily the next, permanently. `charter persona stats` shows both
+numbers, and it is the dispatch column personas get retired on. "Most recently dispatched"
+would be sharper still and is deliberately not used: it would move rows on nearly every
+dispatch, which is the same defect as lifting the row you are standing on.
+
 **A persona row's badges explain themselves.** Clicking the badge column puts the glyph
 legend on the attention row (see *Every glyph on a persona row* above). It works on the
 row you are already on, which is where the question usually comes from.

--- a/tests/test_a_real_click_opens_the_real_palette.py
+++ b/tests/test_a_real_click_opens_the_real_palette.py
@@ -466,9 +466,12 @@ class ARealClickOnARealPersonaRowSwitchesTheFrame(_ARealFrameWithStrips,
         # sidebar child sees it through the same two writes the click will use, and the
         # case below is still measuring the click rather than a second run of itself.
         #
-        # Stated rather than assumed, because `_persona_chip_cells` orders the ACTIVE
-        # persona first: a frame that started on some other name would put every row this
-        # case clicks somewhere else.
+        # Stated rather than assumed, because the case below asserts the marker MOVES: it
+        # has to know which row carries `▸` before the click, and "some persona" is not a
+        # starting point a `▸ {THERE}` assertion can be read against. It is no longer a
+        # statement about the column's ORDER — `_persona_chip_cells` used to lift the
+        # active persona to the top and does not since #882 (`persona.by_use`), which is
+        # also why `_row_of` looks the row up by name instead of assuming an index.
         from charter import persona as p_mod
         p_mod.set_active(self.HERE, session_id=self.fid, terminal_id="")
         state.bump(self.fid)

--- a/tests/test_statusline_persona_cap.py
+++ b/tests/test_statusline_persona_cap.py
@@ -20,6 +20,13 @@ A status line taller than the conversation is not a status line.
 drop exactly the personas worth seeing, so the order is what a truncated column is FOR: the
 active persona, then anything carrying a health mark — `_health_mark` speaks only when
 something is wrong — then the rest.
+
+That is a statement about the CAP and not about the column, and #882 is what split the
+two. The column reads in `persona.by_use` order — the plane's declared default, then
+most-dispatched first — and no row's position depends on which persona the session is on;
+the survival rule above still lifts the active persona, because "which rows fit" is a
+question about identity that "what order do they read in" is not.
+`tests/test_the_persona_switcher_sorts_by_use.py` owns the ordering half.
 """
 
 from __future__ import annotations

--- a/tests/test_the_persona_switcher_sorts_by_use.py
+++ b/tests/test_the_persona_switcher_sorts_by_use.py
@@ -1,0 +1,348 @@
+"""The persona switcher stops lifting the selected persona, and sorts by use — #882.
+
+Two switchers reach one roster. `F2` opens a picker whose names come from
+`frame/switch.personas`, and the frame's sidebar draws a clickable column of the same
+names from `statusline._persona_chip_cells` (`frame/builtins._persona_events` turns a
+click on one into `frame-switch --persona`). The column used to put the ACTIVE persona
+first, so choosing a name re-laid the very list it had been chosen from: every other row
+moved, and where a name sat depended on where the operator already was.
+
+The order is now `persona.by_use` on both surfaces:
+
+    **the plane's declared default first, then most-dispatched first, ties broken by the
+    larger memory count, then by name.**
+
+**Why dispatches and not memories, measured rather than argued.** Both numbers exist and
+they rank differently — on charter's own plane the memory counts read `release 51`,
+`steward 47`, `statusline 14`, `forge 13`, `reddit 7` while the dispatch counts read
+`release 26`, `forge 18`, `steward 11`, `statusline 8`, `reddit 4`; `forge` is second on
+one and fourth on the other. A memory count only ever grows, so it ossifies: a persona
+worked heavily one month outranks one used daily the next, permanently. A dispatch count
+measures use. `TheTwoKeysDisagree` below is the case that pins the choice, because it is
+the only one a sweep swapping the two counts cannot pass.
+
+**Every case here asserts an order in BOTH directions.** `sorted` over a set is not a
+pinnable ordering guarantee — one assertion passes about half the time by luck — so a
+case that says "more dispatches come first" has a twin that swaps the counts and demands
+the other order out of the same code.
+"""
+from __future__ import annotations
+
+import unittest
+from unittest import mock
+
+from charter import config, dispatch, persona, statusline
+from charter.frame import choose, switch
+from tests._isolation import PersonaIso
+
+
+class Roster(PersonaIso):
+    """A plane whose personas have exactly the dispatch and memory counts a case states."""
+
+    def persona_with(self, name: str, *, dispatches: int = 0, memories: int = 0) -> str:
+        """One persona carrying *dispatches* dispatch rows and *memories* memory files.
+
+        Written through `dispatch.record` and `persona.remember` — the real writers — so a
+        case measures the store the switcher reads rather than a shape a fixture invented.
+        """
+        self.make_persona(name, role=name.title(), vault="none")
+        for _ in range(dispatches):
+            self.assertIsNotNone(dispatch.record(name), f"{name}: a dispatch was not recorded")
+        for i in range(memories):
+            persona.remember(name, f"# {name} note {i}\n\nbody {i}\n", title=f"{name} {i}")
+        self.assertEqual(dispatch.tally().get(name, 0), dispatches, name)
+        self.assertEqual(persona.memory_count(name), memories, name)
+        return name
+
+    def declare_default(self, name: str) -> None:
+        """`charter.toml`'s `[persona] default` — the rung `persona.plane_default` reads
+        first, and the one a consumer can find.
+
+        No `config.use` afterwards, deliberately: `declared_default` re-reads the file
+        through `instance.load` on every call, and re-deriving would move
+        `config.PERSONAS_DIR` under personas this fixture has already written.
+        """
+        (config.ROOT / "charter.toml").write_text(
+            f'schema = 1\n\n[persona]\ndefault = "{name}"\n')
+
+    def column(self) -> list[str]:
+        """The sidebar persona column's names, in the order it draws them."""
+        return [c.name for c in statusline._persona_chip_cells(None) if c.name]
+
+
+class TheOrderDoesNotDependOnWhereYouAre(Roster):
+    """#882's whole complaint, on both surfaces."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.persona_with("alfa", dispatches=9)
+        self.persona_with("bravo", dispatches=5)
+        self.persona_with("charlie", dispatches=1)
+
+    def test_the_picker_reads_the_same_whichever_persona_is_active(self):
+        """Two opposite standpoints, one list. Without this the list is a function of the
+        cursor and no operator can learn where a name lives."""
+        persona.set_active("charlie")
+        from_charlie = switch.personas()
+        persona.set_active("alfa")
+        self.assertEqual(switch.personas(), from_charlie)
+        self.assertEqual(from_charlie, ["alfa", "bravo", "charlie"])
+
+    def test_the_sidebar_column_reads_the_same_whichever_persona_is_active(self):
+        """The surface the lift actually lived on (`statusline.py`'s `order = [active] +
+        …`). `charlie` is last by use and was first by the old rule, so this case would
+        have failed before #882 and cannot pass by accident now."""
+        persona.set_active("charlie")
+        from_charlie = self.column()
+        persona.set_active("alfa")
+        self.assertEqual(self.column(), from_charlie)
+        self.assertEqual(from_charlie, ["alfa", "bravo", "charlie"])
+
+    def test_the_least_used_persona_does_not_lead_by_being_chosen(self):
+        """Stated as its own case rather than left implicit in the two above: the defect
+        was specifically that the chosen name went to index 0."""
+        persona.set_active("charlie")
+        self.assertEqual(switch.personas()[0], "alfa")
+        self.assertEqual(self.column()[0], "alfa")
+
+    def test_the_active_persona_is_still_marked(self):
+        """What replaces the lift, and the reason removing it loses nothing: the picker
+        still says which row you are on — it just does not move it.
+
+        Selected for the FRAME's id with no terminal, which is `switch.to_persona`'s own
+        call: `switch.current_persona` reads the frame's rungs and not this process's, so
+        a plane-wide `set_active` would mark nothing here (#411).
+        """
+        persona.set_active("charlie", session_id="f-882", terminal_id="")
+        roster = choose.roster(choose.PERSONA, "f-882")
+        self.assertEqual([r.title for r in roster.rows], ["alfa", "bravo", "charlie"])
+        self.assertEqual([r.title for r in roster.rows if r.mark], ["charlie"])
+
+    def test_the_two_switchers_offer_one_order(self):
+        """A picker and the column beside it drawing the same roster two ways is the drift
+        one shared `persona.by_use` exists to make impossible."""
+        self.assertEqual(self.column(), switch.personas())
+
+
+class TheDefaultIsPinnedFirst(Roster):
+    def test_the_declared_default_leads_a_persona_with_more_dispatches(self):
+        self.persona_with("front", dispatches=0)
+        self.persona_with("worker", dispatches=40)
+        self.declare_default("front")
+        self.assertEqual(switch.personas(), ["front", "worker"])
+
+    def test_and_the_pin_moves_when_the_declaration_does(self):
+        """The twin. Same two personas, same counts, the other name declared — so the pin
+        is read from the declaration rather than from anything about `front` itself."""
+        self.persona_with("front", dispatches=0)
+        self.persona_with("worker", dispatches=40)
+        self.declare_default("worker")
+        self.assertEqual(switch.personas(), ["worker", "front"])
+
+    def test_the_legacy_dotfile_pins_too(self):
+        """`personas/.default` keeps resolving — `persona.plane_default` reads both rungs,
+        so a plane that adopted the dotfile does not lose its front door to #882."""
+        self.persona_with("front", dispatches=0)
+        self.persona_with("worker", dispatches=40)
+        (config.PERSONAS_DIR / ".default").write_text("front\n")
+        self.assertEqual(switch.personas(), ["front", "worker"])
+
+    def test_a_plane_with_no_default_starts_with_the_most_dispatched(self):
+        """No pin is a real and ordinary answer, not a missing one."""
+        self.persona_with("front", dispatches=0)
+        self.persona_with("worker", dispatches=40)
+        self.assertIsNone(persona.plane_default())
+        self.assertEqual(switch.personas(), ["worker", "front"])
+
+    def test_a_default_naming_a_persona_that_is_not_here_pins_nothing(self):
+        """`plane_default` validates against what exists, so a declaration left behind by a
+        rename leads to a roster in use order rather than to a phantom first row."""
+        self.persona_with("worker", dispatches=40)
+        self.persona_with("other", dispatches=1)
+        self.declare_default("renamed-away")
+        self.assertEqual(switch.personas(), ["worker", "other"])
+
+    def test_the_pinned_persona_appears_exactly_once(self):
+        """The pin is a MOVE and not a copy — a roster that listed its front door twice
+        would give one persona two rows and `choose.Roster` two ids for one name."""
+        self.persona_with("front", dispatches=3)
+        self.persona_with("worker", dispatches=40)
+        self.declare_default("front")
+        names = switch.personas()
+        self.assertEqual(names, ["front", "worker"])
+        self.assertEqual(len(names), len(set(names)))
+
+
+class TheRestSortByDispatchCount(Roster):
+    def test_more_dispatches_come_first(self):
+        self.persona_with("aa", dispatches=2)
+        self.persona_with("zz", dispatches=9)
+        self.assertEqual(switch.personas(), ["zz", "aa"])
+
+    def test_and_the_order_flips_when_the_counts_do(self):
+        """The twin, and the reason it is not optional: the names are `aa` and `zz`, so
+        one of these two orders is also the alphabetical one and a switcher that had
+        stopped sorting at all would still pass the case above."""
+        self.persona_with("aa", dispatches=9)
+        self.persona_with("zz", dispatches=2)
+        self.assertEqual(switch.personas(), ["aa", "zz"])
+
+    def test_a_persona_never_dispatched_sorts_last_rather_than_missing(self):
+        """Zero is a count, not an absence — `dispatch.tally` has no row for a persona
+        nobody has dispatched, and reading that as "no data, leave it where it was" is how
+        an unused persona keeps a position it has not earned."""
+        self.persona_with("used", dispatches=4)
+        self.persona_with("never", dispatches=0)
+        self.assertEqual(switch.personas(), ["used", "never"])
+
+
+class TheTieBreakIsTheMemoryCount(Roster):
+    """The tie-break is exactly what a `drop-conjunct` sweep deletes and what a
+    `swap-synonym` sweep points at the other count, so both directions are pinned."""
+
+    def test_a_tie_on_dispatches_is_broken_by_the_larger_memory_count(self):
+        self.persona_with("aa", dispatches=3, memories=1)
+        self.persona_with("zz", dispatches=3, memories=6)
+        self.assertEqual(switch.personas(), ["zz", "aa"])
+
+    def test_and_the_tie_break_flips_when_the_memory_counts_do(self):
+        """The twin. Same dispatch counts, memories swapped — so a switcher that had
+        dropped the tie-break and fallen through to the name would fail here while
+        passing the case above."""
+        self.persona_with("aa", dispatches=3, memories=6)
+        self.persona_with("zz", dispatches=3, memories=1)
+        self.assertEqual(switch.personas(), ["aa", "zz"])
+
+    def test_a_tie_on_both_counts_falls_back_to_the_name(self):
+        """The order is TOTAL. Two personas alike in both numbers still have one order,
+        the same one on every machine — `sorted` over a set would have been an ordering
+        that is right about half the time by luck."""
+        self.persona_with("zz", dispatches=2, memories=2)
+        self.persona_with("aa", dispatches=2, memories=2)
+        self.assertEqual(switch.personas(), ["aa", "zz"])
+        self.assertEqual(switch.personas(), switch.personas())
+
+
+class TheTwoKeysDisagree(Roster):
+    """The case #882 was actually decided on, and the only one that can tell the two
+    counts apart.
+
+    Every other case above would pass just as well with the keys exchanged, because on a
+    plane where the two numbers agree there is nothing to choose between them. Charter's
+    own roster is not such a plane — `forge` is second by dispatch and fourth by memory —
+    and this is that shape reduced to two personas.
+    """
+
+    def test_the_persona_dispatched_more_leads_the_one_remembered_more(self):
+        self.persona_with("used", dispatches=20, memories=1)
+        self.persona_with("remembered", dispatches=2, memories=50)
+        self.assertEqual(switch.personas(), ["used", "remembered"])
+
+    def test_and_it_still_does_when_the_names_would_say_otherwise(self):
+        """The twin: alphabetical order now agrees with the memory count and disagrees
+        with the dispatch count, so neither a fallback to the name nor a swap to memories
+        can pass both halves."""
+        self.persona_with("aa", dispatches=2, memories=50)
+        self.persona_with("zz", dispatches=20, memories=1)
+        self.assertEqual(switch.personas(), ["zz", "aa"])
+
+    def test_growing_a_memory_count_does_not_reorder_the_roster(self):
+        """The ossification argument, measured rather than asserted in a docstring: a
+        memory count only ever grows, so if it ranked, a persona could take a position it
+        had stopped earning and never give it back."""
+        self.persona_with("used", dispatches=20, memories=0)
+        self.persona_with("remembered", dispatches=2, memories=0)
+        before = switch.personas()
+        for i in range(30):
+            persona.remember("remembered", f"# more {i}\n\nbody\n", title=f"more {i}")
+        self.assertEqual(switch.personas(), before)
+        self.assertEqual(before, ["used", "remembered"])
+
+
+class TheMemoryCountIsReadOnlyOnATie(Roster):
+    """The cost half. A switcher opens on a keypress and `persona.memory_count` is a
+    directory glob per persona, so the tie-break is a second pass over the tied runs
+    rather than a second term in one sort key — a key function is called once per element,
+    which would pay one glob per persona on every open to decide an order the dispatch
+    count has almost always already decided.
+    """
+
+    def _counted(self):
+        calls = []
+        real = persona.memory_count
+        patcher = mock.patch.object(
+            persona, "memory_count", side_effect=lambda n: (calls.append(n), real(n))[1])
+        self.enterContext(patcher)
+        return calls
+
+    def test_distinct_dispatch_counts_read_no_memory_directory_at_all(self):
+        self.persona_with("aa", dispatches=1, memories=3)
+        self.persona_with("bb", dispatches=2, memories=3)
+        self.persona_with("cc", dispatches=3, memories=3)
+        calls = self._counted()
+        self.assertEqual(switch.personas(), ["cc", "bb", "aa"])
+        self.assertEqual(calls, [], "a memory directory was walked to break no tie")
+
+    def test_only_the_tied_personas_are_asked(self):
+        """The twin, and the one that keeps the case above from being satisfied by a
+        tie-break that never runs: `bb` and `cc` tie and are read, `aa` stands alone and
+        is not."""
+        self.persona_with("aa", dispatches=1, memories=3)
+        self.persona_with("bb", dispatches=5, memories=1)
+        self.persona_with("cc", dispatches=5, memories=9)
+        calls = self._counted()
+        self.assertEqual(switch.personas(), ["cc", "bb", "aa"])
+        self.assertEqual(sorted(set(calls)), ["bb", "cc"])
+        self.assertNotIn("aa", calls)
+
+    def test_the_dispatch_store_is_read_once_for_the_whole_roster(self):
+        """One glob of `personas/_dispatch/` per open, never one per persona: the store is
+        a handful of month-and-host files, and asking it by name would re-walk all of them
+        for every row."""
+        for i in range(6):
+            self.persona_with(f"p{i}", dispatches=i)
+        with mock.patch.object(dispatch, "tally", wraps=dispatch.tally) as tally:
+            switch.personas()
+        self.assertEqual(tally.call_count, 1)
+
+
+class ItDegradesRatherThanRaising(Roster):
+    """A switcher opens on a keypress and the sidebar repaints several times a second;
+    neither may be taken down by a number that could not be read."""
+
+    def test_an_unreadable_dispatch_store_leaves_an_alphabetical_roster(self):
+        self.persona_with("zz", dispatches=9)
+        self.persona_with("aa", dispatches=1)
+        with mock.patch.object(dispatch, "tally", side_effect=OSError("nope")):
+            self.assertEqual(switch.personas(), ["aa", "zz"])
+
+    def test_an_unreadable_memory_directory_counts_as_zero(self):
+        """The tie-break's own fail-toward-no-change: the persona charter cannot read is
+        demoted within its tie group and nothing raises out of a repaint."""
+        self.persona_with("aa", dispatches=3, memories=0)
+        self.persona_with("zz", dispatches=3, memories=4)
+        with mock.patch.object(persona, "memories", side_effect=OSError("nope")):
+            self.assertEqual(persona.memory_count("zz"), 0)
+            self.assertEqual(switch.personas(), ["aa", "zz"])
+
+    def test_a_plane_with_no_personas_answers_an_empty_list(self):
+        self.assertEqual(persona.by_use(), [])
+        self.assertEqual(switch.personas(), [])
+
+
+class TheNameCheckHappensBeforeTheOrdering(Roster):
+    """`persona.valid_name` is the rule `persona.dir_of`'s join depends on (#442), and
+    `by_use` reads a memory directory per tied name — so a name the switcher may not draw
+    must not reach it."""
+
+    def test_a_name_the_switcher_refuses_is_never_counted(self):
+        self.persona_with("ok", dispatches=1)
+        with mock.patch.object(persona, "list_personas",
+                               return_value=["ok", "../escape", "with space"]), \
+             mock.patch.object(persona, "memory_count", wraps=persona.memory_count) as mc:
+            self.assertEqual(switch.personas(), ["ok"])
+        self.assertNotIn("../escape", [c.args[0] for c in mc.call_args_list])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Two switchers reach one persona roster. `F2` opens a picker built from `frame/switch.personas`, and the frame's sidebar draws a clickable column of the same names from `statusline._persona_chip_cells` (`frame/builtins._persona_events` turns a click on a name into `frame-switch --persona`).

The column put the **active persona first** — `statusline.py`'s `order = ([active] if active in names else []) + [n for n in names if n != active]` — so choosing a name re-laid the very list it had been chosen from: every other row moved, and where a name sat depended on where the operator already was. The picker, meanwhile, was plain alphabetical, so the two surfaces drew one roster in two orders.

## What it is now

`persona.by_use` owns the order and both surfaces ask it:

> **The plane's declared default first, always. Then most-dispatched first. Ties broken by the larger memory count, then by name.**

Nothing in that depends on which persona the session is on. The active persona is still marked — `▸` in magenta, carried as `PersonaChip.active` for the frame's full-row highlight — and being marked costs no other row its position. It is `frame/slots._change_rows`' rule (*"a list whose rows reorder with state is a list nobody learns"*) arriving on the noun it was first broken for.

## Why dispatches and not memories

Both numbers exist and they rank differently. Measured on this plane:

| persona | memories | dispatches |
|---|---|---|
| `release` | 51 | 26 |
| `steward` | 47 | 11 |
| `statusline` | 14 | 8 |
| `forge` | 13 | 18 |
| `reddit` | 7 | 4 |

`forge` is second by dispatch and fourth by memory. **A memory count only ever grows**, so it ossifies: a persona worked heavily one month outranks one used daily the next, permanently, because nothing ever takes a memory back. A dispatch count measures *use*, and it is the same column `charter persona stats` retires personas on.

**"Last dispatched" was considered and rejected.** `dispatch.last_seen` already computes it and it is the sharper signal, but it would move rows on nearly every dispatch, where a count only moves one past a neighbour it has overtaken. That is the same defect as lifting the selected item, one cause over.

## What it costs per switcher open

The counts were found, not invented — both stores already existed and neither needed a new cache.

- **Dispatch counts**: `dispatch.tally()`, one glob of `personas/_dispatch/` and a line walk over a handful of month-and-host jsonl files, read **once for the whole roster**. **0.40 ms** for this plane's 449 rows.
- **Memory counts**: `persona.memory_count` → `memstore.files`, a directory glob **per persona** — the shape to avoid on a keypress. So the tie-break is a **second pass over the tied runs** (`groupby` on the already-sorted list) rather than a second term in one sort key, because a key function is called once per element and would pay one glob per persona on every open to decide an order the dispatch count has almost always already decided. On this plane's five personas the dispatch counts are all distinct and the ordering **reads no memory directory at all**.

`persona.by_use()` end to end: **0.79 ms**. `_persona_chip_cells` — the per-repaint surface — went from ~4.9 ms to ~5.3 ms, and it was already paying two memory globs per persona for its badges.

## Tests

`tests/test_the_persona_switcher_sorts_by_use.py`, 27 cases. **Every ordering case asserts both directions** — `sorted` over a set is not a pinnable ordering guarantee, so a case saying "more dispatches come first" has a twin that swaps the counts and demands the other order out of the same code.

`TheTwoKeysDisagree` is the class that pins the decision: it is the only one that can tell the two counts apart, because on a plane where the numbers agree there is nothing to choose between them.

Checked by hand against seven mutations, all caught:

| mutation | failing cases |
|---|---|
| drop the tie-break | 2 |
| swap the two counts (`swap-synonym`) | 9 |
| drop the default pin | 4 |
| reverse the tie-break | 3 |
| flip dispatch to ascending | 14 |
| put the lift back in the column | 2 |
| switcher stops ordering at all | 12 |

Full suite: 11164 tests, `OK (skipped=8)`.

Closes #882

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Us4MbwkSCJCxwt1CjAd1sf
