### PR TITLE
The tab strips lose their headings, launch one row deep, and workspace tabs carry their chat count (#880)

### DIFF
--- a/charter/cli.py
+++ b/charter/cli.py
@@ -785,7 +785,7 @@ def _add_frame_parsers(sub) -> None:
                                          "frame-resize", "frame-gather", "frame-switch",
                                          "frame-toggle", "frame-chrome", "frame-chat",
                                          "frame-new-chat", "frame-quit", "frame-close",
-                                         "frame-transcript"}
+                                         "frame-transcript", "frame-bar-rows"}
 
     # Which harness (by `.name`, never `.cli_name` — that's the dict key below) has
     # already claimed each word, so a SECOND harness wanting it is told who got there
@@ -1006,6 +1006,21 @@ def _add_frame_parsers(sub) -> None:
     # (`#{@charter_chat}` in this component's own `bind -n`), same reason it is optional.
     tg.add_argument("--chat", dest="chat", default="")
     tg.set_defaults(func=commands_frame.cmd_toggle)
+
+    # Internal, and a top-level sibling for `frame-toggle`'s reason. Fired by
+    # `layout.BAR_ROWS_KEY`'s own `bind -n` and typeable by hand from inside a frame; it
+    # cycles the RUNNING frame's tab strips 1 -> 2 -> 3 rows and back, and charter.toml is
+    # not touched, for `frame-density`'s reason.
+    #
+    # **No argument at all, which is the whole shape of it.** A height is not a name an
+    # operator picks off a set — it is the next one, and `layout.next_bar_rows` is where
+    # that arithmetic lives. A `--rows N` would be a second way to say a thing one key
+    # already says, and a number off an argv that would then need a gate.
+    br = sub.add_parser("frame-bar-rows")
+    # Which chat the key was pressed in — `frame-toggle`'s twin, same source
+    # (`#{@charter_chat}` in the bind), same reason it is optional.
+    br.add_argument("--chat", dest="chat", default="")
+    br.set_defaults(func=commands_frame.cmd_bar_rows)
 
     # Internal, and a top-level sibling for the same `_split_frame_argv` reason as the
     # ones above. Started DETACHED by a palette row whose argv is exactly

--- a/charter/commands_frame.py
+++ b/charter/commands_frame.py
@@ -881,6 +881,21 @@ def conf_text(*, hotkey: str, mouse: bool, history_limit: int, session: str,
     and that this exact bind text survives `source-file` intact (`list-keys` reads it
     back byte for byte).
 
+    **`layout.BAR_ROWS_KEY` is the third key charter binds by default** (#880), and being
+    a third one is the whole of its cost. A `bind -n` is server-wide and takes the key
+    before the harness pane sees it, which is exactly why charter binds NO component toggle
+    by default — but a tab strip's height is charter's own gesture rather than one of an
+    open set, and the alternative the issue weighed (a tmux drag) is recomputed away on the
+    next layout pass because the layout owns bar heights. It runs
+    `charter frame-bar-rows`, which cycles this frame's strips 1 → 2 → 3 and back.
+
+    **It sits with the mouse binds, above the toggles**, for the toggles' own reason read
+    the other way round: emitting it after them would let a component's committed key
+    silently take charter's, and `instance.component_arrangement` refuses that collision
+    precisely so it cannot happen — a refusal that only works while charter's own binds go
+    first. `layout.BAR_ROWS_KEY` is in that function's `bound` set beside
+    `overlay.HATCH_KEY` and the mouse keys.
+
     *toggles* is ``{component name: key}`` (`instance.frame_toggles`) and each pair
     becomes one more `bind -n`, running `charter frame-toggle <name>` — which shows or
     hides that one component on the running frame. Empty for every plane spelled with
@@ -952,6 +967,9 @@ def conf_text(*, hotkey: str, mouse: bool, history_limit: int, session: str,
         " 'send-keys -M' 'copy-mode -e; send-keys -M'",
         f"bind -n {tmuxctl.CLICK_KEY} if-shell -F -t = '#{{{_PANEL_OPTION}}}'"
         " 'send-keys -M' 'select-pane -t =; send-keys -M'",
+        f"bind -n {layout.BAR_ROWS_KEY} run-shell "
+        f"'\"${_CHARTER_PY_ENV}\" -m charter frame-bar-rows "
+        f"--chat \"#{{{_CHAT_OPTION}}}\"'",
     ]
     for name, key in (toggles or {}).items():
         if not component.usable_id(name):
@@ -2227,10 +2245,20 @@ def _slot_sizes(fid: str, slots: list[str], *, window_rows: int, pane_cols: int,
     **A tab strip is a third such fact and it arrives the same way** (#829). How many rows
     a strip needs is a function of the names this plane has — `chats.roster`,
     `switch.workspaces` — so it is a plane read, which is what this function is the
-    boundary for, and `frame_slots.bar_rows_wanted` is the one place it is made. The
-    ceiling on it is `layout.BAR_MAX_ROWS`, carried down from here rather than read there,
-    for `layout.repos_rows`' reason about *pinned_rows*: a policy applied at both ends is a
-    bound one end cannot make observable.
+    boundary for, and `frame_slots.bar_rows_wanted` is the one place it is made.
+
+    **The ceiling on it is the frame's OWN, and that is #880.** It was `layout
+    .BAR_MAX_ROWS` flat, so a plane with many names launched two rows deep whether or not
+    its operator wanted the harness two rows shorter. What is carried down now is
+    `layout.bar_rows_cap` of this frame's recorded height — `layout.BAR_ROWS_DEFAULT` (one)
+    for every frame at launch, and 2 or 3 for a frame whose operator has pressed
+    `layout.BAR_ROWS_KEY`. It is read HERE, once, for the same reason the pin and the
+    content height are: this function is the boundary where a frame's own state becomes a
+    pane height, and a policy applied at both ends is a bound one end cannot make
+    observable.
+
+    A cap is not a height: `bar_rows_wanted` still answers with the rows the strip actually
+    FILLS, so raising the ceiling on a plane whose names fit on one row changes nothing.
 
     **Every slot is asked, and there is deliberately no `slot in BARS` filter in front of
     it.** There was one, and the deletion sweep reported dropping it as a survivor — the
@@ -2265,7 +2293,7 @@ def _slot_sizes(fid: str, slots: list[str], *, window_rows: int, pane_cols: int,
         content_rows=frame_slots.repos_rows_wanted(fid, pane_cols=pane_cols),
         pinned_rows=layout.pinned_repo_rows(),
         bar_rows={slot: frame_slots.bar_rows_wanted(
-            fid, slot, cap=layout.BAR_MAX_ROWS,
+            fid, slot, cap=layout.bar_rows_cap(state.bar_rows(fid)),
             pane_cols=layout.pane_cols(order, slot, window_cols=window_cols))
             for slot in slots})
 
@@ -6928,6 +6956,63 @@ def cmd_toggle(args) -> int:
     # which is what keeps a name that has since left the operator's config from living in
     # this file for the rest of the frame's life.
     state.record_hidden(fid, [n for n in arrangement if n in hidden])
+    _apply_arrangement(fid, where=where,
+                       want=[n for n in arrangement if n not in hidden])
+    return 0
+
+
+def cmd_bar_rows(args) -> int:
+    """`charter frame-bar-rows` — cycle this frame's tab strips 1 → 2 → 3 rows, live.
+
+    Fired by `layout.BAR_ROWS_KEY`'s own `bind -n` (:func:`conf_text`), and typeable by
+    hand from inside a frame. The chat is resolved by :func:`_pressers_chat` — the
+    `--chat` the bind carries out of the presser's own window, falling back to
+    `$CHARTER_SESSION_ID` — because one bind text is shared by every frame on `SOCKET`.
+
+    **charter.toml is not touched**, and every word of :func:`cmd_toggle`'s argument for
+    that applies unchanged: `[[frame.component]] size` says what a strip STARTS at (#687),
+    this changes what one running frame IS, and the override lives in the frame's own state
+    directory (`state.record_bar_rows`) which `state.reap` deletes entire when the frame
+    ends. Relaunch and every strip is back at `layout.BAR_ROWS_DEFAULT`, which is what
+    #880 promises: **the chosen height does not survive a restart.**
+
+    **It raises a CEILING and does not set a height.** `frame_slots.bar_rows_wanted` still
+    answers with the rows a strip actually fills, so a press on a plane whose names already
+    fit on one row moves nothing — there is nothing to put on a second row, and drawing a
+    blank one would be rows off the harness for a picture. What the press buys is the
+    ceiling coming off a strip that IS overflowing.
+
+    **No name to refuse, and that is the difference from :func:`cmd_toggle`.** That command
+    takes a component and has to check it against this frame's arrangement before the word
+    reaches a `split-window`; this takes nothing at all. The height it writes is
+    `layout.next_bar_rows` of what is on disk — charter's own arithmetic over charter's own
+    file — so there is no argument here for a validator to be about.
+
+    **Always 0, and every refusal is a quiet no-op** except the one that is certainly the
+    asker's, for `cmd_toggle`'s reason: this normally runs as a `run-shell` child of a
+    keypress, where the only screen left to report on is the agent's own. `if not fid` says
+    so on the frame's own row when the command is typed outside a frame, exactly as
+    `cmd_toggle` does and pinned by the same test module.
+
+    The relayout is :func:`_apply_arrangement` with the arrangement this frame is already
+    drawing — the same call `cmd_toggle` makes with a changed visible set, made here with
+    an unchanged one. Nothing is added or removed; what moves is `_reassert_sizes`, which
+    re-asks :func:`_slot_sizes`, which reads the height just written. One live re-layout
+    path, which is that function's own requirement.
+    """
+    fid = _pressers_chat(args)
+    if not fid:
+        return outside_a_frame("charter frame-bar-rows")
+    where = _relayout_target(fid)
+    if where is None:
+        return 0
+    # Recorded BEFORE the re-layout, on `_apply_arrangement`'s own discipline: a re-layout
+    # that fails halfway still leaves the panels that survive drawing the height that was
+    # asked for.
+    state.record_bar_rows(fid, layout.next_bar_rows(state.bar_rows(fid)))
+    frame = config.FRAME
+    arrangement = instance.frame_arrangement(frame)
+    hidden = set(_hidden_now(fid, frame))
     _apply_arrangement(fid, where=where,
                        want=[n for n in arrangement if n not in hidden])
     return 0

--- a/charter/frame/chats.py
+++ b/charter/frame/chats.py
@@ -160,6 +160,66 @@ def of_workspace(workspace: str) -> list[str]:
     cached: a cache here is a second source of truth for a fact `.charter/frame/` already
     holds and free to disagree with it, which is the #411 shape this module's own opening
     paragraph refuses.
+
+    **The scan itself is :func:`_by_workspace` since #880**, which groups every chat by its
+    workspace in the walk this used to do for one. Nothing above changes — the same
+    membership rule, the same order, the same cost for this caller — and what it buys is
+    :func:`counts_by_workspace`, which the tab strip needs for fifteen names at once and
+    could not have afforded as fifteen calls to this.
+    """
+    return _by_workspace().get(workspace, [])
+
+
+def counts_by_workspace() -> dict[str, int]:
+    """How many chats each workspace on this plane holds — every workspace at once (#880).
+
+    **The whole point is that it is ONE scan.** The workspaces strip draws a count beside
+    every tab, and asking :func:`of_workspace` per workspace would be one `os.scandir` and
+    two small reads per chat PER NAME: on this repository's own plane that is roughly
+    15 x 30 x 2 = 900 reads for one repaint of one row. :func:`_by_workspace` already
+    computes every chat's workspace on its way to answering about one, so grouping is the
+    same walk and the counts are free.
+
+    **Keyed by the same rule the roster is**, because it is literally the same call —
+    `state.own_workspace`, the chat-owned rungs in the ladder's own order (see
+    :func:`of_workspace`, which is where that argument lives). A count that agreed with
+    nothing the operator can click would be worse than no count.
+
+    A workspace with no chats is ABSENT rather than zero, which is what a caller wants: it
+    is asking about the names on its own strip (`switch.workspaces`), and this answers about
+    the names on disk. The two lists are not the same list — a workspace directory with no
+    chat in it is in the first and not the second, and a chat whose workspace directory has
+    been deleted is in the second and not the first — so the caller reads this with a
+    default rather than trusting the keys.
+
+    Chats whose workspace charter cannot read are left out entirely. They are in no
+    workspace's roster either (:func:`of_workspace` answers for a NAME), so counting them
+    somewhere would be a number no tab on the strip could be pressed to see.
+
+    Never raises, for :func:`of_workspace`'s reason and through the same guard: this is on
+    a panel's render path and an unreadable frame root is "no chats", not an exception.
+    """
+    return {ws: len(ids) for ws, ids in _by_workspace().items() if ws is not None}
+
+
+def _by_workspace() -> dict[str | None, list[str]]:
+    """Every chat on this plane, grouped by the workspace it says it is in.
+
+    The scan both :func:`of_workspace` and :func:`counts_by_workspace` are, written once —
+    the discipline `state.own_workspace` itself is an instance of, said one level up: two
+    walks of `.charter/frame/` that decided membership separately would be two answers to
+    "whose chat is this", and #733 is the bill for having had two.
+
+    **The grouping key is `state.own_workspace`'s answer VERBATIM, ``None`` included**, and
+    that is equivalence with the loop this replaced rather than tidiness. That loop asked
+    ``state.own_workspace(n) == workspace``, so a caller asking about ``None`` was answered
+    with the chats charter cannot place — a state no caller reaches today and one this
+    keeps reachable rather than quietly closing on the way past. :func:`counts_by_workspace`
+    drops the key; :func:`of_workspace` looks its own name up and never asks for it.
+
+    Sorted per group by :func:`_order`, which is where :func:`of_workspace`'s ordinal order
+    is argued. Every group is sorted rather than the one being asked about, and on the ~30
+    entries `state.reap` bounds this to that is not a cost worth a second code path.
     """
     try:
         # **`is_dir()` — kept, and honestly no longer measurable from out here.** A
@@ -190,10 +250,12 @@ def of_workspace(workspace: str) -> list[str]:
         # one, and an unreadable one is the same answer for the caller: no chats to
         # offer. Never a raise — a picker that could not scan refuses with its own
         # sentence one layer up.
-        return []
-    return sorted((n for n in names
-                   if is_chat(n) and state.own_workspace(n) == workspace),
-                  key=_order)
+        return {}
+    out: dict[str | None, list[str]] = {}
+    for name in names:
+        if is_chat(name):
+            out.setdefault(state.own_workspace(name), []).append(name)
+    return {ws: sorted(ids, key=_order) for ws, ids in out.items()}
 
 
 #: How many digits an ordinal `state.new_chat_id` can mint has, derived from its own

--- a/charter/frame/layout.py
+++ b/charter/frame/layout.py
@@ -268,6 +268,17 @@ BAR_MAX_ROWS = 3
 #: and this is a default, and neither is the other.
 BAR_ROWS_DEFAULT = 1
 
+#: Every height a tab strip may be at — :data:`BAR_ROWS_DEFAULT` through
+#: :data:`BAR_MAX_ROWS`.
+#:
+#: **A range and not two comparisons, and the deletion sweep is what settled it.** Written
+#: as ``BAR_ROWS_DEFAULT <= now <= BAR_MAX_ROWS``, the LOWER boundary is an equivalent
+#: mutant by construction: the fallback for a value below the range IS the bottom of the
+#: range, so `<` and `<=` answer the same number for every input there is, and
+#: `shift-boundary` would report it as a survivor forever. A membership test has no
+#: boundary to move and says exactly the same thing.
+_BAR_ROWS = range(BAR_ROWS_DEFAULT, BAR_MAX_ROWS + 1)
+
 #: The key that cycles a tab strip's height, bound by `commands_frame.conf_text`.
 #:
 #: **Here rather than in `commands_frame`, because `instance` has to know it too.** A
@@ -301,14 +312,14 @@ def bar_rows_cap(rows: int | None) -> int:
     outcome: there is nothing to put on a second row. What the key raises is the ceiling
     that was stopping a strip which DOES overflow.
 
-    **Anything outside the range degrades to the default rather than clamping**, and that
-    is `instance.density_level`'s discipline: the value is read back off a file, so `0`,
-    `7`, `-1` and a truncated write are all "this frame has not chosen", not "this frame
-    chose something charter will round for it". Clamping a `7` to `3` would leave a frame
-    silently at the ceiling because a byte went missing.
+    **Anything outside :data:`_BAR_ROWS` degrades to the default rather than clamping**,
+    and that is `instance.density_level`'s discipline: the value is read back off a file,
+    so `0`, `7`, `-1` and a truncated write are all "this frame has not chosen", not "this
+    frame chose something charter will round for it". Clamping a `7` to `3` would leave a
+    frame silently at the ceiling because a byte went missing.
     """
     now = rows if rows is not None else BAR_ROWS_DEFAULT
-    return now if BAR_ROWS_DEFAULT <= now <= BAR_MAX_ROWS else BAR_ROWS_DEFAULT
+    return now if now in _BAR_ROWS else BAR_ROWS_DEFAULT
 
 
 def next_bar_rows(rows: int | None) -> int:

--- a/charter/frame/layout.py
+++ b/charter/frame/layout.py
@@ -244,12 +244,90 @@ HARNESS_MIN_ROWS = 12
 #: measured an operator running at, and stops short of the width where the strip would be
 #: taking six rows off the harness to become a list.
 #:
-#: Read by `commands_frame._slot_sizes` and handed to `frame.slots.bar_rows_wanted` as its
-#: *cap*, never applied twice: this module caps a strip at what the harness can spare and
-#: the SIZER caps it at what a strip is, and a second `min` here would be a bound no input
-#: could make observable — the survivor `tools/sweep.py` reports and this repository
-#: deletes.
+#: The top of the cycle :data:`BAR_ROWS_KEY` walks and NOT the height a frame launches at
+#: — that is :data:`BAR_ROWS_DEFAULT` (#880). `commands_frame._slot_sizes` reads this
+#: frame's own choice through :func:`bar_rows_cap` and hands the answer to
+#: `frame.slots.bar_rows_wanted` as its *cap*, never applying it twice: this module caps a
+#: strip at what the harness can spare and the SIZER caps it at what a strip is, and a
+#: second `min` here would be a bound no input could make observable — the survivor
+#: `tools/sweep.py` reports and this repository deletes.
 BAR_MAX_ROWS = 3
+
+#: How tall a tab strip is when nobody has said otherwise — one row, on every run (#880).
+#:
+#: **The launch default and NOT the ceiling**, which are two numbers and used to be one.
+#: `slots.bar_rows_wanted` composed at 1, 2 … :data:`BAR_MAX_ROWS` and kept the tallest
+#: height it FILLED, so a plane with many names came up two rows deep whether or not its
+#: operator wanted the harness two rows shorter. A strip that overflows is not a strip that
+#: has asked for the room: `+N` is clickable and opens the palette, which lists every name,
+#: so a collapsed strip is one press from the complete list rather than a dead end.
+#:
+#: The operator raises it with :data:`BAR_ROWS_KEY`, which cycles 1 → 2 → 3 and back
+#: (:func:`next_bar_rows`). A plane that always wants three says so once in its own
+#: `[[frame.component]] size` (#687), which :func:`_grown` still honours — that is a pin
+#: and this is a default, and neither is the other.
+BAR_ROWS_DEFAULT = 1
+
+#: The key that cycles a tab strip's height, bound by `commands_frame.conf_text`.
+#:
+#: **Here rather than in `commands_frame`, because `instance` has to know it too.** A
+#: component's own toggle key may not collide with a key charter has already bound
+#: (`instance.component_arrangement`'s `bound` set, which is where `overlay.HATCH_KEY` and
+#: the mouse keys already are); `instance` importing `commands_frame` would close a cycle,
+#: and this module is the one that owns bar heights and is already imported from there.
+#:
+#: **A third shipped `bind -n`, and the cost is stated rather than waved past.** A root-table
+#: binding is server-wide and takes the key before the harness pane sees it, which is why
+#: charter binds NO component toggle by default. It claims exactly two keys today — `F2`
+#: for the palette, `F12` for the escape hatch — and this is the third. It is affordable for
+#: the same reason those two are: `F3` is not a key Claude Code, codex or opencode binds,
+#: it is next to the palette an operator already knows, and unlike a toggle it is charter's
+#: own gesture rather than one of an open set. Unlike `F2` it is NOT configurable, exactly
+#: as `F12` is not: one key, one meaning, and `instance` refuses a component that wants it.
+BAR_ROWS_KEY = "F3"
+
+
+def bar_rows_cap(rows: int | None) -> int:
+    """How tall this frame's strips may grow right now — the *cap*
+    `slots.bar_rows_wanted` takes, out of what the operator has cycled to.
+
+    *rows* is `state.bar_rows`' answer: ``None`` for a frame nobody has pressed
+    :data:`BAR_ROWS_KEY` in, which is every frame at launch, and which is
+    :data:`BAR_ROWS_DEFAULT`.
+
+    **A cap and not a height.** A strip still grows only as far as its own names need
+    (`slots.bar_rows_wanted` measures, `_grown` spends), so pressing the key on a plane
+    whose names already fit on one row changes nothing on screen — which is the honest
+    outcome: there is nothing to put on a second row. What the key raises is the ceiling
+    that was stopping a strip which DOES overflow.
+
+    **Anything outside the range degrades to the default rather than clamping**, and that
+    is `instance.density_level`'s discipline: the value is read back off a file, so `0`,
+    `7`, `-1` and a truncated write are all "this frame has not chosen", not "this frame
+    chose something charter will round for it". Clamping a `7` to `3` would leave a frame
+    silently at the ceiling because a byte went missing.
+    """
+    now = rows if rows is not None else BAR_ROWS_DEFAULT
+    return now if BAR_ROWS_DEFAULT <= now <= BAR_MAX_ROWS else BAR_ROWS_DEFAULT
+
+
+def next_bar_rows(rows: int | None) -> int:
+    """The height :data:`BAR_ROWS_KEY` moves to from *rows* — 1 → 2 → 3 → 1.
+
+    **Through :func:`bar_rows_cap` and not off the raw number**, so the cycle has exactly
+    one idea of what "where we are now" means: a frame that has chosen nothing is at
+    :data:`BAR_ROWS_DEFAULT` and its first press asks for two, and a file charter cannot
+    read is at the default too rather than sending the next press somewhere no one asked
+    for. Written as one clamp shared with the reader, because two clamps are two chances to
+    disagree about whether `3` wraps.
+
+    Wrapping rather than stopping at the ceiling: every press has to do something, which is
+    `builtin_actions._register_strip`'s own rule for the tab walk one surface over. A key
+    that silently did nothing at the top is a key an operator presses twice and then stops
+    trusting.
+    """
+    now = bar_rows_cap(rows)
+    return now + 1 if now < BAR_MAX_ROWS else BAR_ROWS_DEFAULT
 
 #: One row per pane border. tmux charges a horizontal split one row for the divider on
 #: top of the pane's own height — measured on 3.7c: a 50-row window split `-l 8` reads
@@ -947,7 +1025,10 @@ def _grown(sizes: dict[str, int], wanted: dict[str, int], *,
     **This GROWS and never trims**, which is why the shortfall is tested for positivity in
     the loop rather than filtered out of the map: a plane that pinned its strip to three
     rows in its own `[[frame.component]]` table asked for three rows (#687), and a
-    measurement saying its names fit on one is not that operator changing their mind. There
+    measurement saying its names fit on one is not that operator changing their mind. That
+    is also what keeps #687 whole after #880 lowered the default to
+    :data:`BAR_ROWS_DEFAULT`: a want of one against a pin of three leaves the three alone,
+    so a plane that always wants a tall strip still says so once in its own file. There
     is no early return for an empty map either — the loop does not run and the answer is
     the map it was handed, so a guard in front of it is a line no input could make
     observable, which is the survivor `tools/sweep.py` reports and this repository deletes.

--- a/charter/frame/layout.py
+++ b/charter/frame/layout.py
@@ -306,6 +306,13 @@ def bar_rows_cap(rows: int | None) -> int:
     :data:`BAR_ROWS_KEY` in, which is every frame at launch, and which is
     :data:`BAR_ROWS_DEFAULT`.
 
+    **``None`` needs no branch of its own**, and there was one until the deletion sweep
+    asked about it: ``None`` is not in :data:`_BAR_ROWS`, so the membership test already
+    answers for it with the same number a `rows is not None` guard in front would have
+    produced. Written as two expressions, one of them was an equivalent mutant by
+    construction — `collapse-ifexp` to `rows` changed no answer for any input — which is
+    the line this repository deletes rather than documents.
+
     **A cap and not a height.** A strip still grows only as far as its own names need
     (`slots.bar_rows_wanted` measures, `_grown` spends), so pressing the key on a plane
     whose names already fit on one row changes nothing on screen — which is the honest
@@ -318,8 +325,7 @@ def bar_rows_cap(rows: int | None) -> int:
     frame chose something charter will round for it". Clamping a `7` to `3` would leave a
     frame silently at the ceiling because a byte went missing.
     """
-    now = rows if rows is not None else BAR_ROWS_DEFAULT
-    return now if now in _BAR_ROWS else BAR_ROWS_DEFAULT
+    return rows if rows in _BAR_ROWS else BAR_ROWS_DEFAULT
 
 
 def next_bar_rows(rows: int | None) -> int:

--- a/charter/frame/slots.py
+++ b/charter/frame/slots.py
@@ -3412,11 +3412,11 @@ class _Tabs:
         *columns* maps a ``(row, column)`` of the component's OWN canvas — the rectangle
         `ctx.width` and `ctx.height` describe, which is what `events.Dispatcher._on_canvas`
         delivers a click in — to the name of the tab drawn there. Absent means the operator
-        clicked a cell this bar drew no tab into: the heading, the blank under it on a
-        strip that grew a second row, the gap between two tabs, EITHER `+N` count,
-        the `n/N`, the empty space past the last name. `events.Dispatcher._on_canvas` applies
-        the identical rule one axis over for the pad, and `_Viewport.publish` applies it
-        for the table's heading row.
+        clicked a cell this bar drew no tab into: the left inset every row starts at, the
+        gap between two tabs, EITHER `+N` count, the `n/N`, the empty space past the last
+        name. (A strip's own heading was the sixth of those until #880 deleted it.)
+        `events.Dispatcher._on_canvas` applies the identical rule one axis over for the
+        pad, and `_Viewport.publish` applies it for the table's heading row.
 
         *here* is the name this frame is ON, taken from the same paint that drew the
         mark. Not re-resolved when a click arrives: `switch.current_workspace` reads the
@@ -3718,11 +3718,18 @@ def _cuts(fields: list[str], room: int, gap: int) -> list[int]:
     #
     # **Balancing every page instead was measured and is WORSE**, which is why only the
     # last one is rescued. Equal-sized pages ignore what names actually cost: on this
-    # project's own fifteen workspaces it drew 4/4/5/7/7 tabs at 100/120/160/200/240
-    # columns where filling each page draws 4/6/8/10/13, and across those 82 lists it left
+    # project's own fifteen workspaces it drew 4/4/5/7/7 tabs in ROOMS of 86/106/146/186/226
+    # cells where filling each page draws 4/6/8/10/13, and across those 82 lists it left
     # MORE pages holding a single tab (6,969 against 4,775), not fewer. Packing the last
     # page from the right instead removes the drops and puts them on a middle name: the
-    # same fifteen workspaces then draw 8 tabs at 160 and 6 at 200.
+    # same fifteen workspaces then draw 8 tabs in a room of 146 and 6 in one of 186.
+    #
+    # **Stated as a ROOM and not as a pane width, which is what #880 cost to learn.** Those
+    # numbers were written down as the widths a `workspaces` strip was drawn at, and the
+    # heading that strip carried was twelve of those columns; taking it off moved every one
+    # of them and left a paragraph quoting measurements of a row nothing draws any more.
+    # `room` is this function's own argument, so the numbers now follow the lead wherever
+    # it goes.
     #
     # **One condition, and the two that used to sit beside it were deleted rather than
     # documented.** They were written as guards against an empty page before the last one
@@ -3770,9 +3777,9 @@ def _cuts(fields: list[str], room: int, gap: int) -> list[int]:
     return cuts
 
 
-def _bar(head: str, names: list[str], here: str, width: int, *,
-         note: str = "", rows: int = 1, busy=()) -> list[str]:
-    """One bar: *head*, then *names* with *here* marked, in *rows* x *width* cells.
+def _bar(names: list[str], here: str, width: int, *,
+         note: str = "", rows: int = 1, busy=(), counts=None) -> list[str]:
+    """One bar: *names* with *here* marked, in *rows* x *width* cells.
 
     :func:`_compose` composes it and this is what PUBLISHES it — the one call that writes
     :data:`TABS`, so "the map describes what is on screen" is a property of two lines
@@ -3782,17 +3789,17 @@ def _bar(head: str, names: list[str], here: str, width: int, *,
     the launcher's answer overwrite the panel's — a map describing a strip nobody is
     looking at.
 
-    *busy* is :func:`_compose`'s and is passed straight through — see there.
+    *busy* and *counts* are :func:`_compose`'s and are passed straight through — see there.
     """
-    lines, cols, more, add = _compose(head, names, here, width,
-                                      note=note, rows=rows, busy=busy)
+    lines, cols, more, add = _compose(names, here, width, note=note, rows=rows,
+                                      busy=busy, counts=counts)
     TABS.publish(cols, here, more, add)
     return lines
 
 
-def _compose(head: str, names: list[str], here: str, width: int, *,
-             note: str = "", rows: int = 1, busy=()):
-    """The strip *head*/*names*/*here* composes to, and the cells its tabs landed in.
+def _compose(names: list[str], here: str, width: int, *,
+             note: str = "", rows: int = 1, busy=(), counts=None):
+    """The strip *names*/*here* composes to, and the cells its tabs landed in.
 
     Answers ``(lines, columns, more, add)`` — the rows to draw, the ``(row, col)`` map
     :meth:`_Tabs.publish` takes, and the two cell sets that are not tabs. :func:`_bar` is
@@ -3839,11 +3846,11 @@ def _compose(head: str, names: list[str], here: str, width: int, *,
        run that is the whole list is never short.
 
        **This rung used to draw the marked name alone**, and on a real plane that made
-       the whole bar inert: fifteen workspaces need 274 columns for rung 1, so every
-       width an operator actually runs at drew `*harness-wrapper  +14` — one tab, the one
-       they were already on, which `_Tabs.switch_to` correctly refuses. The bar was
-       clickable and reached nothing. A page reaches five more at 120 columns, seven at
-       160 and nine at 200.
+       the whole bar inert: fifteen workspaces need 262 columns for rung 1 (274 while the
+       strip still drew a heading — #880), so every width an operator actually runs at
+       drew `*harness-wrapper  +14` — one tab, the one they were already on, which
+       `_Tabs.switch_to` correctly refuses. The bar was clickable and reached nothing. A
+       page reaches six more at 120 columns, eight at 160 and ten at 200.
     3. **`n/N` alone** — which position you are in and how many there are. This is the
        rung §3.6 calls "marks only", and a count IS what a mark per chat degenerates to
        once there is no room to draw one per chat. It says strictly more: `2/3` tells you
@@ -3888,9 +3895,9 @@ def _compose(head: str, names: list[str], here: str, width: int, *,
     **Every rung answers with its own cell map**, which is what makes the bar clickable at
     all and is the same discipline `_repos` keeps for the table's rows: the handler
     resolves a click against WHAT WAS DRAWN rather than against what it thinks would have
-    been. Only the names actually on the strip get cells — the heading, the blank under it,
-    the gaps, BOTH `+N` counts, the `n/N` and the affordance are cells this bar drew no tab
-    into and a click on one of them switches nothing. **The rungs that draw NOTHING answer
+    been. Only the names actually on the strip get cells — the left inset, the gaps, BOTH
+    `+N` counts, the `n/N` and the affordance are cells this bar drew no tab into and a
+    click on one of them switches nothing. **The rungs that draw NOTHING answer
     too**, with an empty map, and that is the half `_Viewport.blank` exists for one axis
     over: a bar that kept its last map through a resize down to `2/3`, down to one row, or
     down to no row at all, would switch to a tab the operator can see is not on screen.
@@ -3902,22 +3909,25 @@ def _compose(head: str, names: list[str], here: str, width: int, *,
     :func:`_tab_columns` walking the fields each row actually joined), so there is no
     second walk of the ladder to disagree with the first.
     """
-    # **`head` and `note` are NOT contained, and the deletion sweep is what settled it.**
-    # Both are charter's own literals — `"chats"`, `"workspaces"`, :data:`ADD_CHAT` — and
-    # no caller can hand this an open-alphabet one, so a `contain.one_line` on either is a
-    # call whose result is provably its argument. The sweep found both as survivors for
-    # exactly that reason: no input could make the mutation differ. The NAMES are
-    # contained, below, which is where the open alphabet actually is.
+    # **`note` is NOT contained, and the deletion sweep is what settled it.** It is
+    # charter's own literal — :data:`ADD_CHAT` — and no caller can hand this an
+    # open-alphabet one, so a `contain.one_line` on it is a call whose result is provably
+    # its argument. The sweep found it as a survivor for exactly that reason: no input
+    # could make the mutation differ. The NAMES are contained, below, which is where the
+    # open alphabet actually is. (`head` said the same thing beside it until #880 removed
+    # the heading it named.)
     from . import chrome
-    lead = _inset() + head + " " * _BAR_GAP
-    # **The rows under the first start where the first row's tabs do.** The heading names
-    # the strip once — a `chats` repeated down the left of a three-row strip is the same
-    # word three times where names are competing for columns — and the blank under it is
-    # what keeps every row's tabs in one column, so a run of pages reads as one block
-    # rather than as three rows that happen to be adjacent. It is also what lets every page
-    # be cut against ONE `room`: a second row starting further left would be a wider row
-    # than the cut was made for, and the cut is what a click's stability rests on.
-    under = " " * tui.width(lead)
+    # **Every row of the strip starts at the same column, and that column is the frame's
+    # own left edge and nothing more** (#880). It used to carry the strip's heading —
+    # `workspaces `/`chats ` plus a :data:`_BAR_GAP` — with a blank of the same width under
+    # it on rows two and three, so that a run of pages read as one block rather than as
+    # three adjacent rows. The heading is gone and the blank went with it: a lead that is
+    # the same on every row is one expression, where a lead and an `under` that happened to
+    # be equal were two things a reader had to check agreed. What the single lead still
+    # buys is what the blank did — every page is cut against ONE `room`, and a second row
+    # starting further left would be a wider row than the cut was made for, which is what a
+    # click's stability rests on.
+    lead = _inset()
     # **Resolved ONCE, here, and handed to everything below it.** The cut
     # (:func:`_cuts`), the composition and the map (:func:`_tab_columns`) all need to
     # agree about how wide the seam between two tabs is, and `charter.toml` is re-read
@@ -3958,9 +3968,8 @@ def _compose(head: str, names: list[str], here: str, width: int, *,
         cols: dict = {}
         lines: list[str] = []
         for r, (before, body, drawn) in enumerate(drawn_rows):
-            head_cells = lead if r == 0 else under
-            cols.update(_tab_columns(r, tui.width(head_cells + before), drawn, gapw))
-            lines.append(head_cells + before + body)
+            cols.update(_tab_columns(r, tui.width(lead + before), drawn, gapw))
+            lines.append(lead + before + body)
         return lines, cols, more, add
 
     def row(body: str = "", drawn=(), before: str = "", more=(), add=()):
@@ -4189,15 +4198,20 @@ def working_chats() -> frozenset:
 
 
 def _chats_strip(fid: str):
-    """What the chat strip is a strip OF — its heading, its names, the one you are typing
-    in, and its note.
+    """What the chat strip is a strip OF — its names, the one you are typing in, and its
+    note.
 
     Never raises for a plane it cannot read: `chats.roster` already answers with the chat
     asking and nothing else for a frame root it could not scan, and `_bar` answers `[]`
     for an empty list.
+
+    **No heading, and no strip has one since #880.** This answered `"chats"` first for as
+    long as the strip drew that word down its left edge; what the word bought was telling
+    two adjacent strips apart, and position, the `+` and the spinner do that without
+    spending nine columns of a row whose names are competing for them.
     """
     from . import chats as chats_mod
-    return "chats", [c.id for c in chats_mod.roster(fid)], fid, ADD_CHAT
+    return [c.id for c in chats_mod.roster(fid)], fid, ADD_CHAT
 
 
 def _workspaces_strip(fid: str):
@@ -4214,8 +4228,7 @@ def _workspaces_strip(fid: str):
     thing a one-row strip can be.
     """
     from . import switch as switch_mod
-    return ("workspaces", switch_mod.workspaces(),
-            switch_mod.current_workspace(fid), "")
+    return (switch_mod.workspaces(), switch_mod.current_workspace(fid), "")
 
 
 #: The slots that draw a TAB STRIP, mapped to what each one is a strip of.
@@ -4296,11 +4309,11 @@ def bar_rows_wanted(fid: str, slot: str, *, pane_cols: int, cap: int) -> int:
     entry = BARS.get(slot)
     if entry is None:
         return 1
-    head, names, here, note = entry(fid)
+    names, here, note = entry(fid)
     width = pane_cols - 2 * pad_for(slot, pane_cols)
     filled = 1
     for rows in range(1, cap + 1):
-        lines, _cols, _more, _add = _compose(head, names, here, width,
+        lines, _cols, _more, _add = _compose(names, here, width,
                                              note=note, rows=rows)
         if len(lines) == rows:
             filled = rows
@@ -4326,8 +4339,8 @@ def chats_bar(fid: str, width: int, rows: int = 1) -> list[str]:
     dispatches and this chat's notice dwell, and neither is "a sibling chat's harness
     started working".
     """
-    head, names, here, note = _chats_strip(fid)
-    return _bar(head, names, here, width, note=note, rows=rows, busy=working_chats())
+    names, here, note = _chats_strip(fid)
+    return _bar(names, here, width, note=note, rows=rows, busy=working_chats())
 
 
 def workspaces_bar(fid: str, width: int, rows: int = 1) -> list[str]:
@@ -4336,8 +4349,8 @@ def workspaces_bar(fid: str, width: int, rows: int = 1) -> list[str]:
     :func:`chats_bar`'s rules and its ladder, one noun over — see :func:`_workspaces_strip`
     for what it draws and why it draws no `+`.
     """
-    head, names, here, note = _workspaces_strip(fid)
-    return _bar(head, names, here, width, note=note, rows=rows)
+    names, here, note = _workspaces_strip(fid)
+    return _bar(names, here, width, note=note, rows=rows)
 
 
 #: Which slots draw something that CHANGES ON ITS OWN, with no version bump and no

--- a/charter/frame/slots.py
+++ b/charter/frame/slots.py
@@ -4349,6 +4349,11 @@ def _workspaces_strip(fid: str):
     argument that "a picker that creates on a typo leaves litter". A `+` here would have to
     open something that takes a name, which is `charter workspace create` and is not a
     thing a one-row strip can be.
+
+    **The counts are this strip's and the chat strip has none** (#880) — see
+    :func:`_workspace_counts` for the one grouped read and for why it does not put this
+    strip on a clock, and :data:`TAB_COUNT_W` for why the field is there on every tab even
+    when the number is not.
     """
     from . import switch as switch_mod
     return (switch_mod.workspaces(), switch_mod.current_workspace(fid), "",

--- a/charter/frame/slots.py
+++ b/charter/frame/slots.py
@@ -3880,6 +3880,15 @@ def _compose(names: list[str], here: str, width: int, *,
     "add chat" affordance, and nothing else today. Dropped first, before any name, because
     it is a reminder and the names are the readout.
 
+    *counts* is how many chats each name holds, or ``None`` for a strip with no count field
+    at all (:func:`_chats_strip`). Where it is a map, EVERY tab reserves
+    :data:`TAB_COUNT_W` cells whatever the map says — see that constant for why a field
+    that came and went would re-cut the strip under a pointer, and :func:`_workspace_counts`
+    for the one grouped read behind it. A name the map does not carry counts zero and draws
+    blank. The reserve being unconditional is also what keeps :func:`bar_rows_wanted`
+    honest: the sizer composes with the same map the renderer will and could compose with
+    any map at all and still measure the same width.
+
     *busy* is the names whose harness is working right now (#853) — chat ids, straight off
     `inflight.working_chats`. Each one drawn on the strip gets :data:`TAB_SPINNER` in the
     cell :data:`_BAR_MARK` would otherwise leave blank, so **the ladder above cannot see
@@ -3997,6 +4006,20 @@ def _compose(names: list[str], here: str, width: int, *,
     # the raw name beside the drawn field: a click has to switch to what is on disk.
     at = names.index(here) if here in names else -1
     shown = [contain.one_line(n) for n in names]
+    # **The count rides the NAME's field, so the map gives its cells to that name's tab**
+    # (#880): a press on `(5)` switches to the workspace it is the count of, which is the
+    # only thing it could sensibly be about. Applied after `contain.one_line` and never
+    # before — the repair is for the open-alphabet name, and charter minted these digits.
+    #
+    # **`counts is None` is "this strip has no count field", not "every count is zero"**,
+    # and the two must stay tellable apart: the chats strip reserves nothing and the
+    # workspaces strip reserves :data:`TAB_COUNT_W` on every tab whatever the numbers are.
+    # That is what lets `bar_rows_wanted` — which composes with the counts the strip's own
+    # entry answered — measure the identical width the renderer draws, and it is why the
+    # reserve is unconditional: a strip whose counts were all zero must still be cut for
+    # the field, or the first chat to open would re-cut it.
+    if counts is not None:
+        shown = [n + _tab_count(counts.get(raw, 0)) for raw, n in zip(names, shown)]
     # **The mark's cell carries the spinner too, and it is decided on the RAW name for the
     # reason the paragraph above gives about the index**: `busy` holds chat ids off disk,
     # `shown` holds text `contain.one_line` may have repaired, and matching a mark against
@@ -4175,6 +4198,68 @@ def _compose(names: list[str], here: str, width: int, *,
 ADD_CHAT = "+"
 
 
+#: The largest chat count a workspace tab draws as a number. Above it the field says
+#: ``(99+)``, which is the same width and stops being a number rather than growing into one.
+#:
+#: **A constant and not a measurement of the plane, because the FIELD IS FIXED-WIDTH** —
+#: see :data:`TAB_COUNT_W`, which is the whole design. A ceiling derived from the widest
+#: count on the plane would change the moment a workspace crossed ten chats, and every tab
+#: on the strip would move.
+#:
+#: Two digits rather than `state._CHAT_ORDINAL_MAX`'s five: that constant bounds the
+#: ORDINAL a chat id may carry (`api.10000`), not how many chats are open at once, and
+#: sizing a field on every tab for a number no plane reaches would spend three columns per
+#: name on nothing. `state.reap` is what bounds the entries this is counted from, and a
+#: workspace with a hundred live chats has stopped being something a one-row readout is
+#: about — `+N` and the palette are what that operator has.
+TAB_COUNT_MAX = 99
+
+#: How many columns EVERY workspace tab reserves for its chat count, drawn or not.
+#:
+#: **Always reserved, and that is the constraint the whole field is built around.** Tab
+#: widths decide where :func:`_cuts` falls, so a suffix that appeared when a chat opened and
+#: vanished when one closed would move every tab to its right — and the cell the operator
+#: was about to press would hold another workspace's name a moment later. That is the
+#: double-press #767 exists to stop, and it is exactly the shape :data:`TAB_SPINNER` was
+#: refused in: *"A spinner drawn beside a name would re-cut the strip the moment a sibling
+#: started thinking."* The spinner took the mark's cell instead; a count has no cell to
+#: take, so it buys one on every tab and pays for it whether or not it has anything to say.
+#:
+#: **Zero renders blank**, so every count on screen means something. A `(0)` beside twelve
+#: of fifteen names is a column of noise that says only "this feature is on".
+#:
+#: Derived from the widest thing the field can hold rather than written down as `6`, so a
+#: change to :data:`TAB_COUNT_MAX` cannot leave the reserve behind. `tui.width` and never
+#: `len` for this module's own reason, though every character here is ASCII: a field is
+#: display text and the question is cells.
+TAB_COUNT_W = tui.width(f" ({TAB_COUNT_MAX}+)")
+
+
+def _tab_count(n: int) -> str:
+    """The count field for a workspace holding *n* chats — always :data:`TAB_COUNT_W` cells.
+
+    A blank for none, ``(5)`` for five, ``(99+)`` for more than :data:`TAB_COUNT_MAX`,
+    each padded to the reserve. `tui.pad` and not an f-string width, for :func:`_inset`'s
+    reason: it measures with `tui.width`, so the field is the same number of CELLS whatever
+    is in it — which is the property :data:`TAB_COUNT_W` exists to state and the one the cut
+    depends on.
+
+    **Parentheses and ASCII**, :data:`_BAR_RULE`'s rule rather than a preference: a click on
+    this row is resolved by COLUMN, so a glyph a terminal may draw two cells wide would move
+    every field after it. They also keep the count off the name — `alpha 5` reads as a
+    workspace called `alpha 5`, and `workspace.valid_name` is not a strong enough argument
+    to lean on when a parenthesis costs one cell of a field that is reserved anyway.
+
+    A negative *n* cannot arrive — it is `len()` of a list one function over — and is not
+    guarded against separately for that reason: `n <= 0` is the blank, so the one branch
+    that exists answers for it, where a second would be a line no input could reach.
+    """
+    if n <= 0:
+        return " " * TAB_COUNT_W
+    return tui.pad(f" ({n})" if n <= TAB_COUNT_MAX else f" ({TAB_COUNT_MAX}+)",
+                   TAB_COUNT_W)
+
+
 def working_chats() -> frozenset:
     """Which chats' harnesses are working right now — a set of chat ids, possibly empty.
 
@@ -4198,8 +4283,14 @@ def working_chats() -> frozenset:
 
 
 def _chats_strip(fid: str):
-    """What the chat strip is a strip OF — its names, the one you are typing in, and its
-    note.
+    """What the chat strip is a strip OF — its names, the one you are typing in, its note,
+    and no count field.
+
+    **``None`` for the counts and not an empty map**, which are different instructions to
+    :func:`_compose`: ``None`` reserves nothing, ``{}`` reserves :data:`TAB_COUNT_W` on
+    every tab and draws a blank in it. A chat has nothing to count — it is the leaf — and a
+    strip of chats that reserved six columns per name for a field it never fills would be
+    the widest thing on this row spent on nothing.
 
     Never raises for a plane it cannot read: `chats.roster` already answers with the chat
     asking and nothing else for a frame root it could not scan, and `_bar` answers `[]`
@@ -4211,7 +4302,39 @@ def _chats_strip(fid: str):
     spending nine columns of a row whose names are competing for them.
     """
     from . import chats as chats_mod
-    return [c.id for c in chats_mod.roster(fid)], fid, ADD_CHAT
+    return [c.id for c in chats_mod.roster(fid)], fid, ADD_CHAT, None
+
+
+def _workspace_counts() -> dict:
+    """How many chats each workspace holds — the field :data:`TAB_COUNT_W` reserves.
+
+    `chats.counts_by_workspace` behind a guard, and a wrapper for :func:`working_chats`'
+    reason, which is this whole module's rule for a read on the repaint path: **never
+    raises.** A panel that threw out of `render` loses its pane, and a plane charter cannot
+    scan is "no counts" — every tab draws a blank field of exactly the width it would have
+    drawn a number in, so a failed read costs the strip nothing but the numbers.
+
+    **One grouped pass and not one call per name** (#880). `chats.of_workspace` is an
+    `os.scandir` plus two small reads per chat and is uncached by design; asked once per
+    workspace it is roughly 15 x 30 x 2 = 900 reads for one repaint of one row.
+    `chats.counts_by_workspace` is the same walk done once.
+
+    **This is the first thing the workspaces strip reads out of chat state, and it does NOT
+    put the strip on a clock.** :data:`BAR_ANIMATED` is the chats strip and only the chats
+    strip: that one draws a spinner, which changes with nothing but time, so `panel._watch`
+    gives it a ticking gate. A count changes when a chat is opened or closed, which is a
+    thing that happens to the plane and not to the clock, so this rides the repaint the
+    strip already had — `state.version`, one `stat`. The cost is stated rather than hidden:
+    a count can be one repaint stale, and the repaint that clears it is the one a switch
+    back into the window causes anyway (`commands_frame._drop_panels` tears a background
+    window's panels down, so the strip an operator is looking at was drawn after they
+    arrived).
+    """
+    from . import chats as chats_mod
+    try:
+        return chats_mod.counts_by_workspace()
+    except Exception:  # noqa: BLE001 - a readout must never cost a pane
+        return {}
 
 
 def _workspaces_strip(fid: str):
@@ -4228,7 +4351,8 @@ def _workspaces_strip(fid: str):
     thing a one-row strip can be.
     """
     from . import switch as switch_mod
-    return (switch_mod.workspaces(), switch_mod.current_workspace(fid), "")
+    return (switch_mod.workspaces(), switch_mod.current_workspace(fid), "",
+            _workspace_counts())
 
 
 #: The slots that draw a TAB STRIP, mapped to what each one is a strip of.
@@ -4309,12 +4433,12 @@ def bar_rows_wanted(fid: str, slot: str, *, pane_cols: int, cap: int) -> int:
     entry = BARS.get(slot)
     if entry is None:
         return 1
-    names, here, note = entry(fid)
+    names, here, note, counts = entry(fid)
     width = pane_cols - 2 * pad_for(slot, pane_cols)
     filled = 1
     for rows in range(1, cap + 1):
         lines, _cols, _more, _add = _compose(names, here, width,
-                                             note=note, rows=rows)
+                                             note=note, rows=rows, counts=counts)
         if len(lines) == rows:
             filled = rows
     return filled
@@ -4339,8 +4463,9 @@ def chats_bar(fid: str, width: int, rows: int = 1) -> list[str]:
     dispatches and this chat's notice dwell, and neither is "a sibling chat's harness
     started working".
     """
-    names, here, note = _chats_strip(fid)
-    return _bar(names, here, width, note=note, rows=rows, busy=working_chats())
+    names, here, note, counts = _chats_strip(fid)
+    return _bar(names, here, width, note=note, rows=rows, busy=working_chats(),
+                counts=counts)
 
 
 def workspaces_bar(fid: str, width: int, rows: int = 1) -> list[str]:
@@ -4349,8 +4474,8 @@ def workspaces_bar(fid: str, width: int, rows: int = 1) -> list[str]:
     :func:`chats_bar`'s rules and its ladder, one noun over — see :func:`_workspaces_strip`
     for what it draws and why it draws no `+`.
     """
-    names, here, note = _workspaces_strip(fid)
-    return _bar(names, here, width, note=note, rows=rows)
+    names, here, note, counts = _workspaces_strip(fid)
+    return _bar(names, here, width, note=note, rows=rows, counts=counts)
 
 
 #: Which slots draw something that CHANGES ON ITS OWN, with no version bump and no

--- a/charter/frame/state.py
+++ b/charter/frame/state.py
@@ -1261,8 +1261,10 @@ def record_bar_rows(fid: str, rows: int) -> None:
     decision already lives.
 
     Written as text and read back through `int()` (:func:`bar_rows`), not because a number
-    needs a format but because this file is read by another process on the repaint path and
-    every other file in this directory is one line of text.
+    needs a format but because this file is read by another process on the sizing path and
+    every other file in this directory is one line of text. The trailing newline is what
+    every other writer here puts there and `int()` ignores it — see :func:`bar_rows` for
+    why that read has no `.strip()` where :func:`density`'s has one.
 
     Same must-not-raise, atomic-write shape as :func:`bump` and :func:`record_density`.
     """
@@ -1292,12 +1294,18 @@ def bar_rows(fid: str) -> int | None:
     file holding `7` degrades exactly the way an out-of-range `[[frame.component]] size`
     does. A second half-copy of the range living in this module is the thing that comes
     apart.
+
+    **No `.strip()`, where :func:`density`'s read has one**, and the difference is real
+    rather than an oversight: `int()` already ignores surrounding whitespace, so a strip in
+    front of it is a call whose result is provably its argument — the sweep offered
+    `lstrip` for it and neither spelling could change an answer. `density` returns TEXT, so
+    the whitespace is the caller's problem there and this module's here.
     """
     d = frame_dir(fid)
     if d is None:
         return None
     try:
-        return int((d / "bar_rows").read_text().strip())
+        return int((d / "bar_rows").read_text())
     except (OSError, ValueError):
         return None
 

--- a/charter/frame/state.py
+++ b/charter/frame/state.py
@@ -1244,6 +1244,64 @@ def density(fid: str) -> str | None:
         return None
 
 
+def record_bar_rows(fid: str, rows: int) -> None:
+    """Write down how tall THIS RUNNING FRAME's tab strips may grow (#880).
+
+    :func:`record_density`'s shape and every word of its argument: `[[frame.component]]
+    size` is hand-maintained and committed, this directory is machine-written, and `reap`
+    deletes it whole when the frame ends. So `commands_frame.cmd_bar_rows` writes here and
+    the operator's own file is left alone.
+
+    **And that is also what makes "the height does not survive a restart" true without a
+    new kind of state.** A file here IS per-frame runtime state — the same file `density`
+    and `hidden` are — so there is nothing for `doctor` to explain and nothing an operator
+    has to clean up: every run starts at `layout.BAR_ROWS_DEFAULT` because there is no file
+    yet, and the one that a frame wrote goes when the frame does. A plane that genuinely
+    always wants three rows says so once in `charter.toml`, where every other layout
+    decision already lives.
+
+    Written as text and read back through `int()` (:func:`bar_rows`), not because a number
+    needs a format but because this file is read by another process on the repaint path and
+    every other file in this directory is one line of text.
+
+    Same must-not-raise, atomic-write shape as :func:`bump` and :func:`record_density`.
+    """
+    d = frame_dir(fid, create=True)
+    if d is None:
+        return
+    tmp = d / "bar_rows.tmp"
+    try:
+        config.write_for(tmp, f"{int(rows)}\n")
+        os.replace(tmp, d / "bar_rows")
+    except OSError:
+        return
+
+
+def bar_rows(fid: str) -> int | None:
+    """How tall this frame's strips have been told they may grow, or ``None``.
+
+    ``None`` is the ordinary case and is not a failure: a frame comes up at
+    `layout.BAR_ROWS_DEFAULT` and only a keypress writes here. It is also what an
+    unreadable or unparseable file answers, which is :func:`exit_code`'s ``except (OSError,
+    ValueError)`` for :func:`version`'s reason — this is read on a sizing path that runs
+    inside the `frame-resize` child, and a half-written file must degrade to the default
+    rather than take the recompute down.
+
+    **The number is NOT ranged here**, and that is :func:`density`'s split rather than a
+    deferral: `layout.bar_rows_cap` is the one gate and it sits at the point of use, so a
+    file holding `7` degrades exactly the way an out-of-range `[[frame.component]] size`
+    does. A second half-copy of the range living in this module is the thing that comes
+    apart.
+    """
+    d = frame_dir(fid)
+    if d is None:
+        return None
+    try:
+        return int((d / "bar_rows").read_text().strip())
+    except (OSError, ValueError):
+        return None
+
+
 def record_chrome(fid: str, level: str) -> None:
     """Write down the pane surface THIS RUNNING FRAME is on, overriding `[frame] chrome`.
 
@@ -1469,8 +1527,9 @@ def clear_shape(fid: str) -> None:
     """Forget the shape, the pane map and the harness session recorded under *fid*,
     because a NEW frame is claiming the id.
 
-    "The shape" is two files: the ``density`` a keypress chose and the ``hidden`` set a
-    component's own toggle key wrote (:func:`record_hidden`). Both are one operator's
+    "The shape" is three files: the ``density`` a keypress chose, the ``hidden`` set a
+    component's own toggle key wrote (:func:`record_hidden`), and the ``bar_rows`` a press
+    of `layout.BAR_ROWS_KEY` cycled to (:func:`record_bar_rows`). Each is one operator's
     decision about one frame, and that frame is over.
 
     The fourth and fifth lines on :func:`clear_exit`'s bill, and the same recycled pid
@@ -1515,6 +1574,14 @@ def clear_shape(fid: str) -> None:
       take resume away, which is why it is named here rather than only where it is
       written.
 
+    * ``bar_rows`` is the same keypress said about a HEIGHT (:func:`record_bar_rows`), and
+      it inherits with density's consequence in the one place it is worst: a brand-new
+      frame would come up with three rows of tab strip and a three-row-shorter harness,
+      taken from somebody else's session, with nothing on screen to say why. That the
+      height does not survive a restart is the feature's own stated promise (#880), so a
+      file inherited across a recycled id would break exactly the sentence the feature is
+      written to keep.
+
     * ``selection`` is the same keypress or the same click said about a ROW
       (:func:`record_selection`), and it inherits with the mildest of these consequences
       and the same shape: a brand-new frame comes up with one repo highlighted and its
@@ -1527,7 +1594,7 @@ def clear_shape(fid: str) -> None:
     d = frame_dir(fid)
     if d is None:
         return
-    for name in ("density", "hidden", "panes", "session", "selection"):
+    for name in ("density", "hidden", "panes", "session", "selection", "bar_rows"):
         try:
             (d / name).unlink(missing_ok=True)
         except OSError:

--- a/charter/instance.py
+++ b/charter/instance.py
@@ -2394,6 +2394,7 @@ def component_arrangement(section, *,
         # deletion sweep calls a survivor.
         return None, "`component = []` places no components at all"
     from .frame import builtins as _builtins
+    from .frame import layout as _layout
     from .frame import overlay as _overlay
     from .frame import tmuxctl as _tmuxctl
     from .frame.component import EDGES, Fixed
@@ -2423,7 +2424,8 @@ def component_arrangement(section, *,
     # real keys and nothing else. The collision test below leans on that rather than
     # re-checking, so this filter is load-bearing; see the comment there for what a
     # ``None`` in here would cost.
-    bound: set[str] = {k for k in (hotkey, _overlay.HATCH_KEY, *_tmuxctl.MOUSE_KEYS) if k}
+    bound: set[str] = {k for k in (hotkey, _overlay.HATCH_KEY, _layout.BAR_ROWS_KEY,
+                                   *_tmuxctl.MOUSE_KEYS) if k}
     for n, table in enumerate(tables, 1):
         if not isinstance(table, dict):
             return None, (f"the entry {_component_at(None, n)} is "

--- a/docs/frame.md
+++ b/docs/frame.md
@@ -685,6 +685,22 @@ plane declares no `[harness] default`; or charter cannot enter the workspace's d
 workspace is a directory and a *name*, which is `charter workspace create` — and a picker
 that creates on a typo leaves litter.
 
+**Each workspace tab says how many chats it holds** — `some-workspace (5)`. A workspace
+with none draws a blank, so every count you see means something, and past 99 the field says
+`(99+)` rather than growing a digit.
+
+The field is **always there**, whether or not it has a number in it, and that is not
+tidiness. Tab widths decide where the bar cuts its pages, so a suffix that appeared when you
+opened a chat and vanished when you closed one would move every tab to its right — and the
+cell you were about to click would hold another workspace's name. It is the same reason the
+chat spinner takes the mark's column instead of adding one. Six columns per tab is what it
+costs; those fifteen workspaces need 352 columns for one row now rather than 262.
+
+It costs one directory scan per repaint for the whole strip, not one per workspace, and the
+strip still repaints on the same thing it always did — so a count can be a beat behind if
+something else opens a chat in the background, and it is right again the moment you come
+back to that window.
+
 **You do not need a mouse for the strips either.** `F2` → `chat: the next tab` (and
 `previous`, and the same pair for `workspace`) walks the strip one step, in the order it is
 drawn, running the same command a click on that tab runs. It wraps, so every press moves

--- a/docs/frame.md
+++ b/docs/frame.md
@@ -723,11 +723,13 @@ back to that window.
 drawn, running the same command a click on that tab runs. It wraps, so every press moves
 something; a plane with nowhere else to go says so rather than sending you where you
 already are. Those four rows are the only route to *the next one* on a plane with `mouse =
-false`, which is the default — and charter will not bind a bare key to it for the reason
-the repo table's own rows give: a `bind -n` is server-wide and would take the key before
-your harness sees it. Unlike the repo rows they do not leave the palette open, because a
-switch moves your terminal to another window and the palette's pane is in the one you are
-leaving.
+false`, which is the default — and charter will not bind a bare key to **switching** for the
+reason the repo table's own rows give: a `bind -n` is server-wide and would take the key
+before your harness sees it, and *which tab* is an open set that would want a key each.
+`F3` is not a counter-example: a strip's height is one gesture, not one per name, which is
+why it is charter's own key and not a row. Unlike the repo rows these four do not leave the
+palette open, because a switch moves your terminal to another window and the palette's pane
+is in the one you are leaving.
 
 **They are tabs: with `mouse = true`, clicking a name switches to it.** A chat tab does
 exactly what `F2` → `chat` does — the same command, the same five refusals, the same

--- a/docs/frame.md
+++ b/docs/frame.md
@@ -237,9 +237,9 @@ you came from; and nothing else could ever finish the gesture, because a keypres
 reach a panel at all — tmux gives your typing to the active pane, which is the harness.
 
 Clicking the tab you are already on does nothing at all, rather than tearing the panels down
-and putting them back to arrive where you were. So does clicking the heading, the gap between
-two names, or the empty space past the last tab: those are cells no tab was drawn into, and
-charter will not pick the nearest name for you.
+and putting them back to arrive where you were. So does clicking the row's own left inset,
+the gap between two names, or the empty space past the last tab: those are cells no tab was
+drawn into, and charter will not pick the nearest name for you.
 
 **Right-click a chat tab and you get a menu about that chat.** Two rows — `chat: previous
 transcript` and, last, `chat: close` — both about the tab under the pointer rather than the
@@ -249,7 +249,7 @@ close` draws, naming the chat and what stopping it costs, and the keypress on *t
 stops the harness. Escape leaves, `F12` always leaves, and nothing is stopped by a pointer.
 
 Right-click on the tab you *are* on works too — closing the chat you are in is the ordinary
-case of closing one. Right-click on the heading, on the `+`, on a `+N` count or on empty
+case of closing one. Right-click on the left inset, on the `+`, on a `+N` count or on empty
 space does nothing at all, and the `workspaces` bar has no menu: a workspace has neither a
 transcript nor a chat to close.
 
@@ -614,15 +614,21 @@ not all fit the bar draws the page yours falls on and counts what is off each en
 (`+5  *harness-wrapper   news-dispatch-guard  …  +7`); narrower still it says only where you
 are (`2/3`). It never shows half a name.
 
-Fifteen workspaces need 274 columns to fit on one row, so on a real terminal the bar is
-usually drawing a page. At 120 columns it draws six of them, at 160 eight, at 200 ten.
+**Neither strip is labelled.** They used to open with the word `chats` or `workspaces`, and
+that cost 9 and 14 columns of the row the names are competing for. What tells them apart is
+where they are and what is on them: the strips are adjacent and always in the same order, the
+chat bar draws a `+` and a spinner and the workspace bar deliberately draws neither, and a
+chat id ends in an ordinal. A label that never changes is chrome you stop seeing after a day.
+
+Fifteen workspaces need 262 columns to fit on one row, so on a real terminal the bar is
+usually drawing a page. At 120 columns it draws seven of them, at 160 nine, at 200 eleven.
 
 **A strip that cannot fit its names on one row is given another one — up to three.** It is
 one row whenever the names fit, so a plane whose strip is not overflowing never loses a row
 to this; and the rows it does take come out of what your session has above its own 12-row
 floor, so a short terminal grows nothing at all. Fifteen workspaces take two rows at 160
 columns and three at 120, and every name on every row is clickable. Resize the terminal and
-the strip follows: widen it past 274 columns and the strip gives its extra rows back.
+the strip follows: widen it past 262 columns and the strip gives its extra rows back.
 
 Below tmux 3.3 that last part does not happen on its own. `window-resized` is a hook tmux
 added in 3.3, so charter has nothing to trigger a recompute on and the strip keeps the

--- a/docs/frame.md
+++ b/docs/frame.md
@@ -623,12 +623,29 @@ chat id ends in an ordinal. A label that never changes is chrome you stop seeing
 Fifteen workspaces need 262 columns to fit on one row, so on a real terminal the bar is
 usually drawing a page. At 120 columns it draws seven of them, at 160 nine, at 200 eleven.
 
-**A strip that cannot fit its names on one row is given another one — up to three.** It is
-one row whenever the names fit, so a plane whose strip is not overflowing never loses a row
-to this; and the rows it does take come out of what your session has above its own 12-row
-floor, so a short terminal grows nothing at all. Fifteen workspaces take two rows at 160
-columns and three at 120, and every name on every row is clickable. Resize the terminal and
-the strip follows: widen it past 262 columns and the strip gives its extra rows back.
+**A strip starts one row deep, and `F3` cycles it 1 → 2 → 3.** Every run starts at one row
+— a strip that overflows is not a strip that has asked for the room, and the `+N` it draws
+instead is clickable and opens the palette, which lists every name. So a collapsed strip is
+one press from the complete list, not a dead end.
+
+`F3` raises what a strip *may* grow to; what it does grow to is still what its names need.
+Press it on a plane whose names already fit and nothing moves, because there is nothing to
+put on a second row. Press it on one that overflows and the strip takes the rows there are
+names for — out of what your session has above its own 12-row floor, so a short terminal
+grows nothing at all. Fifteen workspaces take two rows at 160 columns and three at 120, and
+every name on every row is clickable. Resize the terminal and the strip follows: widen it
+past 352 columns and the strip gives its extra rows back.
+
+**The height you choose does not survive a restart.** It lives in the frame's own state
+directory, which charter deletes when the frame ends, exactly like the density a palette row
+chose and the panels a toggle key hid. If your plane always wants three rows, say so once in
+`charter.toml` — `[[frame.component]] size = 3` on the bar — and every launch starts there;
+`F3` is the gesture for right now.
+
+`F3` is the third key charter binds, after `F2` for the palette and `F12` for the escape
+hatch. Like `F12` and unlike `F2` it is not configurable, and a component may not claim it
+for its own toggle — charter refuses that table rather than letting a committed key silently
+take the one that cycles your strips.
 
 Below tmux 3.3 that last part does not happen on its own. `window-resized` is a hook tmux
 added in 3.3, so charter has nothing to trigger a recompute on and the strip keeps the

--- a/docs/news/unreleased-the-tab-strips-lose-their-headings-and-gain-a-count.md
+++ b/docs/news/unreleased-the-tab-strips-lose-their-headings-and-gain-a-count.md
@@ -1,0 +1,91 @@
+---
+version: unreleased
+headline: the tab strips drop their headings, launch one row deep with F3 to grow them, and every workspace tab says how many chats it holds
+---
+
+Four changes to the tab strip, made together because they trade columns against each
+other: two free them and one spends them.
+
+```
+before
+  workspaces   authority-audit   autonomy   charter-update-skill   default   fleet  *harness-wrapper   news-dispatch-guard  +8
+
+after
+   authority-audit   autonomy (2)   charter-update-skill   default   fleet  *harness-wrapper (3)   news-dispatch-guard  +8
+```
+
+## The headings go
+
+`workspaces` and `chats` were drawn once at the start of each strip. They were mouse
+targets for nothing, carried no chrome, and never changed — and a label that never changes
+is chrome you stop seeing after a day.
+
+What tells the two strips apart now is where they are and what is on them: they are
+adjacent and permanently ordered, the chats strip draws a `+` and a spinner while the
+workspaces strip deliberately draws neither, and a chat id ends in an ordinal.
+
+**The saving is 12 columns and 7, not 14 and 9.** The issue attributed the whole lead to
+the heading; two of those columns are `slots.INSET`, the left edge every pane's rows start
+at, and they are still there. Measured through the ladder itself: the fifteen workspaces on
+this repository's own plane needed **274** columns to fit on one row and now need **262**.
+
+## One row on launch, `F3` to grow it
+
+`slots.bar_rows_wanted` composes the strip at 1, 2 … `layout.BAR_MAX_ROWS` and keeps the
+tallest height it fills, and `layout._grown` hands those rows out of the harness's spare
+budget — so a plane with many names came up two rows deep whether or not its operator
+wanted the harness two rows shorter.
+
+Every run now starts at one row. The measured objection to that was a strip drawing
+`*harness-wrapper  +14` — one tab, the one you are on, which `switch_to` correctly refuses,
+so *"the bar was clickable and reached nothing"*. That objection no longer stands on its
+own: **`+N` is clickable and opens the palette**, which lists every name. A collapsed strip
+is one press from the complete list, not a dead end.
+
+`F3` cycles a strip 1 → 2 → 3 and back. It **raises a ceiling and does not set a height**:
+`bar_rows_wanted` still answers with the rows the names actually fill, so pressing it on a
+plane whose names already fit moves nothing — there is nothing to put on a second row.
+
+**The height does not survive a restart.** It is a file in the frame's own state directory
+beside the density a palette row chose and the panels a toggle key hid, so charter deletes
+it when the frame ends and there is no new kind of state to explain. A plane that always
+wants three rows says so once in `[[frame.component]] size` (#687), which is still honoured
+as the pinned default.
+
+Two alternatives were weighed. **A tmux drag** is the gesture an operator would reach for
+and is recomputed away on the next layout pass, because the layout owns bar heights (both
+bars are `Fixed(1)`) — making a drag stick means teaching the layout to tell "the operator
+dragged this" from "recompute this". **`charter.toml` alone** already works and is an
+edit-and-restart rather than a gesture.
+
+`F3` is the third key charter binds, after `F2` for the palette and `F12` for the escape
+hatch. A root-table binding is server-wide and takes the key before your harness sees it,
+which is why charter binds no component toggle by default; `F3` is affordable for the same
+reason those two are, and a component that commits `key = "F3"` is refused rather than
+silently taking it.
+
+## A workspace tab says how many chats it holds
+
+`some-workspace (5)`. A workspace with none draws a blank, so every count you see means
+something, and past 99 the field says `(99+)` rather than growing a digit.
+
+**The field is always reserved, whether or not it has a number in it.** Tab widths decide
+where the strip cuts its pages, so a suffix that appeared when a chat opened and vanished
+when one closed would move every tab to its right — and the cell you were about to press
+would hold another workspace's name. charter refused this exact shape once already, for the
+tab spinner: *"A spinner drawn beside a name would re-cut the strip the moment a sibling
+started thinking."* The spinner had the mark's cell to take; a count has none, so it buys
+one on every tab.
+
+That reserve is six columns a tab, which is what item 4 spends of what items 1 and 2 freed:
+those fifteen workspaces need **352** columns for one row now.
+
+**One directory scan for the whole strip, not one per workspace.** `chats.of_workspace` is
+an `os.scandir` plus two small reads per chat and is uncached by design; asked once per name
+it is roughly 15 × 30 × 2 ≈ 900 reads for one repaint of one row. It and the new
+`chats.counts_by_workspace` now share one grouped walk, with the same membership rule and
+the same order.
+
+The workspaces strip is still not on a clock. A count changes when a chat opens or closes,
+which happens to the plane and not to the clock, so it rides the repaint the strip already
+had — one `stat`, the same as before.

--- a/tests/test_a_chat_tab_shows_its_harness_working.py
+++ b/tests/test_a_chat_tab_shows_its_harness_working.py
@@ -461,20 +461,27 @@ class TheStripDrawsItWithoutMovingACell(PersonaIso, unittest.TestCase):
 
     def _row(self, busy=(), width=200, here="api.2", now=0.0):
         with mock.patch("charter.frame.slots.time.monotonic", return_value=now):
-            rows = slots._bar("chats", list(self.NAMES), here, width, busy=busy)
+            rows = slots._bar(list(self.NAMES), here, width, busy=busy)
         return tui.strip_ansi(rows[0]) if rows else ""
 
     def test_an_idle_strip_is_the_strip_that_shipped(self):
-        self.assertEqual("chats   api.1  *api.2   api.3", self._row().strip())
+        self.assertEqual("   api.1  *api.2   api.3", self._row().rstrip())
 
     def test_a_working_chat_wears_the_spinner_where_an_idle_one_wears_a_blank(self):
         """Hand-spelled, and the whole row, because what is being asserted is a POSITION:
         the glyph is in the cell `slots._BAR_MARK[1]` would have left blank, and every
-        other character of the row is where it was."""
-        self.assertEqual("chats  ✢api.1  *api.2   api.3",
-                         self._row(busy={"api.1"}, now=0.0).strip())
-        self.assertEqual("chats   api.1  *api.2  ✶api.3",
-                         self._row(busy={"api.3"}, now=slots.SPINNER_PERIOD).strip())
+        other character of the row is where it was.
+
+        **`rstrip` and never `strip`**, which #880 is what made load-bearing. These rows
+        used to open with the word `chats`, so stripping both ends left the idle mark's
+        blank in the middle of the string where a reader could see it; with the heading
+        gone, `strip` eats exactly the cell this case is about and an idle row and a
+        working one would compare equal. The two leading spaces are `slots.INSET`.
+        """
+        self.assertEqual("  ✢api.1  *api.2   api.3",
+                         self._row(busy={"api.1"}, now=0.0).rstrip())
+        self.assertEqual("   api.1  *api.2  ✶api.3",
+                         self._row(busy={"api.3"}, now=slots.SPINNER_PERIOD).rstrip())
 
     def test_the_chat_you_are_typing_in_keeps_its_star(self):
         """One cell, two facts, and `*` wins. `chrome.block` paints the active tab in
@@ -482,12 +489,12 @@ class TheStripDrawsItWithoutMovingACell(PersonaIso, unittest.TestCase):
         `panel._write` strips SGR under `NO_COLOR` — so on a plain plane the `*` is the
         only thing saying where you are. The chat you are IN is also the one whose harness
         you can watch directly."""
-        self.assertEqual("chats   api.1  *api.2   api.3",
-                         self._row(busy={"api.2"}).strip())
+        self.assertEqual("   api.1  *api.2   api.3",
+                         self._row(busy={"api.2"}).rstrip())
 
     def test_every_tab_on_a_row_shows_the_same_frame(self):
         row = self._row(busy={"api.1", "api.3"}, now=slots.SPINNER_PERIOD * 2)
-        self.assertEqual("chats  ✻api.1  *api.2  ✻api.3", row.strip())
+        self.assertEqual("  ✻api.1  *api.2  ✻api.3", row.rstrip())
 
     def test_a_chat_starting_a_turn_moves_no_column_of_the_click_map(self):
         """**The property the whole design turns on.** The map resolves a click BY COLUMN,
@@ -498,11 +505,11 @@ class TheStripDrawsItWithoutMovingACell(PersonaIso, unittest.TestCase):
         for width in range(0, 120):
             with self.subTest(width=width):
                 slots.TABS.forget()
-                idle = slots._bar("chats", list(self.NAMES), "api.2", width)
+                idle = slots._bar(list(self.NAMES), "api.2", width)
                 idle_map = dict(slots.TABS._cols)
                 slots.TABS.forget()
                 with mock.patch("charter.frame.slots.time.monotonic", return_value=0.0):
-                    busy = slots._bar("chats", list(self.NAMES), "api.2", width,
+                    busy = slots._bar(list(self.NAMES), "api.2", width,
                                       busy={"api.1", "api.3"})
                 self.assertEqual(idle_map, dict(slots.TABS._cols))
                 self.assertEqual([tui.width(r) for r in idle],

--- a/tests/test_a_click_on_a_tab_bar_switches.py
+++ b/tests/test_a_click_on_a_tab_bar_switches.py
@@ -444,7 +444,10 @@ class AClickOnTheOverflowCountOpensThePalette(_ABarThatWasDrawn, unittest.TestCa
         for chat in [f"api.{i}" for i in range(1, 13)]:
             _plant(chat, workspace="api")
         with mock.patch.dict(os.environ, {"CHARTER_WORKSPACE": "api"}):
-            row = tui.strip_ansi(slots.chats_bar("api.6", 44)[0])
+            # 37 rather than 44: `_column_of` refuses a field that is not unique on the
+            # row, and at 44 this list draws `+4` at BOTH ends. That was 51 columns while
+            # the strip still spent nine on a `chats` heading (#880).
+            row = tui.strip_ansi(slots.chats_bar("api.6", 37)[0])
         counts = [f.strip() for f in row.split(" " * slots._BAR_GAP)
                   if f.strip().startswith("+")]
         self.assertTrue(counts, f"this width draws no count: {row!r}")

--- a/tests/test_a_key_cycles_the_tab_strips_height.py
+++ b/tests/test_a_key_cycles_the_tab_strips_height.py
@@ -178,6 +178,16 @@ class TheHeightIsRememberedForThisFrameAndNoLonger(PersonaIso, unittest.TestCase
         state.clear_shape(self.FID)
         self.assertIsNone(state.bar_rows(self.FID))
 
+    def test_an_id_the_state_directory_refuses_writes_nothing_and_raises_nothing(self):
+        """`state.frame_dir` resolves through `contain.child`, which refuses a traversal
+        outright — so this writer has an id it cannot have a directory for, and the answer
+        to that is a no-op. `record_density`'s guard, kept for the same reason: this runs
+        from a keypress, where raising costs the frame its re-layout."""
+        state.record_bar_rows("../evil", 3)
+        state.record_bar_rows("", 3)
+        self.assertIsNone(state.bar_rows("../evil"))
+        self.assertIsNone(state.bar_rows(""))
+
     def test_an_unreadable_or_unparseable_file_is_the_default_and_not_a_raise(self):
         """This is read on a sizing path that runs inside the `frame-resize` child, so a
         half-written file must degrade rather than take the recompute down. The RANGE is

--- a/tests/test_a_key_cycles_the_tab_strips_height.py
+++ b/tests/test_a_key_cycles_the_tab_strips_height.py
@@ -1,0 +1,426 @@
+"""A tab strip launches one row deep and one key cycles it 1 → 2 → 3 (#880).
+
+**The default changed and the way out of it is a keypress.** `slots.bar_rows_wanted`
+composes at 1, 2 … `layout.BAR_MAX_ROWS` and keeps the tallest height it FILLS, and
+`layout._grown` hands those rows out of the harness's spare budget — so a plane with many
+names came up two rows deep whether or not its operator wanted the harness two rows
+shorter. The measured objection to one row no longer stands on its own: `+N` is clickable
+and opens the palette, which lists every name, so a collapsed strip is one press from the
+complete list rather than a dead end.
+
+**What the key changes is a CEILING**, which is the property that keeps the whole feature
+honest. `bar_rows_wanted` still answers with the rows a strip actually fills, so a press on
+a plane whose names already fit changes nothing on screen — and a press on one that
+overflows buys exactly the rows there are names for. `TheKeyRaisesACeilingAndNotAHeight`
+is that half.
+
+**The chosen height does not survive a restart.** It is a file in the frame's own state
+directory, which `state.reap` deletes whole when the frame ends and `state.clear_shape`
+deletes when a new frame claims a recycled id — the same place `density` and `hidden`
+live, so there is no new kind of state and nothing for `doctor` to explain. A plane that
+always wants three rows says so once in `[[frame.component]] size` (#687), which
+`layout._grown` still honours.
+
+**Three alternatives were weighed and this is the one that survived.** A tmux drag-resize
+is the gesture an operator would reach for and is recomputed away on the next layout pass,
+because the layout owns bar heights (both bars are `Fixed(1)`). `charter.toml` alone
+already works and is an edit-and-restart rather than a gesture. A key costs one more
+server-wide `bind -n`, and `TheKeyIsCharactersOwnAndNotAComponentsToTake` is where that
+cost is held down.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import unittest
+from types import SimpleNamespace
+from unittest import mock
+
+from charter import commands_frame, config, instance
+from charter.frame import layout, overlay, slots, state, tmuxctl
+
+from tests import _tmuxchain
+from tests._isolation import PersonaIso
+
+#: The fifteen workspaces this repository's own plane has — `test_a_tab_strip_grows_a_row
+#: _when_its_tabs_overflow`'s list, repeated rather than imported for the reason that
+#: module's own `_a_dead_pid` copy states.
+NAMES = sorted([
+    "authority-audit", "autonomy", "charter-update-skill", "default", "fleet",
+    "harness-wrapper", "news-dispatch-guard", "opencode-integration", "plane-shape",
+    "relations-and-delegations", "showcase", "statusline-improvements", "todos",
+    "tracking-github-issues", "user-reporting",
+])
+
+SLOTS = ["top", "chats", "workspaces", "bottom", "repos", "right"]
+
+
+def _a_dead_pid() -> int:
+    """A real pid that has exited and been reaped."""
+    p = subprocess.Popen([sys.executable, "-c", "pass"])
+    p.wait()
+    return p.pid
+
+
+def _placed(**sizes):
+    """The resolved arrangement that places both bars, built the way an operator's
+    `charter.toml` reaches `config.FRAME` — a bar has to be PLACED for `layout` to have
+    any geometry for it at all (#687).
+
+    *sizes* pins a component to a committed height, which is the one route a bar's own
+    `[[frame.component]] size` has and the thing #880 leaves alone."""
+    tables = []
+    for use in ("identity", "chats", "workspaces", "attention", "repos", "sidebar"):
+        table = {"use": use}
+        if use in sizes:
+            table.update(edge="top", size=sizes[use])
+        tables.append(table)
+    return instance.frame_of({"frame": {"component": tables}})
+
+
+class _Tmux:
+    """A recording stand-in for `tmuxctl.run` — `tests/test_component_toggle_keys.py`'s
+    fake, repeated for the reason that module's own copy states. It answers the two
+    queries a re-layout reads a value out of and reports success for everything else."""
+
+    def __init__(self, *, size="200:50", new_panes=("%7", "%8", "%9")):
+        self.size = size
+        self.new_panes = list(new_panes)
+        self.calls: list[list[str]] = []
+
+    def __call__(self, action, argv, *, env=None, timeout=None, report=True):
+        return _tmuxchain.answer_run(self._one, action, argv, env=env, timeout=timeout,
+                                     report=report)
+
+    def _one(self, action, argv, *, env=None, timeout=None, report=True):
+        self.calls.append(list(argv))
+        out = ""
+        if "display-message" in argv:
+            out = self.size
+        elif "split-window" in argv:
+            out = self.new_panes.pop(0) if self.new_panes else "%9"
+        return SimpleNamespace(returncode=0, stdout=out, stderr="")
+
+    def resized(self, pane):
+        """Every `-y` a `resize-pane` asserted for *pane*, in the order it asserted it."""
+        return [c[c.index("-y") + 1] for c in self.calls
+                if "resize-pane" in c and "-y" in c and c[c.index("-t") + 1] == pane]
+
+
+class TheCycleIsOneToTwoToThreeAndBack(unittest.TestCase):
+    """`layout.next_bar_rows` and `layout.bar_rows_cap` — the arithmetic, with no plane
+    and no tmux under it, for `test_frame_bars`' reason: it has to be right at every value
+    and a case that needed a frame would be measuring the fixture."""
+
+    def test_a_frame_that_has_chosen_nothing_is_at_the_default(self):
+        self.assertEqual(layout.BAR_ROWS_DEFAULT, 1)
+        self.assertEqual(layout.bar_rows_cap(None), 1)
+
+    def test_the_cycle_wraps_at_the_ceiling(self):
+        """Every press has to do something — `builtin_actions._register_strip`'s rule for
+        the tab walk one surface over. A key that silently did nothing at the top is one an
+        operator presses twice and then stops trusting."""
+        self.assertEqual([layout.next_bar_rows(n) for n in (None, 1, 2, 3)],
+                         [2, 2, 3, 1])
+
+    def test_the_ceiling_the_cycle_reaches_is_the_shipped_one(self):
+        """Two constants and not three: the cycle's top IS `BAR_MAX_ROWS`, which is where
+        the measurement behind it lives."""
+        self.assertEqual(layout.BAR_MAX_ROWS, 3)
+        self.assertEqual(max(layout.next_bar_rows(n) for n in range(0, 9)),
+                         layout.BAR_MAX_ROWS)
+
+    def test_a_value_outside_the_range_degrades_to_the_default(self):
+        """`instance.density_level`'s discipline. The number is read back off a file, so
+        `0`, `7` and a truncated write are "this frame has not chosen" and not "this frame
+        chose something charter will round for it". Clamping a `7` to `3` would leave a
+        frame silently at the ceiling because a byte went missing."""
+        for bad in (0, -1, 4, 7, 10_000):
+            with self.subTest(bad=bad):
+                self.assertEqual(layout.bar_rows_cap(bad), layout.BAR_ROWS_DEFAULT)
+                self.assertEqual(layout.next_bar_rows(bad),
+                                 layout.BAR_ROWS_DEFAULT + 1)
+
+    def test_the_reader_and_the_cycle_share_one_clamp(self):
+        """Two clamps are two chances to disagree about whether `3` wraps. Asked as the
+        property: whatever the cycle answers is a value the reader accepts unchanged."""
+        for n in (None, *range(-2, 9)):
+            with self.subTest(n=n):
+                self.assertEqual(layout.bar_rows_cap(layout.next_bar_rows(n)),
+                                 layout.next_bar_rows(n))
+
+
+class TheHeightIsRememberedForThisFrameAndNoLonger(PersonaIso, unittest.TestCase):
+    """`state.record_bar_rows` / `state.bar_rows` — where the choice lives and what
+    happens to it."""
+
+    FID = "api.1"
+
+    def test_a_frame_nobody_has_pressed_it_in_has_no_file_and_no_answer(self):
+        """``None`` is the ordinary case and not a failure: every frame comes up at the
+        default because there is nothing on disk to say otherwise. That IS "the height
+        does not survive a restart", with no new kind of state behind it."""
+        self.assertIsNone(state.bar_rows(self.FID))
+
+    def test_what_was_written_is_what_is_read_back(self):
+        for n in (1, 2, 3):
+            state.record_bar_rows(self.FID, n)
+            self.assertEqual(state.bar_rows(self.FID), n)
+
+    def test_a_new_frame_claiming_a_recycled_id_does_not_inherit_it(self):
+        """`state.clear_shape`'s list. A brand-new frame inheriting three rows would come
+        up with a three-row-shorter harness taken from somebody else's session, with
+        nothing on screen to say why — and it would break the sentence #880 is written to
+        keep."""
+        state.record_bar_rows(self.FID, 3)
+        state.clear_shape(self.FID)
+        self.assertIsNone(state.bar_rows(self.FID))
+
+    def test_an_unreadable_or_unparseable_file_is_the_default_and_not_a_raise(self):
+        """This is read on a sizing path that runs inside the `frame-resize` child, so a
+        half-written file must degrade rather than take the recompute down. The RANGE is
+        not checked here — `layout.bar_rows_cap` is the one gate, at the point of use."""
+        d = state.frame_dir(self.FID, create=True)
+        (d / "bar_rows").write_text("not a number\n")
+        self.assertIsNone(state.bar_rows(self.FID))
+        (d / "bar_rows").write_text("7\n")
+        self.assertEqual(state.bar_rows(self.FID), 7)
+        self.assertEqual(layout.bar_rows_cap(state.bar_rows(self.FID)),
+                         layout.BAR_ROWS_DEFAULT)
+
+    def test_it_is_written_in_the_frames_own_state_directory(self):
+        """`cmd_toggle`'s argument, one file over: `[[frame.component]] size` says what a
+        strip STARTS at and this says what one running frame IS — so it goes where the
+        machine-written per-frame files go, beside `density` and `hidden`, and `reap`
+        deletes it with them.
+
+        Asserted as WHERE rather than as "charter.toml is unchanged", which is the claim
+        that has teeth: `tests/_planeguard.py` already refuses a write to the operator's
+        own file, so a case about that one would pass whatever this function did."""
+        state.record_bar_rows(self.FID, 2)
+        d = state.frame_dir(self.FID)
+        self.assertTrue((d / "bar_rows").is_file())
+        self.assertEqual((d / "bar_rows").read_text(), "2\n")
+        self.assertFalse((d / "bar_rows.tmp").exists(),
+                         "the atomic write left its temp file behind")
+
+
+class TheKeyRaisesACeilingAndNotAHeight(PersonaIso, unittest.TestCase):
+    """The boundary, end to end with a real plane and no tmux —
+    `commands_frame._slot_sizes` is where a frame's own state becomes a pane height."""
+
+    def setUp(self):
+        super().setUp()
+        for name in NAMES:
+            (config.WORKSPACES_DIR / name).mkdir(parents=True, exist_ok=True)
+        self.enterContext(mock.patch.dict(config.FRAME, _placed()))
+
+    def _rows(self, fid, cols):
+        return commands_frame._slot_sizes(fid, SLOTS, window_rows=50, pane_cols=cols,
+                                          order=SLOTS, window_cols=cols)["workspaces"]
+
+    def test_every_width_launches_one_row_deep(self):
+        """The headline. These fifteen names need three rows at 120 columns and two at 160,
+        and a launch gives them one."""
+        for cols in (80, 100, 120, 160, 200, 360):
+            with self.subTest(cols=cols):
+                self.assertEqual(self._rows("f-1", cols), 1)
+
+    def test_a_press_buys_the_rows_the_names_actually_need(self):
+        state.record_bar_rows("f-1", 2)
+        self.assertEqual(self._rows("f-1", 120), 2)
+        state.record_bar_rows("f-1", 3)
+        self.assertEqual(self._rows("f-1", 120), 3)
+
+    def test_a_press_on_a_plane_whose_names_fit_changes_nothing(self):
+        """**A cap and not a demand**, which is the honest outcome rather than a
+        limitation: there is nothing to put on a second row, and drawing a blank one would
+        be rows off the harness for a picture."""
+        state.record_bar_rows("f-1", 3)
+        self.assertEqual(self._rows("f-1", 400), 1)
+
+    def test_a_plane_that_pinned_a_height_still_gets_it_at_launch(self):
+        """**#687 stays honoured, and it is the other half of "one row on launch".** A pin
+        is a committed decision about how a frame STARTS; the ceiling this issue lowered is
+        a default for a plane that committed nothing. `layout._grown` only ever grows, so a
+        want of one against a pin of three leaves the three alone — and an operator who
+        always wants three rows says so once, in the file where every other layout decision
+        already lives.
+        """
+        with mock.patch.dict(config.FRAME, _placed(workspaces=3)):
+            got = commands_frame._slot_sizes("f-1", SLOTS, window_rows=50, pane_cols=120,
+                                             order=SLOTS, window_cols=120)
+        self.assertEqual(got["workspaces"], 3, got)
+
+    def test_the_height_is_this_frames_and_not_the_planes(self):
+        """Two chats of one workspace are two frames on one plane, and the file is per
+        frame — so a press in one does not shorten the other's harness."""
+        state.record_bar_rows("f-1", 3)
+        self.assertEqual(self._rows("f-1", 120), 3)
+        self.assertEqual(self._rows("f-2", 120), 1)
+
+
+class TheKeyRunsTheCommandLive(PersonaIso, unittest.TestCase):
+    """`commands_frame.cmd_bar_rows` — what the press actually does to a running frame."""
+
+    def setUp(self):
+        super().setUp()
+        self.fid = f"br-{_a_dead_pid()}"
+        self.enterContext(mock.patch.dict(os.environ,
+                                          {"CHARTER_SESSION_ID": self.fid}))
+        self.enterContext(mock.patch("charter.frame.tmuxctl.version",
+                                     return_value=(3, 7)))
+        self.enterContext(mock.patch.dict(config.FRAME, _placed()))
+        for name in NAMES:
+            (config.WORKSPACES_DIR / name).mkdir(parents=True, exist_ok=True)
+        state.record_harness_pane(self.fid, "%0")
+        state.record_panes(self.fid, panels={"top": "%1", "chats": "%3",
+                                             "workspaces": "%6", "bottom": "%2",
+                                             "repos": "%5", "right": "%4"})
+
+    def _press(self):
+        fake = _Tmux()
+        with mock.patch("charter.frame.tmuxctl.run", side_effect=fake):
+            rc = commands_frame.cmd_bar_rows(SimpleNamespace(chat=""))
+        return rc, fake
+
+    def test_a_press_cycles_the_recorded_height(self):
+        self.assertIsNone(state.bar_rows(self.fid))
+        for want in (2, 3, 1, 2):
+            rc, _fake = self._press()
+            self.assertEqual(rc, 0)
+            self.assertEqual(state.bar_rows(self.fid), want)
+
+    def test_a_press_re_asserts_the_strips_pane_at_its_new_height(self):
+        """The number has to reach tmux, or it is the inert value the whole seam is written
+        against. `_apply_arrangement` → `_relayout` → `_reassert_sizes` is the one live
+        re-layout path, the same one a toggle and a density change go through."""
+        _rc, fake = self._press()
+        self.assertEqual(fake.resized("%6")[-1], "2", fake.calls)
+
+    def test_a_press_kills_no_pane_and_splits_nothing(self):
+        """Nothing is added or removed — the arrangement this frame is drawing is handed
+        back unchanged, and what moves is the size."""
+        _rc, fake = self._press()
+        self.assertEqual([c for c in fake.calls if "kill-pane" in c], [])
+        self.assertEqual([c for c in fake.calls if "split-window" in c], [])
+
+    def test_a_press_bumps_the_version_so_the_panels_repaint(self):
+        before = state.version(self.fid)
+        self._press()
+        self.assertGreater(state.version(self.fid), before)
+
+    def test_a_frame_with_no_recorded_harness_pane_is_a_quiet_no_op(self):
+        """`_relayout_target`'s refusal, shared with `cmd_toggle` and `cmd_density` so the
+        three keypresses cannot come to disagree about what a frame must have before its
+        panes may be moved."""
+        state.record_harness_pane(self.fid, "not-a-pane-id")
+        rc, fake = self._press()
+        self.assertEqual(rc, 0)
+        self.assertEqual(fake.calls, [])
+
+    def test_outside_a_frame_it_says_so_rather_than_dying_in_a_target(self):
+        """`cmd_toggle`'s `if not fid`, and it carries the same consequence: with an empty
+        id this command would fall through to `_relayout_target`, where "you are not in a
+        frame" and "this frame has no recorded harness pane" are one silence."""
+        out = []
+        with mock.patch.dict(os.environ, {"CHARTER_SESSION_ID": ""}), \
+                mock.patch.object(commands_frame, "outside_a_frame",
+                                  side_effect=lambda cmd: out.append(cmd) or 1):
+            rc = commands_frame.cmd_bar_rows(SimpleNamespace(chat=""))
+        self.assertEqual(rc, 1)
+        self.assertEqual(out, ["charter frame-bar-rows"])
+
+
+class TheKeyIsCharactersOwnAndNotAComponentsToTake(unittest.TestCase):
+    """The cost of a third shipped `bind -n`, held down where the other two are."""
+
+    def test_the_bind_reaches_the_config_charter_sources(self):
+        text = commands_frame.conf_text(hotkey="F2", mouse=True, history_limit=5,
+                                        session="s", toggles={})
+        line, = [ln for ln in text.splitlines() if "frame-bar-rows" in ln]
+        self.assertTrue(line.startswith(f"bind -n {layout.BAR_ROWS_KEY} run-shell "),
+                        line)
+
+    def test_the_bind_carries_the_pressers_chat_and_no_client_name(self):
+        """One bind text is shared by every frame on `SOCKET`, so which chat pressed comes
+        out of the presser's own window (`#{@charter_chat}`) — `frame-toggle`'s twin."""
+        text = commands_frame.conf_text(hotkey="F2", mouse=True, history_limit=5,
+                                        session="s", toggles={})
+        line, = [ln for ln in text.splitlines() if "frame-bar-rows" in ln]
+        self.assertIn('--chat "#{@charter_chat}"', line)
+        self.assertNotIn("-t ", line)
+
+    def test_the_interpreter_is_carried_out_of_band(self):
+        """An absolute path re-embedded inside this nested tmux-quote layer is one
+        apostrophe away from the silent corruption `commands_frame`'s module docstring
+        measures."""
+        text = commands_frame.conf_text(hotkey="F2", mouse=True, history_limit=5,
+                                        session="s", toggles={})
+        line, = [ln for ln in text.splitlines() if "frame-bar-rows" in ln]
+        self.assertIn('"$CHARTER_PY" -m charter frame-bar-rows', line)
+        self.assertNotIn(sys.executable, line)
+
+    def test_it_is_bound_above_the_toggles_and_below_the_hatch(self):
+        """**Both ends are load-bearing.** Above the toggles, because tmux has no notion of
+        a key conflict — a later `bind -n` replaces an earlier one — so a component
+        emitting after charter would silently take the key the refusal below exists to
+        protect. Below the hatch, because `overlay.hatch_bind` uses `run-shell -C`, which a
+        tmux under `tmuxctl.FLOOR` cannot parse, and everything charter needs must already
+        have been applied by the time `source-file` reaches it."""
+        text = commands_frame.conf_text(hotkey="F2", mouse=True, history_limit=5,
+                                        session="s", toggles={"repos": "F7"})
+        lines = text.splitlines()
+        mine = next(i for i, ln in enumerate(lines) if "frame-bar-rows" in ln)
+        toggle = next(i for i, ln in enumerate(lines) if "frame-toggle repos" in ln)
+        hatch = next(i for i, ln in enumerate(lines) if overlay.HATCH_KEY in ln)
+        self.assertLess(mine, toggle)
+        self.assertLess(mine, hatch)
+
+    def test_a_component_may_not_take_the_key(self):
+        """`instance.component_arrangement`'s `bound` set, which already holds the palette
+        key and the escape hatch. A component that took this one would leave the operator a
+        key that cycles nothing and a strip stuck at one row."""
+        frame = instance.frame_of({"frame": {"component": [
+            {"use": "repos", "key": layout.BAR_ROWS_KEY}]}})
+        self.assertEqual(frame["components"], [])
+        self.assertEqual(frame["slots"], instance.FRAME_DEFAULTS["slots"])
+        # The control: the same table with a free key is placed, so what the line above
+        # measures is the collision and not a component charter refused for another reason.
+        ok = instance.frame_of({"frame": {"component": [
+            {"use": "repos", "key": "F9"}]}})
+        self.assertEqual([c["key"] for c in ok["components"]], ["F9"])
+
+    def test_it_is_a_key_that_costs_the_harness_nothing_it_was_using(self):
+        """The stated cost of a root-table bind, kept honest: charter claims exactly three
+        keys and this is the third, beside the palette's and the escape hatch's. A test
+        that only counted would pass on any number; this names them, so a fourth has to be
+        argued for here."""
+        text = commands_frame.conf_text(hotkey="F2", mouse=True, history_limit=5,
+                                        session="s", toggles={})
+        keys = {ln.split()[2] for ln in text.splitlines() if ln.startswith("bind -n ")}
+        self.assertEqual(keys - set(tmuxctl.MOUSE_KEYS),
+                         {"F2", overlay.HATCH_KEY, layout.BAR_ROWS_KEY})
+
+
+class TheStripStillMeasuresItsOwnNames(unittest.TestCase):
+    """`slots.bar_rows_wanted`'s contract is unchanged by #880, and that is deliberate:
+    the ceiling moved and the measurement did not."""
+
+    def test_the_cap_is_still_the_callers_and_still_bounds_the_answer(self):
+        strip = lambda fid: (list(NAMES), "harness-wrapper", "", None)  # noqa: E731
+        with mock.patch.dict(slots.BARS, {"probe": strip}):
+            answers = [slots.bar_rows_wanted("f-1", "probe", pane_cols=120, cap=c)
+                       for c in (1, 2, 3)]
+        self.assertEqual(answers, [1, 2, 3])
+
+    def test_a_cap_of_one_is_the_shape_the_launcher_now_asks_for(self):
+        """`layout.bar_rows_cap(None)` is 1, so this is what every launch composes — and
+        it is the answer the ladder gave at `rows=1` before #829 could grow it."""
+        self.assertEqual(layout.bar_rows_cap(state.bar_rows("no-such-frame")), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_a_key_cycles_the_tab_strips_height.py
+++ b/tests/test_a_key_cycles_the_tab_strips_height.py
@@ -188,6 +188,17 @@ class TheHeightIsRememberedForThisFrameAndNoLonger(PersonaIso, unittest.TestCase
         self.assertIsNone(state.bar_rows("../evil"))
         self.assertIsNone(state.bar_rows(""))
 
+    def test_a_write_that_fails_after_the_directory_exists_is_swallowed(self):
+        """The other half of `record_density`'s must-not-raise shape, and the half a
+        traversal-refusing id cannot reach: the directory is there and the WRITE fails — a
+        full filesystem, a permission that changed under the frame. This runs from a
+        keypress, where raising costs the frame its re-layout."""
+        state.frame_dir(self.FID, create=True)
+        with mock.patch.object(state.config, "write_for",
+                               side_effect=OSError("no space")):
+            state.record_bar_rows(self.FID, 3)
+        self.assertIsNone(state.bar_rows(self.FID))
+
     def test_an_unreadable_or_unparseable_file_is_the_default_and_not_a_raise(self):
         """This is read on a sizing path that runs inside the `frame-resize` child, so a
         half-written file must degrade rather than take the recompute down. The RANGE is
@@ -317,6 +328,22 @@ class TheKeyRunsTheCommandLive(PersonaIso, unittest.TestCase):
         self.assertEqual([c for c in fake.calls if "kill-pane" in c], [])
         self.assertEqual([c for c in fake.calls if "split-window" in c], [])
 
+    def test_a_press_never_brings_back_a_panel_a_toggle_key_hid(self):
+        """**The filter on `want`, and the harm it stops.** This hands
+        `_apply_arrangement` the arrangement the frame is ALREADY drawing, which means
+        subtracting the hidden set — `cmd_toggle`'s own read (`_hidden_now`). Without that
+        subtraction a press of a key about HEIGHT would split a pane for every component
+        the operator had dismissed, which is `cmd_toggle`'s work undone by a key that is
+        not about visibility at all."""
+        state.record_hidden(self.fid, ["repos"])
+        state.record_panes(self.fid, panels={"top": "%1", "chats": "%3",
+                                             "workspaces": "%6", "bottom": "%2",
+                                             "right": "%4"})
+        _rc, fake = self._press()
+        self.assertEqual([c for c in fake.calls if "split-window" in c], [],
+                         "a height key re-split a panel the operator had hidden")
+        self.assertNotIn("repos", state.panes(self.fid))
+
     def test_a_press_bumps_the_version_so_the_panels_repaint(self):
         before = state.version(self.fid)
         self._press()
@@ -346,6 +373,24 @@ class TheKeyRunsTheCommandLive(PersonaIso, unittest.TestCase):
 
 class TheKeyIsCharactersOwnAndNotAComponentsToTake(unittest.TestCase):
     """The cost of a third shipped `bind -n`, held down where the other two are."""
+
+    def test_the_key_is_F3_and_it_is_spelled(self):
+        """**Spelled, for `BAR_MAX_ROWS`' reason**: it is a choice with an argument behind
+        it rather than a derived value. `F3` sits beside the palette an operator already
+        knows, it is not a key Claude Code, codex or opencode binds, and it is in the
+        function-key band charter already claims. Every other case here reads the constant
+        on both sides, so a change to it would be silent without this line — and a change
+        to it takes a key off somebody's harness.
+
+        Asked with the two properties that make it usable as well as the value: it survives
+        the alphabet a committed key is held to (`instance._HOTKEY_RE`, through
+        `toggle_key`), and it is not one charter has already claimed elsewhere."""
+        self.assertEqual(layout.BAR_ROWS_KEY, "F3")
+        self.assertEqual(instance.toggle_key(layout.BAR_ROWS_KEY),
+                         layout.BAR_ROWS_KEY)
+        self.assertNotIn(layout.BAR_ROWS_KEY,
+                         {overlay.HATCH_KEY, *tmuxctl.MOUSE_KEYS,
+                          instance.FRAME_DEFAULTS["hotkey"]})
 
     def test_the_bind_reaches_the_config_charter_sources(self):
         text = commands_frame.conf_text(hotkey="F2", mouse=True, history_limit=5,

--- a/tests/test_a_real_click_on_a_real_tab_bar_switches.py
+++ b/tests/test_a_real_click_on_a_real_tab_bar_switches.py
@@ -478,10 +478,16 @@ class ARealClickOnTheWorkspaceBarReachesTheSwitch(_ARealFrameWithBars,
                          "the tab the frame is on started a switch")
         self.assertEqual(self._bar_row(self.bar), before)
 
-    def test_clicking_the_heading_moves_nothing(self):
-        """`  workspaces  ` is about no workspace. It is a field the operator can see and
-        click, so "nothing happens" has to be what happens rather than the nearest name
-        being picked for them."""
+    def test_clicking_the_strips_own_inset_moves_nothing(self):
+        """Column 0 is about no workspace. It is a cell the operator can see and click, so
+        "nothing happens" has to be what happens rather than the nearest name being picked
+        for them.
+
+        **This case used to be about the `  workspaces  ` heading and it is the same
+        press.** #880 deleted the heading; the cells this clicks are the ones that are
+        still there on that side of the row — `slots.INSET`, the frame's own left edge —
+        and the claim is unchanged: a cell the strip drew no tab into switches nothing.
+        Column 0 was always the column it pressed."""
         self._click(self.bar, col=0)
         time.sleep(2.0)
         self.assertEqual(state.frame_workspace(self.fid), self.HERE)
@@ -750,8 +756,8 @@ class ARealRightClickOnTheChatBarOpensARealMenu(_ARealChatBarOverTwoChats,
         self.assertIn(self.other_harness,
                       self._tmux("list-panes", "-a", "-F", "#{pane_id}").stdout.split())
 
-    def test_a_right_press_on_the_heading_opens_nothing(self):
-        """`  chats  ` is about no chat. A cell the strip drew no tab into is absent from
+    def test_a_right_press_on_the_strips_own_inset_opens_nothing(self):
+        """Column 0 is about no chat. A cell the strip drew no tab into is absent from
         `slots._Tabs`' map whatever asks about it, so this costs not even an interpreter
         start — which is what makes the empty pane list below a real assertion rather than
         a race this case happened to win.
@@ -778,11 +784,16 @@ class ARealRightClickOnTheChatBarOpensARealMenu(_ARealChatBarOverTwoChats,
         and whatever the server already had as the else-branch, so a right click on a pane
         charter did not create still gets tmux's own pane menu. The bar is a panel, so this
         press takes the forwarding branch without the `select-pane` — the report arrives,
-        `slots._Tabs.tab_at` answers nothing for a heading cell, and nothing at all
-        happens, which is what a miss should cost.
+        `slots._Tabs.tab_at` answers nothing for an inset cell, and nothing at all happens,
+        which is what a miss should cost.
+
+        **The cell it presses was the strip's `chats` heading until #880 deleted it**, and
+        the case is unchanged by that: what is left on the left of the row is
+        `slots.INSET`, which is a cell the operator can see and press and which no tab was
+        drawn into. The three assertions below are about the press missing, not about what
+        it missed.
         """
-        self._click(self.bar, col=self._column_of(self.bar, "chats"),
-                    button=self.BUTTON)
+        self._click(self.bar, col=0, button=self.BUTTON)
         time.sleep(2.0)
         self.assertEqual(self._menu_pane(), "")
         self.assertIn(self.harness, self._panes(self.WS))
@@ -949,15 +960,20 @@ class ARealClickOnAWINDOWEDWorkspaceBarReachesTheSwitch(_ARealFrameWithBars,
                    or "chat" in self._shown(opened[0])),
             f"the new pane is not the palette: {self._shown(opened[0])!r}")
 
-    def test_clicking_the_heading_still_opens_nothing(self):
+    def test_clicking_the_strips_own_inset_still_opens_nothing(self):
         """The control the case above cannot do without: a row that answers EVERY click is
-        as wrong as one that answers none. `workspaces` is a label — the frame naming what
-        the row is about — and the cells it occupies were measured, not made live."""
+        as wrong as one that answers none. Column 0 is the strip's own left inset — the
+        frame's edge, not a field — and the cells the counts occupy were measured, not the
+        whole row made live.
+
+        **It pressed the `workspaces` heading until #880 deleted it.** The heading was the
+        widest run of dead cells the row had; the inset is what is left of that run, and it
+        is the same claim about the same side of the same row."""
         before = self._panes()
-        self._click(self.bar, col=self._column_of(self.bar, "workspaces"))
+        self._click(self.bar, col=0)
         time.sleep(2.0)
         self.assertEqual(self._panes(), before,
-                         "a click on the heading opened something")
+                         "a click on the strip's inset opened something")
         self.assertEqual(self._active(), self.harness)
 
 

--- a/tests/test_a_real_click_on_a_real_tab_bar_switches.py
+++ b/tests/test_a_real_click_on_a_real_tab_bar_switches.py
@@ -834,7 +834,11 @@ class ARealClickOnAWINDOWEDWorkspaceBarReachesTheSwitch(_ARealFrameWithBars,
     #: are asserted to be on the drawn row in `setUp` rather than assumed, so a change to
     #: the cut fails loudly here instead of silently clicking empty cells.
     HERE = "harness-wrapper"
-    THERE = "authority-audit"
+    #: `news-dispatch-guard` and not `authority-audit`: since #880 every workspace tab
+    #: reserves `slots.TAB_COUNT_W` for its chat count, so at :data:`COLS` the page the
+    #: mark falls on starts at `harness-wrapper` rather than at the head of the list. The
+    #: assertion in `setUp` is what caught it, which is why it is an assertion.
+    THERE = "news-dispatch-guard"
 
     def setUp(self) -> None:
         super().setUp()

--- a/tests/test_a_real_resize_gives_a_real_strip_another_row.py
+++ b/tests/test_a_real_resize_gives_a_real_strip_another_row.py
@@ -159,8 +159,8 @@ class AResizeGivesTheStripTheRowsItsNamesNeed(_TmuxServerFixture, PersonaIso):
         `slots.chats_bar`'s sibling. A renderer handed the width alone would leave the row
         the resize just bought blank, and nothing above would notice.
 
-        Asserted on what the pane SHOWS, captured from tmux: the `+7` that stood for the
-        seven workspaces one row could not draw is gone, and the seven names are there.
+        Asserted on what the pane SHOWS, captured from tmux: the `+6` that stood for the
+        six workspaces one row could not draw is gone, and the six names are there.
         """
         plane = make_plane(self)
         for name in NAMES:
@@ -198,10 +198,10 @@ class AResizeGivesTheStripTheRowsItsNamesNeed(_TmuxServerFixture, PersonaIso):
         self.assertTrue(_await(lambda: "harness-wrapper" in shown()),
                         f"the panel never drew its strip: {shown()!r}")
         one = shown()
-        self.assertIn("+7", one, f"160 columns drew every name on one row: {one!r}")
+        self.assertIn("+6", one, f"160 columns drew every name on one row: {one!r}")
 
         self.assertEqual(_tmux("resize-pane", "-t", pane, "-y", "2").returncode, 0)
-        self.assertTrue(_await(lambda: "+7" not in shown()),
+        self.assertTrue(_await(lambda: "+6" not in shown()),
                         f"the panel kept one row's worth of names in a two-row pane: "
                         f"{shown()!r}")
         two = shown()

--- a/tests/test_a_real_resize_gives_a_real_strip_another_row.py
+++ b/tests/test_a_real_resize_gives_a_real_strip_another_row.py
@@ -57,8 +57,9 @@ def _await(predicate, timeout: float = _DEADLINE) -> bool:
     return predicate()
 
 #: The fifteen workspaces this repository's own plane has — the list #725 measured the
-#: windowed rung against. At 120 columns they need three rows and at 300 they need one,
-#: which is exactly the band a resize crosses.
+#: windowed rung against. At 120 columns they need three rows and at 360 they need one,
+#: which is exactly the band a resize crosses. (300 was the top of that band until #880
+#: gave every workspace tab a `slots.TAB_COUNT_W` reserve for its chat count.)
 NAMES = sorted([
     "authority-audit", "autonomy", "charter-update-skill", "default", "fleet",
     "harness-wrapper", "news-dispatch-guard", "opencode-integration", "plane-shape",
@@ -109,6 +110,13 @@ class AResizeGivesTheStripTheRowsItsNamesNeed(_TmuxServerFixture, PersonaIso):
         self.assertEqual(_tmux("resize-window", "-t", session,
                                "-x", str(cols), "-y", str(rows)).returncode, 0)
         fid = state.frame_id(session, os.getpid())
+        # **The ceiling is raised first, and since #880 that is what makes any of this
+        # measurable.** A launch is one row deep whatever the names need, so a case about
+        # the recompute giving a strip its rows has to have pressed `layout.BAR_ROWS_KEY`
+        # — this is `commands_frame.cmd_bar_rows`' write, made directly because what is
+        # under test here is the RESIZE and not the keypress
+        # (`tests/test_a_key_cycles_the_tab_strips_height.py` is that one).
+        state.record_bar_rows(fid, layout.BAR_MAX_ROWS)
         with mock.patch.dict(config.FRAME, self.placed), \
                 mock.patch("charter.frame.slots.repos_rows_wanted", return_value=6):
             commands_frame._reassert_sizes(SOCKET, fid=fid, panes=panes,
@@ -138,13 +146,13 @@ class AResizeGivesTheStripTheRowsItsNamesNeed(_TmuxServerFixture, PersonaIso):
 
     def test_widening_the_window_takes_the_rows_back(self):
         """The gesture in both directions, which is the half a launch-time-only answer
-        cannot have. 300 columns draws all fifteen names on one row, so the strip that
+        cannot have. 360 columns draws all fifteen names on one row, so the strip that
         grew to three gives two of them back to the harness rather than keeping a height
         it no longer needs."""
         harness, panes = self._window("shrink-strip", 120, 40)
         self._reassert("shrink-strip", harness, panes, 120, 40)
         self.assertEqual(self._height(panes["workspaces"]), 3)
-        self._reassert("shrink-strip", harness, panes, 300, 40)
+        self._reassert("shrink-strip", harness, panes, 360, 40)
         self.assertEqual(self._height(panes["workspaces"]), 1)
         self.assertEqual(self._height(harness), 27)
 
@@ -159,8 +167,14 @@ class AResizeGivesTheStripTheRowsItsNamesNeed(_TmuxServerFixture, PersonaIso):
         `slots.chats_bar`'s sibling. A renderer handed the width alone would leave the row
         the resize just bought blank, and nothing above would notice.
 
-        Asserted on what the pane SHOWS, captured from tmux: the `+6` that stood for the
-        six workspaces one row could not draw is gone, and the six names are there.
+        Asserted on what the pane SHOWS, captured from tmux: the `+8` that stood for the
+        eight workspaces one row could not draw is gone, and the eight names are there.
+
+        **Three rows and not two**, since #880: every workspace tab reserves
+        `slots.TAB_COUNT_W` for its chat count, so 160 columns holds seven names a row and
+        the fifteen need three. The property is the one it always was — the panel draws
+        into every row its pane was given — and the number it takes is measured rather than
+        assumed.
         """
         plane = make_plane(self)
         for name in NAMES:
@@ -198,16 +212,16 @@ class AResizeGivesTheStripTheRowsItsNamesNeed(_TmuxServerFixture, PersonaIso):
         self.assertTrue(_await(lambda: "harness-wrapper" in shown()),
                         f"the panel never drew its strip: {shown()!r}")
         one = shown()
-        self.assertIn("+6", one, f"160 columns drew every name on one row: {one!r}")
+        self.assertIn("+8", one, f"160 columns drew every name on one row: {one!r}")
 
-        self.assertEqual(_tmux("resize-pane", "-t", pane, "-y", "2").returncode, 0)
-        self.assertTrue(_await(lambda: "+6" not in shown()),
-                        f"the panel kept one row's worth of names in a two-row pane: "
+        self.assertEqual(_tmux("resize-pane", "-t", pane, "-y", "3").returncode, 0)
+        self.assertTrue(_await(lambda: "+8" not in shown()),
+                        f"the panel kept one row's worth of names in a three-row pane: "
                         f"{shown()!r}")
-        two = shown()
+        grown = shown()
         for name in NAMES:
-            self.assertIn(name, two, f"{name} is on neither row: {two!r}")
-        self.assertEqual(len([ln for ln in two.splitlines() if ln.strip()]), 2, two)
+            self.assertIn(name, grown, f"{name} is on no row: {grown!r}")
+        self.assertEqual(len([ln for ln in grown.splitlines() if ln.strip()]), 3, grown)
 
     def test_a_short_window_keeps_its_harness_and_the_strip_stays_one_row(self):
         """The bound, against the server that would otherwise grant it. A 22-row window

--- a/tests/test_a_right_click_on_a_tab_acts_on_that_tab.py
+++ b/tests/test_a_right_click_on_a_tab_acts_on_that_tab.py
@@ -159,10 +159,15 @@ class ARightClickResolvesToTheTabItLandedOn(_ABarThatWasDrawn, unittest.TestCase
                 self.assertLessEqual(len(kinds), 1, f"({row}, {col}) answers {kinds}")
 
     def test_a_cell_no_tab_was_drawn_into_answers_nothing(self):
-        """The heading, and every column past the last name. `switch_to` already promises
-        this and `tab_at` reads the identical mapping, so the promise is structural: a
-        cell nothing drew into is absent from the map, whatever asks about it."""
-        for col in range(self._column_of("chats")):
+        """The inset the row starts at, and every column past the last name. `switch_to`
+        already promises this and `tab_at` reads the identical mapping, so the promise is
+        structural: a cell nothing drew into is absent from the map, whatever asks about
+        it.
+
+        The left-hand half of this was the strip's `chats` heading until #880 deleted it;
+        what is left on that side is `slots.INSET`, and it is the same claim about the same
+        cells."""
+        for col in range(slots.INSET):
             self.assertIsNone(slots.TABS.tab_at(0, col), f"column {col}")
         for col in range(tui.width(self.row) + 1, self.WIDTH):
             self.assertIsNone(slots.TABS.tab_at(0, col), f"column {col}")
@@ -243,7 +248,7 @@ class ARightClickOpensTheMenuAndNothingElse(_ABarThatWasDrawn, unittest.TestCase
         self.assertEqual(self.spawned, [], row)
 
     def test_a_right_press_on_a_cell_that_is_not_a_tab_does_nothing(self):
-        for col in (0, self._column_of("chats"), tui.width(self.row) + 5):
+        for col in (0, slots.INSET - 1, tui.width(self.row) + 5):
             self._handler("chats")(_click(0, col, name="right"))
         self.assertEqual(self.spawned, [])
 

--- a/tests/test_a_tab_strip_grows_a_row_when_its_tabs_overflow.py
+++ b/tests/test_a_tab_strip_grows_a_row_when_its_tabs_overflow.py
@@ -84,14 +84,20 @@ def _placed(*, style=None, **sizes):
     return instance.frame_of({"frame": {"component": tables}})
 
 
-def _strip(names=NAMES, here=HERE, note=""):
+def _strip(names=NAMES, here=HERE, note="", counts=None):
     """A `slots.BARS` entry that answers *names* without touching a plane.
 
     The seam the sizer reads through, used as one. `TheRealStripsGoThroughTheSameSeam`
     is what says charter's own two entries reach it, so this is a fixture for the
     arithmetic rather than a stand-in for the feature.
+
+    *counts* defaults to ``None`` — no count field — which is what makes the widths below
+    the ladder's own rather than the workspace strip's (#880). The reserve that strip spends
+    is `slots.TAB_COUNT_W` per tab and has its own cases; every number in this module is
+    about how many rows a list of names needs, and folding a fixed six cells per name into
+    them would measure the field as much as the ladder.
     """
-    return lambda fid: (list(names), here, note)
+    return lambda fid: (list(names), here, note, counts)
 
 
 class TheStripAsksForTheRowsItsNamesNeed(unittest.TestCase):
@@ -623,11 +629,14 @@ class TheLauncherSplitsThePaneTheStripAskedFor(PersonaIso, unittest.TestCase):
     def test_the_boundary_asks_the_strip_and_hands_the_answer_to_the_arithmetic(self):
         got = commands_frame._slot_sizes("f-1", SLOTS, window_rows=50, pane_cols=200,
                                          order=SLOTS, window_cols=160)
-        self.assertEqual(got["workspaces"], 2, got)
+        self.assertEqual(got["workspaces"], 3, got)
 
     def test_a_wide_window_leaves_the_strip_at_one_row(self):
-        got = commands_frame._slot_sizes("f-1", SLOTS, window_rows=50, pane_cols=300,
-                                         order=SLOTS, window_cols=300)
+        """360 columns and not 300: every workspace tab reserves `slots.TAB_COUNT_W` for
+        its chat count now (#880), so these fifteen names need 352 columns for one row
+        rather than 262."""
+        got = commands_frame._slot_sizes("f-1", SLOTS, window_rows=50, pane_cols=360,
+                                         order=SLOTS, window_cols=360)
         self.assertEqual(got["workspaces"], 1, got)
 
     def test_the_height_the_strip_asked_for_reaches_split_window(self):
@@ -639,7 +648,7 @@ class TheLauncherSplitsThePaneTheStripAskedFor(PersonaIso, unittest.TestCase):
         argvs = layout.panel_argvs(slots=SLOTS, session="s", socket="k",
                                    harness_pane="%1", sizes=sizes)
         bar, = [a for a in argvs if "workspaces" in a]
-        self.assertEqual(bar[bar.index("-l") + 1], "2")
+        self.assertEqual(bar[bar.index("-l") + 1], "3")
 
     def test_the_strips_own_pane_width_is_what_it_is_measured_at(self):
         """#500 one slot over. A strip split AFTER the sidebar is carved out of a pane the
@@ -649,10 +658,10 @@ class TheLauncherSplitsThePaneTheStripAskedFor(PersonaIso, unittest.TestCase):
         self.assertEqual(layout.pane_cols(inset, "workspaces", window_cols=160), 137)
         self.assertEqual(layout.pane_cols(SLOTS, "workspaces", window_cols=160), 160)
         wide = commands_frame._slot_sizes("f-1", SLOTS, window_rows=50, pane_cols=200,
-                                          order=SLOTS, window_cols=274)
+                                          order=SLOTS, window_cols=360)
         narrow = commands_frame._slot_sizes(
             "f-1", inset, window_rows=50, pane_cols=200, order=inset,
-            window_cols=274)
+            window_cols=360)
         self.assertEqual(wide["workspaces"], 1)
         self.assertEqual(narrow["workspaces"], 2,
                          "the strip was sized from the window rather than its pane")

--- a/tests/test_a_tab_strip_grows_a_row_when_its_tabs_overflow.py
+++ b/tests/test_a_tab_strip_grows_a_row_when_its_tabs_overflow.py
@@ -91,7 +91,7 @@ def _strip(names=NAMES, here=HERE, note=""):
     is what says charter's own two entries reach it, so this is a fixture for the
     arithmetic rather than a stand-in for the feature.
     """
-    return lambda fid: ("workspaces", list(names), here, note)
+    return lambda fid: (list(names), here, note)
 
 
 class TheStripAsksForTheRowsItsNamesNeed(unittest.TestCase):
@@ -108,10 +108,10 @@ class TheStripAsksForTheRowsItsNamesNeed(unittest.TestCase):
             return slots.bar_rows_wanted("f-1", slot, pane_cols=cols, cap=cap)
 
     def test_a_strip_whose_names_all_fit_on_one_row_asks_for_one(self):
-        """274 columns is where rung 1 draws all fifteen (`test_frame_bars` pins the
+        """262 columns is where rung 1 draws all fifteen (`test_frame_bars` pins the
         number), and a strip that is not overflowing must not take a row off the harness
         — which is the whole argument against the fixed two-row launch #829 rejected."""
-        self.assertEqual(self._want(274), 1)
+        self.assertEqual(self._want(262), 1)
         self.assertEqual(self._want(400), 1)
 
     def test_a_strip_that_overflows_asks_for_the_rows_its_pages_need(self):
@@ -136,7 +136,7 @@ class TheStripAsksForTheRowsItsNamesNeed(unittest.TestCase):
                     with self.subTest(here=here, cols=cols, cap=cap):
                         want = self._want(cols, cap=cap, here=here)
                         slots.TABS.forget()
-                        lines = slots._bar("workspaces", list(NAMES), here, cols,
+                        lines = slots._bar(list(NAMES), here, cols,
                                            rows=want)
                         if lines:
                             self.assertEqual(
@@ -153,7 +153,7 @@ class TheStripAsksForTheRowsItsNamesNeed(unittest.TestCase):
             if want >= 40:
                 continue
             slots.TABS.forget()
-            lines = slots._bar("workspaces", list(NAMES), HERE, cols, rows=want)
+            lines = slots._bar(list(NAMES), HERE, cols, rows=want)
             drawn = {slots.TABS.switch_to(r, c)
                      for r in range(want) for c in range(cols)} - {None}
             if lines and len(drawn) > 1:
@@ -168,26 +168,28 @@ class TheStripAsksForTheRowsItsNamesNeed(unittest.TestCase):
         the harness for a count — the exact trade `layout.visible_slots` refuses one rung
         down when it drops both bars whole.
 
-        30 columns is the `6/15` rung and 0 is the rung that draws nothing. Both were 3
+        20 columns is the `6/15` rung and 0 is the rung that draws nothing. Both were 3
         before the "did it fill what it was given" test went in beside the coverage one,
-        which is two rows of harness spent on a count.
+        which is two rows of harness spent on a count. (30 columns was the `6/15` rung
+        while the strip drew a heading; without one, 30 has room for a page — #880.)
         """
-        self.assertEqual(self._want(30), 1)
+        self.assertEqual(self._want(20), 1)
         self.assertEqual(self._want(0), 1)
-        self.assertEqual(self._want(30, cap=8), 1)
+        self.assertEqual(self._want(20, cap=8), 1)
 
     def test_the_ceiling_is_the_callers_and_it_bounds_the_answer(self):
         """Carried rather than read, `layout.repos_rows`' discipline for *pinned_rows*:
         applying `BAR_MAX_ROWS` here AND in `layout._grown` would be a bound no input
-        could make observable. 80 columns wants six rows and gets what it is allowed."""
-        self.assertEqual(self._want(80, cap=8), 6)
+        could make observable. 80 columns wants five rows and gets what it is allowed."""
+        self.assertEqual(self._want(80, cap=8), 5)
         self.assertEqual(self._want(80, cap=3), 3)
         self.assertEqual(self._want(80, cap=1), 1)
 
     def test_the_shipped_ceiling_is_three(self):
         """Spelled, because it is a number with a measurement behind it rather than a
         derived one: this plane's fifteen workspaces need 2 rows at 160 columns, 3 at 120,
-        4 at 100 and 6 at 80, and three is where a strip stops being a strip."""
+        3 at 100 and 5 at 80, and three is where a strip stops being a strip. (They were
+        2/3/4/6 while the strip still spent twelve columns on a heading — #880.)"""
         self.assertEqual(layout.BAR_MAX_ROWS, 3)
 
     def test_the_panes_own_pad_comes_off_the_width_before_the_names_are_measured(self):
@@ -196,15 +198,15 @@ class TheStripAsksForTheRowsItsNamesNeed(unittest.TestCase):
         `pane_cols - 2 * pad` and asking the unpadded question would size the pane from a
         number the renderer never sees.
 
-        The two-row band for these names starts at 150 columns, so a 152-column pane with a
+        The two-row band for these names starts at 138 columns, so a 140-column pane with a
         two-cell pad each side is a three-row strip and the same pane without one is a
         two-row strip. Asked through a real `[[frame.component]]` table, because a pad only
         exists where an operator committed one.
         """
         with mock.patch.dict(config.FRAME, _placed(style={"chats": {"pad": 2}})):
-            self.assertEqual(self._want(152, slot="chats"), 3)
+            self.assertEqual(self._want(140, slot="chats"), 3)
         with mock.patch.dict(config.FRAME, _placed()):
-            self.assertEqual(self._want(152, slot="chats"), 2)
+            self.assertEqual(self._want(140, slot="chats"), 2)
 
     def test_a_slot_that_draws_no_strip_is_answered_rather_than_raised_at(self):
         """`layout.slot_sizes`' filter-don't-refuse discipline: the slot list is committed,
@@ -219,11 +221,12 @@ class TheStripAsksForTheRowsItsNamesNeed(unittest.TestCase):
         wrote `slots.TABS` would leave a map describing a strip nobody is looking at, and
         in a test process it would describe one another case had just drawn."""
         slots.TABS.forget()
-        slots._bar("chats", ["api.1", "api.2"], "api.1", 200)
-        before = slots.TABS.switch_to(0, tui.width(slots._inset() + "chats  ") + 1)
+        slots._bar(["api.1", "api.2"], "api.1", 200)
+        at = tui.width(slots._inset()) + 1
+        before = slots.TABS.switch_to(0, at)
         self._want(120)
-        self.assertEqual(slots.TABS.switch_to(0, tui.width(slots._inset() + "chats  ") + 1),
-                         before, "the sizing question overwrote the paint's own map")
+        self.assertEqual(slots.TABS.switch_to(0, at), before,
+                         "the sizing question overwrote the paint's own map")
 
 
 class EveryRowOfAGrownStripIsClickable(unittest.TestCase):
@@ -240,11 +243,12 @@ class EveryRowOfAGrownStripIsClickable(unittest.TestCase):
         self.addCleanup(slots.TABS.forget)
 
     def _strip(self, width, rows, names=NAMES, here=HERE, note=""):
-        return slots._bar("workspaces", list(names), here, width, note=note, rows=rows)
+        return slots._bar(list(names), here, width, note=note, rows=rows)
 
     def test_a_second_row_draws_the_names_the_first_could_not(self):
-        """The operator's own sentence, measured: 160 columns reaches seven workspaces on
-        one row and every one of the fifteen on two."""
+        """The operator's own sentence, measured: 160 columns reaches eight workspaces on
+        one row and every one of the fifteen on two. (Seven, until #880 gave the heading's
+        twelve columns back to the names.)"""
         one = self._strip(160, 1)
         reachable_one = {slots.TABS.switch_to(0, c) for c in range(160)} - {None}
         two = self._strip(160, 2)
@@ -252,7 +256,7 @@ class EveryRowOfAGrownStripIsClickable(unittest.TestCase):
                          for r in range(2) for c in range(160)} - {None}
         self.assertEqual(len(one), 1)
         self.assertEqual(len(two), 2)
-        self.assertEqual(len(reachable_one), 7)
+        self.assertEqual(len(reachable_one), 8)
         self.assertEqual(reachable_two | {HERE}, set(NAMES))
 
     def test_every_drawn_tab_answers_at_its_own_row_and_at_no_other(self):
@@ -273,45 +277,54 @@ class EveryRowOfAGrownStripIsClickable(unittest.TestCase):
                     self.assertNotIn(name, [slots.TABS.switch_to(o, at) for o in others],
                                      "a column answers with a name from another row")
 
-    def test_the_blank_under_the_heading_is_not_a_tab(self):
-        """The heading names the strip once and the rows under it are indented to line up
-        with the first row's tabs. Those cells are charter's, no name was drawn in them,
-        and a click there switches nothing — `_Tabs`' rule for the heading itself, one
-        row down."""
+    def test_the_inset_every_row_starts_at_is_not_a_tab(self):
+        """Every row of the strip begins at the frame's own left edge, and those cells are
+        charter's: no name was drawn in them and a click there switches nothing.
+
+        **Asked on EVERY row, which is what it took over from the case it replaces.** Until
+        #880 this was the blank under the `workspaces` heading, and it could only ever be
+        asked about rows two and three because row one held the word itself. With no
+        heading there is one lead on every row and the same question to ask of all of
+        them."""
         rows = self._strip(120, 3)
-        lead = tui.width(slots._inset() + "workspaces" + "  ")
-        for r in range(1, len(rows)):
+        lead = tui.width(slots._inset())
+        for r in range(len(rows)):
             for c in range(lead):
                 with self.subTest(row=r, col=c):
                     self.assertIsNone(slots.TABS.switch_to(r, c))
                     self.assertFalse(slots.TABS.more_at(r, c))
                     self.assertFalse(slots.TABS.add_at(r, c))
 
-    def test_the_heading_names_the_strip_once_and_not_once_per_row(self):
-        """The rows under the first are BLANK to the width of the heading, not the heading
-        again — `chats` repeated down the left of a three-row strip is the same word three
-        times where names are competing for columns.
+    def test_every_row_of_the_strip_starts_its_tabs_at_the_same_left_edge(self):
+        """**What is left of the heading case after #880, and it is the half that was ever
+        load-bearing.** This class used to assert that `workspaces` was drawn on row one
+        and blanked to the same width on the rows below it — a heading repeated down the
+        left of a three-row strip being the same word three times where names are competing
+        for columns. The heading is gone; the property the blank under it existed for is
+        not, and it is this one: every row begins its names in the SAME column, which is
+        what lets every page be cut against one `room` and is what a click's stability
+        rests on.
 
-        **Nothing else here can see this**, which is why it is its own case and why the
-        deletion sweep found it: `slots._compose` blanks those cells with
-        ``" " * tui.width(lead)``, so the heading and its blank are the same WIDTH by
-        construction and every column assertion in this class is unmoved by drawing one in
-        place of the other. Only the text tells them apart.
+        **Nothing else here can see it**, which is why it is still its own case. Every
+        column assertion in this class is taken from the row it is about, so a second row
+        that started three cells to the left would map its own tabs correctly and still be
+        cut for a room it does not have. Only comparing the rows to each other tells them
+        apart.
         """
         for cols, rows in ((120, 3), (160, 2), (100, 3)):
             drawn = [tui.strip_ansi(r) for r in self._strip(cols, rows)]
             with self.subTest(cols=cols, rows=rows):
                 self.assertGreater(len(drawn), 1, "this width drew no second row")
-                head = "workspaces"
-                self.assertIn(head, drawn[0])
-                self.assertEqual([r for r in drawn if head in r], [drawn[0]],
-                                 f"the heading is drawn on more than the first row: "
-                                 f"{drawn!r}")
-                lead = tui.width(slots._inset() + head + "  ")
-                for r, line in enumerate(drawn[1:], start=1):
-                    self.assertEqual(line[:lead], " " * lead,
-                                     f"row {r} does not start with the heading's blank: "
-                                     f"{line!r}")
+                lead = tui.width(slots._inset())
+                indents = {tui.width(line) - tui.width(line.lstrip()) for line in drawn}
+                # A row whose first field is a tab carries `_BAR_MARK`'s blank in front of
+                # the name, so its text begins one cell past the lead; a row whose first
+                # field is a leading `+N`, or whose first tab is the marked one, begins at
+                # the lead itself. Both are the same lead — what this refuses is a row
+                # composed against a different one.
+                self.assertLessEqual(
+                    indents, {lead, lead + tui.width(slots._BAR_MARK[1])},
+                    f"a row was composed against a different lead: {drawn!r}")
 
     def test_a_row_the_strip_did_not_draw_answers_nothing(self):
         """A pane taller than the names need draws fewer rows than it has, and the rows
@@ -398,12 +411,12 @@ class EveryRowOfAGrownStripIsClickable(unittest.TestCase):
         that reaches the END of the list but starts partway into it has no trailing count
         and a leading one, and that is the state where "is there a `+N` anywhere" and "is
         there a trailing field" stop being the same question. 120 columns cuts these
-        fifteen into three pages, so a mark on the third draws that page alone with `+11`
+        fifteen into three pages, so a mark on the last draws that page alone with `+13`
         in front of it and nothing after it.
         """
         rows = self._strip(120, 1, here=NAMES[13], note=slots.ADD_CHAT)
         drawn = tui.strip_ansi(rows[0])
-        self.assertIn("+11", drawn, f"this is not the run the case is about: {drawn!r}")
+        self.assertIn("+13", drawn, f"this is not the run the case is about: {drawn!r}")
         self.assertFalse(drawn.rstrip().endswith(slots.ADD_CHAT),
                          f"a `+` rode a run that starts mid-list: {drawn!r}")
         self.assertEqual({c for c in range(120) if slots.TABS.add_at(0, c)}, set(),

--- a/tests/test_a_tab_strip_grows_a_row_when_its_tabs_overflow.py
+++ b/tests/test_a_tab_strip_grows_a_row_when_its_tabs_overflow.py
@@ -37,7 +37,7 @@ import unittest
 from unittest import mock
 
 from charter import commands_frame, config, instance, tui
-from charter.frame import layout, slots, tmuxctl
+from charter.frame import layout, slots, state, tmuxctl
 from tests._isolation import PersonaIso
 from tests.test_frame_chat_switch import _plant
 
@@ -626,15 +626,39 @@ class TheLauncherSplitsThePaneTheStripAskedFor(PersonaIso, unittest.TestCase):
             (config.WORKSPACES_DIR / name).mkdir(parents=True, exist_ok=True)
         self.enterContext(mock.patch.dict(config.FRAME, _placed()))
 
+    def test_a_frame_nobody_has_pressed_the_key_in_launches_one_row_deep(self):
+        """**The default #880 changed, at the widths where the old one was visible.**
+        `bar_rows_wanted` still measures what these fifteen names need — three rows at 160
+        columns — and the boundary hands it a ceiling of `layout.BAR_ROWS_DEFAULT` instead,
+        so a plane with many names no longer launches two rows deep and two rows shorter in
+        the harness. What it launches with instead is `+N`, which is clickable and opens
+        the palette; a collapsed strip is one press from the complete list.
+        """
+        for cols in (100, 160, 200, 360):
+            with self.subTest(cols=cols):
+                got = commands_frame._slot_sizes("f-1", SLOTS, window_rows=50,
+                                                 pane_cols=cols, order=SLOTS,
+                                                 window_cols=cols)
+                self.assertEqual(got["workspaces"], 1, got)
+
     def test_the_boundary_asks_the_strip_and_hands_the_answer_to_the_arithmetic(self):
+        """With the ceiling raised, which since #880 is the only way to reach a strip
+        taller than one row: `state.bar_rows` is what `layout.bar_rows_cap` reads and the
+        boundary carries down."""
+        state.record_bar_rows("f-1", 3)
         got = commands_frame._slot_sizes("f-1", SLOTS, window_rows=50, pane_cols=200,
                                          order=SLOTS, window_cols=160)
         self.assertEqual(got["workspaces"], 3, got)
 
-    def test_a_wide_window_leaves_the_strip_at_one_row(self):
-        """360 columns and not 300: every workspace tab reserves `slots.TAB_COUNT_W` for
-        its chat count now (#880), so these fifteen names need 352 columns for one row
-        rather than 262."""
+    def test_a_raised_ceiling_is_not_a_height_and_a_wide_window_stays_at_one_row(self):
+        """**A cap and not a demand.** The key raises what a strip MAY grow to; what it
+        does grow to is still what its names need, so a pane wide enough for every name
+        stays one row however high the ceiling has been cycled.
+
+        360 columns and not 300: every workspace tab reserves `slots.TAB_COUNT_W` for its
+        chat count now (#880), so these fifteen names need 352 columns for one row rather
+        than 262."""
+        state.record_bar_rows("f-1", 3)
         got = commands_frame._slot_sizes("f-1", SLOTS, window_rows=50, pane_cols=360,
                                          order=SLOTS, window_cols=360)
         self.assertEqual(got["workspaces"], 1, got)
@@ -642,7 +666,11 @@ class TheLauncherSplitsThePaneTheStripAskedFor(PersonaIso, unittest.TestCase):
     def test_the_height_the_strip_asked_for_reaches_split_window(self):
         """The measurement #687 filed for the pinned height, asked for the measured one:
         a number that stopped at `slot_sizes` would be the inert value the whole seam is
-        written against."""
+        written against.
+
+        The ceiling is raised first, because since #880 a launch is one row deep and the
+        seam this is about would then be carrying a number no press had changed."""
+        state.record_bar_rows("f-1", 3)
         sizes = commands_frame._launch_sizes("f-1", SLOTS, window_cols=160,
                                              window_rows=50)
         argvs = layout.panel_argvs(slots=SLOTS, session="s", socket="k",
@@ -657,6 +685,7 @@ class TheLauncherSplitsThePaneTheStripAskedFor(PersonaIso, unittest.TestCase):
         inset = ["right", "top", "workspaces", "bottom", "repos"]
         self.assertEqual(layout.pane_cols(inset, "workspaces", window_cols=160), 137)
         self.assertEqual(layout.pane_cols(SLOTS, "workspaces", window_cols=160), 160)
+        state.record_bar_rows("f-1", 3)
         wide = commands_frame._slot_sizes("f-1", SLOTS, window_rows=50, pane_cols=200,
                                           order=SLOTS, window_cols=360)
         narrow = commands_frame._slot_sizes(

--- a/tests/test_a_workspace_tab_carries_its_chat_count.py
+++ b/tests/test_a_workspace_tab_carries_its_chat_count.py
@@ -153,6 +153,17 @@ class TheFieldIsReservedWhetherOrNotItIsDrawn(unittest.TestCase):
             self.assertEqual(slots.TABS.switch_to(0, col), "alpha",
                              f"column {col} of {row!r}")
 
+    def test_the_reserve_is_six_columns_a_tab_and_that_is_the_price(self):
+        """**Spelled, because it is what this feature costs and the cost is the argument
+        against it.** Six columns on every workspace tab is why these fifteen names need
+        352 columns for one row rather than 262, and every other case here reads
+        `TAB_COUNT_W` on both sides — so a wider ceiling would spend more of the row with
+        nothing going red. A change to `TAB_COUNT_MAX` has to come back to this line and
+        restate the price, which is `layout.BAR_MAX_ROWS`' own discipline one constant
+        over."""
+        self.assertEqual(slots.TAB_COUNT_W, 6)
+        self.assertEqual(slots.TAB_COUNT_MAX, 99)
+
     def test_the_reserve_is_derived_from_the_widest_thing_it_can_hold(self):
         """A `6` written down beside a ceiling of 99 is two numbers that can drift apart.
         Asked of the function rather than of the constant, at both ends and past them."""

--- a/tests/test_a_workspace_tab_carries_its_chat_count.py
+++ b/tests/test_a_workspace_tab_carries_its_chat_count.py
@@ -81,6 +81,15 @@ class TheCountIsDrawnBesideTheName(unittest.TestCase):
         row = self._row({"alpha": slots.TAB_COUNT_MAX + 1})
         self.assertIn(f"alpha ({slots.TAB_COUNT_MAX}+)", row)
 
+    def test_the_ceiling_itself_is_still_drawn_as_a_number(self):
+        """`n <= TAB_COUNT_MAX` and not `n <`: the ceiling is the last count drawn in full,
+        so `(99)` is a number and `(100)` is the overflow. One cell apart on screen and one
+        boundary apart in the code, which is exactly the shift `tools/sweep.py` asks about
+        and which the case above — asked at `MAX + 1` — cannot see."""
+        row = self._row({"alpha": slots.TAB_COUNT_MAX})
+        self.assertIn(f"alpha ({slots.TAB_COUNT_MAX})", row)
+        self.assertNotIn("+", row, "the ceiling itself was drawn as an overflow")
+
     def test_the_chats_strip_reserves_nothing_at_all(self):
         """``None`` and ``{}`` are different instructions: no field, against a field with
         nothing in it. A chat is the leaf and has nothing to count, so a strip of chats

--- a/tests/test_a_workspace_tab_carries_its_chat_count.py
+++ b/tests/test_a_workspace_tab_carries_its_chat_count.py
@@ -1,0 +1,248 @@
+"""`some-workspace (5)` — the chat count on a workspace tab, and the two constraints
+that decide its shape (#880).
+
+**Both constraints are measurements, and both are about a cell an operator is about to
+press.**
+
+*The field is fixed-width and always reserved.* Tab widths decide where `slots._cuts`
+falls, so a suffix that appeared when a chat opened and vanished when one closed would move
+every tab to its right — and the cell the operator was aiming at would hold another
+workspace's name a moment later. charter refused exactly this shape once already, for the
+tab spinner: *"It takes the mark's cell rather than adding one… A spinner drawn beside a
+name would re-cut the strip the moment a sibling started thinking."* The spinner had a cell
+to take; a count has none, so it buys one on every workspace tab and pays for it whether or
+not it has a number to put there. `TheFieldIsReservedWhetherOrNotItIsDrawn` is that,
+asserted as the property it protects rather than as the width it happens to be.
+
+*One grouped pass.* `chats.of_workspace` is an `os.scandir` plus two small reads per chat
+and is uncached by design; asked once per workspace it is roughly 15 x 30 x 2 = 900 reads
+for one repaint of one row. `chats.counts_by_workspace` is the same walk done once, and
+`OneScanAnswersForEveryWorkspace` counts the scans rather than trusting the docstring.
+
+**And it does not put the strip on a clock.** `slots.BAR_ANIMATED` is the chats strip and
+only the chats strip — that one draws a spinner, which changes with nothing but time. A
+count changes when a chat opens or closes, which is a thing that happens to the plane, so
+this rides the repaint the strip already had.
+"""
+
+from __future__ import annotations
+
+import os
+import unittest
+from unittest import mock
+
+from charter import config, tui
+from charter.frame import chats, slots, state
+
+from tests._isolation import PersonaIso
+from tests.test_frame_chat_switch import _plant
+
+#: Three workspaces, so a strip has a middle tab whose columns a leading tab's field can
+#: push — which is what the reserve exists to stop.
+NAMES = ["alpha", "beta", "gamma"]
+
+
+def _plain(rows):
+    """The strip's first row with no SGR, or ``""`` — `tui.strip_ansi`, which is what
+    `panel._write` runs for a plane under `NO_COLOR`."""
+    return tui.strip_ansi(rows[0]) if rows else ""
+
+
+class TheCountIsDrawnBesideTheName(unittest.TestCase):
+    """`slots._bar` with a counts map and no plane under it."""
+
+    def setUp(self):
+        slots.TABS.forget()
+        self.addCleanup(slots.TABS.forget)
+
+    def _row(self, counts, here="beta", width=120, names=None):
+        return _plain(slots._bar(list(names or NAMES), here, width, counts=counts))
+
+    def test_a_workspace_with_chats_says_how_many(self):
+        self.assertIn("alpha (5)", self._row({"alpha": 5}))
+
+    def test_a_workspace_with_none_draws_a_blank_and_never_a_zero(self):
+        """Zero renders blank, so every count on screen means something. A `(0)` beside
+        twelve of fifteen names is a column of noise saying only that the feature is on."""
+        row = self._row({"alpha": 5})
+        self.assertNotIn("(0)", row)
+        self.assertNotIn("beta (", row)
+
+    def test_a_name_the_map_does_not_carry_counts_zero(self):
+        """`chats.counts_by_workspace` answers about the chats on disk and the strip draws
+        the workspaces on disk, and those are not the same list — a workspace directory
+        with no chat in it is in the second and not the first. The strip reads the map with
+        a default rather than trusting its keys."""
+        self.assertNotIn("(", self._row({}))
+
+    def test_a_count_past_the_ceiling_stops_being_a_number(self):
+        """`(99+)` rather than `(100)`, and it is the same width — which is the point:
+        a field that grew a digit at a hundred chats would move every tab right of it."""
+        row = self._row({"alpha": slots.TAB_COUNT_MAX + 1})
+        self.assertIn(f"alpha ({slots.TAB_COUNT_MAX}+)", row)
+
+    def test_the_chats_strip_reserves_nothing_at_all(self):
+        """``None`` and ``{}`` are different instructions: no field, against a field with
+        nothing in it. A chat is the leaf and has nothing to count, so a strip of chats
+        that reserved six columns a name would be the widest thing on the row spent on
+        nothing."""
+        without = self._row(None)
+        blank = self._row({})
+        self.assertNotEqual(tui.width(without), tui.width(blank))
+        self.assertEqual(tui.width(blank) - tui.width(without),
+                         len(NAMES) * slots.TAB_COUNT_W)
+
+
+class TheFieldIsReservedWhetherOrNotItIsDrawn(unittest.TestCase):
+    """**The constraint the whole design is built around**, asserted as the property it
+    buys rather than as the constant it is spelled with.
+
+    A chat opening or closing must move NO column of the strip: not the names, not the
+    counts, not the cut, and not the click map. That is `slots.TAB_SPINNER`'s rule said
+    about a field that has no cell of its own — it takes six, on every tab, always.
+    """
+
+    #: Every count a caller can reach, including both sides of the ceiling and a plane
+    #: whose map is empty. The width is one number for all of them or the reserve is not a
+    #: reserve.
+    MAPS = ({}, {"alpha": 1}, {"alpha": 9}, {"alpha": 10}, {"alpha": 99},
+            {"alpha": 100}, {"alpha": 4000},
+            {"alpha": 3, "beta": 12, "gamma": 99})
+
+    def setUp(self):
+        slots.TABS.forget()
+        self.addCleanup(slots.TABS.forget)
+
+    def test_no_map_at_any_width_moves_a_single_column_of_the_row(self):
+        """Every width from 0 to 200, every map above, and the whole click map compared —
+        not just the rendered text. A strip that drew the same row and published a
+        different map would switch to the neighbour of the tab that was pressed."""
+        for width in range(0, 201):
+            shape = None
+            for counts in self.MAPS:
+                slots.TABS.forget()
+                rows = slots._bar(list(NAMES), "beta", width, counts=counts)
+                drawn = [tui.width(tui.strip_ansi(r)) for r in rows]
+                cells = {(r, c): slots.TABS.switch_to(r, c)
+                         for r in range(len(rows) or 1) for c in range(width)}
+                if shape is None:
+                    shape = (drawn, cells)
+                    continue
+                self.assertEqual(
+                    (drawn, cells), shape,
+                    f"{width} columns: {counts} draws a different strip from "
+                    f"{self.MAPS[0]} — a chat opening re-cut the row")
+
+    def test_a_count_belongs_to_the_tab_it_is_the_count_of(self):
+        """It is drawn against that name, there is nothing else it could be a click on,
+        and `slots._tab_columns` gives it those cells because the field it walks IS the
+        name plus the count."""
+        rows = slots._bar(list(NAMES), "beta", 120, counts={"alpha": 5})
+        row = tui.strip_ansi(rows[0])
+        at = row.index("(5)")
+        for col in range(at, at + len("(5)")):
+            self.assertEqual(slots.TABS.switch_to(0, col), "alpha",
+                             f"column {col} of {row!r}")
+
+    def test_the_reserve_is_derived_from_the_widest_thing_it_can_hold(self):
+        """A `6` written down beside a ceiling of 99 is two numbers that can drift apart.
+        Asked of the function rather than of the constant, at both ends and past them."""
+        for n in (0, 1, 9, 10, 99, 100, 10_000):
+            self.assertEqual(tui.width(slots._tab_count(n)), slots.TAB_COUNT_W, n)
+
+
+class TheSizerAndTheRendererMeasureOneStrip(PersonaIso, unittest.TestCase):
+    """#500's shape one slot over: the launcher sizes the pane and the renderer spends it,
+    so a want the renderer does not fill is blank rows off the harness.
+
+    The count field is where that could have gone wrong quietly — a sizer that composed
+    without the counts would plan a strip six cells a name narrower than the one that gets
+    drawn.
+    """
+
+    def test_the_want_is_the_rows_the_strip_then_fills(self):
+        for name in NAMES:
+            (config.WORKSPACES_DIR / name).mkdir(parents=True, exist_ok=True)
+        for i in range(1, 8):
+            _plant(f"alpha.{i}", workspace="alpha")
+        for cols in range(0, 200, 3):
+            with self.subTest(cols=cols):
+                want = slots.bar_rows_wanted("alpha.1", "workspaces",
+                                             pane_cols=cols, cap=3)
+                slots.TABS.forget()
+                lines = slots.workspaces_bar("alpha.1", cols, want)
+                if lines:
+                    self.assertEqual(len(lines), want,
+                                     f"{cols} columns asked for {want} rows and filled "
+                                     f"{len(lines)}")
+
+    def test_the_strip_draws_the_count_the_plane_actually_has(self):
+        """End to end through the real entry, so the map the renderer reads is the one
+        `chats.counts_by_workspace` answers and not a fixture's."""
+        for name in NAMES:
+            (config.WORKSPACES_DIR / name).mkdir(parents=True, exist_ok=True)
+        for i in range(1, 4):
+            _plant(f"alpha.{i}", workspace="alpha")
+        _plant("gamma.1", workspace="gamma")
+        row = _plain(slots.workspaces_bar("alpha.1", 200))
+        self.assertIn("alpha (3)", row)
+        self.assertIn("gamma (1)", row)
+        self.assertNotIn("beta (", row)
+
+    def test_a_plane_it_cannot_read_costs_the_numbers_and_not_the_pane(self):
+        """`_workspace_counts` is guarded for `slots.working_chats`' reason and this
+        module's own rule: a readout must never cost a pane. What is left is the strip that
+        shipped before this feature, with the field still reserved."""
+        with mock.patch.object(chats, "counts_by_workspace",
+                               side_effect=OSError("no plane")):
+            self.assertEqual(slots._workspace_counts(), {})
+
+
+class OneScanAnswersForEveryWorkspace(PersonaIso, unittest.TestCase):
+    """The second constraint, counted rather than argued."""
+
+    def setUp(self):
+        super().setUp()
+        for i in range(1, 4):
+            _plant(f"alpha.{i}", workspace="alpha")
+        _plant("beta.1", workspace="beta")
+
+    def test_every_workspaces_count_costs_one_scandir(self):
+        """**Not one per name**, which is what the strip would have paid asking
+        `of_workspace` fifteen times. Counted with a real spy on `os.scandir`, because the
+        cost is the syscall and not the function that wraps it."""
+        real = os.scandir
+        calls = []
+
+        def spy(path):
+            calls.append(str(path))
+            return real(path)
+
+        with mock.patch.object(chats.os, "scandir", spy):
+            counts = chats.counts_by_workspace()
+        self.assertEqual(counts, {"alpha": 3, "beta": 1})
+        self.assertEqual(len(calls), 1, calls)
+
+    def test_the_counts_agree_with_the_roster_name_by_name(self):
+        """One membership rule, asked once. A count that disagreed with the list a click
+        on that tab reaches would be worse than no count at all."""
+        for name in ("alpha", "beta", "gamma"):
+            self.assertEqual(chats.counts_by_workspace().get(name, 0),
+                             len(chats.of_workspace(name)), name)
+
+    def test_a_chat_charter_cannot_place_is_counted_nowhere(self):
+        """It is in no workspace's roster either, so counting it somewhere would be a
+        number no tab on the strip could be pressed to see."""
+        os.makedirs(state._root() / "orphan.1", exist_ok=True)
+        counts = chats.counts_by_workspace()
+        self.assertEqual(counts, {"alpha": 3, "beta": 1})
+        self.assertTrue(all(isinstance(k, str) for k in counts))
+
+    def test_an_unreadable_frame_root_is_no_counts_and_no_raise(self):
+        with mock.patch.object(chats.os, "scandir", side_effect=OSError("gone")):
+            self.assertEqual(chats.counts_by_workspace(), {})
+            self.assertEqual(chats.of_workspace("alpha"), [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_frame_bars.py
+++ b/tests/test_frame_bars.py
@@ -57,7 +57,7 @@ class TheLadderGivesUpWholeThings(unittest.TestCase):
     NAMES = ["api.1", "api.2", "api.3"]
 
     def _row(self, width, names=None, here="api.2", **kw):
-        rows = slots._bar("chats", list(names or self.NAMES), here, width, **kw)
+        rows = slots._bar(list(names or self.NAMES), here, width, **kw)
         self.assertLessEqual(
             len(rows), 1,
             "a strip given one row draws one row or none — the rungs below are what it "
@@ -86,7 +86,7 @@ class TheLadderGivesUpWholeThings(unittest.TestCase):
         is already standing on — correct, and inert. What the row can hold is drawn
         instead, and the rest is counted at whichever end it fell off.
         """
-        row = self._row(30)
+        row = self._row(23)
         self.assertIn("*api.2", row)
         self.assertIn("api.1", row, "the row had room for a neighbour and drew none")
         self.assertNotIn("api.3", row)
@@ -124,8 +124,8 @@ class TheLadderGivesUpWholeThings(unittest.TestCase):
         a name away**. The reserve is what keeps the ladder monotone: without it a wider
         room cuts a page one name longer, the leading count that page has to carry was
         never budgeted for, the row overflows and the whole rung is given up. Measured on
-        the mutant — with these fifteen names the row is drawn at 31 columns, gone at 42
-        through 45, and back at 46. A bar that loses its names when the pane gets bigger is
+        the mutant — with these fifteen names the row is drawn at 24 columns, gone at 35
+        through 38, and back at 39. A bar that loses its names when the pane gets bigger is
         a bug an operator reports as a flicker.
 
         Every name of the list, at every width from 0 to 200, plus the narrowest row for
@@ -141,9 +141,9 @@ class TheLadderGivesUpWholeThings(unittest.TestCase):
             self.assertEqual(missing, [],
                              f"{here} was drawn at {min(drawn)} columns and gone at "
                              f"{missing[:3]} — the pane got wider and lost a name")
-        for here, expected in (("workspace-02", "chats  +2  *workspace-02  +12"),
-                               ("workspace-07", "chats  +7  *workspace-07  +7"),
-                               ("workspace-13", "chats  +13  *workspace-13  +1")):
+        for here, expected in (("workspace-02", "+2  *workspace-02  +12"),
+                               ("workspace-07", "+7  *workspace-07  +7"),
+                               ("workspace-13", "+13  *workspace-13  +1")):
             narrowest = min(w for w in range(201)
                             if here in self._row(w, names=names, here=here))
             row = self._row(narrowest, names=names, here=here)
@@ -212,10 +212,10 @@ class TheLadderGivesUpWholeThings(unittest.TestCase):
         ws = ThisPlaneIsWhyTheRungIsWindowed.NAMES
         drawn = []
         for width in (100, 120, 160, 200, 240):
-            rows = slots._bar("workspaces", list(ws), "harness-wrapper", width)
+            rows = slots._bar(list(ws), "harness-wrapper", width)
             row = rows[0] if rows else ""
             drawn.append(len([n for n in ws if n in row]))
-        self.assertEqual(drawn, [4, 6, 8, 10, 13],
+        self.assertEqual(drawn, [6, 7, 9, 11, 13],
                          "the rescue took a tab off a plane it was not for")
 
     def test_the_page_is_the_same_page_for_every_name_on_it(self):
@@ -244,12 +244,12 @@ class TheLadderGivesUpWholeThings(unittest.TestCase):
     def test_a_row_with_no_room_for_a_name_says_where_you_are_and_how_many(self):
         """§3.6's "marks only", and a count IS the mark: `2/3` says where you are, which
         three dots do not."""
-        self.assertEqual(self._row(16).strip(), "chats  2/3")
+        self.assertEqual(self._row(9).strip(), "2/3")
 
     def test_a_row_with_no_room_for_the_count_draws_nothing_at_all(self):
         """Rather than a fragment of one. A bar that could not say anything true says
         nothing — nothing is lost but the reminder (§3.6)."""
-        self.assertEqual(self._row(11), "")
+        self.assertEqual(self._row(4), "")
 
     def test_no_name_is_ever_shown_in_part_at_any_width(self):
         """**The property §3.6 asks `slots._NAME_MIN_W` to guarantee, asserted directly.**
@@ -260,23 +260,21 @@ class TheLadderGivesUpWholeThings(unittest.TestCase):
         could reach. Asked at every width from 0 to 200 so there is no gap between the
         three widths the spec names.
 
-        Asserted on the row's FIELDS rather than by substring search: every name shares a
-        prefix with the heading and with each other, so `name[:3] in row` answers yes for
-        rows that are perfectly correct. Splitting the row on its own gap and asking what
-        each field IS is the property; anything else is a coincidence about spelling.
+        Asserted on the row's FIELDS rather than by substring search: the names share a
+        prefix with each other, so `name[:3] in row` answers yes for rows that are
+        perfectly correct. Splitting the row on its own gap and asking what each field IS
+        is the property; anything else is a coincidence about spelling.
         """
         names = ["api-staging.1", "api-standby.2", "api.3"]
         counts = {f"+{n}" for n in range(1, len(names) + 1)}
         positions = {f"{i}/{len(names)}" for i in range(1, len(names) + 1)}
         for width in range(0, 201):
-            row = slots._bar("chats", list(names), "api-standby.2", width)
+            row = slots._bar(list(names), "api-standby.2", width)
             text = _plain(row[0]) if row else ""
             self.assertLessEqual(tui.width(text), width, repr(text))
             if not text:
                 continue
-            head, _, body = text.strip().partition(" ")
-            self.assertEqual(head, "chats", repr(text))
-            for field in body.split(" " * slots._BAR_GAP):
+            for field in text.strip().split(" " * slots._BAR_GAP):
                 field = field.strip()
                 if not field:
                     continue
@@ -317,7 +315,7 @@ class TheLadderGivesUpWholeThings(unittest.TestCase):
         self.assertNotIn(slots.ADD_CHAT, row, repr(row))
 
     def test_no_names_at_all_is_no_row(self):
-        self.assertEqual(slots._bar("chats", [], "api.1", 200), [])
+        self.assertEqual(slots._bar([], "api.1", 200), [])
 
     def test_a_row_you_are_not_on_still_lists_and_still_counts(self):
         """`here` naming nothing in the list is a real state — the workspace bar draws it
@@ -328,7 +326,7 @@ class TheLadderGivesUpWholeThings(unittest.TestCase):
         self.assertNotIn(slots._BAR_MARK[0], wide)
         for name in self.NAMES:
             self.assertIn(name, wide)
-        self.assertEqual(self._row(16, here="nowhere").strip(), "chats  3")
+        self.assertEqual(self._row(9, here="nowhere").strip(), "3")
 
     def test_the_only_chat_is_never_counted_as_plus_zero(self):
         """The count is of the OTHERS, so one name has none. `+0` would be a field that
@@ -337,7 +335,7 @@ class TheLadderGivesUpWholeThings(unittest.TestCase):
         self.assertNotIn("+0", row)
 
     def _rung(self, width, names=None, here="api.2", note=""):
-        rows = slots._bar("chats", list(names or self.NAMES), here, width, note=note)
+        rows = slots._bar(list(names or self.NAMES), here, width, note=note)
         return rows[0] if rows else ""
 
     def _fits_at(self, names, here, note=""):
@@ -392,7 +390,7 @@ class TheLadderGivesUpWholeThings(unittest.TestCase):
         self.assertTrue(rung2, "rung 2 was never reached with the first name marked")
         self.assertIn(f"{slots._BAR_MARK[0]}api.1", rung2[0])
         counted = [r for r, _ in self._fits_at(self.NAMES, "api.1") if "/" in r]
-        self.assertEqual([r.strip() for r in counted], ["chats  1/3"])
+        self.assertEqual([r.strip() for r in counted], ["1/3"])
 
     def test_a_row_with_no_note_spends_no_columns_pretending_to_have_one(self):
         """`note and …` — without it an empty note still buys its own gap, and the row
@@ -445,7 +443,7 @@ class TheLadderGivesUpWholeThings(unittest.TestCase):
         (`chats.ID_RE` and `workspace.valid_name` both refuse those characters), which is
         why the index is taken before containment rather than left to be found later."""
         names = ["api x", "apix"]
-        row = _plain(slots._bar("chats", list(names), "apix", 200)[0])
+        row = _plain(slots._bar(list(names), "apix", 200)[0])
         marks = [f for f in row.split(" " * slots._BAR_GAP)
                  if f.strip().startswith(slots._BAR_MARK[0])]
         self.assertEqual(len(marks), 1,
@@ -459,7 +457,7 @@ class TheLadderGivesUpWholeThings(unittest.TestCase):
         one line of."""
         hostile = "z" * 20 + " " + "y" * 20
         for width in (200, 80, 40):
-            row = slots._bar("chats", ["api.1", hostile], "api.1", width)
+            row = slots._bar(["api.1", hostile], "api.1", width)
             text = row[0] if row else ""
             self.assertEqual(text, "".join(text.splitlines()), repr(text))
             self.assertLessEqual(tui.width(tui.strip_ansi(text)), width, repr(text))
@@ -493,7 +491,7 @@ class AClickResolvesAgainstWhatWasDrawn(unittest.TestCase):
         self.addCleanup(slots.TABS.forget)
 
     def _draw(self, width, names=None, here="api.2", note=""):
-        rows = slots._bar("chats", list(names or self.NAMES), here, width, note=note)
+        rows = slots._bar(list(names or self.NAMES), here, width, note=note)
         return rows[0] if rows else ""
 
     def _cells(self, row, field):
@@ -655,7 +653,7 @@ class AClickResolvesAgainstWhatWasDrawn(unittest.TestCase):
         names = [f"workspace-{i:02d}" for i in range(15)]
         here = "workspace-07"
         row = self._draw(80, names=names, here=here)
-        self.assertTrue(row.lstrip().split("  ")[1].startswith("+"),
+        self.assertTrue(row.lstrip().split("  ")[0].startswith("+"),
                         f"this row has no leading count to displace anything: {row!r}")
         drawn = [n for n in names if n in row and n != here]
         self.assertTrue(drawn, f"no switchable tab on the page: {row!r}")
@@ -666,8 +664,8 @@ class AClickResolvesAgainstWhatWasDrawn(unittest.TestCase):
 
     def test_the_rung_that_says_only_where_you_are_has_no_tabs_at_all(self):
         """`2/3` is a position, not a name, and there is no name on the row to click."""
-        row = _plain(self._draw(16, here="api.2"))
-        self.assertEqual(row.strip(), "chats  2/3", repr(row))
+        row = _plain(self._draw(9, here="api.2"))
+        self.assertEqual(row.strip(), "2/3", repr(row))
         for col in range(0, 200):
             self.assertIsNone(slots.TABS.switch_to(0, col), f"column {col} of {row!r}")
 
@@ -678,13 +676,15 @@ class AClickResolvesAgainstWhatWasDrawn(unittest.TestCase):
         the counts are, saying the same thing about all three names instead of about nine
         of fifteen, so it opens the same chooser.
 
-        The heading and the space past it stay inert, which is what says the cells were
-        measured rather than the whole row being made live."""
-        row = _plain(self._draw(16, here="api.2"))
+        The inset every row starts at and the space past the field stay inert, which is
+        what says the cells were measured rather than the whole row being made live. (The
+        left-hand control was the strip's own heading until #880 deleted it; the inset is
+        what is left of that side of the row, and it is the same assertion.)"""
+        row = _plain(self._draw(9, here="api.2"))
         for col in self._cells(row, "2/3"):
             self.assertTrue(slots.TABS.more_at(0, col), f"column {col} of {row!r}")
-        for col in self._cells(row, "chats"):
-            self.assertFalse(slots.TABS.more_at(0, col), f"the heading opened a picker")
+        for col in range(slots.INSET):
+            self.assertFalse(slots.TABS.more_at(0, col), "the inset opened a picker")
         self.assertFalse(slots.TABS.more_at(0, tui.width(row) + 5),
                          "the space past the row opened a picker")
 
@@ -696,7 +696,7 @@ class AClickResolvesAgainstWhatWasDrawn(unittest.TestCase):
         self._draw(80, names=[f"workspace-{i:02d}" for i in range(15)],
                    here="workspace-07")
         self.assertTrue(any(slots.TABS.more_at(0, c) for c in range(80)))
-        self.assertEqual(self._draw(11), "")
+        self.assertEqual(self._draw(4), "")
         self.assertEqual([c for c in range(200) if slots.TABS.more_at(0, c)], [],
                          "a bar that drew no row kept the counts it is no longer drawing")
 
@@ -708,7 +708,7 @@ class AClickResolvesAgainstWhatWasDrawn(unittest.TestCase):
         wide = self._draw(200, here="nowhere")
         col = self._cells(wide, "api.3").start
         self.assertEqual(slots.TABS.switch_to(0, col), "api.3")
-        for width in (30, 16, 11):
+        for width in (23, 9, 4):
             self._draw(width, here="api.2")
             self.assertIsNone(slots.TABS.switch_to(0, col),
                               f"width {width} kept a stale tab")
@@ -718,7 +718,7 @@ class AClickResolvesAgainstWhatWasDrawn(unittest.TestCase):
         could not scan, and `_bar` answers `[]` for an empty list — so this is the
         unreadable-plane path, and it must leave nothing clickable behind either."""
         self._draw(200, here="nowhere")
-        self.assertEqual(slots._bar("chats", [], "api.1", 200), [])
+        self.assertEqual(slots._bar([], "api.1", 200), [])
         for col in range(0, 200):
             self.assertIsNone(slots.TABS.switch_to(0, col), f"column {col}")
 
@@ -796,7 +796,7 @@ class AClickResolvesAgainstWhatWasDrawn(unittest.TestCase):
         for names in lists:
             for here in names:
                 for width in range(0, 120):
-                    rows = slots._bar("chats", list(names), here, width)
+                    rows = slots._bar(list(names), here, width)
                     row = rows[0] if rows else ""
                     self.assertNotIn("+-", row,
                                      f"{names} at {width}: a count went negative: {row!r}")
@@ -823,7 +823,7 @@ class AClickResolvesAgainstWhatWasDrawn(unittest.TestCase):
         this asks with a name that needs repairing rather than waiting for a caller to stop
         refusing one."""
         raw = "api\t1"
-        row = slots._bar("chats", [raw, "api.2"], "api.2", 200)[0]
+        row = slots._bar([raw, "api.2"], "api.2", 200)[0]
         drawn = contain.one_line(raw)
         self.assertNotEqual(drawn, raw, "this name needs no repair, so it measures none")
         at = row.index(drawn)
@@ -896,7 +896,7 @@ class TheTabYouAreOnIsDrawnAsOne(unittest.TestCase):
         self.addCleanup(slots.TABS.forget)
 
     def _row(self, width=200, names=None, here="api.2"):
-        rows = slots._bar("chats", list(names or self.NAMES), here, width)
+        rows = slots._bar(list(names or self.NAMES), here, width)
         return rows[0] if rows else ""
 
     def test_the_tab_you_are_on_is_a_block_and_no_other_tab_is(self):
@@ -1001,7 +1001,7 @@ class TheSeamBetweenTwoTabsIsThePlanesOwnAnswer(unittest.TestCase):
 
     def _row(self, width=200, names=None, here="api.2", rules="hidden"):
         with self._with(rules):
-            rows = slots._bar("chats", list(names or self.NAMES), here, width)
+            rows = slots._bar(list(names or self.NAMES), here, width)
         return rows[0] if rows else ""
 
     def test_a_plane_whose_rules_are_hidden_draws_the_row_it_always_drew(self):
@@ -1009,12 +1009,12 @@ class TheSeamBetweenTwoTabsIsThePlanesOwnAnswer(unittest.TestCase):
         row that is already short of columns. Byte for byte the old composition: two
         blanks between two tabs and no glyph anywhere."""
         row = _plain(self._row(rules="hidden"))
-        self.assertEqual(row.strip(), "chats   api.1  *api.2   api.3")
+        self.assertEqual(row.strip(), "api.1  *api.2   api.3")
         self.assertNotIn(slots._BAR_RULE, row)
 
     def test_a_plane_whose_rules_are_visible_puts_one_between_every_pair(self):
         row = _plain(self._row(rules="visible"))
-        self.assertEqual(row.strip(), "chats   api.1 | *api.2 |  api.3")
+        self.assertEqual(row.strip(), "api.1 | *api.2 |  api.3")
         self.assertEqual(row.count(slots._BAR_RULE), len(self.NAMES) - 1)
 
     def test_the_rule_is_a_glyph_no_terminal_draws_two_cells_wide(self):
@@ -1084,7 +1084,7 @@ class TheSeamBetweenTwoTabsIsThePlanesOwnAnswer(unittest.TestCase):
         names = [f"workspace-{i:02d}" for i in range(15)]
         for width in range(0, 301):
             with self._with("visible"):
-                rows = slots._bar("workspaces", list(names), "workspace-07", width)
+                rows = slots._bar(list(names), "workspace-07", width)
             text = _plain(rows[0]) if rows else ""
             self.assertLessEqual(tui.width(text), width, f"{width}: {text!r}")
         widest = next(w for w in range(500)
@@ -1102,9 +1102,9 @@ class ThisPlaneIsWhyTheRungIsWindowed(unittest.TestCase):
 
     **The measurement #725 shipped with, kept as a test.** That change made both bars
     clickable and the `workspaces` bar stayed inert on the plane it was reported from:
-    those names need 274 columns for rung 1, so every real width fell to a rung whose only
-    drawn tab was the one the operator was already on. "Clickable" and "reaches nothing"
-    are the same screen.
+    those names need 262 columns for rung 1 — 274 while the strip still drew a heading
+    (#880) — so every real width fell to a rung whose only drawn tab was the one the
+    operator was already on. "Clickable" and "reaches nothing" are the same screen.
 
     Written against the real names rather than a fixture of even-width ones, because the
     greedy cut is about the widths names actually have — `relations-and-delegations` is 25
@@ -1124,19 +1124,21 @@ class ThisPlaneIsWhyTheRungIsWindowed(unittest.TestCase):
         self.addCleanup(slots.TABS.forget)
 
     def _switchable(self, width):
-        rows = slots._bar("workspaces", list(self.NAMES), self.HERE, width)
+        rows = slots._bar(list(self.NAMES), self.HERE, width)
         row = rows[0] if rows else ""
         self.assertLessEqual(tui.width(row), width, repr(row))
         return row, {slots.TABS.switch_to(0, col) for col in range(width)} - {None}
 
-    def test_rung_one_still_needs_two_hundred_and_seventy_four_columns(self):
+    def test_rung_one_still_needs_two_hundred_and_sixty_two_columns(self):
         """The number the whole change is about. Measured off the ladder, so it follows
-        the inset and the gap if either moves."""
+        the inset and the gap if either moves — and it did move: it was 274 for as long as
+        the strip drew a `workspaces` heading, and #880 gave those twelve columns back to
+        the names."""
         widest = next(w for w in range(400)
-                      if len(slots._bar("workspaces", list(self.NAMES), self.HERE, w)) == 1
-                      and all(n in slots._bar("workspaces", list(self.NAMES),
+                      if len(slots._bar(list(self.NAMES), self.HERE, w)) == 1
+                      and all(n in slots._bar(list(self.NAMES),
                                               self.HERE, w)[0] for n in self.NAMES))
-        self.assertEqual(widest, 274)
+        self.assertEqual(widest, 262)
 
     def test_every_real_width_now_reaches_workspaces_the_operator_is_not_on(self):
         """120, 160 and 200 columns. Before this change each of them drew


### PR DESCRIPTION
Closes #880.

Four changes to the tab strip, in one PR because they trade columns against each other.

## 1. The row headings go

`workspaces` and `chats` were drawn once at the start of each strip, were mouse targets for
nothing, carried no chrome and never changed. `head` is gone from `_bar`, `_compose` and
every `BARS` entry, and the `under` blank went with it — a lead that is the same on every
row is one expression where a lead and an `under` that happened to be equal were two things
a reader had to check agreed.

**Measured saving: 12 columns and 7, not the 14 and 9 the issue attributes to the
heading.** Two of those columns are `slots.INSET`, the left edge every pane's rows start
at, and they are still there — dropping them would put the bars flush at column 0 while
every other pane's rows start at column 2. Through the ladder itself: the fifteen
workspaces on this plane needed **274** columns for rung 1 and now need **262**.

The measurements in `_cuts`' own comment are re-anchored to `room`, which is that
function's argument, rather than to a pane width that moves whenever the lead does. That is
what went stale here.

## 2. One row on launch

`commands_frame._slot_sizes` carries `layout.bar_rows_cap(state.bar_rows(fid))` down as the
cap instead of `layout.BAR_MAX_ROWS` flat, and `layout.BAR_ROWS_DEFAULT` is one. The
measured objection to a one-row strip — `*harness-wrapper  +14`, one tab, the one you are
on, which `switch_to` correctly refuses — no longer stands on its own: `+N` is clickable and
opens the palette.

## 3. `F3` cycles the strip 1 → 2 → 3

`layout.next_bar_rows` is the arithmetic, `state.record_bar_rows` the per-frame file,
`commands_frame.cmd_bar_rows` the command, `conf_text` the bind.

It **raises a ceiling and does not set a height** — `bar_rows_wanted` still answers with the
rows a strip fills, so a press on a plane whose names already fit moves nothing.

**The height does not survive a restart.** The file lives beside `density` and `hidden` in
the frame's own state directory, so `reap` deletes it with the frame and `clear_shape`
deletes it when a new frame claims a recycled id — no new kind of state, no `doctor` row.
`[[frame.component]] size` (#687) stays honoured as the pinned default, because
`layout._grown` only ever grows.

`F3` is the third key charter binds, after `F2` and `F12`. It is in
`instance.component_arrangement`'s `bound` set, so a committed `key = "F3"` is refused
rather than silently taking it, and it is emitted above the toggle binds so that refusal
stays honest.

## 4. Workspace tabs carry their chat count

`some-workspace (5)`. Zero renders blank; past `TAB_COUNT_MAX` the field says `(99+)`.

**The field is fixed-width and always reserved** — `TAB_COUNT_W`, six columns on every
workspace tab whether or not there is a number for it. A suffix that came and went would
re-cut the strip the moment a chat opened, and the cell the operator was about to press
would hold another workspace's name. `TheFieldIsReservedWhetherOrNotItIsDrawn` asserts that
as the property: every width from 0 to 200 and eight different maps draw byte-identical
rows and publish an identical click map.

**One grouped pass.** `chats.of_workspace` and the new `chats.counts_by_workspace` now
share `_by_workspace`, which groups every chat by its workspace in the walk `of_workspace`
already did for one — same membership rule, same order, same cost for the old caller.
`test_every_workspaces_count_costs_one_scandir` spies on `os.scandir` and counts.

The strip is **not** put on a clock: `BAR_ANIMATED` stays the chats strip alone. The reserve
costs six columns a tab, so the fifteen workspaces need **352** columns for one row.

## Tests

New: `tests/test_a_key_cycles_the_tab_strips_height.py` (33),
`tests/test_a_workspace_tab_carries_its_chat_count.py` (17).

The three dead-cell cases the issue named are updated rather than deleted — what they
pressed was the heading, and what is left on that side of the row is `slots.INSET`, which is
the same claim about the same cells. The heading-once-per-strip case became
`test_every_row_of_the_strip_starts_its_tabs_at_the_same_left_edge`, which is the half of it
that was ever load-bearing.

Full suite: **11215 tests, OK, 8 skipped.**

## The sweep

Planned locally with `tools/sweep.py --plan` and read line by line rather than waited for.
Two of the 30 mutations it offered were equivalent by construction and the lines are
**deleted**: `bar_rows_cap`'s `rows is not None` branch (`None` is not in `_BAR_ROWS`, so
the membership test already answered) and `bar_rows`' `.strip()` in front of `int()` (which
already ignores surrounding whitespace, so the `lstrip` swap could not differ). Four more
were real claims nothing was watching and now have a case each — the shipped key literal,
the field's six-column price, `record_bar_rows` swallowing a failed write, and
`cmd_bar_rows` subtracting the hidden set. That last one carries actual harm: without the
subtraction, a key about HEIGHT would re-split a pane for every component the operator had
toggled off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Us4MbwkSCJCxwt1CjAd1sf
