### PR TITLE
Every workspace has a workspace.json, from birth and by backfill (#884)

### DIFF
--- a/charter/commands.py
+++ b/charter/commands.py
@@ -409,6 +409,13 @@ def cmd_clone(args) -> int:
         report_submodule_drift(dest, r["name"])
         _hint_repo_docs(dest, r)
     _wire_clones(ws)
+    # The manifest records what was cloned BEFORE the frames are told to repaint
+    # (#884 under #886): the fan-out below is what makes a frame re-read this plane,
+    # and a repaint that arrives ahead of the write reads a manifest one command out of
+    # date — the same off-by-one #886 exists to end, moved from the clone to the file
+    # describing it.
+    _record_membership(ws, [res["dest"].name for res in results
+                            if res["status"] in ("ok", "exists")])
     # **The reported symptom of #886**: this command wrote clones to disk and told nobody,
     # so the `repos` component stayed empty until charter was restarted. Here rather than
     # inside the loop above because ten repos are ONE change to the plane — `notify` has no
@@ -426,6 +433,36 @@ def cmd_clone(args) -> int:
     from .frame import notify
     notify.plane_changed_everywhere()
     return 1 if failures else 0
+
+
+def _record_membership(ws: str, repos: list[str]) -> None:
+    """Put the repos now in *ws* into its committed manifest (#884).
+
+    The structural change the manifest is maintained for: membership is a fact about the
+    workspace, and a `workspace.json` that learns it only when somebody runs `snapshot`
+    describes the workspaces nobody shared. Here rather than in `_clone_one`, for
+    `cmd_clone`'s own reason: eight workers must not write one file, and this runs once,
+    from the thread that already renders their results.
+
+    **No branch is recorded** — `workspace.record_members` will not write one — which is
+    what keeps ADR 0010's enforce-push guarantee intact: a branch in this file promises
+    `restore` can check it out on another machine, and a clone makes no such promise.
+    `charter workspace snapshot` still pins them.
+
+    Silent on success. A clone already announces itself per repo, and a second line saying
+    the manifest agrees is the kind of confirmation people learn to stop reading — but a
+    manifest charter may not touch is different, because the invariant is quietly untrue
+    there until somebody acts.
+
+    The frame is NOT told the roster moved; that is #886's, deliberately, so the two
+    changes do not each grow half a notification.
+    """
+    if not repos:
+        return
+    if workspace.record_members(ws, repos) == "operator":
+        util.warn(f"workspaces/{ws}/workspace.json was not written by charter — left "
+                  f"untouched, so it does not record what was just cloned. "
+                  f"`charter workspace snapshot {ws}` rewrites it deliberately.")
 
 
 def _wire_clones(ws: str) -> None:

--- a/charter/commands_workspace.py
+++ b/charter/commands_workspace.py
@@ -516,8 +516,12 @@ def _pin(row) -> str:
     its own writes ``{"name"}`` alone (#884). `row['branch']` was a `KeyError` waiting for
     the first manifest charter wrote itself, and one function is what keeps the reading and
     the reporting from disagreeing about which rows have a branch.
+
+    Stripped, so the value the leading-dash guard inspects is the value git is handed:
+    ``" -b"`` is not a ref anybody writes and `startswith` says nothing about it, while
+    `git checkout` reads the argument it is actually given (#334).
     """
-    return str((row or {}).get("branch") or "").strip()
+    return str(row.get("branch") or "").strip()
 
 
 def _git_user() -> str:

--- a/charter/commands_workspace.py
+++ b/charter/commands_workspace.py
@@ -1276,7 +1276,14 @@ def cmd_workspace_reinit(args) -> int:
         # tab. That is the right trade there and it costs this command its honesty unless
         # the file is looked at again — "added workspace.json" printed over a manifest that
         # is not there is exactly the tick that stops somebody checking.
-        if "workspace.json" in before["missing"] and not workspace.manifest_path(n).exists():
+        #
+        # The absence is the whole test, and the `"workspace.json" in before["missing"]`
+        # half this started with is gone: `structure_status` derives `missing` from the
+        # same `exists()`, so before `scaffold` runs the two always agree, and after it the
+        # only way the file is still absent is that this call could not write it. The
+        # sweep found the conjunct as a survivor and it was right — an equivalent mutant
+        # and dead code are one finding.
+        if not workspace.manifest_path(n).exists():
             blocked += 1
             before["missing"] = [m for m in before["missing"] if m != "workspace.json"]
             before["ok"] = not before["missing"] and before["version"] >= before["target"]

--- a/charter/commands_workspace.py
+++ b/charter/commands_workspace.py
@@ -508,6 +508,18 @@ def _repo_branch(clone) -> str:
     return _git(["rev-parse", "--abbrev-ref", "HEAD"], cwd=clone).stdout.strip() or "HEAD"
 
 
+def _pin(row) -> str:
+    """The branch a manifest row pins, or ``""`` for one that pins none.
+
+    Two shapes reach this and both are ordinary. `snapshot` writes ``{"name", "branch"}``,
+    because an operator asked for the branches to be captured; everything charter writes on
+    its own writes ``{"name"}`` alone (#884). `row['branch']` was a `KeyError` waiting for
+    the first manifest charter wrote itself, and one function is what keeps the reading and
+    the reporting from disagreeing about which rows have a branch.
+    """
+    return str((row or {}).get("branch") or "").strip()
+
+
 def _git_user() -> str:
     return _git(["config", "user.name"]).stdout.strip() or os.environ.get("USER", "unknown")
 
@@ -605,7 +617,8 @@ def cmd_workspace_restore(args) -> int:
               f"(updated {m.get('updated_at', '?')} by {m.get('updated_by', '?')}).")
     if getattr(args, "on_demand", False):
         for r in repos:
-            util.info(f"  on-demand: {r['name']} @ {r['branch']} (clone when you enter it)")
+            util.info(f"  on-demand: {r.get('name')} @ {_pin(r) or 'no branch recorded'} "
+                      f"(clone when you enter it)")
         util.info("Enter the workspace and clone as you go: charter clone <repo> -w " + name)
         return 0
     # #325/#334/#328 all describe this join and each frames it as another's: #325 claims
@@ -645,6 +658,17 @@ def cmd_workspace_restore(args) -> int:
         if not workspace.is_git_repo(d):
             util.warn(f"  {r['name']}: not cloned (no access?) — skipped.")
             continue
+        # An UNPINNED row is restored by existing (#884). Every manifest charter writes
+        # itself records membership and no branch — a branch here carries `snapshot`'s
+        # promise that it is on the remote, and the writers nobody asked for cannot make
+        # it — so `restore` has to read a row that has none. Before the forge lookup,
+        # because there is nothing to check out and nothing to pull: the clone above is
+        # already on whatever the remote calls default, which is what "unpinned" means.
+        if not _pin(r):
+            util.ok(f"  {r['name']} @ default branch (no branch recorded — "
+                    f"`charter workspace snapshot {name}` pins one)")
+            ok += 1
+            continue
         forge = gitpolicy.forge_for(d)  # THIS clone's own forge — never a hardcoded one.
         if forge is None:
             # Unrecognised host (not a default forge, not declared in charter.toml) —
@@ -663,7 +687,7 @@ def cmd_workspace_restore(args) -> int:
         # `-b`, because a leading dash is legal inside a ref. Ref grammar answers a
         # different question than argv safety, and reaching for it here would have cost a
         # subprocess per repo while closing nothing.
-        branch = str(r.get("branch") or "")
+        branch = _pin(r)   # the value the guard below inspects IS the one git is handed
         if branch.startswith("-"):
             util.err(f"  {r['name']}: refused branch {branch!r} — a branch read from a "
                      f"committed manifest may not begin with '-', which git would read as "
@@ -1182,7 +1206,12 @@ def cmd_workspace_fork(args) -> int:
 #: Baseline components a LIVE workspace actually shares (see the managed block in
 #: .gitignore that `workspace live` writes). A workspace's refs/ and its structure
 #: marker stay local, so restoring only those gives `save` nothing to commit.
-_LIVE_SHARED_COMPONENTS = {"workspace.md", "memory/MEMORY.md"}
+#:
+#: `workspace.json` joined the baseline with #884, and it belongs here rather than only in
+#: `_required_components`: it is the FIRST path in the managed LIVE block, so a backfill
+#: that healed it and then said nothing would leave the manifest this whole change exists
+#: to share sitting uncommitted on one machine.
+_LIVE_SHARED_COMPONENTS = {"workspace.md", "workspace.json", "memory/MEMORY.md"}
 
 
 def cmd_workspace_reinit(args) -> int:
@@ -1203,6 +1232,11 @@ def cmd_workspace_reinit(args) -> int:
         util.info("No workspaces to reinitialize.")
         return 0
     healed = 0
+    #: Workspaces whose manifest `reinit` was asked for and could not write. Counted
+    #: separately from `healed` so the closing line does not say "nothing to do" over an
+    #: error two lines above it — a repair command that contradicts itself is one nobody
+    #: trusts the next time.
+    blocked = 0
     for n in names:
         before = workspace.reinit(n)
         # The HARNESS LAYER, reported as its own line rather than folded into the
@@ -1232,6 +1266,18 @@ def cmd_workspace_reinit(args) -> int:
                 util.ok(f"Reinitialized '{n}' → "
                         f"{'wrote' if did == 'created' else 'refreshed'} {rel} "
                         f"(charter's harness layer).")
+        # The BACKFILL half of #884, and the reason it is checked after rather than read
+        # off `before`: `workspace.scaffold_manifest` swallows its own failure, because it
+        # runs from `ensure` on a launch path where raising would cost the operator their
+        # tab. That is the right trade there and it costs this command its honesty unless
+        # the file is looked at again — "added workspace.json" printed over a manifest that
+        # is not there is exactly the tick that stops somebody checking.
+        if "workspace.json" in before["missing"] and not workspace.manifest_path(n).exists():
+            blocked += 1
+            before["missing"] = [m for m in before["missing"] if m != "workspace.json"]
+            before["ok"] = not before["missing"] and before["version"] >= before["target"]
+            util.err(f"'{n}': workspace.json could not be written — something is in the "
+                     f"way at that path. charter never deletes or renames existing content.")
         if before["ok"]:
             continue
         healed += 1
@@ -1244,7 +1290,7 @@ def cmd_workspace_reinit(args) -> int:
         # command that prints "Nothing to save".
         if workspace.is_live(n) and set(before["missing"]) & _LIVE_SHARED_COMPONENTS:
             util.info(f"  '{n}' is LIVE — commit the restored files: charter workspace save {n}")
-    if healed == 0:
+    if healed == 0 and blocked == 0:
         util.ok(f"Up to date (structure v{workspace.STRUCTURE_VERSION}) — nothing to do.")
     elif len(names) > 1:
         util.info(f"Healed {healed} of {len(names)} workspace(s); the rest were current.")

--- a/charter/workspace.py
+++ b/charter/workspace.py
@@ -24,6 +24,7 @@ Secrets are deliberately *not* part of this — vaults are cross-workspace.
 
 from __future__ import annotations
 
+import datetime
 import hashlib
 import json
 import os
@@ -1054,9 +1055,209 @@ def read_manifest(name: str) -> dict:
         return {}
 
 
+#: The key charter stamps into a manifest it wrote, holding the digest of everything else
+#: in the document.
+#:
+#: :data:`GENERATED_MARKER`'s rule in the one spelling this file can carry. That marker is a
+#: SIDECAR because the document it describes belongs to Claude Code, and an unknown key in
+#: it would be charter making a claim on somebody else's schema. `workspace.json` is
+#: charter's own document, so there is no such claim to make — and a sidecar could not do
+#: this job anyway: everything beside a manifest is gitignored and the manifest itself is
+#: COMMITTED, so a teammate who pulls the plane would get the file and none of charter's
+#: bookkeeping, and every shared manifest would read as hand-written on every machine but
+#: the one that wrote it.
+#:
+#: A digest rather than a flag, for `_charter_owned`'s reason: a file whose content no
+#: longer matches what charter wrote is the operator's now, and the writers nobody asked
+#: for leave it completely alone.
+MANIFEST_MARKER = "charter_generated"
+
+
+def _manifest_body(doc: dict) -> str:
+    """The text :data:`MANIFEST_MARKER` is the digest OF — the document without it.
+
+    One function, so the stamp and the check are not two spellings of "the same content";
+    :func:`content_digest` records what that costs when they drift. Canonical (sorted keys)
+    rather than the bytes on disk, so re-indenting a manifest by hand does not take it away
+    from charter while every value in it is still charter's.
+    """
+    return json.dumps({k: v for k, v in doc.items() if k != MANIFEST_MARKER},
+                      indent=2, sort_keys=True, default=str)
+
+
+def manifest_owner(name: str) -> str:
+    """Whose manifest is on disk: ``"absent"``, ``"charter"``, or ``"operator"``.
+
+    The ownership question #884 turns on. charter creates this file and maintains its
+    membership, and it must never overwrite one somebody else wrote — so "there is no
+    manifest" and "there is one charter did not write" have to be different answers.
+
+    **Present-but-unreadable answers ``"operator"``, never ``"absent"``.** A file charter
+    cannot parse is emphatically not one charter wrote, and treating it as absent would
+    make the automatic writers create a fresh manifest over exactly the hand-made file this
+    rule exists to protect.
+    """
+    p = manifest_path(name)
+    try:
+        if not p.exists():
+            return "absent"
+    except (OSError, ValueError):
+        # `exists()` raises on a path holding a NUL (ValueError) and can raise EACCES on
+        # Linux, where pathlib does not swallow it — `_unreadable`'s case, answered the
+        # cautious way: something is there that charter cannot account for.
+        return "operator"
+    doc = read_manifest(name)
+    if isinstance(doc, dict) and doc and doc.get(MANIFEST_MARKER) == content_digest(
+            _manifest_body(doc)):
+        return "charter"
+    return "operator"
+
+
 def write_manifest(name: str, data: dict) -> None:
+    """Replace *name*'s manifest with *data*, stamped as charter's.
+
+    The DELIBERATE writer — `snapshot`, `fork`, `rename` — which is why it asks
+    :func:`manifest_owner` nothing: an operator who types `charter workspace snapshot` is
+    asking for this file to be rewritten, and #884's rule is about the writes nobody asked
+    for. Those are :func:`scaffold_manifest` and :func:`record_members`, and they check.
+    """
     ensure(name)
-    contain.writable(manifest_path(name)).write_text(json.dumps(data, indent=2) + "\n")
+    _write_manifest(name, data)
+
+
+def _write_manifest(name: str, data: dict) -> None:
+    """:func:`write_manifest` without the `ensure` — the writer this module calls, because
+    `ensure` scaffolds and scaffolding is what calls this.
+
+    **Atomic**: a temp file plus ``os.replace``, the shape `state.bump` and `gather.save`
+    already use, for a reason a committed file sharpens — one of this file's readers is
+    `git add`, so half a manifest is not a glitch somebody re-runs past, it is half a
+    manifest a teammate pulls. The temp file goes through `config.write_for` for
+    `state.bump`'s stated reason: ``os.replace`` carries the SOURCE's mode onto the target,
+    so the dispatch has to happen on the file that is moved rather than the one it lands on.
+
+    `contain.writable` first and by itself: a manifest path redirected out of the plane by a
+    symlink is refused here rather than followed (#328), and the refusal RAISES, because
+    every caller of this is on a command path where a write that quietly did nothing would
+    print a tick over a fact nobody recorded.
+    """
+    p = contain.writable(manifest_path(name))
+    doc = {k: v for k, v in data.items() if k != MANIFEST_MARKER}
+    doc[MANIFEST_MARKER] = content_digest(_manifest_body(doc))
+    tmp = p.with_name(p.name + ".tmp")
+    config.write_for(tmp, json.dumps(doc, indent=2, default=str) + "\n")
+    os.replace(tmp, p)
+
+
+def _now() -> str:
+    return datetime.datetime.now(datetime.timezone.utc).isoformat(timespec="seconds")
+
+
+def _author() -> str:
+    """Who charter records as having last touched a manifest, WITHOUT a subprocess.
+
+    `commands_workspace._git_user` asks `git config user.name`, which is the better answer
+    and costs a child process. This one runs from :func:`ensure`, which a tab press reaches
+    with no operator waiting and which this module has never started a process from — so
+    the cheap reading is the right one here. The field is provenance rather than identity,
+    and `snapshot` restamps it with git's answer the moment anybody pins a branch.
+    """
+    return os.environ.get("USER") or os.environ.get("LOGNAME") or "unknown"
+
+
+def _membership_rows(name: str) -> list[dict]:
+    """The workspace's repos as MEMBERSHIP — a name each, and deliberately no branch.
+
+    #884: recording a branch here would record whatever happens to be checked out at that
+    instant, which for a workspace mid-work is a scratch branch — and a scratch branch
+    written into a teammate's restore target is confidently wrong where an empty one is
+    honestly empty, with `snapshot` there to fill it the moment an operator means to.
+
+    It is also exactly where ADR 0010 draws its line. A branch in this file carries
+    `snapshot`'s enforce-push promise — *"a manifest branch is only meaningful if it's
+    actually on the remote"* — and a writer that runs without being asked can make no such
+    promise, so it records the half of the file that needs none.
+    """
+    return [{"name": d.name} for d in clones(name)]
+
+
+def scaffold_manifest(name: str) -> None:
+    """Create the workspace's manifest if it has none. Never touches one that is there.
+
+    #884: the file is committed *precisely so a teammate can restore someone else's
+    workspace*, and while `snapshot` was its only writer it existed wherever somebody
+    happened to run that command — 5 of 17 workspaces on the plane this was measured on. A
+    file designed to be shared cannot be an opt-in side effect, so a workspace has one from
+    birth and its presence is an invariant rather than a coincidence.
+
+    A new workspace's manifest says ``repos: []``, which is a true and useful statement:
+    this workspace exists, it is called *name*, and it has no repos yet. `repos` is one
+    field among several rather than the point of the file. A workspace that already has
+    clones when this first runs — every workspace the backfill reaches, via
+    `charter workspace reinit` — records them as membership, unpinned
+    (:func:`_membership_rows`).
+
+    **Swallows its own failures.** `scaffold` runs from :func:`ensure`, which a tab press
+    reaches with nobody waiting, and the components after this one in `scaffold` still have
+    to run: a manifest that could not be written leaves the workspace exactly as it was, and
+    `structure_status` goes on reporting the file missing, which is the honest answer and
+    the one `charter workspace reinit` acts on.
+    """
+    try:
+        if manifest_owner(name) != "absent":
+            return
+        _write_manifest(name, {"name": name, "description": "",
+                               "repos": _membership_rows(name),
+                               "updated_at": _now(), "updated_by": _author()})
+    except (OSError, ValueError, contain.Refused):
+        return
+
+
+def record_members(name: str, repos) -> str:
+    """Record *repos* as members of *name*'s workspace. Returns what happened —
+    ``"unchanged"``, ``"recorded"``, ``"operator"`` or ``"blocked"``.
+
+    The auto-update half of #884: membership is a fact about the workspace, so a repo
+    cloned into one changes the manifest, and a manifest that learns its own membership
+    only when somebody runs `snapshot` describes the workspaces nobody shared.
+
+    **Additive, and that is a measurement rather than a shortcut.** Absence from disk does
+    not mean a repo was removed: `restore --on-demand` deliberately leaves every recorded
+    repo uncloned, and `restore` itself skips the ones this machine cannot reach
+    (*"Partial access is normal"*). A reconcile against the directory would therefore erase
+    the restore target of the teammate this file exists for, on their first launch, and
+    their next `charter save` would push the erasure. Removal is recorded by
+    `charter workspace snapshot`, which sets the list outright because an operator asked it
+    to.
+
+    **Never a branch** — see :func:`_membership_rows`.
+
+    ``"operator"`` for a manifest charter did not write, which is left byte for byte alone.
+    The caller says so rather than this deciding for them: a clone that could not be
+    recorded is a fact the person at the keyboard can act on (`snapshot` rewrites the file
+    deliberately), and swallowing it would make the invariant quietly untrue.
+    """
+    owner = manifest_owner(name)
+    if owner == "operator":
+        return "operator"
+    doc = read_manifest(name) if owner == "charter" else {}
+    rows = [r for r in (doc.get("repos") or []) if isinstance(r, dict) and r.get("name")]
+    have = {str(r["name"]) for r in rows}
+    add = [n for n in dict.fromkeys(str(r) for r in repos) if n and n not in have]
+    if not add and owner == "charter":
+        return "unchanged"
+    doc.setdefault("name", name)
+    doc.setdefault("description", "")
+    # Sorted, so the committed file has one row order however the rows arrived — a clone,
+    # a snapshot and a backfill all produce the same diff for the same membership.
+    doc["repos"] = sorted(rows + [{"name": n} for n in add], key=lambda r: str(r["name"]))
+    doc["updated_at"] = _now()
+    doc["updated_by"] = _author()
+    try:
+        _write_manifest(name, doc)
+    except (OSError, ValueError, contain.Refused):
+        return "blocked"
+    return "recorded"
 
 
 def merge_repo_rows(manifest_rows, disk_rows) -> tuple[list[dict], list[str]]:
@@ -1150,6 +1351,7 @@ def scaffold(name: str) -> None:
         rr.write_text(f"# {name} — task references\n\nDrop docs, links, and snippets for "
                       f"this task here (local, gitignored).\n")
     scaffold_charter(name)  # workspace.md — the living vision/context/glossary charter
+    scaffold_manifest(name)  # workspace.json — the committed manifest (#884)
     wire_harnesses(name)    # the harness layer — see `harness_layer`
     _structure_marker(name).write_text(str(STRUCTURE_VERSION) + "\n")  # stamp the layout version
 
@@ -1984,9 +2186,16 @@ def read_vision(name: str) -> str:
 # workspace picks up the three new un-ignore lines. Without it a plane that went LIVE
 # before this version keeps a block that never mentions `changes`, and the records simply
 # never travel — the same silent half-failure `todos/` had.
-STRUCTURE_VERSION = 4  # v2: memory is a per-file DB (MEMORY.md index), not a lone notes.md
+# v5 is the backfill #884 asks for, and it is why the manifest is a required component
+# rather than only something `scaffold` now writes. 12 of this plane's 17 workspaces
+# predate the invariant; without a bump they would go on having no `workspace.json` until
+# somebody happened to run `snapshot`, which is the state the issue exists to end. With
+# one, each flags itself in the status line and `charter workspace reinit --all` writes
+# every missing manifest — membership only, branches unpinned.
+STRUCTURE_VERSION = 5  # v2: memory is a per-file DB (MEMORY.md index), not a lone notes.md
                        # v3: the managed .gitignore block shares `changes/` (not its log)
                        # v4: the workspace carries charter's harness layer (#850)
+                       # v5: every workspace has a workspace.json, from birth (#884)
 _STRUCTURE_MARKER = ".charter-structure"
 _LEGACY_STRUCTURE_MARKER = ".edm-structure"   # pre-rename; migrated in place on read
 
@@ -2019,6 +2228,7 @@ def _required_components(name: str) -> dict[str, Path]:
     scaffold(). Add to this (and bump STRUCTURE_VERSION) when the layout grows."""
     return {
         "workspace.md": charter_file(name),
+        "workspace.json": manifest_path(name),
         "memory/MEMORY.md": memory_index(name),
         "refs/README.md": refs_dir(name) / "README.md",
     }

--- a/charter/workspace.py
+++ b/charter/workspace.py
@@ -1300,8 +1300,16 @@ def merge_repo_rows(manifest_rows, disk_rows) -> tuple[list[dict], list[str]]:
     `snapshot`'s guarantee that the branch was pushed, where the disk only knows whatever
     happens to be checked out now.
 
-    Returns ``(rows, disk_only)`` — rows sorted by name, and the names no snapshot
-    recorded, which the caller reports rather than silently passing off as snapshotted.
+    Returns ``(rows, disk_only)`` — rows sorted by name, and the names whose BRANCH came
+    off the disk rather than out of a snapshot, which the caller reports rather than
+    silently passing off as snapshotted.
+
+    **Membership without a branch does not count as recorded, and since #884 that is the
+    ordinary case.** Every manifest charter writes itself lists the workspace's repos with
+    no branch, so keying this on "is the repo in the manifest" would have made `fork` stop
+    saying *"their branch is whatever is checked out now, which may not be pushed"* about
+    exactly the repos that sentence is true of. What the caller is warning about is the
+    provenance of the BRANCH, so that is what is asked.
     """
     by_name: dict[str, dict] = {}
     for r in disk_rows or []:
@@ -1313,9 +1321,11 @@ def merge_repo_rows(manifest_rows, disk_rows) -> tuple[list[dict], list[str]]:
         n = str(r.get("name") or "").strip()
         if not n:
             continue
-        disk_only.discard(n)
+        pinned = str(r.get("branch") or "").strip()
+        if pinned:
+            disk_only.discard(n)
         by_name[n] = {"name": n,
-                      "branch": r.get("branch") or by_name.get(n, {}).get("branch") or "HEAD"}
+                      "branch": pinned or by_name.get(n, {}).get("branch") or "HEAD"}
     return [by_name[n] for n in sorted(by_name)], sorted(disk_only)
 
 

--- a/charter/workspace.py
+++ b/charter/workspace.py
@@ -1082,7 +1082,7 @@ def _manifest_body(doc: dict) -> str:
     from charter while every value in it is still charter's.
     """
     return json.dumps({k: v for k, v in doc.items() if k != MANIFEST_MARKER},
-                      indent=2, sort_keys=True, default=str)
+                      sort_keys=True)
 
 
 def manifest_owner(name: str) -> str:
@@ -1107,7 +1107,12 @@ def manifest_owner(name: str) -> str:
         # cautious way: something is there that charter cannot account for.
         return "operator"
     doc = read_manifest(name)
-    if isinstance(doc, dict) and doc and doc.get(MANIFEST_MARKER) == content_digest(
+    # `isinstance` and not a truth test: `read_manifest` hands back whatever JSON the file
+    # holds, and `[]` is valid JSON. A committed file is an untrusted file (`restore`'s own
+    # comment says so), and the digest is not a secret — anybody editing this by hand can
+    # compute a matching one — so a list here would reach `.get` and take the command down
+    # rather than being told it is the operator's.
+    if isinstance(doc, dict) and doc.get(MANIFEST_MARKER) == content_digest(
             _manifest_body(doc)):
         return "charter"
     return "operator"
@@ -1142,10 +1147,10 @@ def _write_manifest(name: str, data: dict) -> None:
     print a tick over a fact nobody recorded.
     """
     p = contain.writable(manifest_path(name))
-    doc = {k: v for k, v in data.items() if k != MANIFEST_MARKER}
+    doc = dict(data)
     doc[MANIFEST_MARKER] = content_digest(_manifest_body(doc))
     tmp = p.with_name(p.name + ".tmp")
-    config.write_for(tmp, json.dumps(doc, indent=2, default=str) + "\n")
+    config.write_for(tmp, json.dumps(doc, indent=2) + "\n")
     os.replace(tmp, p)
 
 
@@ -1161,8 +1166,13 @@ def _author() -> str:
     with no operator waiting and which this module has never started a process from — so
     the cheap reading is the right one here. The field is provenance rather than identity,
     and `snapshot` restamps it with git's answer the moment anybody pins a branch.
+
+    ``"unknown"`` rather than an absent field or an empty string, which is what
+    `_git_user` answers too: a shell with no `$USER` is ordinary (a `cron`, a container),
+    and a manifest field somebody has to guess the meaning of is worse than one that says
+    nobody knows.
     """
-    return os.environ.get("USER") or os.environ.get("LOGNAME") or "unknown"
+    return os.environ.get("USER") or "unknown"
 
 
 def _membership_rows(name: str) -> list[dict]:
@@ -1237,17 +1247,25 @@ def record_members(name: str, repos) -> str:
     recorded is a fact the person at the keyboard can act on (`snapshot` rewrites the file
     deliberately), and swallowing it would make the invariant quietly untrue.
     """
+    if manifest_owner(name) == "absent":
+        # `ensure` gives every workspace a manifest, so getting here means the creating
+        # write failed (a `workspaces/` nobody can write into) and a clone has since
+        # succeeded. Through the one constructor rather than a second shape of "a fresh
+        # manifest" assembled here — two of those drift, and the drift is invisible until
+        # a field one of them omits is read.
+        scaffold_manifest(name)
     owner = manifest_owner(name)
-    if owner == "operator":
-        return "operator"
-    doc = read_manifest(name) if owner == "charter" else {}
+    if owner != "charter":
+        return "operator" if owner == "operator" else "blocked"
+    doc = read_manifest(name)
+    # Rows that are not rows are dropped rather than crashed on. A committed manifest is an
+    # untrusted document and the digest is not a secret, so `repos: [1, 2, 3]` with a
+    # matching stamp is a file somebody can hand this plane.
     rows = [r for r in (doc.get("repos") or []) if isinstance(r, dict) and r.get("name")]
     have = {str(r["name"]) for r in rows}
     add = [n for n in dict.fromkeys(str(r) for r in repos) if n and n not in have]
-    if not add and owner == "charter":
+    if not add:
         return "unchanged"
-    doc.setdefault("name", name)
-    doc.setdefault("description", "")
     # Sorted, so the committed file has one row order however the rows arrived — a clone,
     # a snapshot and a backfill all produce the same diff for the same membership.
     doc["repos"] = sorted(rows + [{"name": n} for n in add], key=lambda r: str(r["name"]))

--- a/docs/adr/0010-the-manifest-is-a-snapshot-not-an-inventory.md
+++ b/docs/adr/0010-the-manifest-is-a-snapshot-not-an-inventory.md
@@ -46,6 +46,40 @@ that fires on the intended state teaches people to ignore warnings.
 
 `snapshot` stays the only writer, and its enforce-push guard keeps meaning what it says.
 
+**Amended by #884 (2026-09-04): `snapshot` is the only writer of BRANCHES.** The paragraph
+above stated the rule one level too broadly, and the file it protected went on not existing:
+5 of 17 workspaces on the plane this was measured on had a `workspace.json` at all. A file
+that is committed *precisely so a teammate can restore someone else's workspace* cannot be a
+side effect of a command somebody happened to run, so its presence is now an invariant —
+`workspace.ensure` creates it, `charter workspace reinit` backfills the ones that predate
+this, and `charter clone` records what it just cloned.
+
+Read what this section actually names as the harm: *"it fills the manifest with branches
+recorded outside `snapshot`'s guarantee — so `restore` starts failing on branches that were
+never pushed, which is the one thing the manifest exists to prevent."* That is a statement
+about **branches**, and every writer added here records **membership only** —
+`workspace._membership_rows` writes `{"name": …}` and no `branch`, on every path. So no
+branch enters this file except through `snapshot` and its enforce-push guard, and there is
+nothing for `restore` to fail on: an unpinned row is restored by the clone existing.
+
+The second objection stands and is honoured rather than argued with: *"it makes read
+commands mutate a committed, shared file."* None of the writers is a read command. `ensure`
+and `clone` are write paths by definition; `reinit` is the repair command an operator types.
+`status` and `workspace list` still only scan.
+
+One reading is stronger after this, not weaker. **Absence from disk is still not removal** —
+`restore --on-demand` deliberately leaves every recorded repo uncloned and `restore` skips
+what this machine cannot reach — so the automatic maintenance is additive and never
+reconciles the file against the directory. A workspace's membership shrinks when an operator
+runs `snapshot`, which sets the list outright because they asked for it. The union
+`merge_repo_rows` returns is unchanged and still the answer to "which repos", because a
+manifest still cannot see a clone nobody has recorded yet.
+
+And the ownership rule is new, because presence brought a file charter maintains into
+workspaces where somebody may already have written one by hand: a manifest whose contents no
+longer match the digest charter stamped into it is the operator's, and the automatic writers
+leave it completely alone.
+
 The union is not a merge of equals and must not become one. If a future change starts
 writing the manifest automatically, the guard is gone whether or not the code still calls
 it — and `restore` will fail on someone else's machine, which is the failure that is

--- a/docs/news/unreleased-every-workspace-has-a-manifest.md
+++ b/docs/news/unreleased-every-workspace-has-a-manifest.md
@@ -1,0 +1,81 @@
+---
+version: unreleased
+headline: every workspace has a `workspace.json` — written when the workspace is made, kept in step when a repo is cloned into it, and backfilled for the ones that predate it
+adopt: workspace reinit --all
+---
+
+**5 of 17 workspaces on the plane this was measured had a manifest.** The file was written
+only by `charter workspace snapshot`, so it existed wherever somebody happened to run that
+command and nowhere else — while everything about it says it is meant to be shared.
+`charter workspace restore` calls it *"committed precisely so a teammate can restore someone
+else's"* workspace, and the managed `.gitignore` block un-ignores it by name, first in the
+list. A file designed to travel cannot be an opt-in side effect.
+
+## Born with one
+
+`workspace.ensure` writes it, so a new workspace's manifest reads:
+
+```json
+{
+  "name": "alpha",
+  "description": "",
+  "repos": [],
+  "updated_at": "2026-09-04T09:12:31+00:00",
+  "updated_by": "ada"
+}
+```
+
+`repos: []` is a true and useful statement — this workspace exists, it is called `alpha`,
+and it has no repos yet — and `repos` is one field among several rather than the point of
+the file. Making its presence an invariant rather than a coincidence is what lets anything
+else rely on it.
+
+## Membership is maintained; branches are not
+
+The file records repos **and** branches, and those have different lifetimes.
+
+A repo cloned into the workspace is recorded, because which repos a workspace is made of is
+a fact about the workspace. The checked-out branch is a fact about this minute, so charter
+never writes one on its own: a manifest updated on every `git checkout` would churn a
+committed file constantly, and — the part that matters more — a branch in this file carries
+`snapshot`'s promise that it is on the remote, which is the whole reason `restore` can
+check one out on somebody else's machine. `charter workspace snapshot` is unchanged and
+stays what it always was: the way an operator deliberately pins branches for someone else
+to restore.
+
+`restore` reads both shapes. A repo with no branch recorded is restored by being cloned at
+all, on whatever the remote calls default, and says so rather than reporting a failed
+checkout.
+
+## The backfill
+
+```
+charter workspace reinit --all
+```
+
+The workspace structure version moved to 5, so every workspace made by an earlier charter
+flags itself in the status line and in `charter workspace list` until this runs. It records
+**membership only, with branches unpinned** — backfilling a branch would record whatever
+happens to be checked out at that instant, which for a workspace mid-work is a scratch
+branch, and a scratch branch written into a teammate's restore target is confidently wrong
+where an empty one is honestly empty. `snapshot` fills it when you mean to.
+
+Nothing new commits it: `charter save` already commits `workspace.json` alongside
+`workspace.md` and `memory/`, for a LIVE workspace.
+
+## A manifest you wrote is yours
+
+charter stamps the manifests it writes with a digest of their own contents. A
+`workspace.json` whose contents no longer match — one you wrote by hand, or one of
+charter's you have edited — is the operator's: no membership is recorded into it, `reinit`
+does not replace it, and `charter clone` says out loud that it left it alone. `snapshot`
+still rewrites it, because that is you asking.
+
+The stamp is a key inside the document rather than a `.charter-generated` sidecar, and the
+reason is the opposite of the harness layer's. That marker is a sidecar because
+`.claude/settings.json` belongs to Claude Code and an unknown key in it would be charter
+claiming somebody else's schema. `workspace.json` is charter's own document — and a sidecar
+could not do this job anyway, because everything beside a manifest is gitignored while the
+manifest is committed: a teammate who pulled the plane would get the file and none of the
+bookkeeping, so every shared manifest would read as hand-written on every machine but the
+one that wrote it.

--- a/docs/workspaces.md
+++ b/docs/workspaces.md
@@ -136,10 +136,11 @@ memory, persona memory, shared memory and refs — which is the only search you 
 remember.
 
 **`workspace.json` is there from the start.** Every workspace has one — `workspace.ensure`
-writes it, saying which workspace this is and that it has no repos yet — because the file is
-committed so a *teammate* can rebuild the workspace, and a file designed to be shared cannot
-depend on somebody having run a command. A workspace made by an earlier charter gets one from
-`charter workspace reinit --all`.
+writes it, saying which workspace this is and that it has no repos yet. The file exists to
+be shared: make the workspace LIVE (below) and it is committed, which is how a *teammate*
+rebuilds it with `restore`. A file for that cannot depend on somebody having run a command
+first, so its presence is an invariant rather than a coincidence. A workspace made by an
+earlier charter gets one from `charter workspace reinit --all`.
 
 **Its two halves have different lifetimes.** Membership is maintained: a repo cloned into
 the workspace is recorded, because which repos a workspace is made of is a fact about the

--- a/docs/workspaces.md
+++ b/docs/workspaces.md
@@ -116,7 +116,7 @@ Three stores, three jobs. Putting a thing in the wrong one is the common mistake
 | --- | --- | --- |
 | `workspace.md` | Vision, Context & decisions, Glossary | when the *task* changes |
 | `memory/` | facts learned while working | constantly, one file per fact |
-| `workspace.json` | repos + branches | when you `snapshot` |
+| `workspace.json` | which repos, and which branches | membership when a repo is cloned; branches when you `snapshot` |
 
 Two more stores sit beside them with their own lifetimes: `todos/` (intent, which expires —
 [ADR 0004](adr/0004-intent-is-its-own-store.md)) and `changes/`, one file per cross-repo
@@ -135,8 +135,23 @@ adds one; `charter recall <query>` searches **across every base at once** — wo
 memory, persona memory, shared memory and refs — which is the only search you need to
 remember.
 
-**`workspace.json` is a snapshot, not an inventory.** It records what was there when you
-asked, and is what `restore` rebuilds from. It does not track drift; see ADR 0010.
+**`workspace.json` is there from the start.** Every workspace has one — `workspace.ensure`
+writes it, saying which workspace this is and that it has no repos yet — because the file is
+committed so a *teammate* can rebuild the workspace, and a file designed to be shared cannot
+depend on somebody having run a command. A workspace made by an earlier charter gets one from
+`charter workspace reinit --all`.
+
+**Its two halves have different lifetimes.** Membership is maintained: a repo cloned into
+the workspace is recorded, because which repos a workspace is made of is a fact about the
+workspace. Branches are not — they are a fact about this minute, and writing one on every
+`git checkout` would churn a committed file. So charter records a repo with no branch, and
+`snapshot` is where an operator deliberately pins the branches somebody else will restore.
+Nothing but `snapshot` ever writes a branch here; see ADR 0010 for why that line is where it
+is. `restore` treats an unpinned repo as restored by being cloned at all.
+
+**A manifest you wrote is yours.** charter stamps the file with a digest of what it wrote;
+a `workspace.json` whose contents no longer match is left completely untouched — no
+membership is recorded into it — until you rewrite it with `snapshot`.
 
 ## LIVE or LOCAL — where your notes go
 
@@ -179,14 +194,17 @@ line says so:
     ⚠ reinit 3 ws · charter ws reinit --all
 
 `charter workspace reinit <name>` creates what is missing and re-stamps the marker. It is
-additive: nothing you wrote is touched.
+additive: nothing you wrote is touched. `--all` is also the **backfill** for a structural
+element that older workspaces predate — v5 is `workspace.json`, written with the repos the
+workspace has and no branches.
 
 ## Moving a workspace around
 
 - **`fork <src> <new>`** — a new workspace pre-loaded with the source's charter, manifest
   and memory, so a branch of the work starts with the context rather than without it.
   Repos come with `--restore`, or on demand later.
-- **`snapshot`** — write the current repos and branches into `workspace.json`.
+- **`snapshot`** — pin the current repos *and branches* into `workspace.json`. Refuses
+  while a repo has unpushed work, so a recorded branch is one `restore` can check out.
 - **`restore <name>`** — rebuild from that manifest on another machine: clone each repo,
   check out each branch.
 - **`rename <old> <new>`** — moves the clones and the memory, and commits the move if the

--- a/tests/test_every_workspace_has_a_manifest.py
+++ b/tests/test_every_workspace_has_a_manifest.py
@@ -1,0 +1,439 @@
+"""Every workspace has a `workspace.json` — from birth, and by backfill (#884).
+
+Measured on the plane this was written for: **5 of 17 workspaces had one.** The file was
+written only by `charter workspace snapshot`, so it existed wherever somebody happened to
+run that command — while its whole purpose argues the other way. `cmd_workspace_restore`
+says it is *"committed precisely so a teammate can restore someone else's"* workspace, and
+`workspace._live_block` maintains a `.gitignore` block whose first line un-ignores it. A
+file designed to be shared cannot be an opt-in side effect.
+
+Three promises are pinned here, and they pull against each other on purpose:
+
+* **presence is an invariant** — `workspace.ensure` creates the manifest, so a workspace
+  has one from birth and `charter workspace reinit` writes the ones that predate this;
+* **membership is maintained, branches are not** — a repo cloned into a workspace is
+  recorded, with no branch, because a branch in this file carries `snapshot`'s enforce-push
+  promise (ADR 0010) and a writer nobody asked for cannot make it;
+* **a manifest charter did not write is never overwritten** — the ownership rule the
+  harness layer states with `GENERATED_MARKER`, carried here as a digest inside the
+  document, because this file is committed and a sidecar beside it would not be.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import os
+import unittest
+from contextlib import redirect_stderr
+from types import SimpleNamespace
+from unittest import mock
+
+from charter import commands, config, contain, workspace
+from charter import commands_workspace as cw
+from tests._isolation import PersonaIso
+
+
+def _clone(ws: str, name: str):
+    """A directory `workspace.clones` counts as a repo — a `.git` DIRECTORY is git's own
+    test (`workspace.is_clone`) and the only one membership depends on. No real repository,
+    because nothing here asks a repo a question; the cases that need a branch build one."""
+    d = workspace.workspace_dir(ws) / name
+    (d / ".git").mkdir(parents=True)
+    return d
+
+
+class ManifestCase(PersonaIso):
+    def manifest(self, ws: str) -> dict:
+        return json.loads(workspace.manifest_path(ws).read_text())
+
+    def reinit(self, name: str) -> str:
+        buf = io.StringIO()
+        with redirect_stderr(buf):
+            cw.cmd_workspace_reinit(SimpleNamespace(name=name, all=False))
+        return buf.getvalue()
+
+
+class AWorkspaceIsBornWithOne(ManifestCase):
+    def test_ensure_writes_the_manifest(self):
+        workspace.ensure("alpha")
+        self.assertTrue(workspace.manifest_path("alpha").is_file())
+
+    def test_it_carries_the_identity_fields_not_only_repos(self):
+        """`repos` is one field among several rather than the point of the file — the
+        manifest of a workspace with nothing cloned still says which workspace it is."""
+        with mock.patch.dict(os.environ, {"USER": "ada"}):
+            workspace.ensure("alpha")
+        m = self.manifest("alpha")
+        self.assertEqual(m["name"], "alpha")
+        self.assertEqual(m["description"], "")
+        self.assertEqual(m["repos"], [])
+        self.assertEqual(m["updated_by"], "ada")
+        self.assertRegex(m["updated_at"], r"^\d{4}-\d\d-\d\dT\d\d:\d\d:\d\d\+00:00$")
+
+    def test_a_new_workspace_records_no_repos_rather_than_no_manifest(self):
+        """*"this workspace exists, is called alpha, and has no repos yet"* is a true and
+        useful statement, and it is the one that lets anything else rely on the file."""
+        workspace.ensure("alpha")
+        self.assertEqual(workspace.read_manifest("alpha")["repos"], [])
+
+    def test_the_manifest_is_charters_to_maintain(self):
+        workspace.ensure("alpha")
+        self.assertEqual(workspace.manifest_owner("alpha"), "charter")
+
+    def test_a_second_ensure_does_not_rewrite_it(self):
+        """Created, never refreshed. `ensure` runs on every launch; a manifest restamped
+        each time would put a committed file in every `git status` for the rest of time."""
+        workspace.ensure("alpha")
+        before = workspace.manifest_path("alpha").read_bytes()
+        workspace.ensure("alpha")
+        self.assertEqual(workspace.manifest_path("alpha").read_bytes(), before)
+
+    def test_ensure_still_builds_the_workspace_when_the_manifest_cannot_be_written(self):
+        """`ensure` is reached from a tab press with no operator waiting — it degrades and
+        never raises, and the components after the manifest in `scaffold` still have to
+        run. Without the swallow, a `workspaces/` charter cannot write into would take the
+        harness layer and the structure marker down with the manifest."""
+        wd = workspace.workspace_dir("alpha")
+        wd.mkdir(parents=True)
+        wd.chmod(0o500)
+        self.addCleanup(wd.chmod, 0o700)
+        workspace.ensure("alpha")            # must not raise
+        wd.chmod(0o700)
+        self.assertFalse(workspace.manifest_path("alpha").exists())
+
+    def test_a_manifest_that_could_not_be_written_is_reported_as_missing(self):
+        """The honest reading, and what makes `charter workspace reinit` the repair: a
+        write that failed leaves the workspace exactly as it was, and `structure_status`
+        goes on saying the file is not there."""
+        wd = workspace.workspace_dir("alpha")
+        wd.mkdir(parents=True)
+        wd.chmod(0o500)
+        self.addCleanup(wd.chmod, 0o700)
+        workspace.ensure("alpha")
+        wd.chmod(0o700)
+        self.assertIn("workspace.json", workspace.structure_status("alpha")["missing"])
+
+
+class TheManifestIsPartOfTheLayout(ManifestCase):
+    """The backfill's mechanism: the manifest is a required component, so a workspace made
+    before #884 flags itself and one command heals every one of them."""
+
+    def test_a_workspace_without_one_is_stale(self):
+        workspace.ensure("alpha")
+        workspace.manifest_path("alpha").unlink()
+        self.assertIn("workspace.json", workspace.structure_status("alpha")["missing"])
+        self.assertTrue(workspace.needs_reinit("alpha"))
+
+    def test_reinit_writes_the_missing_manifest(self):
+        workspace.ensure("alpha")
+        workspace.manifest_path("alpha").unlink()
+        cw.cmd_workspace_reinit(SimpleNamespace(name="alpha", all=False))
+        self.assertTrue(workspace.manifest_path("alpha").is_file())
+        self.assertFalse(workspace.needs_reinit("alpha"))
+
+    def test_reinit_all_backfills_every_workspace_that_lacks_one(self):
+        """The command the operator runs once: 12 of 17 workspaces on the plane this was
+        measured on."""
+        for n in ("alpha", "beta", "gamma"):
+            workspace.ensure(n)
+            workspace.manifest_path(n).unlink()
+        cw.cmd_workspace_reinit(SimpleNamespace(name=None, all=True))
+        for n in ("alpha", "beta", "gamma"):
+            self.assertTrue(workspace.manifest_path(n).is_file(), n)
+
+    def test_the_backfill_records_membership(self):
+        workspace.ensure("alpha")
+        workspace.manifest_path("alpha").unlink()
+        _clone("alpha", "svc")
+        _clone("alpha", "web")
+        cw.cmd_workspace_reinit(SimpleNamespace(name="alpha", all=False))
+        self.assertEqual([r["name"] for r in self.manifest("alpha")["repos"]],
+                         ["svc", "web"])
+
+    def test_the_backfill_pins_no_branch(self):
+        """Backfilling a branch would record whatever is checked out at that instant —
+        for a workspace mid-work, a scratch branch. A scratch branch written into a
+        teammate's restore target is confidently wrong; an empty one is honestly empty,
+        and `snapshot` fills it when the operator means to."""
+        workspace.ensure("alpha")
+        workspace.manifest_path("alpha").unlink()
+        _clone("alpha", "svc")
+        cw.cmd_workspace_reinit(SimpleNamespace(name="alpha", all=False))
+        self.assertEqual(self.manifest("alpha")["repos"], [{"name": "svc"}])
+
+    def test_reinit_leaves_a_manifest_that_is_already_there_alone(self):
+        """Additive, like every other component it heals: *"nothing you wrote is
+        touched"*."""
+        workspace.ensure("alpha")
+        workspace.write_manifest("alpha", {"name": "alpha", "description": "the task",
+                                           "repos": [{"name": "svc", "branch": "release"}]})
+        before = workspace.manifest_path("alpha").read_bytes()
+        cw.cmd_workspace_reinit(SimpleNamespace(name="alpha", all=False))
+        self.assertEqual(workspace.manifest_path("alpha").read_bytes(), before)
+
+    def test_reinit_says_so_when_the_manifest_could_not_be_written(self):
+        """`reinit` reports what it DID, never what it found. `scaffold_manifest` swallows
+        its own failure so the rest of the structure still lands, and without this the
+        command would print "added workspace.json" over a file that is not there."""
+        workspace.ensure("alpha")
+        workspace.manifest_path("alpha").unlink()
+        wd = workspace.workspace_dir("alpha")
+        wd.chmod(0o500)
+        self.addCleanup(wd.chmod, 0o700)
+        said = self.reinit("alpha")
+        wd.chmod(0o700)
+        self.assertIn("workspace.json could not be written", said)
+        self.assertNotIn("added workspace.json", said)
+
+    def test_a_backfilled_live_workspace_is_told_to_commit_it(self):
+        """`workspace.json` is the first path in the managed LIVE block, so a backfill that
+        healed it and said nothing would leave the manifest this change exists to share
+        sitting uncommitted on one machine."""
+        (config.ROOT / ".gitignore").write_text("/workspaces/*/*\n!/workspaces/.gitkeep\n")
+        workspace.ensure("alpha")
+        workspace.set_live("alpha", True)
+        workspace.manifest_path("alpha").unlink()
+        self.assertIn("charter workspace save", self.reinit("alpha"))
+
+
+class MembershipIsMaintained(ManifestCase):
+    def test_a_cloned_repo_is_recorded(self):
+        workspace.ensure("alpha")
+        self.assertEqual(workspace.record_members("alpha", ["svc"]), "recorded")
+        self.assertEqual(self.manifest("alpha")["repos"], [{"name": "svc"}])
+
+    def test_no_branch_is_ever_recorded(self):
+        """The line ADR 0010 draws. A branch in this file promises `restore` can check it
+        out on another machine — `snapshot` refuses while a repo has unpushed work,
+        precisely so the promise holds. Nothing that writes without being asked can make
+        it, so nothing that writes without being asked writes a branch."""
+        workspace.ensure("alpha")
+        workspace.record_members("alpha", ["svc"])
+        self.assertNotIn("branch", self.manifest("alpha")["repos"][0])
+
+    def test_recording_the_same_repo_twice_rewrites_nothing(self):
+        """Idempotent and silent: every `charter clone` into a workspace already holding
+        the repo would otherwise restamp `updated_at` and dirty a committed file."""
+        workspace.ensure("alpha")
+        workspace.record_members("alpha", ["svc"])
+        before = workspace.manifest_path("alpha").read_bytes()
+        self.assertEqual(workspace.record_members("alpha", ["svc"]), "unchanged")
+        self.assertEqual(workspace.manifest_path("alpha").read_bytes(), before)
+
+    def test_a_recorded_branch_survives_a_later_clone(self):
+        """The two halves of the file have different lifetimes and neither erases the
+        other: `snapshot` pins the branches, a clone adds a member."""
+        workspace.ensure("alpha")
+        workspace.write_manifest("alpha", {"name": "alpha", "description": "",
+                                           "repos": [{"name": "svc", "branch": "release"}]})
+        workspace.record_members("alpha", ["web"])
+        rows = {r["name"]: r.get("branch") for r in self.manifest("alpha")["repos"]}
+        self.assertEqual(rows, {"svc": "release", "web": None})
+
+    def test_a_repo_that_is_not_on_this_machine_is_not_dropped(self):
+        """**Absence is not removal**, and that is measured rather than cautious:
+        `restore --on-demand` deliberately leaves every recorded repo uncloned, and
+        `restore` skips the ones this machine cannot reach. A reconcile against the
+        directory would erase the restore target of the teammate this file exists for,
+        on their first launch — and their next `charter save` would push the erasure."""
+        workspace.ensure("alpha")
+        workspace.write_manifest("alpha", {"name": "alpha", "description": "",
+                                           "repos": [{"name": "svc", "branch": "release"},
+                                                     {"name": "gone", "branch": "main"}]})
+        workspace.record_members("alpha", ["web"])
+        self.assertEqual([r["name"] for r in self.manifest("alpha")["repos"]],
+                         ["gone", "svc", "web"])
+
+    def test_membership_is_restamped_with_who_and_when(self):
+        workspace.ensure("alpha")
+        workspace.write_manifest("alpha", {"name": "alpha", "repos": [],
+                                           "updated_at": "1999-01-01T00:00:00+00:00",
+                                           "updated_by": "someone else"})
+        with mock.patch.dict(os.environ, {"USER": "ada"}):
+            workspace.record_members("alpha", ["svc"])
+        self.assertEqual(self.manifest("alpha")["updated_by"], "ada")
+        self.assertNotEqual(self.manifest("alpha")["updated_at"], "1999-01-01T00:00:00+00:00")
+
+    def test_cloning_records_the_repo_it_just_cloned(self):
+        """End to end through `cmd_clone`, which is the structural change: a repo cloned
+        into a workspace is a member of it, and a manifest that learns that only when
+        somebody runs `snapshot` describes the workspaces nobody shared."""
+        workspace.ensure("alpha")
+        dest = _clone("alpha", "svc")
+        r = {"name": "svc", "default_branch": "main", "forge": "github",
+             "path_with_namespace": "g/svc"}
+        with mock.patch.object(commands, "_clone_one",
+                               lambda rr, wd: {"repo": rr, "dest": dest, "status": "ok",
+                                               "forge": SimpleNamespace(cli="gh")}), \
+                mock.patch.object(commands.workspace, "banner", lambda *a, **k: None), \
+                mock.patch.object(commands.inventory, "load", lambda: {}), \
+                mock.patch.object(commands.inventory, "repos", lambda d=None: [r]), \
+                mock.patch.object(commands, "_resolve_targets", lambda a, d: [r]):
+            rc = commands.cmd_clone(SimpleNamespace(repos=["svc"], workspace="alpha"))
+        self.assertEqual(rc, 0)
+        self.assertEqual(self.manifest("alpha")["repos"], [{"name": "svc"}])
+
+
+class AManifestCharterDidNotWriteIsNeverOverwritten(ManifestCase):
+    """The ownership rule `GENERATED_MARKER` states for the harness layer, in the one
+    spelling a committed JSON document can carry."""
+
+    def hand_written(self, ws: str, text: str = '{"name": "alpha", "repos": []}\n') -> bytes:
+        workspace.workspace_dir(ws).mkdir(parents=True, exist_ok=True)
+        workspace.manifest_path(ws).write_text(text)
+        return text.encode()
+
+    def test_a_hand_written_manifest_is_the_operators(self):
+        self.hand_written("alpha")
+        self.assertEqual(workspace.manifest_owner("alpha"), "operator")
+
+    def test_ensure_leaves_it_exactly_as_it_found_it(self):
+        before = self.hand_written("alpha")
+        workspace.ensure("alpha")
+        self.assertEqual(workspace.manifest_path("alpha").read_bytes(), before)
+
+    def test_membership_is_not_recorded_into_it(self):
+        before = self.hand_written("alpha")
+        self.assertEqual(workspace.record_members("alpha", ["svc"]), "operator")
+        self.assertEqual(workspace.manifest_path("alpha").read_bytes(), before)
+
+    def test_an_edited_manifest_stops_being_charters(self):
+        """A digest rather than a flag, for `_charter_owned`'s reason: a file whose content
+        no longer matches what charter wrote is the operator's now, whoever created it."""
+        workspace.ensure("alpha")
+        doc = workspace.read_manifest("alpha")
+        doc["description"] = "mine now"
+        workspace.manifest_path("alpha").write_text(json.dumps(doc, indent=2) + "\n")
+        self.assertEqual(workspace.manifest_owner("alpha"), "operator")
+
+    def test_the_stamp_travels_in_the_committed_file(self):
+        """Why the marker is a key and not a `.charter-generated` sidecar: everything
+        beside a manifest is gitignored and the manifest is not, so a teammate who pulls
+        the plane would get the file with none of charter's bookkeeping — and every shared
+        manifest would read as hand-written on every machine but the one that wrote it."""
+        workspace.ensure("alpha")
+        raw = workspace.manifest_path("alpha").read_text()
+        self.assertIn(workspace.MANIFEST_MARKER, raw)
+        pulled = json.loads(raw)                       # what git would hand a teammate
+        workspace.manifest_path("beta").parent.mkdir(parents=True, exist_ok=True)
+        workspace.manifest_path("beta").write_text(json.dumps(pulled, indent=2) + "\n")
+        self.assertEqual(workspace.manifest_owner("beta"), "charter")
+
+    def test_reindenting_a_manifest_does_not_take_it_away_from_charter(self):
+        """The digest is over the document, not the bytes: a value charter wrote is still
+        charter's however the file is formatted."""
+        workspace.ensure("alpha")
+        doc = workspace.read_manifest("alpha")
+        workspace.manifest_path("alpha").write_text(json.dumps(doc))   # one line, no indent
+        self.assertEqual(workspace.manifest_owner("alpha"), "charter")
+
+    def test_a_manifest_charter_cannot_read_is_not_a_missing_one(self):
+        """"Present but unparseable" must answer `operator`, never `absent`: treating it as
+        absent would make the automatic writers create a fresh manifest over exactly the
+        hand-made file this rule exists to protect."""
+        before = self.hand_written("alpha", "this is not json\n")
+        self.assertEqual(workspace.manifest_owner("alpha"), "operator")
+        workspace.ensure("alpha")
+        workspace.record_members("alpha", ["svc"])
+        self.assertEqual(workspace.manifest_path("alpha").read_bytes(), before)
+
+    def test_snapshot_still_rewrites_it_because_somebody_asked(self):
+        """The rule governs the writes nobody asked for. `charter workspace snapshot` is
+        the operator saying *rewrite this file*, and #884 leaves it exactly as it was."""
+        self.hand_written("alpha")
+        _clone("alpha", "svc")
+        with mock.patch.object(cw, "_restore_blockers", lambda n: []), \
+                mock.patch.object(cw, "_repo_branch", lambda d: "release"):
+            rc = cw.cmd_workspace_snapshot(SimpleNamespace(name="alpha", force=False,
+                                                           description=None))
+        self.assertEqual(rc, 0)
+        self.assertEqual(self.manifest("alpha")["repos"], [{"name": "svc",
+                                                            "branch": "release"}])
+
+    def test_a_snapshot_hands_the_file_back_to_charter(self):
+        """So the clone AFTER a snapshot is recorded. A deliberate rewrite that left the
+        file unstamped would make charter treat its own document as the operator's, and
+        membership would silently stop being maintained on exactly the workspaces somebody
+        cared enough to snapshot."""
+        workspace.ensure("alpha")
+        _clone("alpha", "svc")
+        with mock.patch.object(cw, "_restore_blockers", lambda n: []), \
+                mock.patch.object(cw, "_repo_branch", lambda d: "release"):
+            cw.cmd_workspace_snapshot(SimpleNamespace(name="alpha", force=False,
+                                                      description=None))
+        self.assertEqual(workspace.manifest_owner("alpha"), "charter")
+        self.assertEqual(workspace.record_members("alpha", ["web"]), "recorded")
+
+
+class TheWriteIsAtomic(ManifestCase):
+    """A reader of this file can be `git add`, so half a manifest is not a glitch somebody
+    re-runs past — it is half a manifest a teammate pulls."""
+
+    def test_the_previous_manifest_survives_a_write_that_fails(self):
+        workspace.ensure("alpha")
+        workspace.write_manifest("alpha", {"name": "alpha", "description": "",
+                                           "repos": [{"name": "svc", "branch": "release"}]})
+        before = workspace.manifest_path("alpha").read_bytes()
+        with mock.patch("os.replace", side_effect=OSError(28, "No space left on device")):
+            self.assertEqual(workspace.record_members("alpha", ["web"]), "blocked")
+        self.assertEqual(workspace.manifest_path("alpha").read_bytes(), before)
+
+    def test_no_temporary_file_is_left_beside_it(self):
+        workspace.ensure("alpha")
+        workspace.record_members("alpha", ["svc"])
+        litter = [p.name for p in workspace.workspace_dir("alpha").iterdir()
+                  if p.name.endswith(".tmp")]
+        self.assertEqual(litter, [])
+
+    def test_a_redirected_manifest_path_is_refused_rather_than_followed(self):
+        """`contain.writable` first and by itself — the atomic shape must not become a way
+        around containment (#328). `os.replace` onto a symlink replaces the link, so a
+        refusal here is what keeps the write inside the plane at all."""
+        outside = self.tmp / "outside.json"
+        outside.write_text("{}\n")
+        workspace.workspace_dir("alpha").mkdir(parents=True)
+        workspace.manifest_path("alpha").symlink_to(outside)
+        with self.assertRaises(contain.Refused):
+            workspace.write_manifest("alpha", {"repos": []})
+        self.assertEqual(outside.read_text(), "{}\n")
+
+
+class RestoringAWorkspaceWhoseBranchesAreUnpinned(ManifestCase):
+    """The backfill's output is a manifest with membership and no branches, and `restore`
+    is what reads it. Without this it asked `git checkout ''` for every repo and reported
+    a workspace it had in fact restored as one it could not."""
+
+    def test_an_unpinned_repo_is_restored_by_being_there(self):
+        workspace.ensure("alpha")
+        _clone("alpha", "svc")
+        workspace.write_manifest("alpha", {"name": "alpha", "repos": [{"name": "svc"}]})
+        buf = io.StringIO()
+        with redirect_stderr(buf):
+            rc = cw.cmd_workspace_restore(SimpleNamespace(name="alpha", on_demand=False))
+        self.assertEqual(rc, 0)
+        self.assertIn("Restored 1/1", buf.getvalue())
+
+    def test_it_is_named_as_unpinned_rather_than_as_a_branch(self):
+        workspace.ensure("alpha")
+        _clone("alpha", "svc")
+        workspace.write_manifest("alpha", {"name": "alpha", "repos": [{"name": "svc"}]})
+        buf = io.StringIO()
+        with redirect_stderr(buf):
+            cw.cmd_workspace_restore(SimpleNamespace(name="alpha", on_demand=False))
+        self.assertIn("no branch recorded", buf.getvalue())
+
+    def test_the_on_demand_listing_survives_a_row_with_no_branch(self):
+        """`r['branch']` was a KeyError waiting for the first manifest charter wrote
+        itself."""
+        workspace.ensure("alpha")
+        workspace.write_manifest("alpha", {"name": "alpha", "repos": [{"name": "svc"}]})
+        buf = io.StringIO()
+        with redirect_stderr(buf):
+            rc = cw.cmd_workspace_restore(SimpleNamespace(name="alpha", on_demand=True))
+        self.assertEqual(rc, 0)
+        self.assertIn("svc", buf.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_every_workspace_has_a_manifest.py
+++ b/tests/test_every_workspace_has_a_manifest.py
@@ -138,9 +138,12 @@ class TheManifestIsPartOfTheLayout(ManifestCase):
     def test_reinit_writes_the_missing_manifest(self):
         workspace.ensure("alpha")
         workspace.manifest_path("alpha").unlink()
-        cw.cmd_workspace_reinit(SimpleNamespace(name="alpha", all=False))
+        said = self.reinit("alpha")
         self.assertTrue(workspace.manifest_path("alpha").is_file())
         self.assertFalse(workspace.needs_reinit("alpha"))
+        self.assertIn("added workspace.json", said)
+        self.assertNotIn("Up to date", said,
+                         "a repair that wrote a manifest reported having nothing to do")
 
     def test_reinit_all_backfills_every_workspace_that_lacks_one(self):
         """The command the operator runs once: 12 of 17 workspaces on the plane this was
@@ -393,6 +396,16 @@ class MembershipIsNotASnapshot(ManifestCase):
                                                     [{"name": "svc", "branch": "scratch"}])
         self.assertEqual(disk_only, ["svc"])
         self.assertEqual(rows, [{"name": "svc", "branch": "scratch"}])
+
+    def test_a_pin_is_trimmed_at_both_ends(self):
+        """Both ends, because only one of them is dangerous and neither is a ref. A
+        leading space hides an option from the `-` guard (`" -b"`); a trailing one is
+        simply a branch `git checkout` will not find, and the reading that produces the
+        row is the reading that produces the argument."""
+        rows, _ = workspace.merge_repo_rows([{"name": "svc", "branch": "release "}], [])
+        self.assertEqual(rows, [{"name": "svc", "branch": "release"}])
+        self.assertEqual(cw._pin({"branch": "release "}), "release")
+        self.assertEqual(cw._pin({"branch": " release"}), "release")
 
     def test_a_membership_row_with_nothing_on_disk_still_forks(self):
         """A teammate who has just pulled the plane has no clones at all, and the manifest

--- a/tests/test_every_workspace_has_a_manifest.py
+++ b/tests/test_every_workspace_has_a_manifest.py
@@ -71,6 +71,16 @@ class AWorkspaceIsBornWithOne(ManifestCase):
         self.assertEqual(m["updated_by"], "ada")
         self.assertRegex(m["updated_at"], r"^\d{4}-\d\d-\d\dT\d\d:\d\d:\d\d\+00:00$")
 
+    def test_a_shell_with_no_user_records_unknown(self):
+        """A `cron` or a container has no `$USER`, and `ensure` runs there too. "unknown"
+        rather than an absent field or an empty string, which is `_git_user`'s answer as
+        well — a field somebody has to guess the meaning of is worse than one that says
+        nobody knows."""
+        with mock.patch.dict(os.environ):
+            os.environ.pop("USER", None)
+            workspace.ensure("alpha")
+        self.assertEqual(self.manifest("alpha")["updated_by"], "unknown")
+
     def test_a_new_workspace_records_no_repos_rather_than_no_manifest(self):
         """*"this workspace exists, is called alpha, and has no repos yet"* is a true and
         useful statement, and it is the one that lets anything else rely on the file."""
@@ -185,6 +195,10 @@ class TheManifestIsPartOfTheLayout(ManifestCase):
         wd.chmod(0o700)
         self.assertIn("workspace.json could not be written", said)
         self.assertNotIn("added workspace.json", said)
+        self.assertNotIn("Reinitialized", said,
+                         "a workspace whose only gap could not be filled was reported healed")
+        self.assertNotIn("Up to date", said,
+                         "a repair command that contradicts its own error two lines up")
 
     def test_a_backfilled_live_workspace_is_told_to_commit_it(self):
         """`workspace.json` is the first path in the managed LIVE block, so a backfill that
@@ -255,24 +269,109 @@ class MembershipIsMaintained(ManifestCase):
         self.assertEqual(self.manifest("alpha")["updated_by"], "ada")
         self.assertNotEqual(self.manifest("alpha")["updated_at"], "1999-01-01T00:00:00+00:00")
 
-    def test_cloning_records_the_repo_it_just_cloned(self):
-        """End to end through `cmd_clone`, which is the structural change: a repo cloned
-        into a workspace is a member of it, and a manifest that learns that only when
-        somebody runs `snapshot` describes the workspaces nobody shared."""
+    def test_a_repo_named_twice_is_recorded_once(self):
         workspace.ensure("alpha")
-        dest = _clone("alpha", "svc")
-        r = {"name": "svc", "default_branch": "main", "forge": "github",
-             "path_with_namespace": "g/svc"}
-        with mock.patch.object(commands, "_clone_one",
-                               lambda rr, wd: {"repo": rr, "dest": dest, "status": "ok",
-                                               "forge": SimpleNamespace(cli="gh")}), \
+        workspace.record_members("alpha", ["svc", "svc"])
+        self.assertEqual(self.manifest("alpha")["repos"], [{"name": "svc"}])
+
+    def test_a_nameless_repo_is_not_a_member(self):
+        """A row with no name is a row `restore` cannot act on and `merge_repo_rows`
+        already skips — recording one would put an entry in a committed file that every
+        reader has to know to ignore."""
+        workspace.ensure("alpha")
+        self.assertEqual(workspace.record_members("alpha", [""]), "unchanged")
+        self.assertEqual(self.manifest("alpha")["repos"], [])
+
+    def test_the_rows_are_sorted_however_they_arrived(self):
+        """One row order for one membership, so a clone, a snapshot and a backfill produce
+        the same diff rather than three."""
+        workspace.ensure("alpha")
+        workspace.record_members("alpha", ["svc"])
+        workspace.record_members("alpha", ["api"])
+        self.assertEqual([r["name"] for r in self.manifest("alpha")["repos"]],
+                         ["api", "svc"])
+
+    def test_rows_that_are_not_rows_are_dropped_rather_than_crashed_on(self):
+        """A committed manifest is an untrusted document — `restore` says so in as many
+        words — and the stamp is not a secret, so `repos: [1, 2, 3]` carrying a matching
+        digest is a file somebody can hand this plane."""
+        workspace.ensure("alpha")
+        workspace.write_manifest("alpha", {"name": "alpha",
+                                           "repos": ["svc", 3, None, {"branch": "main"}]})
+        self.assertEqual(workspace.record_members("alpha", ["svc"]), "recorded")
+        self.assertEqual(self.manifest("alpha")["repos"], [{"name": "svc"}])
+
+    def test_membership_cannot_be_recorded_where_no_manifest_can_be_created(self):
+        """`blocked`, not `recorded`: the caller is told the fact did not land rather than
+        being handed a tick over a file that is not there."""
+        wd = workspace.workspace_dir("alpha")
+        wd.mkdir(parents=True)
+        wd.chmod(0o500)
+        self.addCleanup(wd.chmod, 0o700)
+        self.assertEqual(workspace.record_members("alpha", ["svc"]), "blocked")
+
+
+class CloningRecordsWhatItCloned(ManifestCase):
+    """End to end through `cmd_clone`, which is the structural change: a repo cloned into a
+    workspace is a member of it, and a manifest that learns that only when somebody runs
+    `snapshot` describes the workspaces nobody shared."""
+
+    def clone(self, ws: str, repo: str, status: str) -> str:
+        dest = workspace.workspace_dir(ws) / repo
+        r = {"name": repo, "default_branch": "main", "forge": "github",
+             "path_with_namespace": f"g/{repo}"}
+        result = {"repo": r, "dest": dest, "status": status,
+                  "forge": SimpleNamespace(cli="gh"), "stderr": "", "reason": "no"}
+        buf = io.StringIO()
+        with mock.patch.object(commands, "_clone_one", lambda rr, wd: result), \
                 mock.patch.object(commands.workspace, "banner", lambda *a, **k: None), \
                 mock.patch.object(commands.inventory, "load", lambda: {}), \
                 mock.patch.object(commands.inventory, "repos", lambda d=None: [r]), \
-                mock.patch.object(commands, "_resolve_targets", lambda a, d: [r]):
-            rc = commands.cmd_clone(SimpleNamespace(repos=["svc"], workspace="alpha"))
-        self.assertEqual(rc, 0)
+                mock.patch.object(commands, "_resolve_targets", lambda a, d: [r]), \
+                redirect_stderr(buf):
+            commands.cmd_clone(SimpleNamespace(repos=[repo], workspace=ws))
+        return buf.getvalue()
+
+    def test_the_repo_it_cloned_is_a_member(self):
+        workspace.ensure("alpha")
+        _clone("alpha", "svc")
+        self.clone("alpha", "svc", "ok")
         self.assertEqual(self.manifest("alpha")["repos"], [{"name": "svc"}])
+
+    def test_a_repo_that_was_already_there_is_a_member_too(self):
+        """`exists` is the ordinary outcome of re-cloning into a workspace, and it is as
+        much a statement of membership as a fresh clone — a manifest that only learned
+        from first clones would never catch up on a workspace built before this."""
+        workspace.ensure("alpha")
+        _clone("alpha", "svc")
+        self.clone("alpha", "svc", "exists")
+        self.assertEqual(self.manifest("alpha")["repos"], [{"name": "svc"}])
+
+    def test_a_clone_that_failed_is_not_a_member(self):
+        """Membership is what the workspace HAS. A repo whose clone failed — no access, no
+        network — is not in it, and recording it would send `restore` after a repo this
+        machine could not reach in the first place."""
+        workspace.ensure("alpha")
+        self.clone("alpha", "svc", "failed")
+        self.assertEqual(self.manifest("alpha")["repos"], [])
+
+    def test_it_says_a_hand_written_manifest_was_left_alone(self):
+        """The invariant is quietly untrue there until somebody acts, so the person at the
+        keyboard is told rather than left to find out from a restore."""
+        workspace.workspace_dir("alpha").mkdir(parents=True)
+        workspace.manifest_path("alpha").write_text('{"name": "alpha", "repos": []}\n')
+        _clone("alpha", "svc")
+        said = self.clone("alpha", "svc", "ok")
+        self.assertIn("was not written by charter", said)
+
+    def test_a_clone_that_landed_nothing_says_nothing_about_the_manifest(self):
+        """The warning above is about a repo that could not be recorded. With no repo to
+        record there is nothing to warn about, and a line that fires on a failed clone
+        blames the manifest for the network."""
+        workspace.workspace_dir("alpha").mkdir(parents=True)
+        workspace.manifest_path("alpha").write_text('{"name": "alpha", "repos": []}\n')
+        said = self.clone("alpha", "svc", "failed")
+        self.assertNotIn("was not written by charter", said)
 
 
 class AManifestCharterDidNotWriteIsNeverOverwritten(ManifestCase):
@@ -326,6 +425,41 @@ class AManifestCharterDidNotWriteIsNeverOverwritten(ManifestCase):
         workspace.ensure("alpha")
         doc = workspace.read_manifest("alpha")
         workspace.manifest_path("alpha").write_text(json.dumps(doc))   # one line, no indent
+        self.assertEqual(workspace.manifest_owner("alpha"), "charter")
+
+    def test_a_manifest_that_is_not_even_an_object_is_the_operators(self):
+        """`[]` is valid JSON, `read_manifest` hands back whatever the file holds, and the
+        digest is not a secret — so a list here has to be told it is somebody else's rather
+        than reaching `.get` and taking the command down."""
+        before = self.hand_written("alpha", "[]\n")
+        self.assertEqual(workspace.manifest_owner("alpha"), "operator")
+        workspace.record_members("alpha", ["svc"])
+        self.assertEqual(workspace.manifest_path("alpha").read_bytes(), before)
+
+    def test_a_manifest_that_cannot_be_stat_ed_is_the_operators(self):
+        """`Path.exists` raises EACCES on Linux, where pathlib does not swallow it, and
+        answers False on macOS — `workspace._unreadable`'s divergence, at the one call
+        where guessing wrong means writing over somebody's file."""
+        from pathlib import Path
+        real = Path.exists
+        target = workspace.manifest_path("alpha")
+
+        def strict(self_, *a, **kw):
+            if self_ == target:
+                raise PermissionError(13, "Permission denied", str(self_))
+            return real(self_, *a, **kw)
+
+        Path.exists = strict
+        self.addCleanup(setattr, Path, "exists", real)
+        self.assertEqual(workspace.manifest_owner("alpha"), "operator")
+
+    def test_reordering_the_keys_does_not_take_it_away_from_charter(self):
+        """The digest is over the document, not over one serialisation of it. A manifest
+        round-tripped through a tool that sorts keys differently is still charter's."""
+        workspace.ensure("alpha")
+        doc = workspace.read_manifest("alpha")
+        flipped = {k: doc[k] for k in reversed(list(doc))}
+        workspace.manifest_path("alpha").write_text(json.dumps(flipped, indent=2) + "\n")
         self.assertEqual(workspace.manifest_owner("alpha"), "charter")
 
     def test_a_manifest_charter_cannot_read_is_not_a_missing_one(self):
@@ -422,6 +556,19 @@ class RestoringAWorkspaceWhoseBranchesAreUnpinned(ManifestCase):
         with redirect_stderr(buf):
             cw.cmd_workspace_restore(SimpleNamespace(name="alpha", on_demand=False))
         self.assertIn("no branch recorded", buf.getvalue())
+
+    def test_a_branch_that_is_an_option_in_disguise_is_still_refused(self):
+        """#334's guard, asked of the value git is actually handed. `" -b"` does not
+        `startswith("-")` and `git checkout` reads the argument it is given, so the reading
+        and the guard have to be the same string."""
+        workspace.ensure("alpha")
+        _clone("alpha", "svc")
+        workspace.write_manifest("alpha", {"name": "alpha",
+                                           "repos": [{"name": "svc", "branch": " -b"}]})
+        buf = io.StringIO()
+        with redirect_stderr(buf):
+            cw.cmd_workspace_restore(SimpleNamespace(name="alpha", on_demand=False))
+        self.assertIn("may not begin with '-'", buf.getvalue())
 
     def test_the_on_demand_listing_survives_a_row_with_no_branch(self):
         """`r['branch']` was a KeyError waiting for the first manifest charter wrote

--- a/tests/test_every_workspace_has_a_manifest.py
+++ b/tests/test_every_workspace_has_a_manifest.py
@@ -311,6 +311,34 @@ class MembershipIsMaintained(ManifestCase):
         self.assertEqual(workspace.record_members("alpha", ["svc"]), "blocked")
 
 
+class MembershipIsNotASnapshot(ManifestCase):
+    """`merge_repo_rows` reports which repos got their BRANCH from disk rather than from a
+    snapshot, and `fork` says so out loud: *"their branch is whatever is checked out now,
+    which may not be pushed."* Since every manifest charter writes lists repos with no
+    branch, "is it in the manifest" stopped being the same question."""
+
+    def test_a_repo_recorded_as_membership_is_still_attributed_to_disk(self):
+        rows, disk_only = workspace.merge_repo_rows([{"name": "svc"}],
+                                                    [{"name": "svc", "branch": "scratch"}])
+        self.assertEqual(disk_only, ["svc"])
+        self.assertEqual(rows, [{"name": "svc", "branch": "scratch"}])
+
+    def test_a_snapshotted_repo_is_not(self):
+        """The positive control: a pinned branch was recorded under `snapshot`'s promise
+        that it is on the remote, and that one is not a disk reading."""
+        rows, disk_only = workspace.merge_repo_rows([{"name": "svc", "branch": "release"}],
+                                                    [{"name": "svc", "branch": "scratch"}])
+        self.assertEqual(disk_only, [])
+        self.assertEqual(rows, [{"name": "svc", "branch": "release"}])
+
+    def test_a_membership_row_with_nothing_on_disk_still_forks(self):
+        """A teammate who has just pulled the plane has no clones at all, and the manifest
+        is the only thing that can tell them which repos this workspace is made of."""
+        rows, disk_only = workspace.merge_repo_rows([{"name": "svc"}], [])
+        self.assertEqual(rows, [{"name": "svc", "branch": "HEAD"}])
+        self.assertEqual(disk_only, [])
+
+
 class CloningRecordsWhatItCloned(ManifestCase):
     """End to end through `cmd_clone`, which is the structural change: a repo cloned into a
     workspace is a member of it, and a manifest that learns that only when somebody runs

--- a/tests/test_every_workspace_has_a_manifest.py
+++ b/tests/test_every_workspace_has_a_manifest.py
@@ -200,6 +200,39 @@ class TheManifestIsPartOfTheLayout(ManifestCase):
         self.assertNotIn("Up to date", said,
                          "a repair command that contradicts its own error two lines up")
 
+    def _unwritable_manifest(self, ws: str):
+        """A manifest path charter refuses to write and nothing else in the workspace.
+
+        A symlink out of the plane, dangling: `contain.writable` refuses the write (#328),
+        `Path.exists` answers False through it, and every other component stays writable —
+        which is what lets a case ask whether the rest of the repair still happened.
+        """
+        workspace.manifest_path(ws).symlink_to(self.tmp / "nowhere.json")
+
+    def test_the_rest_of_the_repair_still_lands_when_the_manifest_cannot(self):
+        """One component charter cannot write must not swallow the report of the ones it
+        did. The blocked manifest is taken out of `missing`, and what is left is still a
+        heal that happened and has to be named."""
+        workspace.ensure("alpha")
+        workspace.manifest_path("alpha").unlink()
+        workspace.charter_file("alpha").unlink()
+        self._unwritable_manifest("alpha")
+        said = self.reinit("alpha")
+        self.assertIn("workspace.json could not be written", said)
+        self.assertIn("added workspace.md", said)
+        self.assertTrue(workspace.charter_file("alpha").is_file())
+
+    def test_a_stale_layout_is_still_reported_when_the_manifest_cannot_be_written(self):
+        """The other half of the same recomputation: nothing is missing any more once the
+        blocked manifest is taken out, and the workspace is still older than this layout."""
+        workspace.ensure("alpha")
+        workspace.manifest_path("alpha").unlink()
+        workspace._structure_marker("alpha").write_text("0\n")
+        self._unwritable_manifest("alpha")
+        said = self.reinit("alpha")
+        self.assertIn("workspace.json could not be written", said)
+        self.assertIn(f"structure v0 → v{workspace.STRUCTURE_VERSION}", said)
+
     def test_a_backfilled_live_workspace_is_told_to_commit_it(self):
         """`workspace.json` is the first path in the managed LIVE block, so a backfill that
         healed it and said nothing would leave the manifest this change exists to share
@@ -258,6 +291,27 @@ class MembershipIsMaintained(ManifestCase):
         workspace.record_members("alpha", ["web"])
         self.assertEqual([r["name"] for r in self.manifest("alpha")["repos"]],
                          ["gone", "svc", "web"])
+
+    def test_a_manifest_with_no_repos_key_at_all_is_read_as_no_repos(self):
+        """A field this charter writes is not a field every manifest has. `repos` missing
+        and `repos: []` are the same statement, and the second must not be the only shape
+        that can be read."""
+        workspace.ensure("alpha")
+        workspace.write_manifest("alpha", {"name": "alpha", "description": "no repos key"})
+        self.assertEqual(workspace.record_members("alpha", ["svc"]), "recorded")
+        self.assertEqual(self.manifest("alpha")["repos"], [{"name": "svc"}])
+
+    def test_a_workspace_whose_manifest_went_missing_gets_one_back(self):
+        """`ensure` gives every workspace a manifest, so this is one whose creating write
+        failed and where a clone has since succeeded. Recorded through the one constructor
+        rather than a second shape of "a fresh manifest" — two of those drift, and the
+        drift is invisible until a field one of them omits is read."""
+        workspace.ensure("alpha")
+        workspace.manifest_path("alpha").unlink()
+        self.assertEqual(workspace.record_members("alpha", ["svc"]), "recorded")
+        m = self.manifest("alpha")
+        self.assertEqual(m["name"], "alpha")
+        self.assertEqual(m["repos"], [{"name": "svc"}])
 
     def test_membership_is_restamped_with_who_and_when(self):
         workspace.ensure("alpha")
@@ -330,6 +384,15 @@ class MembershipIsNotASnapshot(ManifestCase):
                                                     [{"name": "svc", "branch": "scratch"}])
         self.assertEqual(disk_only, [])
         self.assertEqual(rows, [{"name": "svc", "branch": "release"}])
+
+    def test_a_branch_of_whitespace_pins_nothing(self):
+        """The same reading `_pin` makes one module over. Two answers to "does this row
+        record a branch" is how a workspace gets forked with a warning it deserved
+        withheld."""
+        rows, disk_only = workspace.merge_repo_rows([{"name": "svc", "branch": "  "}],
+                                                    [{"name": "svc", "branch": "scratch"}])
+        self.assertEqual(disk_only, ["svc"])
+        self.assertEqual(rows, [{"name": "svc", "branch": "scratch"}])
 
     def test_a_membership_row_with_nothing_on_disk_still_forks(self):
         """A teammate who has just pulled the plane has no clones at all, and the manifest
@@ -526,6 +589,25 @@ class AManifestCharterDidNotWriteIsNeverOverwritten(ManifestCase):
                                                       description=None))
         self.assertEqual(workspace.manifest_owner("alpha"), "charter")
         self.assertEqual(workspace.record_members("alpha", ["web"]), "recorded")
+
+
+class TheMarkersNameIsPartOfTheOnDiskContract(ManifestCase):
+    """`charter_generated` is spelled out here once, by hand.
+
+    Every other reference in this suite reads `workspace.MANIFEST_MARKER`, which agrees
+    with itself however it is renamed — and the rename lands on manifests that are already
+    committed. The old key is one this charter does not look for, so every workspace on
+    every machine hands its manifest back to the operator at once and membership silently
+    stops being maintained. The name is on disk, in git, on other people's clones; it is
+    part of the format, not a variable.
+    """
+
+    def test_the_key_charter_stamps_is_named(self):
+        self.assertEqual(workspace.MANIFEST_MARKER, "charter_generated")
+
+    def test_it_is_the_key_that_actually_lands_in_the_file(self):
+        workspace.ensure("alpha")
+        self.assertIn('"charter_generated"', workspace.manifest_path("alpha").read_text())
 
 
 class TheWriteIsAtomic(ManifestCase):

--- a/tests/test_fork_inherits_repos.py
+++ b/tests/test_fork_inherits_repos.py
@@ -133,7 +133,7 @@ class ForkCase(unittest.TestCase):
 
 
 class TestForkingAnUnsnapshottedWorkspace(ForkCase):
-    """The live report: nine clones, no manifest, `fork` inherits nothing."""
+    """The live report: nine clones, nothing recorded, `fork` inherits nothing."""
 
     def setUp(self):
         super().setUp()
@@ -141,8 +141,18 @@ class TestForkingAnUnsnapshottedWorkspace(ForkCase):
         self._clone("src", "repoA")
         self._clone("src", "repoB")
 
-    def test_the_premise_holds_there_is_no_manifest(self):
-        self.assertEqual(workspace.read_manifest("src"), {})
+    def test_the_premise_holds_the_manifest_records_no_repos(self):
+        """The premise moved with #884 and the defect it describes did not.
+
+        This used to read `read_manifest("src") == {}` — there was no file at all, because
+        `snapshot` was the only thing that wrote one. Since #884 every workspace has a
+        manifest from birth, and these clones were made by the fixture rather than by
+        `charter clone`, so the manifest is present and its `repos` is empty. That is the
+        same divergence #81 is about, and the same one `merge_repo_rows` closes: what the
+        workspace HAS and what it RECORDED are two lists, and forking from the second alone
+        inherits nothing.
+        """
+        self.assertEqual(workspace.read_manifest("src").get("repos"), [])
         self.assertEqual(len(workspace.clones("src")), 2)
 
     def test_the_fork_inherits_the_clones(self):

--- a/tests/test_todos_are_committed.py
+++ b/tests/test_todos_are_committed.py
@@ -223,12 +223,16 @@ class TestTheStructureBumpFlagsEveryOlderWorkspace(PersonaIso):
         workspace.reinit("alpha")
         self.assertFalse(change.changes_dir("alpha").exists())
 
-    def test_the_version_this_layout_stamps_is_four(self):
+    def test_the_version_this_layout_stamps_is_five(self):
         """The NUMBER, not merely that it moved. The marker file records this value on
         every machine that scaffolds a workspace, and `structure_status` compares against
         it — so it is the plane's upgrade anchor rather than a counter, and changing it is
-        a deliberate act that belongs in the same commit as the layout it describes."""
-        self.assertEqual(workspace.STRUCTURE_VERSION, 4)
+        a deliberate act that belongs in the same commit as the layout it describes.
+
+        v5 is #884: every workspace has a `workspace.json` from birth, and the bump is what
+        backfills the ones that predate the invariant.
+        """
+        self.assertEqual(workspace.STRUCTURE_VERSION, 5)
 
     def test_a_fresh_workspace_is_current(self):
         """Positive control: the bump must flag OLD workspaces, not every workspace."""


### PR DESCRIPTION
Closes #884.

**5 of 17 workspaces on this plane had a `workspace.json`.** It was written only by
`charter workspace snapshot`, so it existed wherever somebody happened to run that command
— while everything about the file says it is meant to travel. `cmd_workspace_restore` calls
it *"committed precisely so a teammate can restore someone else's"* workspace, and
`workspace._live_block` maintains a `.gitignore` block that un-ignores it by name, first in
the list. A file designed to be shared cannot be an opt-in side effect.

## What changed

**Born with one.** `workspace.ensure` writes the manifest, so a new workspace's is
`{"name", "description", "repos": [], "updated_at", "updated_by"}` — a true and useful
statement, and what lets anything else rely on the file. `repos` is one field among several
rather than the point of it.

**Membership is maintained; branches are not.** `charter clone` records the repos it just
cloned. Nothing automatic ever writes a branch: the checked-out branch is a fact about this
minute, and a branch in this file carries `snapshot`'s enforce-push promise that `restore`
depends on. `charter workspace snapshot` is untouched — it is still where an operator
deliberately pins branches for somebody else to restore.

**Backfilled by `charter workspace reinit --all`.** `workspace.json` is a required
structure component and `STRUCTURE_VERSION` moves to 5, so every workspace that predates
the invariant flags itself in the status line and in `charter workspace list` until the
operator runs the repair that already heals workspace structure. It records **membership
only, branches unpinned** — a branch backfilled from whatever is checked out is, for a
workspace mid-work, a scratch branch, and confidently wrong beats honestly empty here.
`restore` reads an unpinned row as restored by the clone existing, rather than asking `git
checkout ''` for it.

**No new commit path.** `charter save` already commits `workspace.json` beside
`workspace.md` and `memory/`.

## Care

* `workspace.ensure` is reached from a tab press with no operator waiting, so
  `scaffold_manifest` swallows its own failure: the components after it in `scaffold` still
  run, `structure_status` goes on reporting the file missing, and `reinit` says out loud
  that it could not write one rather than printing a tick over a file that is not there.
* **A manifest charter did not write is never overwritten.** charter stamps a digest of the
  document into the document, and a file whose contents no longer match is the operator's:
  `ensure` leaves it, `reinit` leaves it, and `charter clone` says it left it. The marker is
  a key rather than a `.charter-generated` sidecar for the opposite of the harness layer's
  reason — `workspace.json` is charter's own schema, and a sidecar is gitignored while the
  manifest is committed, so a teammate's pulled copy would read as hand-written on every
  machine but the one that wrote it.
* Writes are atomic — temp file through `config.write_for`, then `os.replace`, the shape
  `state.bump` and `gather.save` use — and `contain.writable` still refuses a redirected
  path before any of it.

## ADR 0010 is amended, not contradicted quietly

The ADR says *"snapshot stays the only writer"*, and the harm it names is specific:
*"branches recorded outside `snapshot`'s guarantee — so `restore` starts failing on branches
that were never pushed."* Every writer added here records **membership only**, so no branch
enters the file except through `snapshot`. Its second objection — read commands must not
mutate a committed file — is honoured: `ensure` and `clone` are write paths and `reinit` is
a repair the operator types; `status` and `workspace list` still only scan. The amendment is
in the ADR.

## Two things this deliberately does not do

**Removal is not inferred from absence.** `restore --on-demand` leaves every recorded repo
uncloned on purpose and `restore` skips the ones a machine cannot reach (*"Partial access is
normal"*), so a manifest reconciled against the directory would erase the teammate's restore
target on their first launch and their next `charter save` would push the erasure. charter
has no command that takes a repo out of a workspace; `snapshot` sets the list outright,
because an operator asked it to.

**The frame is not told the roster moved by anything here.** #886/#888 landed while this
was being written and wired `notify.plane_changed_everywhere()` into `cmd_clone`; the rebase
put this branch's manifest write **before** that fan-out, so a frame that repaints reads a
manifest which already records what was cloned rather than one command's worth of stale. No
other writer here calls it, and that is a measurement rather than an omission: no panel reads
`workspace.json` or `needs_reinit` — `gather.scan` derives its repo list from
`workspace.clones(ws)`, a directory scan — so `ensure` creating a manifest changes nothing a
frame draws.

## The sweep

CI's first sweep of this branch named **4 survivors**; the verdict check now reads **no
survivors**. Two `.strip()` calls were pinned at the other end — the survivor was `lstrip`,
because every case here used leading whitespace (`" -b"`, the option in disguise) and a
trailing space is not a ref either. `healed == 0` is pinned by a reinit that wrote a manifest
and must not also say it had nothing to do. And `"workspace.json" in before["missing"]` was
**deleted**: `structure_status` derives `missing` from the same `exists()`, so the conjunct
never changed an answer. Nineteen further mutations were hand-applied before that, each
watched RED and reverted, with an equivalent rewrite as a negative control.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Us4MbwkSCJCxwt1CjAd1sf
