### PR TITLE
Installing charter installs charter — one command, and the plugin comes with it (#881)

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,7 @@ same render in any spare terminal.
 ![Terminal recording: charter init scaffolds a control plane, charter discover writes an inventory of every repo in the org, charter clone pulls one into the active workspace, and charter status shows the result.](docs/assets/demo.svg)
 
 ```bash
-uv tool install charter-cp                        # the CLI  — one per machine, for your terminal
-claude plugin marketplace add diazoxide/charter   # Claude Code's plugin — one per project, and it carries the version
-claude plugin install charter@charter
+uv tool install charter-cp
 
 mkdir my-control-plane && cd my-control-plane
 charter init --forge github --owner my-org
@@ -37,21 +35,26 @@ charter discover
 charter clone some-repo
 ```
 
-**Two artifacts, and you want both.** The CLI is a single machine-global install — what you
-type in your own terminal, and what CI or a cron job runs. The plugin is installed **per
-project**, out of a cache Claude Code keeps holding every version at once, which is why a
-*plane's* pinned version is the plugin's and not the binary's: two planes on one laptop can
-sit on different charters without fighting. A CLI-only install leaves the plugin's hooks
-inert, and the plugin ships no Python of its own — every hook it declares shells out to the
-CLI. The plugin loads on the **next** session, so restart after installing it.
+**One command, and Claude Code's plugin comes with it.** `uv tool install charter-cp` puts
+the `charter` CLI on your `PATH` — a single machine-global install, what you type in your
+own terminal and what CI or a cron job runs. `charter init` then installs charter's Claude
+Code plugin **for that plane**, out of a cache Claude Code keeps holding every version at
+once, which is why a *plane's* pinned version is the plugin's and not the binary's: two
+planes on one laptop can sit on different charters without fighting. The plugin ships no
+Python of its own — every hook it declares shells out to the CLI, which is why the CLI is
+the thing you install and the plugin is the thing it installs for you. It loads on the
+**next** session, so restart after `charter init`. Already have a plane? `charter doctor`
+says whether its plugin is there and `charter doctor --fix` puts it there.
 → **[docs/install.md](docs/install.md)**
 
 - **`charter init`** scaffolds `charter.toml`, the baseline directories (`personas/`,
-  `inventory/`, `workspaces/`), a `.gitignore` tuned for the layout, and the status line
-  above. Additive and idempotent — re-running it is always safe. It converts *the directory
-  it runs in* into a control plane, so run it somewhere you mean to.
+  `inventory/`, `workspaces/`), a `.gitignore` tuned for the layout, the status line above,
+  and Claude Code's charter plugin for this plane. Additive and idempotent — re-running it
+  is always safe. It converts *the directory it runs in* into a control plane, so run it
+  somewhere you mean to.
 - **`charter doctor`** preflights python, git, git identity, the forge CLI and its auth,
-  and names what's missing before anything else trips over it.
+  and names what's missing before anything else trips over it. `--fix` installs the pieces
+  charter can install; nothing is ever installed without it.
 - **`charter discover`** queries the forge and writes `inventory/repos.json` — the tracked
   map of every repo in the org, complete even when nothing is cloned yet.
 - **`charter clone <repo>`** clones on demand into the active workspace, already carrying
@@ -355,8 +358,9 @@ charter docs show secrets     # the page, from the install that implements it
 skill. It never tells you to delete it — an override may be deliberate — only that a local
 copy wins, is compared to nothing, and drifts unwatched in both directions.
 
-- [docs/install.md](docs/install.md) — both artifacts, alternatives to `uv`, and what
-  `charter init` writes before you let it.
+- [docs/install.md](docs/install.md) — the one command, alternatives to `uv`, what
+  `charter init` writes before you let it, and the by-hand version of the plugin install it
+  does for you.
 - [docs/control-plane.md](docs/control-plane.md) — `charter.toml` in full: every key, a
   self-hosted example, a mixed-forge example, the memory posture, the version pin.
 - [docs/personas.md](docs/personas.md) — the charter format, inheritance, the memory model,

--- a/charter/cli.py
+++ b/charter/cli.py
@@ -121,6 +121,14 @@ def build_parser() -> argparse.ArgumentParser:
         help="Preflight: check python/git/glab/auth/ssh/inventory before working.",
     )
     doc_check.add_argument("--json", action="store_true", help="Emit machine-readable results.")
+    # The second of the two doors an install may come through (#881); `charter init` is the
+    # first. A flag rather than a behaviour, because a preflight that installed software
+    # every time it ran would be doing it as a side effect of a question — and `doctor` runs
+    # from a SessionStart hook on every session.
+    doc_check.add_argument("--fix", action="store_true",
+                           help="Install what charter can install for this plane before "
+                                "reporting — today, the Claude Code plugin. Never runs "
+                                "without this flag.")
     doc_check.set_defaults(func=commands.cmd_doctor)
 
     ri = sub.add_parser(

--- a/charter/commands.py
+++ b/charter/commands.py
@@ -1984,6 +1984,29 @@ def _wire_harnesses(root: Path) -> list[tuple[str, str]]:
     return out
 
 
+def _provision_harnesses(root: Path) -> list[tuple[str, str]]:
+    """Install every registered harness's own ARTIFACT for the plane at *root* (#881).
+
+    The same loop shape as :func:`_wire_harnesses` and deliberately NOT the same function.
+    `wire` writes files inside the plane and is safe to re-run from `reinit`; this shells
+    out to a package manager and installs software, so it runs only from `charter init`
+    and `charter doctor --fix` — the two commands a person types when they are asking for
+    an install. `charter workspace list` must never install anything, which is #857's
+    surprise and the same reason charter refuses to write `~/.claude/settings.json`
+    unasked.
+
+    Nothing here names a harness: `Harness.provision` is empty by default and Claude Code
+    is the one that overrides it, so a harness that grows an installable artifact is
+    covered the day its class says so.
+    """
+    from .harness import registry
+
+    out: list[tuple[str, str]] = []
+    for h in registry.all():
+        out.extend(h.provision(root))
+    return out
+
+
 # --------------------------------------------------------------------------- #
 # init's one offer: the repo you are standing in                               #
 #                                                                              #
@@ -2363,6 +2386,17 @@ def cmd_init(args) -> int:
         else:
             (created if status == "created" else present).append(label)
 
+    # After the wiring and before the guard hook, because the plugin is what DISPATCHES
+    # that guard — a plane whose settings name `charter hook pretooluse` and whose plugin
+    # is absent is wired to nothing. `init` is one of the two doors an install may come
+    # through (#881); `reinit` is not one of them, which is why this is not folded into
+    # `_wire_harnesses` above.
+    for status, label in _provision_harnesses(root):
+        if status == "unvouched":
+            unvouched.append(label)
+        else:
+            (created if status == "created" else present).append(label)
+
     fd = _ensure_front_door(root, getattr(args, "front_door", None))
     if fd:
         created.append(fd[1])
@@ -2540,8 +2574,61 @@ def cmd_reinit(args) -> int:
 # --------------------------------------------------------------------------- #
 # doctor                                                                       #
 # --------------------------------------------------------------------------- #
+def doctor_fix(root: Path) -> list[tuple[str, str]]:
+    """Install what `doctor` can install for the plane at *root*. ``(status, label)`` pairs.
+
+    The other half of #881's answer, and the reason `doctor` gained a flag rather than a
+    behaviour: **installation happens where somebody asked for it and nowhere else.**
+    `charter init` is the first door and this is the second; nothing installs as a side
+    effect of an ordinary command, which is #857's surprise and the same reason charter
+    refuses to write `~/.claude/settings.json` unasked.
+
+    Deliberately the same call `init` makes — `_provision_harnesses` — rather than a second
+    installer that could drift from it. `doctor`'s own row names this command, so the two
+    would be a remedy and a report disagreeing about what the remedy does.
+
+    `doctor.py` stays read-only ("Nothing here changes the system"), which is why this lives
+    here and not beside the row that hints at it.
+    """
+    return _provision_harnesses(root)
+
+
+def _run_doctor_fix() -> None:
+    """Print what `--fix` did. Never raises, and never changes `doctor`'s verdict.
+
+    The rows below are the verdict: a fix that failed must show up as the row it failed to
+    turn green, not as an exit code from the fixing. Everything here goes to **stderr**
+    (`util.*`), so `charter doctor --json --fix` still emits parseable JSON on stdout.
+    """
+    if not config.HAS_CONTROL_PLANE:
+        util.warn("no control plane here (no charter.toml in this directory or any "
+                  "parent), and charter installs the Claude Code plugin per project — so "
+                  "there is nothing for --fix to install it for.")
+        util.info("  Run `charter init` in the directory you want to be a control plane; "
+                  "it installs the plugin as part of scaffolding.")
+        return
+    done = doctor_fix(config.ROOT)
+    if not done:
+        util.info("--fix had nothing to install.")
+        return
+    for status, label in done:
+        if status == "unvouched":
+            util.warn(label)
+        elif status == "created":
+            util.ok(f"Installed {label}")
+        else:
+            util.info(f"Already there: {label}")
+
+
 def cmd_doctor(args) -> int:
-    """Preflight the environment. Exit non-zero if any hard requirement fails."""
+    """Preflight the environment. Exit non-zero if any hard requirement fails.
+
+    ``--fix`` runs FIRST and then the checks run as usual, so the report the operator reads
+    is the state after the repair rather than the one that prompted it. A `--fix` that fixed
+    nothing is therefore not silent: the row that asked for it is still there, still yellow,
+    still naming what to do."""
+    if getattr(args, "fix", False):
+        _run_doctor_fix()
     if getattr(args, "json", False):
         results = doctor.run_all()
         print(json.dumps(

--- a/charter/commands.py
+++ b/charter/commands.py
@@ -2574,8 +2574,8 @@ def cmd_reinit(args) -> int:
 # --------------------------------------------------------------------------- #
 # doctor                                                                       #
 # --------------------------------------------------------------------------- #
-def doctor_fix(root: Path) -> list[tuple[str, str]]:
-    """Install what `doctor` can install for the plane at *root*. ``(status, label)`` pairs.
+def _run_doctor_fix() -> None:
+    """Install what `doctor` can install for this plane, and say what happened (#881).
 
     The other half of #881's answer, and the reason `doctor` gained a flag rather than a
     behaviour: **installation happens where somebody asked for it and nowhere else.**
@@ -2583,22 +2583,17 @@ def doctor_fix(root: Path) -> list[tuple[str, str]]:
     effect of an ordinary command, which is #857's surprise and the same reason charter
     refuses to write `~/.claude/settings.json` unasked.
 
-    Deliberately the same call `init` makes — `_provision_harnesses` — rather than a second
-    installer that could drift from it. `doctor`'s own row names this command, so the two
-    would be a remedy and a report disagreeing about what the remedy does.
+    Deliberately the same call `init` makes — :func:`_provision_harnesses` — rather than a
+    second installer that could drift from it. `doctor`'s own row names this command, so
+    the two would be a remedy and a report disagreeing about what the remedy does.
 
-    `doctor.py` stays read-only ("Nothing here changes the system"), which is why this lives
-    here and not beside the row that hints at it.
-    """
-    return _provision_harnesses(root)
+    `doctor.py` stays read-only ("Nothing here changes the system"), which is why this
+    lives here and not beside the row that hints at it.
 
-
-def _run_doctor_fix() -> None:
-    """Print what `--fix` did. Never raises, and never changes `doctor`'s verdict.
-
-    The rows below are the verdict: a fix that failed must show up as the row it failed to
-    turn green, not as an exit code from the fixing. Everything here goes to **stderr**
-    (`util.*`), so `charter doctor --json --fix` still emits parseable JSON on stdout.
+    Never raises, and never changes `doctor`'s verdict: the rows are the verdict, so a fix
+    that failed shows up as the row it did not turn green rather than as an exit code from
+    the fixing. Everything here goes to **stderr** (`util.*`), so `charter doctor --json
+    --fix` still emits parseable JSON on stdout.
     """
     if not config.HAS_CONTROL_PLANE:
         util.warn("no control plane here (no charter.toml in this directory or any "
@@ -2607,7 +2602,7 @@ def _run_doctor_fix() -> None:
         util.info("  Run `charter init` in the directory you want to be a control plane; "
                   "it installs the plugin as part of scaffolding.")
         return
-    done = doctor_fix(config.ROOT)
+    done = _provision_harnesses(config.ROOT)
     if not done:
         util.info("--fix had nothing to install.")
         return

--- a/charter/commands.py
+++ b/charter/commands.py
@@ -2386,11 +2386,23 @@ def cmd_init(args) -> int:
         else:
             (created if status == "created" else present).append(label)
 
-    # After the wiring and before the guard hook, because the plugin is what DISPATCHES
-    # that guard — a plane whose settings name `charter hook pretooluse` and whose plugin
-    # is absent is wired to nothing. `init` is one of the two doors an install may come
-    # through (#881); `reinit` is not one of them, which is why this is not folded into
-    # `_wire_harnesses` above.
+    # BEFORE `_ensure_guard_hook`, and the order is load-bearing rather than tidy.
+    #
+    # `claude plugin install --scope project` writes `enabledPlugins` into the plane's own
+    # `.claude/settings.json` — measured on a real machine, where that file holds exactly
+    # `enabledPlugins`, `env` and `statusLine` and no `hooks` block. So by the time
+    # `_ensure_guard_hook` runs, `_plugin_dispatches_guard` finds an enabled plugin that
+    # dispatches `charter hook pretooluse` and correctly writes nothing.
+    #
+    # Run the other way round, `init` writes its own `hooks.PreToolUse` block first (the
+    # plugin is not installed yet, so there is nothing to find), the install enables the
+    # plugin a moment later, and the plane ends up with BOTH — the guard running twice on
+    # every Bash call, which is the doubling `doctor.check_guard_wired` reports as *declared
+    # twice* and which nobody finds, because two denials for one command read as one
+    # stubborn denial. That was the ordinary outcome of the old two-step install.
+    #
+    # `init` is one of the two doors an install may come through (#881); `reinit` is not one
+    # of them, which is why this is not folded into `_wire_harnesses` above.
     for status, label in _provision_harnesses(root):
         if status == "unvouched":
             unvouched.append(label)

--- a/charter/doctor.py
+++ b/charter/doctor.py
@@ -2740,9 +2740,21 @@ def check_plugin_install() -> Result:
     plane has no Claude Code plugin to be missing, and `check_harness` already states what
     each harness cannot carry.
     """
+    name = "plugin install"
+    try:
+        return _plugin_install(name)
+    except Exception as e:
+        # The row-level guard `check_plugin_freshness` carries, for the same reason:
+        # `_checks()` is an eager list literal with no per-check guard, so ONE raising
+        # check returns no rows at all — and `hooks/hooks.json` renders a non-zero `charter
+        # doctor` as "charter preflight failed - fix before working:" at every SessionStart.
+        return Result(name, WARN, detail=f"not checked ({e})", hint=_NOT_CHECKED_HINT)
+
+
+def _plugin_install(name: str) -> Result:
+    """The body of :func:`check_plugin_install`, which owns the story and the guard."""
     from . import config as _config, plugincache
 
-    name = "plugin install"
     if not plugincache.available():
         return Result(name, OK, detail="no `claude` on PATH — no Claude Code plugin here")
     if not _config.HAS_CONTROL_PLANE:

--- a/charter/doctor.py
+++ b/charter/doctor.py
@@ -2768,6 +2768,29 @@ def _plugin_install(name: str) -> Result:
                       detail="not checked (could not read `claude plugin list --json`)",
                       hint=_NOT_CHECKED_HINT)
     if entry is not None:
+        # **Installed is not enabled, and only enabled loads anything** (#177). `claude
+        # plugin list --json` carries `enabled`, and a tick over an installed-but-disabled
+        # plugin is exactly the failure 0.31.1 shipped and `check_guard_wired` was written
+        # to stop: the absence of a protection rendered as health.
+        #
+        # Absent rather than False is read as enabled. An older `claude` that does not emit
+        # the field would otherwise have every plane told its plugin is off — inventing a
+        # problem out of a missing key, which is the opposite error and just as expensive.
+        #
+        # **Reported, never fixed**, and `--fix` deliberately does not enable it. Somebody
+        # disabling a plugin is a choice, and charter does not revert a deliberate edit —
+        # the rule `_ensure_statusline` exists to keep. The row says what is not happening;
+        # the operator decides.
+        if entry.get("enabled") is False:
+            return Result(
+                name, WARN,
+                detail=f"{entry.get('id')} is installed ({entry.get('scope')} scope) and "
+                       f"DISABLED — an installed plugin loads nothing until it is enabled, "
+                       f"so charter's hooks do not run here",
+                hint=f"Run: claude plugin enable {entry.get('id')} --scope "
+                     f"{entry.get('scope')}  (charter does not enable it for you: if you "
+                     f"turned it off on purpose, this row is only telling you what that "
+                     f"costs). The plugin loads at the NEXT session.")
         return Result(name, OK,
                       detail=f"{entry.get('id')} installed ({entry.get('scope')} scope)")
     return Result(

--- a/charter/doctor.py
+++ b/charter/doctor.py
@@ -2704,6 +2704,70 @@ def check_plugin_skew() -> Result:
                          f"plugin, dispatching every handler. Upgrade: {upgrade}")
 
 
+#: What to type when the Claude Code plugin is missing. One string, because `doctor`'s row
+#: and `init`'s warning must never disagree about the remedy — and because the remedy is
+#: now a charter command rather than three lines of `claude plugin …` the reader has to
+#: copy correctly (#881).
+PLUGIN_FIX_CMD = "charter doctor --fix"
+
+
+def check_plugin_install() -> Result:
+    """Is charter's own Claude Code plugin installed for THIS plane — and if not, the one
+    command that installs it (#881).
+
+    A third question about the plugin, beside the two rows that already exist, and the
+    split is the same one `check_guard_wired` records: *installed*, *enabled* and *wired*
+    are different states. `check_plugin_skew` compares version numbers and answers nothing
+    at all outside a plugin process; `check_plugin_freshness` compares the installed files
+    with the marketplace clone. Neither says *there is no plugin here* — freshness reports
+    that as a green ``the charter plugin is not installed here``, which is true and is read
+    as health.
+
+    **WARN and never FAIL.** `cmd_doctor` exits non-zero only on FAIL, and that exit code
+    is what makes the SessionStart wrapper print — so a FAIL here would put a red preflight
+    in front of every CLI-only install, which `docs/install.md` supports and CI uses. It
+    would also be wrong about protection: a plane that declares `charter hook pretooluse`
+    in its own `.claude/settings.json` is guarded with no plugin at all, and
+    `check_guard_wired` is the row that answers whether the guard fires. This row answers
+    whether the artifact charter can install for you is there.
+
+    **Scoped to this plane, not to the machine.** `plugincache.installed_for` refuses a
+    project-scoped install belonging to somebody else's checkout, because reading one as an
+    answer here would print "installed" over a plane with no plugin — #168's own defect in
+    a new row.
+
+    Silent, green and specific where there is no `claude` at all: an opencode or Codex
+    plane has no Claude Code plugin to be missing, and `check_harness` already states what
+    each harness cannot carry.
+    """
+    from . import config as _config, plugincache
+
+    name = "plugin install"
+    if not plugincache.available():
+        return Result(name, OK, detail="no `claude` on PATH — no Claude Code plugin here")
+    if not _config.HAS_CONTROL_PLANE:
+        # The plugin is installed per PROJECT, so without a plane there is no directory to
+        # install it for. Not a fault: `charter doctor` outside a plane is a supported way
+        # to preflight a machine.
+        return Result(name, OK, detail="no control plane here — nothing to install it for")
+    entry = plugincache.installed_for(_config.ROOT)
+    if entry is plugincache.UNKNOWN:
+        return Result(name, WARN,
+                      detail="not checked (could not read `claude plugin list --json`)",
+                      hint=_NOT_CHECKED_HINT)
+    if entry is not None:
+        return Result(name, OK,
+                      detail=f"{entry.get('id')} installed ({entry.get('scope')} scope)")
+    return Result(
+        name, WARN,
+        detail="charter's Claude Code plugin is not installed for this plane, so none of "
+               "its hooks run here — no session context, no plane-root guard, no auto-save",
+        hint=f"Run: {PLUGIN_FIX_CMD}  (installs `{plugincache.PLUGIN_ID}` at "
+             f"{plugincache.INSTALL_SCOPE} scope from `{plugincache.MARKETPLACE_SOURCE}`; "
+             f"`charter init` does the same thing on a fresh plane). The plugin loads at "
+             f"the NEXT session, so restart afterwards.")
+
+
 def check_plugin_freshness() -> Result:
     """Is the INSTALLED plugin the same FILES as the marketplace clone it came from?
 
@@ -3059,7 +3123,8 @@ def _checks():
                 check_ask_rules(),
                 check_shadowed_knowledge(),
                 check_credential_paths(),
-                check_mcp_launchers(), check_plugin_skew(), check_plugin_freshness()]
+                check_mcp_launchers(), check_plugin_install(), check_plugin_skew(),
+                check_plugin_freshness()]
     return results
 
 
@@ -3094,7 +3159,7 @@ _FIXED_CHECK_NAMES = (
     "workspace layer", "changes",
     "inventory", "vaults", "vault registry", "version lock", "memory indexes",
     "personas", "persona grant", "front door", "news", "ask rules", "shadowed docs",
-    "credential paths", "mcp", "plugin", "plugin files",
+    "credential paths", "mcp", "plugin install", "plugin", "plugin files",
 )
 
 #: Where the forge pair goes in `_FIXED_CHECK_NAMES` — after `git identity`, which is

--- a/charter/harness/base.py
+++ b/charter/harness/base.py
@@ -321,6 +321,30 @@ class Harness:
         """
         return []
 
+    def provision(self, root: Path) -> list[tuple[str, str]]:
+        """Install this harness's own ARTIFACT for the plane at *root*, if it has one.
+
+        Same ``(status, label)`` vocabulary as :meth:`wire`, so `init` reports both through
+        one code path — and the same restraint one level up: `wire` writes files charter
+        can see, while this asks a package manager charter does not own to install
+        something. Neither repairs what it finds.
+
+        **Empty by default, and that is a statement about the other harnesses rather than
+        an unfinished method.** Only Claude Code ships an artifact charter can install
+        without touching a machine-global file. opencode's plugin already arrives through
+        :meth:`wire` — one file under ``~/.config/opencode/``, because that is the only
+        place opencode reads for every project — and Codex's wiring is ``~/.codex/
+        config.toml``, which charter writes ONLY from `charter harness install codex`,
+        where running the command IS the consent (ADR 0003). `doctor` reports those gaps;
+        nothing here closes one by writing a machine-global file nobody asked it to.
+
+        **Never reached except from a command a person typed** — `charter init` and
+        `charter doctor --fix`. Installing software as a side effect of an unrelated
+        command is #857's surprise, so this is deliberately NOT called from
+        `commands._wire_harnesses`, which runs from `reinit` as well.
+        """
+        return []
+
     def workspace_files(self) -> dict[str, str]:
         """What this harness needs inside a directory charter OWNS — ``{relpath: text}``.
 

--- a/charter/harness/claude_code.py
+++ b/charter/harness/claude_code.py
@@ -152,6 +152,45 @@ class ClaudeCodeHarness(Harness):
         status, _path = commands.ensure_env_var(root, "CHARTER_HARNESS", self.name)
         return [(status, ".claude/settings.json (env)")]
 
+    def provision(self, root: Path) -> list[tuple[str, str]]:
+        """Install charter's own Claude Code plugin for the plane at *root* (#881).
+
+        The CLI is the front door: it is what sits on ``PATH``, what every hook in
+        ``hooks/hooks.json`` dispatches to, and what already writes `.claude/settings.json`
+        — so it exists before a harness session does. The inverse shape, a plugin that
+        bootstraps a CLI, has to guess at a Python environment it does not own.
+
+        **Project scope**, from the plane's own directory, for the reason the README states
+        as a feature: the plugin is what carries a plane's pinned version, so two planes on
+        one laptop can sit on different charters without fighting. A ``user``-scope install
+        would collapse that to one version per machine and would put charter's hooks into
+        repositories nobody pointed charter at.
+
+        A machine with no `claude` gets **no row at all** rather than a warning. An opencode
+        or Codex plane is a supported install and has no Claude Code plugin to be missing;
+        `check_harness` already states what each harness cannot carry, and a warning here
+        would be the cry-wolf failure `doctor.py` keeps returning to.
+        """
+        from .. import plugincache
+
+        status, detail = plugincache.install(root)
+        if status == "installed":
+            return [("created", f"the Claude Code plugin — {detail}")]
+        if status == "present":
+            return [("present", f"the Claude Code plugin ({detail})")]
+        if status == "unavailable":
+            return []
+        # `unknown` and `failed`. A SENTENCE, in the bucket `init` warns about rather than
+        # lists: "the plugin is not installed" is exactly the state a reader must not take
+        # away from a line under "already present" (#433, one level up).
+        return [("unvouched",
+                 f"The Claude Code plugin was not installed — {detail}. Without it charter's "
+                 f"hooks do not run in this plane: no session context, no plane-root guard, "
+                 f"no auto-save. Retry with `charter doctor --fix`, or install it by hand: "
+                 f"`claude plugin marketplace add {plugincache.MARKETPLACE_SOURCE}` then "
+                 f"`claude plugin install {plugincache.PLUGIN_ID} --scope "
+                 f"{plugincache.INSTALL_SCOPE}`.")]
+
     def workspace_files(self) -> dict[str, str]:
         """The plane's own three settings keys, as one document for a workspace to hold.
 

--- a/charter/harness/claude_code.py
+++ b/charter/harness/claude_code.py
@@ -175,9 +175,17 @@ class ClaudeCodeHarness(Harness):
 
         status, detail = plugincache.install(root)
         if status == "installed":
-            return [("created", f"the Claude Code plugin — {detail}")]
+            # Shaped for `commands._fold_entries`, which splits a label on `" ("`: the
+            # head is the thing, the parenthesis is the note. `init` lists one line per
+            # FILE and folds several notes onto it, and a label with no fold point makes
+            # that line grow instead — the 254-column headline #231 capped.
+            return [("created", f"the Claude Code plugin ({plugincache.PLUGIN_ID}, "
+                                f"{plugincache.INSTALL_SCOPE} scope)")]
         if status == "present":
-            return [("present", f"the Claude Code plugin ({detail})")]
+            # No parenthetical. Every caller here already says "already present" or
+            # "Already there", so `(charter@charter is already installed …)` would be the
+            # same word twice in one line.
+            return [("present", "the Claude Code plugin")]
         if status == "unavailable":
             return []
         # `unknown` and `failed`. A SENTENCE, in the bucket `init` warns about rather than

--- a/charter/plugincache.py
+++ b/charter/plugincache.py
@@ -186,10 +186,16 @@ def _our_entries():
     standing between `charter doctor --fix` and a plugin that is not charter's to touch.
     """
     entries = _claude_json(["list"])
-    if entries is None:
-        return UNKNOWN
+    # ONE test, and it used to be two. `_claude_json` answers `None` for every way a read
+    # can fail, and the line above it — `if entries is None: return UNKNOWN` — was carried
+    # here from `installed_charter_plugin` and is strictly subsumed by this one: `None` is
+    # not a list either, and both returned the same sentinel. The deletion sweep found it
+    # as a survivor no test could tell from its own absence, which is the honest name for a
+    # branch nothing can reach. What the two spellings meant is preserved here: "could not
+    # read" and "`--json` answered something that is not a list of rows" are the same
+    # answer — nothing is known — and neither is "there is nothing installed".
     if not isinstance(entries, list):
-        return UNKNOWN          # `--json` answered something that is not a list of rows
+        return UNKNOWN
     ours = []
     for e in entries:
         if not isinstance(e, dict):

--- a/charter/plugincache.py
+++ b/charter/plugincache.py
@@ -13,12 +13,16 @@ among them.
 follows the CLI and not the plugin's bundled copy of ``charter/*.py``. Skills are different:
 they are text the model loads, and a stale one is wrong instructions delivered confidently.
 
-Two callers, one mechanism:
+Three callers, one mechanism:
 
 * `doctor.check_plugin_freshness` compares by CONTENT, which is the question a version
   string cannot answer.
 * `commands_update` force-refreshes on the dev channel, where a version-keyed update can
   never see the change.
+* `commands.cmd_init` and `charter doctor --fix` INSTALL it (#881), so that installing
+  charter installs charter and the operator types one command rather than three. Those two
+  entry points and no other: :func:`install` says at length why nothing may reach it as a
+  side effect of an unrelated command.
 
 **Everything here talks to `claude plugin … --json`, never to Claude Code's files.**
 ``~/.claude/plugins/installed_plugins.json``, ``known_marketplaces.json`` and the cache
@@ -107,6 +111,25 @@ _MARKETPLACE_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$")
 #: `tests/test_plugin.py` already pins those two to each other.
 PLUGIN_ID = "charter@charter"
 
+#: What ``claude plugin marketplace add`` is given — the GitHub ``<owner>/<repo>`` charter
+#: is published from, which is how a marketplace comes to be called ``charter`` at all.
+#:
+#: A literal rather than something read at runtime, because the wheel does not ship
+#: `.claude-plugin/`: `[tool.hatch.build.targets.wheel] packages = ["charter"]`, so a CLI
+#: installed from PyPI has no manifest to read this out of. `tests/test_plugin_install.py`
+#: pins it to `pyproject.toml`'s own `Repository` URL instead, so the day charter moves
+#: house the suite fails rather than every stranger's first install.
+MARKETPLACE_SOURCE = "diazoxide/charter"
+
+#: The scope charter installs its own plugin at, and NOT ``user``.
+#:
+#: The README states the consequence and it is the whole reason a plane pins the plugin's
+#: version rather than the binary's: *"two planes on one laptop can sit on different
+#: charters without fighting"*. A machine-global install collapses that — one version for
+#: every plane on the machine — and it also puts charter's hooks into repositories nobody
+#: pointed charter at, which is #857's category exactly.
+INSTALL_SCOPE = "project"
+
 
 def available() -> bool:
     """True when the `claude` CLI is on PATH. False is an ordinary answer, not a fault —
@@ -154,6 +177,175 @@ def _claude_json(args: list[str], cwd=None, timeout: float = LIST_TIMEOUT):
         return None
 
 
+def _our_entries():
+    """Every ``claude plugin list`` row that IS charter's plugin, or :data:`UNKNOWN`.
+
+    Split out of :func:`installed_charter_plugin` when :func:`installed_for` needed the
+    same rows asked a different question. One reader, because two of them would eventually
+    disagree about which rows count as charter's — and the id check below is the only thing
+    standing between `charter doctor --fix` and a plugin that is not charter's to touch.
+    """
+    entries = _claude_json(["list"])
+    if entries is None:
+        return UNKNOWN
+    if not isinstance(entries, list):
+        return UNKNOWN          # `--json` answered something that is not a list of rows
+    ours = []
+    for e in entries:
+        if not isinstance(e, dict):
+            continue
+        pid = e.get("id")
+        # Equality against a module constant, and NOT also `_PLUGIN_ID_RE` — which used to
+        # sit on the line above and became dead the moment this narrowed to one id. An
+        # equality test against a constant is strictly stronger than any pattern: what
+        # survives it IS the constant. The regex was kept for a while as "defence in
+        # depth", which is the honest name for a check no test can distinguish from its own
+        # absence; `refresh_argvs` still applies it, because that function takes an id from
+        # a caller rather than producing one.
+        if pid != PLUGIN_ID:
+            continue
+        if e.get("scope") not in _SCOPES:
+            continue
+        ours.append(e)
+    return ours
+
+
+def _same_dir(a, b) -> bool:
+    """Do two paths name the same directory? ``False`` for anything unresolvable.
+
+    `Path.resolve` is what makes ``/var/…`` and ``/private/var/…`` the same answer on
+    macOS, which is not a test-only concern: a plane under ``/tmp`` is a symlinked path in
+    every terminal on that machine.
+    """
+    if not isinstance(a, str) or not isinstance(b, (str, Path)):
+        return False
+    try:
+        return Path(a).resolve() == Path(b).resolve()
+    except (OSError, RuntimeError, ValueError):
+        return False
+
+
+def covers(entry: dict, project) -> bool:
+    """Does this install of charter's plugin apply to a session rooted at *project*?
+
+    ``user`` scope is machine-wide and covers everything. ``project`` and ``local`` are
+    bound to the directory they were installed from, so an install belonging to somebody
+    else's checkout is **not** an answer for this plane — and reading it as one is how
+    "already installed" would be printed over a plane with no plugin at all, which is
+    `check_guard_wired`'s #168 defect wearing a different row.
+    """
+    if entry.get("scope") == "user":
+        return True
+    return _same_dir(entry.get("projectPath"), project)
+
+
+def installed_for(project):
+    """The charter plugin install that covers *project* — or :data:`UNKNOWN`, or ``None``.
+
+    :func:`installed_charter_plugin` answers a different question and keeps answering it:
+    *which install may charter refresh*, where every project-scoped install points at the
+    same versioned cache directory, so any one of them will do. This one answers *is this
+    plane covered*, where they are not interchangeable at all.
+    """
+    ours = _our_entries()
+    if ours is UNKNOWN:
+        return UNKNOWN
+    for e in ours:
+        if covers(e, project):
+            return e
+    return None
+
+
+def install_argvs(scope: str = INSTALL_SCOPE,
+                  source: str = MARKETPLACE_SOURCE) -> list[list[str]] | None:
+    """The two commands that put charter's plugin on a machine, in order.
+
+    ``None`` if *scope* is not one charter will install at, so a caller cannot run half a
+    sequence against a value charter would not have built an argv from — the discipline
+    :func:`refresh_argvs` already keeps.
+
+    **The order is the mechanism**, and it is the fact this repository used to keep in
+    prose: `tests/test_docs.py` pinned *"installing from a marketplace that has not been
+    added fails"* against the README's paste-in block. The README no longer types these
+    commands, so the assertion moved here, onto the code that runs them.
+
+    ``-y`` on the install because charter runs it non-interactively; `claude` requires it
+    when stdout is not a TTY and would otherwise refuse rather than prompt.
+    """
+    if scope not in _SCOPES:
+        return None
+    if not isinstance(source, str) or not source or source.startswith("-"):
+        return None
+    return [
+        ["claude", "plugin", "marketplace", "add", source],
+        ["claude", "plugin", "install", PLUGIN_ID, "--scope", scope, "-y"],
+    ]
+
+
+def _step(argv: list[str], cwd) -> tuple[bool, str]:
+    """Run one `claude plugin` step. ``(ok, why)``, never raising — same reasons as
+    :func:`force_refresh`, which this sits beside."""
+    try:
+        proc = util.run(argv, cwd=cwd, check=False, timeout=REFRESH_TIMEOUT)
+    except (util.ProcTimeout, OSError) as e:
+        return False, str(e) or type(e).__name__
+    if proc.returncode != 0:
+        why = (proc.stderr or proc.stdout or "").strip().splitlines()
+        return False, (why[-1][:200] if why else f"exit {proc.returncode}")
+    return True, ""
+
+
+def install(project, scope: str = INSTALL_SCOPE) -> tuple[str, str]:
+    """Install charter's own Claude Code plugin for *project*. ``(status, detail)``.
+
+    Five statuses, because five different things are true and only one of them is a fault:
+
+    * ``present`` — an install already covers *project*. Nothing runs.
+    * ``installed`` — charter added the marketplace and installed the plugin.
+    * ``unavailable`` — no `claude` on PATH. An opencode or Codex plane, or a terminal
+      with no Claude Code at all; a perfectly ordinary state and never an error.
+    * ``unknown`` — `claude plugin list --json` could not be read. **Nothing is installed
+      on a guess.** An older `claude` that does not understand `--json` is the population
+      this is for, and installing over an unknown state is how a second copy appears.
+    * ``failed`` — a step ran and did not succeed.
+
+    **Only ever called from a command a person typed** — `charter init` and `charter doctor
+    --fix`. Nothing here may be reached as a side effect of `charter workspace list`:
+    installing software because some unrelated command ran is #857's surprise, and the same
+    reason charter refuses to write `~/.claude/settings.json` unasked.
+    """
+    if not available():
+        return "unavailable", ("the `claude` CLI is not on PATH, so there is no Claude "
+                               "Code to install a plugin into")
+    entry = installed_for(project)
+    if entry is UNKNOWN:
+        return "unknown", ("could not read `claude plugin list --json`, so charter does "
+                           "not know what is installed and will not install over it")
+    if entry is not None:
+        return "present", (f"{entry.get('id')} is already installed "
+                           f"({entry.get('scope')} scope)")
+    argvs = install_argvs(scope)
+    if argvs is None:
+        return "failed", f"{scope!r} is not a scope charter will install at"
+    add, put = argvs
+    cwd = str(project) if project is not None and Path(project).is_dir() else None
+    added, why_add = _step(add, cwd)
+    ok, why = _step(put, cwd)
+    if ok:
+        return "installed", f"{PLUGIN_ID} installed at {scope} scope"
+    # The marketplace step is allowed to fail and the install still to be attempted: a
+    # marketplace that is ALREADY registered is the common way `add` exits non-zero, and
+    # refusing to continue there would make the second install on a machine impossible.
+    # So the install's own failure is the verdict — and when the step before it failed too,
+    # that is said, because "already registered" and "offline" fail identically here and
+    # the reader needs to know a second command was also unhappy.
+    if not added:
+        return "failed", (f"`{' '.join(put)}` failed: {why}. `{' '.join(add)}` failed "
+                          f"first ({why_add}) — an already-registered marketplace fails "
+                          f"that way harmlessly, so read the install error above it.")
+    return "failed", f"`{' '.join(put)}` failed: {why}"
+
+
 def installed_charter_plugin(prefer_project=None):
     """The installed charter plugin entry — or :data:`UNKNOWN`, or ``None``.
 
@@ -186,28 +378,9 @@ def installed_charter_plugin(prefer_project=None):
     charter's to touch. A plugin outside that id reads as "not installed" here, which is
     the honest answer: charter cannot identify it as its own.
     """
-    entries = _claude_json(["list"])
-    if entries is None:
+    ours = _our_entries()
+    if ours is UNKNOWN:
         return UNKNOWN
-    if not isinstance(entries, list):
-        return UNKNOWN          # `--json` answered something that is not a list of rows
-    ours = []
-    for e in entries:
-        if not isinstance(e, dict):
-            continue
-        pid = e.get("id")
-        # Equality against a module constant, and NOT also `_PLUGIN_ID_RE` — which used to
-        # sit on the line above and became dead the moment this narrowed to one id. An
-        # equality test against a constant is strictly stronger than any pattern: what
-        # survives it IS the constant. The regex was kept for a while as "defence in
-        # depth", which is the honest name for a check no test can distinguish from its own
-        # absence; `refresh_argvs` still applies it, because that function takes an id from
-        # a caller rather than producing one.
-        if pid != PLUGIN_ID:
-            continue
-        if e.get("scope") not in _SCOPES:
-            continue
-        ours.append(e)
     if not ours:
         return None
     if prefer_project is not None:

--- a/docs/harnesses.md
+++ b/docs/harnesses.md
@@ -37,7 +37,7 @@ offer**, and `charter doctor` prints the gap rather than leaving you to find it:
 
 | | how it is installed | how it updates | what it cannot carry | what to do about it |
 | --- | --- | --- | --- | --- |
-| Claude Code | the plugin (`claude plugin install charter@charter`) | `claude plugin update charter@charter` | — | — |
+| Claude Code | `charter init` — the plugin, at `project` scope, for the plane it creates (`charter doctor --fix` for a plane that already exists) | `claude plugin update charter@charter` | — | — |
 | opencode | `charter init` — one plugin under opencode's config dir, read by every project | charter moves it — its own file, compared byte for byte (`read_bytes`) with the one charter generates; anything else in that plugin directory is named too, and nothing charter did not write is ever overwritten | no status bar; no per-turn prompt hook; no ask at tool time; no per-workspace config; **no isolation from other plugins** | `charter statusline --watch`; mid-session notes ride tool output already; charter's own tool-time asks allow and are not shown — denials are unaffected; a second plugin in that directory shares charter's globals and can disable its guards, so `doctor` names it — charter reports the realm, it cannot contain it |
 | Codex | the same plugin (`codex plugin`), plus `charter harness install codex` to name the harness | `codex plugin marketplace upgrade charter && codex plugin add charter@charter` | no status bar; no command-pattern permissions; no project-level config *file*, so no per-workspace config (a project `.codex/skills/` **is** read — a skills surface, not config) | `charter statusline --watch`; `guard ask` rules stay in charter's own hook |
 
@@ -53,8 +53,16 @@ exist costs more to chase than an honest gap.
 
 ## Wiring, and when it happens
 
-`charter init` writes each harness's wiring into the plane. Nothing to install per harness,
-with one exception (Codex, below).
+`charter init` writes each harness's wiring into the plane, and installs the one artifact
+charter can install for you: Claude Code's charter plugin, at `project` scope, for the plane
+it is creating. Codex is the exception (below) — its wiring is machine-global, so it waits
+to be asked by name.
+
+**`init` and `charter doctor --fix`, and nothing else.** Installation never happens as a
+side effect of an ordinary command: `charter workspace list` does not install software, and
+`charter reinit` — which re-runs the *wiring* — does not either. Both doors are commands
+somebody typed, which is the same shape `charter harness install codex` has and the same
+reason charter refuses to write `~/.claude/settings.json` unasked.
 
 **Plus one generated file per workspace, and only for Claude Code.** Claude Code reads
 project settings from the session's working directory and does not walk up, so a chat

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -4,8 +4,11 @@ The CLI is one of charter's two artifacts. The other is a **Claude Code plugin**
 plugin is almost entirely hooks: the things that have to happen without anyone remembering
 to ask for them.
 
-Install both — a CLI with no plugin leaves every guard and every injection dead, while
-looking completely installed. See [install.md](install.md).
+You install one of them. `uv tool install charter-cp` puts the CLI on your `PATH`, and
+`charter init` installs the plugin for the plane it creates — `charter doctor --fix` for a
+plane that already exists. A CLI with no plugin leaves every guard and every injection
+dead, while looking completely installed, which is why `charter doctor`'s `plugin install`
+row names the gap rather than leaving you to notice it. See [install.md](install.md).
 
 The plugin ships **no Python**. Every hook is a `charter hook <name>` call against the CLI
 on `PATH`, which is why a version skew between the two is worth shouting about and is the
@@ -641,6 +644,13 @@ the guard, while "the harness did not get this" can still become a refusal.
 The deliberate exception is version skew, in **both** directions — that is the failure shape
 this project keeps paying for, so it is the one thing a hook says out loud, once, at session
 start.
+
+**Out loud, and never fatal.** The two artifacts update through different channels (`uv
+tool upgrade`, `claude plugin update`), so skew is normal rather than exceptional and will
+happen mid-session. A hook that hard-failed on it would refuse every tool call in that
+session, turning a cosmetic mismatch into an outage — so the hooks warn and keep guarding,
+and it is `charter doctor` that refuses, on a row naming the exact command. Same fact, two
+surfaces, and only the one you can act on without losing the session is allowed to block.
 
 - **Plugin newer than the CLI** — the manifest dispatches `charter hook <name>` for a handler
   this CLI does not have, so it errors. `doctor` FAILs, which is what makes the SessionStart

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,28 +1,42 @@
 # Install
 
-charter ships as **two artifacts** — install both. A CLI-only install leaves the plugin's
-hooks inert (no session context injection, no golden-rule guard, no auto-save), since the
-plugin is what actually wires them into Claude Code.
+**One command installs charter.**
+
+```bash
+uv tool install charter-cp
+```
+
+That is the CLI, and the CLI is the front door: it is what sits on your `PATH`, what every
+hook charter declares shells out to, and what writes `.claude/settings.json`. Claude Code's
+charter plugin is the *second* artifact, and you do not install it by hand — `charter init`
+installs it for the plane it creates, and `charter doctor --fix` installs it for a plane
+that already exists. The inverse shape, a plugin that bootstraps a CLI, would have to guess
+at a Python environment it does not own.
+
+Nothing installs itself. `init` and `doctor --fix` are the only two commands that install
+anything, and both are commands you typed; `charter workspace list` will never install
+software as a side effect of answering a question.
 
 ## Paste this into Claude Code
 
-Both artifacts, installed and checked, without looking anything up:
+Installed and checked, without looking anything up:
 
 ```
 Install charter (https://github.com/diazoxide/charter) for me:
 
-1. CLI: run `uv tool install charter-cp`. charter needs Python 3.11+, which uv can
+1. Run `uv tool install charter-cp`. charter needs Python 3.11+, which uv can
    fetch for me; fall back to pipx or pip only if uv is missing.
-2. Plugin: run `claude plugin marketplace add diazoxide/charter`, then
-   `claude plugin install charter@charter`.
-3. Run `charter doctor` and show me the output.
-4. Do NOT run `charter init` — tell me what it would create and let me pick the
-   directory first.
+2. Run `charter doctor` and show me the output. Its `plugin install` row will say
+   Claude Code's charter plugin is missing — that is expected here, because the
+   plugin is installed per control plane and there is no plane yet.
+3. Do NOT run `charter init` — tell me what it would create and let me pick the
+   directory first. `charter init` is what installs the plugin, for the plane it
+   creates.
 
-Then tell me to restart this session so the plugin's hooks load.
+Then tell me to restart this session once the plane exists, so the plugin's hooks load.
 ```
 
-Step 4 is not caution for its own sake: `charter init` makes the directory it runs in a
+Step 3 is not caution for its own sake: `charter init` makes the directory it runs in a
 control plane, writing `charter.toml` and scaffolding `personas/`, `inventory/` and
 `workspaces/` (see [control-plane.md](control-plane.md)). Run from an unrelated project by
 accident, it would quietly convert it — so the prompt stops before the step that writes
@@ -59,15 +73,34 @@ uvx --from charter-cp charter <cmd>
 > `charter` as a project name, so the distribution carries a suffix — but everything you
 > type, and everything in the docs, is `charter`.
 
-## 2. The Claude Code plugin
+## 2. The Claude Code plugin — charter installs it
 
 This repo also ships as a Claude Code plugin — `.claude-plugin/plugin.json` +
-`hooks/hooks.json` — installed the way you install any Claude Code plugin from a git repo.
-From a shell:
+`hooks/hooks.json` — and you do not type the commands for it:
+
+```bash
+charter init          # creates a control plane, and installs the plugin for it
+charter doctor --fix  # installs it into a plane that already exists
+```
+
+**Per plane, at `project` scope, and that is a feature rather than an accident.** Claude
+Code keeps a cache holding every version of a plugin at once, so a plane's pinned version
+is the plugin's and not the binary's: two planes on one laptop can sit on different
+charters without fighting. A machine-wide install would collapse that to one version, and
+would put charter's hooks into repositories you never pointed charter at.
+
+`charter doctor` reports the plugin's absence on its own `plugin install` row and names
+`charter doctor --fix` as the remedy. It **warns** rather than failing: a plane that
+declares `charter hook pretooluse` in its own `.claude/settings.json` is guarded with no
+plugin at all, and a CLI-only install is supported — `charter clone`, `charter persona
+show` and the rest work with no plugin anywhere.
+
+By hand, if you would rather, or if `charter doctor --fix` could not (an old `claude`, no
+network):
 
 ```bash
 claude plugin marketplace add diazoxide/charter
-claude plugin install charter@charter
+claude plugin install charter@charter --scope project
 ```
 
 Or inside a session: `/plugin marketplace add diazoxide/charter`, then `/plugin install
@@ -76,22 +109,34 @@ on since this was written.
 
 The plugin loads on the **next** session, so restart after installing. Upgrading the CLI
 does not upgrade the plugin — they are two artifacts with two version numbers, pinned to
-each other, so `claude plugin update charter@charter` is its own step. A plugin *newer*
-than the CLI says so loudly at session start; an older one is quietly supported.
+each other, so `claude plugin update charter@charter` is its own step, and skew between
+them is normal rather than exceptional. `charter doctor` **refuses** on skew, with a row
+naming the exact command; charter's hooks only **warn**, at session start and nowhere else.
+That asymmetry is deliberate: a hook that hard-failed on a version mismatch would brick
+every tool call in the session, turning a cosmetic difference into an outage. A plugin
+*newer* than the CLI says so loudly at session start; an older one is quietly supported.
 
 The plugin supplies the pieces that only make sense running *inside* a Claude Code
 session: injecting the active persona's memory at session start, the `PreToolUse` guard
 that enforces the [one-credential rule](git-policy.md), the record-memory nudges, and the
 Stop-hook auto-save. **The plugin ships no Python of its own** — every hook it declares
-just shells out to the `charter` CLI you installed in step 1, so the CLI must be on `PATH`
-first. The CLI works standalone for everything else (`charter clone`, `charter persona
-show`, …) with the plugin absent; install the plugin too if you want charter actively
-driving a live session, not just scripted from a terminal.
+just shells out to the `charter` CLI you installed in step 1, which is why the CLI is the
+artifact you install and the plugin is the one it installs for you.
 
 ## 3. opencode and Codex
 
 Each harness gets **one installed artifact**, the same way Claude Code does. Nothing is
 written into the repos you work in.
+
+**Only Claude Code's artifact is one charter installs for you, and the difference is
+scope.** The Claude Code plugin is installed per project, so `charter init` installing it
+touches exactly the plane you just asked charter to create. Codex's wiring lives only in
+`~/.codex/config.toml` — a machine-global file, in force for every repository on the
+machine — so charter writes it only when you run `charter harness install codex`, where
+running the command *is* the consent. `charter doctor` reports the gap and stops there;
+one documented one-time edit is a smaller cost than charter silently rewriting a
+machine-wide config, and unlike the plugin that file is not something a charter upgrade
+has to keep in lockstep.
 
 **opencode — `charter init` does it.** The plugin goes to `~/.config/opencode/plugin/`
 (`$XDG_CONFIG_HOME` is honoured), which opencode reads for every project, along with a

--- a/docs/install.md
+++ b/docs/install.md
@@ -95,6 +95,11 @@ declares `charter hook pretooluse` in its own `.claude/settings.json` is guarded
 plugin at all, and a CLI-only install is supported — `charter clone`, `charter persona
 show` and the rest work with no plugin anywhere.
 
+The same row says so when the plugin is installed and **disabled**, because an installed
+plugin loads nothing until it is enabled. charter will not enable it for you — `claude
+plugin enable charter@charter --scope project` is yours to run, since turning a plugin off
+is a choice and charter does not revert a deliberate edit.
+
 By hand, if you would rather, or if `charter doctor --fix` could not (an old `claude`, no
 network):
 

--- a/docs/news/unreleased-installing-charter-installs-charter.md
+++ b/docs/news/unreleased-installing-charter-installs-charter.md
@@ -50,6 +50,12 @@ The row is scoped to the **plane**, not the machine: a project-scoped install be
 somebody else's checkout is not an answer here, and reading one as an answer would print
 "installed" over a plane with no plugin — #168's defect wearing a new row.
 
+It also refuses to tick over an install that is **disabled**. `claude plugin list --json`
+carries `enabled`, and installed is not enabled (#177) — an installed plugin loads nothing
+until it is switched on, and a green row over that is 0.31.1's failure exactly. charter
+names `claude plugin enable charter@charter --scope project` and stops there: turning a
+plugin off is a choice, and `--fix` does not revert a deliberate edit.
+
 ## Project scope, and never `user`
 
 The plugin is what carries a plane's pinned version, which is why `[charter].version` is

--- a/docs/news/unreleased-installing-charter-installs-charter.md
+++ b/docs/news/unreleased-installing-charter-installs-charter.md
@@ -1,0 +1,84 @@
+---
+version: unreleased
+headline: Installing charter installs charter — `uv tool install charter-cp`, and `charter init` brings Claude Code's plugin with it
+adopt: doctor --fix
+---
+
+The README used to ask for three commands and hope you ran all of them:
+
+```bash
+uv tool install charter-cp
+claude plugin marketplace add diazoxide/charter
+claude plugin install charter@charter
+```
+
+It now asks for one. `uv tool install charter-cp` puts the `charter` CLI on your `PATH`,
+and `charter init` installs Claude Code's charter plugin for the plane it just created.
+For a plane that already exists, `charter doctor --fix`.
+
+## The CLI is the front door
+
+The CLI is what sits on `PATH`, what all twelve hooks in `hooks/hooks.json` shell out to,
+and what already writes `.claude/settings.json` — so it exists before a harness session
+does. The inverse shape, a plugin that bootstraps a CLI, would have to guess at a Python
+environment it does not own.
+
+A third install of one of them was the failure this closes: the plugin ships **no Python**,
+so a CLI-only install leaves every guard and every injection dead while looking completely
+installed — and the person who skipped the second and third commands had no way to know.
+
+## `charter doctor` gained a row and a flag
+
+```
+  !  plugin install   charter's Claude Code plugin is not installed for this plane, so none
+                      of its hooks run here — no session context, no plane-root guard, no
+                      auto-save
+        → Run: charter doctor --fix  (installs `charter@charter` at project scope from
+          `diazoxide/charter`; `charter init` does the same thing on a fresh plane). The
+          plugin loads at the NEXT session, so restart afterwards.
+```
+
+**WARN, not FAIL**, and the distinction is load-bearing. `cmd_doctor` exits non-zero only
+on FAIL, and that exit code is what makes the SessionStart preflight print — so a FAIL here
+would put a red preflight in front of every CLI-only install, which `docs/install.md`
+supports and CI uses. It would also be wrong about protection: a plane that declares
+`charter hook pretooluse` in its own `.claude/settings.json` is guarded with no plugin at
+all, and `plane-root guard` is the row that answers whether the guard fires. This row
+answers whether the artifact charter can install for you is there.
+
+The row is scoped to the **plane**, not the machine: a project-scoped install belonging to
+somebody else's checkout is not an answer here, and reading one as an answer would print
+"installed" over a plane with no plugin — #168's defect wearing a new row.
+
+## Project scope, and never `user`
+
+The plugin is what carries a plane's pinned version, which is why `[charter].version` is
+measured against the plugin and not the binary: two planes on one laptop can sit on
+different charters without fighting. A machine-wide install would collapse that to one
+version per machine, and would put charter's hooks into repositories nobody pointed charter
+at.
+
+## Nothing self-heals
+
+`charter init` and `charter doctor --fix` install. Nothing else does — not `charter
+reinit`, which re-runs the *wiring*, and certainly not `charter workspace list`. A tool
+that installs software as a side effect of answering a question is the surprise #857 is
+about, and the same reason charter refuses to write `~/.claude/settings.json` unasked.
+
+## Version skew: `doctor` refuses, hooks only warn
+
+Unchanged, and now written down where it can be read. The two artifacts update through
+different channels (`uv tool upgrade`, `claude plugin update`), so skew is normal rather
+than exceptional and happens mid-session. A hook that hard-failed on it would refuse every
+tool call in that session, turning a cosmetic mismatch into an outage — so the hooks warn
+once at session start and keep guarding, and `charter doctor` is the surface that refuses.
+
+## Only Claude Code
+
+opencode's plugin already arrives with `charter init` — one file under
+`~/.config/opencode/`, because that is the only place opencode reads for every project.
+Codex's wiring lives only in `~/.codex/config.toml`, in force for every repository on the
+machine, so charter writes it only when you run `charter harness install codex`, where
+running the command is the consent. `charter doctor` reports that gap and stops there: one
+documented one-time edit is a smaller cost than charter silently rewriting a machine-wide
+config.

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -92,6 +92,15 @@ from . import _forgeprobe      # noqa: E402
 
 _forgeprobe.install()
 
+# One more fact about the machine that CI does not have and a laptop does: the `claude`
+# CLI. `charter init` now installs charter's own Claude Code plugin through it (#881), and
+# nine modules call `cmd_init` — so on a developer's machine a suite run would install a
+# plugin into their real Claude Code, per fixture plane, and CI would never have seen it.
+# See `tests/_claudeguard.py`; the opt-in is the one `test_plugin_freshness` already uses.
+from . import _claudeguard      # noqa: E402
+
+_claudeguard.install()
+
 # And the one thing no guard can prevent, only clean up after: a run that was KILLED.
 # Measured — a `kill -9` two seconds into `test_frame_overlay_escape_hatch` leaves a live
 # tmux server and its socket file behind, because the signal skips every `addCleanup`

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -94,9 +94,11 @@ _forgeprobe.install()
 
 # One more fact about the machine that CI does not have and a laptop does: the `claude`
 # CLI. `charter init` now installs charter's own Claude Code plugin through it (#881), and
-# nine modules call `cmd_init` — so on a developer's machine a suite run would install a
-# plugin into their real Claude Code, per fixture plane, and CI would never have seen it.
-# See `tests/_claudeguard.py`; the opt-in is the one `test_plugin_freshness` already uses.
+# nine modules call `cmd_init` in-process while `test_cli_smoke` runs it as a real
+# subprocess — so on a developer's machine a suite run installed a plugin into their real
+# Claude Code, once per fixture plane, scoped to temp directories that no longer exist.
+# Measured: five such rows in `claude plugin list`. See `tests/_claudeguard.py`; the
+# in-process opt-in is the one `test_plugin_freshness` already uses.
 from . import _claudeguard      # noqa: E402
 
 _claudeguard.install()

--- a/tests/_claudeguard.py
+++ b/tests/_claudeguard.py
@@ -1,0 +1,38 @@
+"""The suite answers what CI answers about the `claude` CLI: it is not on this machine.
+
+`charter init` installs charter's own Claude Code plugin (#881) — `claude plugin
+marketplace add`, then `claude plugin install charter@charter --scope project`. Nine test
+modules call `commands.cmd_init` directly, so on a developer's laptop, where `claude` IS on
+`PATH`, a suite run would install and reinstall a plugin into their real Claude Code, once
+per fixture plane, from throwaway temp directories that no longer exist by the time anyone
+looks at `claude plugin list`.
+
+CI has no `claude`, so CI would never have seen it. That is the shape `tests/_ttyguard.py`
+already records for the suite's file descriptors — *"all three streams now answer what CI
+answers, and a test that wants a different answer has to say so"* — and this is the same
+move for one more fact about the machine.
+
+**A test that wants a `claude` says so, and the idiom already exists.**
+`tests/test_plugin_freshness.py` opts in seventeen times with
+
+    mock.patch.object(plugincache, "available", return_value=True)
+
+and stubs the seam underneath it in the same `with`. Opting in without stubbing
+`plugincache.util.run` spawns the real binary, which is the one thing this file cannot
+answer for: `available` is a fact about the machine, not a fake `claude`.
+"""
+
+from __future__ import annotations
+
+
+def install() -> None:
+    """Make `plugincache.available()` answer ``False`` for the whole run.
+
+    Patched on the module rather than on `shutil.which`, because `which` answers for every
+    binary the suite looks up — `git`, `gh`, `tmux` — and this is a statement about one of
+    them. `available` is also the exact seam every existing opt-in already patches, so a
+    test that wants the other answer needs to know about one name and not two.
+    """
+    from charter import plugincache
+
+    plugincache.available = lambda: False

--- a/tests/_claudeguard.py
+++ b/tests/_claudeguard.py
@@ -1,38 +1,79 @@
-"""The suite answers what CI answers about the `claude` CLI: it is not on this machine.
+"""No test, in this process or in a child, may reach the developer's real Claude Code.
 
 `charter init` installs charter's own Claude Code plugin (#881) — `claude plugin
-marketplace add`, then `claude plugin install charter@charter --scope project`. Nine test
-modules call `commands.cmd_init` directly, so on a developer's laptop, where `claude` IS on
-`PATH`, a suite run would install and reinstall a plugin into their real Claude Code, once
-per fixture plane, from throwaway temp directories that no longer exist by the time anyone
-looks at `claude plugin list`.
+marketplace add`, then `claude plugin install charter@charter --scope project`. Nine
+modules call `commands.cmd_init` in-process and `tests/test_cli_smoke.py` runs it as a real
+subprocess, so on a laptop with `claude` on `PATH` a suite run installs a plugin into the
+operator's real Claude Code once per fixture plane. Measured before this file existed: five
+`charter@charter` rows in `claude plugin list`, every one of them scoped to a temp directory
+that no longer existed.
 
-CI has no `claude`, so CI would never have seen it. That is the shape `tests/_ttyguard.py`
-already records for the suite's file descriptors — *"all three streams now answer what CI
-answers, and a test that wants a different answer has to say so"* — and this is the same
-move for one more fact about the machine.
+CI has no `claude`, so CI would never have shown it — the same shape `tests/_ttyguard.py`
+records for the suite's file descriptors and `tests/__init__.py` for `$XDG_CONFIG_HOME`.
 
-**A test that wants a `claude` says so, and the idiom already exists.**
-`tests/test_plugin_freshness.py` opts in seventeen times with
+**Two mechanisms, because a child process cannot be patched.**
 
-    mock.patch.object(plugincache, "available", return_value=True)
+* In this process, :func:`install` makes `plugincache.available()` answer ``False`` — CI's
+  answer. A test that wants the other one says so, with the idiom
+  `tests/test_plugin_freshness.py` already uses seventeen times::
 
-and stubs the seam underneath it in the same `with`. Opting in without stubbing
-`plugincache.util.run` spawns the real binary, which is the one thing this file cannot
-answer for: `available` is a fact about the machine, not a fake `claude`.
+      mock.patch.object(plugincache, "available", return_value=True)
+
+  and stubs the seam underneath it in the same `with`. Opting in without also stubbing
+  `plugincache.util.run` spawns a real binary — `available` is a fact about the machine,
+  not a fake `claude`.
+
+* For children, a fake `claude` goes FIRST on ``$PATH``. It answers `plugin list --json`
+  and `plugin marketplace list --json` with ``[]`` — *Claude Code is here and charter's
+  plugin is not* — and accepts the mutating subcommands silently. So a subprocess `charter
+  init` walks the whole install path and reports what a first install reports, having
+  touched nothing. It is deliberately stateless: a fixture that remembered its own installs
+  would be a second implementation of Claude Code's plugin registry, and every test here
+  asks one question of it.
 """
 
 from __future__ import annotations
 
+import os
+import stat
+import tempfile
+from pathlib import Path
+
+#: A `claude` that knows exactly as much as this suite asks it. Everything it does not
+#: recognise exits 0 and says nothing, which is what makes it safe rather than complete:
+#: the failure mode of an unknown subcommand is "nothing happened", never "something
+#: happened to the operator's machine".
+_FAKE = '''#!/usr/bin/env python3
+"""The test suite's `claude`. See tests/_claudeguard.py — nothing here is real."""
+import sys
+
+argv = sys.argv[1:]
+if argv[:1] == ["plugin"] and "--json" in argv:
+    # `plugin list` and `plugin marketplace list`: an empty registry, so charter reads
+    # "Claude Code is installed here and charter's plugin is not" and takes the install
+    # path. An unreadable answer would instead be `UNKNOWN`, which is the branch that
+    # deliberately installs NOTHING.
+    print("[]")
+sys.exit(0)
+'''
+
 
 def install() -> None:
-    """Make `plugincache.available()` answer ``False`` for the whole run.
-
-    Patched on the module rather than on `shutil.which`, because `which` answers for every
-    binary the suite looks up — `git`, `gh`, `tmux` — and this is a statement about one of
-    them. `available` is also the exact seam every existing opt-in already patches, so a
-    test that wants the other answer needs to know about one name and not two.
-    """
+    """Arm both halves. Idempotent, and called once from `tests/__init__.py`."""
     from charter import plugincache
 
+    # Patched on the module rather than on `shutil.which`, because `which` answers for
+    # every binary the suite looks up — `git`, `gh`, `tmux` — and this is a statement about
+    # one of them. It is also the exact seam every existing opt-in already patches, so a
+    # test that wants the other answer needs to know one name and not two.
     plugincache.available = lambda: False
+
+    d = Path(tempfile.mkdtemp(prefix="charter-suite-claude-")) / "bin"
+    d.mkdir(parents=True, exist_ok=True)
+    fake = d / "claude"
+    fake.write_text(_FAKE)
+    fake.chmod(fake.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+    # PREPENDED, not appended: the operator's real `claude` is further down this same PATH
+    # and appending would leave it winning. A child that spawns a grandchild inherits this
+    # too, which is the point.
+    os.environ["PATH"] = f"{d}{os.pathsep}{os.environ.get('PATH', '')}"

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -5,7 +5,6 @@ drifted: the install command, the config keys, and the two framings that protect
 (the vault is not a password manager; memory defaults to local)."""
 from __future__ import annotations
 
-import json
 import re
 import unittest
 from pathlib import Path
@@ -32,6 +31,23 @@ class TestReadme(unittest.TestCase):
     def test_documents_both_artifacts(self):
         """Install is the CLI *and* the plugin — omitting the plugin leaves hooks dead."""
         self.assertIn("plugin", README.lower())
+
+    def test_the_install_section_asks_for_one_command(self):
+        """#881. The README used to print three commands and hope the reader ran all of
+        them; a CLI-only install leaves every hook inert while looking complete.
+
+        Asserted against the CODE BLOCK rather than the prose, because the prose still
+        names `claude plugin update charter@charter` — correctly, since updating the
+        plugin remains its own step — and a whole-document search would pass on a README
+        that had gone back to typing the install by hand.
+        """
+        block = next(b for b in re.findall(r"```bash\n(.*?)```", README, re.S)
+                     if "charter init" in b)
+        self.assertIn("uv tool install charter-cp", block)
+        for gone in ("claude plugin marketplace add", "claude plugin install"):
+            self.assertNotIn(gone, block,
+                             f"the 60-seconds block still types {gone!r} — `charter init` "
+                             f"installs the plugin (#881)")
 
     def test_frames_the_vault_honestly(self):
         """It stores plaintext at 0600. Saying anything that implies encryption at rest
@@ -74,21 +90,32 @@ class TestPasteInInstall(unittest.TestCase):
 
     Prose that drifts merely reads oddly; a prompt that drifts *fails*, in someone else's
     session, on their first contact with the project. Every command in it is therefore
-    checked against the thing it names — the distribution on PyPI, and the plugin id built
-    from the two manifests — rather than trusted to stay true.
+    checked against the thing it names — the distribution on PyPI — rather than trusted to
+    stay true. The plugin id and the order its two `claude plugin` steps run in used to be
+    checked here too; #881 moved both into code (`plugincache.install_argvs`) and
+    `tests/test_plugin_install.py` holds them there, against the same two manifests.
 
     The prompt is looked for in the README *and* in `docs/install.md`, because which page
     hosts it is a layout decision and these checks are not: they must keep holding when it
     moves, or moving it silently retires them.
     """
 
+    #: Fences are paired by ANCHORING both ends at the start of a line and letting the
+    #: opener carry an optional language, which is what keeps the pairing in phase.
+    #:
+    #: The previous spelling matched only a bare "```\n" as an opener, so a ```bash block
+    #: anywhere ABOVE the prompt put the whole document out of phase: its closing fence
+    #: reads as an opening one, and every pair from there on is shifted by one. #881 put a
+    #: `uv tool install charter-cp` block at the top of `docs/install.md` and the prompt
+    #: stopped being found at all — four cases failing for a document that still said the
+    #: right thing. The old comment named that hazard and defended against only half of it.
+    _FENCE = re.compile(r"^```[A-Za-z0-9_+-]*\n(.*?)^```", re.S | re.M)
+
     def _paste_block(self) -> str:
-        # Each document is scanned on its own. Concatenating them first puts the fence
-        # matcher out of phase — a ```bash block opens with "```bash", not "```\n", so
-        # its *closing* fence reads as an opening one and the pairing shifts by one from
-        # there on. Joined, the prompt stops being found at all.
+        # Each document is still scanned on its own: concatenating them would let a fence
+        # in one pair with a fence in the other.
         for doc in (README, INSTALL):
-            for block in re.findall(r"```\n(.*?)```", doc, re.S):
+            for block in self._FENCE.findall(doc):
                 if "Install charter" in block:
                     return block
         self.fail("the paste-in install prompt is gone from the docs")
@@ -100,18 +127,19 @@ class TestPasteInInstall(unittest.TestCase):
         pkg = tomllib.loads((ROOT / "pyproject.toml").read_text())["project"]["name"]
         self.assertIn(pkg, self._paste_block())
 
-    def test_the_plugin_id_matches_both_manifests(self):
-        """`plugin@marketplace`, built from `.claude-plugin/plugin.json` and
-        `marketplace.json`. Rename either and the prompt keeps looking right while
-        installing nothing — the same silent-rot shape as the version drift."""
-        plugin = json.loads((ROOT / ".claude-plugin" / "plugin.json").read_text())["name"]
-        market = json.loads((ROOT / ".claude-plugin" / "marketplace.json").read_text())["name"]
-        self.assertIn(f"claude plugin install {plugin}@{market}", self._paste_block())
-
-    def test_it_adds_the_marketplace_before_installing_from_it(self):
+    def test_it_no_longer_types_the_plugin_install_by_hand(self):
+        """The two assertions this replaces — that the prompt names
+        `claude plugin install <plugin>@<marketplace>`, and that it adds the marketplace
+        first — were pinning a real mechanism to prose. #881 moved the mechanism into
+        `plugincache.install_argvs`, which `tests/test_plugin_install.py` now holds to both
+        facts against the same two manifests. What is left to say here is that the prompt
+        does not go back to typing them: it installs the CLI, and `charter init` installs
+        the plugin for the plane the reader picks."""
         block = self._paste_block()
-        self.assertLess(block.index("marketplace add"), block.index("plugin install"),
-                        "installing from a marketplace that has not been added fails")
+        self.assertNotIn("claude plugin install", block)
+        self.assertNotIn("marketplace add", block)
+        self.assertIn("charter init", block,
+                      "the prompt must still say which command installs the plugin")
 
     def test_it_does_not_tell_an_agent_to_run_init(self):
         """`charter init` inside an existing git repo makes THAT repo a control plane.

--- a/tests/test_plugin_install.py
+++ b/tests/test_plugin_install.py
@@ -141,6 +141,31 @@ class AnInstallBelongingToSomebodyElsesCheckoutIsNotAnAnswerHere(unittest.TestCa
         with rows([{"id": "charter@someone-else", "scope": "user"}]):
             self.assertIsNone(plugincache.installed_for("/planes/a"))
 
+    def test_the_same_directory_spelled_two_ways_is_the_same_directory(self):
+        """Not a test-only nicety. macOS resolves `/tmp` to `/private/tmp` and `/var` to
+        `/private/var`, so a plane under either is spelled one way by `claude plugin list`
+        and another by the shell — and an unresolved compare would report "not installed"
+        for an install that is right there."""
+        import os
+        import tempfile
+
+        real = Path(tempfile.mkdtemp(prefix="charter-samedir-"))
+        self.addCleanup(lambda: __import__("shutil").rmtree(real, ignore_errors=True))
+        link = real.parent / (real.name + "-link")
+        os.symlink(real, link)
+        self.addCleanup(lambda: link.unlink(missing_ok=True))
+        entry = {"id": "charter@charter", "scope": "project", "projectPath": str(real)}
+        with rows([entry]):
+            self.assertIsNotNone(plugincache.installed_for(link))
+
+    def test_a_projectPath_that_is_not_a_string_is_not_a_match(self):
+        """`claude plugin list --json` is a machine's own output, not a committed file, but
+        it is still input: a row whose `projectPath` is null or a number must answer "no",
+        not raise out of a `doctor` row."""
+        for junk in (None, 17, ["/planes/a"]):
+            with rows([{"id": "charter@charter", "scope": "project", "projectPath": junk}]):
+                self.assertIsNone(plugincache.installed_for("/planes/a"), junk)
+
 
 class TheInstallItself(unittest.TestCase):
     def test_it_installs_when_nothing_covers_this_plane(self):
@@ -150,6 +175,27 @@ class TheInstallItself(unittest.TestCase):
         self.assertEqual(status, "installed")
         self.assertEqual([c[0] for c in calls], plugincache.install_argvs())
         self.assertIn("charter@charter", detail)
+
+    def test_it_runs_from_the_plane_so_project_scope_lands_on_the_plane(self):
+        """`claude plugin install --scope project` installs for the CWD. Run it from
+        anywhere else and the plugin is installed for that other directory instead —
+        silently, since the command succeeds either way."""
+        import tempfile
+
+        plane = Path(tempfile.mkdtemp(prefix="charter-installcwd-"))
+        self.addCleanup(lambda: __import__("shutil").rmtree(plane, ignore_errors=True))
+        calls: list = []
+        with rows([]), spawns(calls):
+            plugincache.install(plane)
+        self.assertEqual([c[1] for c in calls], [str(plane), str(plane)])
+
+    def test_a_plane_path_that_is_not_a_directory_spawns_with_no_cwd(self):
+        """Rather than handing `subprocess` a directory that is not there, which raises
+        where a returned failure is wanted."""
+        calls: list = []
+        with rows([]), spawns(calls):
+            plugincache.install("/no/such/plane")
+        self.assertEqual([c[1] for c in calls], [None, None])
 
     def test_it_runs_nothing_when_an_install_already_covers_this_plane(self):
         calls: list = []
@@ -247,6 +293,50 @@ class InstallationHappensWhereSomebodyAskedForIt(PersonaIso):
             self._provisions(
                 lambda: commands.cmd_doctor(SimpleNamespace(json=True, fix=True))), 1)
 
+    def test_fix_outside_a_plane_installs_nothing_and_says_where_to_go(self):
+        """The plugin is installed per PROJECT, so with no plane there is no directory to
+        install it for. `doctor` outside a plane is a supported way to preflight a machine
+        — it must not become a way to install into whatever directory you stood in."""
+        import io
+        from contextlib import redirect_stderr
+
+        from charter import config
+
+        config.use(self.tmp / "not-a-plane")
+        buf = io.StringIO()
+        n = 0
+        with redirect_stderr(buf):
+            n = self._provisions(lambda: commands._run_doctor_fix())
+        self.assertEqual(n, 0)
+        self.assertIn("charter init", buf.getvalue())
+
+    def test_fix_with_nothing_to_do_says_so_rather_than_nothing(self):
+        """A command that produced no output would read as one that did not run."""
+        import io
+        from contextlib import redirect_stderr
+
+        commands.cmd_init(SimpleNamespace(forge="github", owner="acme", host=None))
+        buf = io.StringIO()
+        with redirect_stderr(buf), \
+                mock.patch.object(commands, "_provision_harnesses", return_value=[]):
+            commands._run_doctor_fix()
+        self.assertIn("nothing to install", buf.getvalue())
+
+    def test_fix_warns_about_an_install_it_could_not_vouch_for(self):
+        """`unvouched` carries a sentence, and a `--fix` that failed must not read as a
+        `--fix` that worked — the row it did not turn green is the verdict, but the reason
+        is only here."""
+        import io
+        from contextlib import redirect_stderr
+
+        commands.cmd_init(SimpleNamespace(forge="github", owner="acme", host=None))
+        buf = io.StringIO()
+        with redirect_stderr(buf), \
+                mock.patch.object(commands, "_provision_harnesses",
+                                  return_value=[("unvouched", "it did not work because X")]):
+            commands._run_doctor_fix()
+        self.assertIn("it did not work because X", buf.getvalue())
+
     def test_the_flag_is_reachable_from_the_command_line(self):
         """A flag argparse does not define is a flag nobody can type."""
         from charter import cli
@@ -321,6 +411,27 @@ class TheDoctorRowReportsTheGapWithoutCryingWolf(PersonaIso):
             res = doctor.check_plugin_install()
         self.assertEqual(res.status, doctor.OK)
         self.assertIn("project", res.detail)
+
+    def test_a_plane_with_no_claude_at_all_is_green_and_says_why(self):
+        """opencode and Codex planes are supported installs with no Claude Code plugin to
+        be missing. A yellow row on every one of them is the cry-wolf failure that costs
+        the rows that matter."""
+        with mock.patch.object(plugincache, "available", return_value=False):
+            res = doctor.check_plugin_install()
+        self.assertEqual(res.status, doctor.OK)
+        self.assertIn("no `claude` on PATH", res.detail)
+
+    def test_a_green_row_keeps_no_remedy_back_in_a_hint(self):
+        """`Result.render` drops the hint entirely at OK, so guidance written there is
+        invisible while looking shipped — #856, and `TestAGreenRowKeepsNothingBack` holds
+        every check to it. Stated here too because this row has three green branches."""
+        cases = [mock.patch.object(plugincache, "available", return_value=False),
+                 rows([{"id": "charter@charter", "scope": "user"}])]
+        for ctx in cases:
+            with ctx:
+                res = doctor.check_plugin_install()
+            if res.status == doctor.OK:
+                self.assertEqual(res.hint, "", res.detail)
 
     def test_an_unreadable_list_is_not_checked_rather_than_a_tick(self):
         """#171: a check that silently does nothing is worse than no check, and the

--- a/tests/test_plugin_install.py
+++ b/tests/test_plugin_install.py
@@ -412,6 +412,38 @@ class TheDoctorRowReportsTheGapWithoutCryingWolf(PersonaIso):
         self.assertEqual(res.status, doctor.OK)
         self.assertIn("project", res.detail)
 
+    def test_an_installed_but_DISABLED_plugin_is_not_a_tick(self):
+        """#177: installed, enabled and wired are three states and only the third protects
+        anything. 0.31.1 printed a tick over an installed-and-disabled plugin — the absence
+        of a protection rendered as health — and this row must not do it again."""
+        entry = {"id": "charter@charter", "scope": "project", "enabled": False,
+                 "projectPath": str(self.tmp)}
+        with rows([entry]):
+            res = doctor.check_plugin_install()
+        self.assertEqual(res.status, doctor.WARN)
+        self.assertIn("DISABLED", res.detail)
+        self.assertIn("claude plugin enable charter@charter", res.hint)
+
+    def test_a_claude_that_does_not_report_enabled_is_not_reported_as_disabled(self):
+        """Absent is not False. An older `claude` omitting the field would otherwise have
+        every plane told its plugin is off — a problem invented out of a missing key, which
+        is the same error pointing the other way."""
+        entry = {"id": "charter@charter", "scope": "project", "projectPath": str(self.tmp)}
+        with rows([entry]):
+            self.assertEqual(doctor.check_plugin_install().status, doctor.OK)
+
+    def test_fix_does_not_enable_a_plugin_somebody_turned_off(self):
+        """charter reports; it does not revert a deliberate edit. Disabling a plugin is a
+        choice, and a `--fix` that silently undid it is the thing `_ensure_statusline`
+        exists not to do."""
+        entry = {"id": "charter@charter", "scope": "project", "enabled": False,
+                 "projectPath": str(self.tmp)}
+        calls: list = []
+        with rows([entry]), spawns(calls):
+            status, _ = plugincache.install(self.tmp)
+        self.assertEqual(status, "present")
+        self.assertEqual(calls, [])
+
     def test_a_plane_with_no_claude_at_all_is_green_and_says_why(self):
         """opencode and Codex planes are supported installs with no Claude Code plugin to
         be missing. A yellow row on every one of them is the cry-wolf failure that costs

--- a/tests/test_plugin_install.py
+++ b/tests/test_plugin_install.py
@@ -1,0 +1,402 @@
+"""Installing charter installs charter (#881).
+
+The README used to print three commands and hope the reader ran all of them. It prints one
+now, and `charter init` installs Claude Code's charter plugin for the plane it creates —
+`charter doctor --fix` for a plane that already exists.
+
+Three obligations are pinned here, and they fail in three different places:
+
+* **The argv is right.** `install_argvs` carries the ordering fact `tests/test_docs.py`
+  used to hold against README prose — a marketplace that has not been added cannot be
+  installed from — plus the plugin id, built from the same two manifests the prose was
+  checked against.
+* **It happens where somebody asked and nowhere else.** `charter init` and `charter doctor
+  --fix` install; `charter reinit`, which re-runs the *wiring*, does not, and neither does
+  any other command. Installing software as a side effect is #857.
+* **`doctor` reports the gap without crying wolf.** WARN, never FAIL: a CLI-only install is
+  supported, and `cmd_doctor`'s exit code is what makes the SessionStart preflight shout.
+
+No test here runs `claude`. `plugincache._claude_json` and `plugincache.util.run` are the
+two seams every call goes through and both are stubbed; `tests/_claudeguard.py` is the belt
+for anything that is not, in this process and in children.
+"""
+
+from __future__ import annotations
+
+import json
+import unittest
+from contextlib import contextmanager
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
+
+from charter import commands, doctor, plugincache
+from charter.harness import claude_code, registry
+from tests._isolation import PersonaIso
+
+REPO = Path(__file__).resolve().parents[1]
+
+
+@contextmanager
+def rows(entries):
+    """Answer `claude plugin list --json` with *entries*, and every other read with ``[]``."""
+    def fake(args, cwd=None, timeout=None):
+        return entries if args[:1] == ["list"] else []
+
+    with mock.patch.object(plugincache, "available", return_value=True), \
+            mock.patch.object(plugincache, "_claude_json", side_effect=fake):
+        yield
+
+
+@contextmanager
+def spawns(calls, code=0, err=""):
+    """Record every `util.run` argv into *calls* and answer with *code*."""
+    def run(cmd, cwd=None, check=True, **kw):
+        calls.append((list(cmd), cwd))
+        return mock.Mock(returncode=code, stdout="", stderr=err)
+
+    with mock.patch.object(plugincache.util, "run", run):
+        yield
+
+
+class TheArgvIsBuiltFromTheManifestsAndNotFromMemory(unittest.TestCase):
+    """What `docs/install.md` used to spell out in prose, now spelled in code."""
+
+    def _manifest(self, filename: str) -> dict:
+        return json.loads((REPO / ".claude-plugin" / filename).read_text())
+
+    def test_the_plugin_id_matches_both_manifests(self):
+        """`plugin@marketplace`. Rename either manifest and `charter@charter` stops
+        resolving, while every command charter builds keeps looking right — the silent-rot
+        shape `TestVersionsMoveInLockstep` guards for the version numbers."""
+        plugin = self._manifest("plugin.json")["name"]
+        market = self._manifest("marketplace.json")["name"]
+        self.assertEqual(plugincache.PLUGIN_ID, f"{plugin}@{market}")
+
+    def test_the_marketplace_source_is_the_repository_charter_publishes_from(self):
+        """`claude plugin marketplace add <owner>/<repo>`. A literal, because the wheel
+        does not ship `.claude-plugin/` — so this pins it to `pyproject.toml`'s own
+        `Repository` URL and the day charter moves house the suite fails, rather than
+        every stranger's first install."""
+        import tomllib
+        url = tomllib.loads((REPO / "pyproject.toml").read_text())["project"]["urls"]["Repository"]
+        self.assertTrue(url.endswith("/" + plugincache.MARKETPLACE_SOURCE), url)
+
+    def test_it_adds_the_marketplace_before_installing_from_it(self):
+        """The assertion that used to read the README's paste-in block: *"installing from a
+        marketplace that has not been added fails"*."""
+        add, put = plugincache.install_argvs()
+        self.assertEqual(add[:4], ["claude", "plugin", "marketplace", "add"])
+        self.assertEqual(put[:3], ["claude", "plugin", "install"])
+
+    def test_it_installs_at_project_scope_non_interactively(self):
+        """`project`, because the plugin is what carries a plane's pinned version — a
+        machine-wide install collapses two planes onto one charter. `-y`, because `claude`
+        refuses rather than prompts when stdout is not a TTY."""
+        _add, put = plugincache.install_argvs()
+        self.assertIn("--scope", put)
+        self.assertEqual(put[put.index("--scope") + 1], "project")
+        self.assertEqual(plugincache.INSTALL_SCOPE, "project")
+        self.assertIn("-y", put)
+
+    def test_a_scope_charter_would_not_install_at_yields_no_argv_at_all(self):
+        """`None` rather than a list with a bad element in it, so a caller cannot run half
+        a sequence against a value charter would not have built an argv from — the
+        discipline `refresh_argvs` already keeps."""
+        self.assertIsNone(plugincache.install_argvs("../../etc"))
+        self.assertIsNone(plugincache.install_argvs(scope="project", source="--flag"))
+
+
+class AnInstallBelongingToSomebodyElsesCheckoutIsNotAnAnswerHere(unittest.TestCase):
+    """`installed_for` asks a different question from `installed_charter_plugin`.
+
+    The older one answers *which install may charter refresh*, where every project-scoped
+    install points at the same versioned cache directory and any one of them will do. This
+    one answers *is THIS plane covered*, where they are not interchangeable at all — and
+    reading a stranger's install as an answer would print "installed" over a plane with no
+    plugin, which is `check_guard_wired`'s #168 defect wearing a new row.
+    """
+
+    def test_a_user_scope_install_covers_every_directory(self):
+        with rows([{"id": "charter@charter", "scope": "user"}]):
+            self.assertIsNotNone(plugincache.installed_for("/somewhere"))
+
+    def test_a_project_scope_install_covers_only_its_own_project(self):
+        entry = {"id": "charter@charter", "scope": "project", "projectPath": "/planes/a"}
+        with rows([entry]):
+            self.assertIsNotNone(plugincache.installed_for("/planes/a"))
+            self.assertIsNone(plugincache.installed_for("/planes/b"))
+
+    def test_an_unreadable_list_is_UNKNOWN_and_not_absence(self):
+        """"I could not look" must never render as "there is nothing installed" — the
+        distinction `plugincache.UNKNOWN` exists for, and the population most likely to be
+        affected is an older `claude` that does not understand `--json`."""
+        with mock.patch.object(plugincache, "available", return_value=True), \
+                mock.patch.object(plugincache, "_claude_json", return_value=None):
+            self.assertIs(plugincache.installed_for("/planes/a"), plugincache.UNKNOWN)
+
+    def test_a_plugin_that_is_not_charters_is_not_charters(self):
+        """Only `charter@charter`. Matching `charter@<anything>` would let charter act on a
+        plugin called `charter` published by somebody else's marketplace."""
+        with rows([{"id": "charter@someone-else", "scope": "user"}]):
+            self.assertIsNone(plugincache.installed_for("/planes/a"))
+
+
+class TheInstallItself(unittest.TestCase):
+    def test_it_installs_when_nothing_covers_this_plane(self):
+        calls: list = []
+        with rows([]), spawns(calls):
+            status, detail = plugincache.install("/planes/a")
+        self.assertEqual(status, "installed")
+        self.assertEqual([c[0] for c in calls], plugincache.install_argvs())
+        self.assertIn("charter@charter", detail)
+
+    def test_it_runs_nothing_when_an_install_already_covers_this_plane(self):
+        calls: list = []
+        with rows([{"id": "charter@charter", "scope": "user"}]), spawns(calls):
+            status, _ = plugincache.install("/planes/a")
+        self.assertEqual(status, "present")
+        self.assertEqual(calls, [], "an install that is already there is not reinstalled")
+
+    def test_it_installs_NOTHING_over_a_state_it_could_not_read(self):
+        """The branch that matters most. An older `claude` answers here, and installing on
+        a guess is how a second copy appears."""
+        calls: list = []
+        with mock.patch.object(plugincache, "available", return_value=True), \
+                mock.patch.object(plugincache, "_claude_json", return_value=None), \
+                spawns(calls):
+            status, detail = plugincache.install("/planes/a")
+        self.assertEqual(status, "unknown")
+        self.assertEqual(calls, [])
+        self.assertIn("claude plugin list", detail)
+
+    def test_no_claude_on_PATH_is_an_ordinary_answer(self):
+        """An opencode or Codex plane, or a terminal with no Claude Code. Never an error."""
+        calls: list = []
+        with mock.patch.object(plugincache, "available", return_value=False), spawns(calls):
+            status, _ = plugincache.install("/planes/a")
+        self.assertEqual(status, "unavailable")
+        self.assertEqual(calls, [])
+
+    def test_a_failing_install_is_reported_as_failed_and_never_as_done(self):
+        calls: list = []
+        with rows([]), spawns(calls, code=1, err="offline"):
+            status, detail = plugincache.install("/planes/a")
+        self.assertEqual(status, "failed")
+        self.assertIn("offline", detail)
+
+    def test_an_already_registered_marketplace_does_not_stop_the_install(self):
+        """`claude plugin marketplace add` exits non-zero when the marketplace is already
+        there, which is the ordinary state on a machine's second plane. Refusing to
+        continue would make every install after the first impossible."""
+        calls: list = []
+
+        def run(cmd, cwd=None, check=True, **kw):
+            calls.append(list(cmd))
+            failed = "marketplace" in cmd
+            return mock.Mock(returncode=1 if failed else 0, stdout="",
+                             stderr="already exists" if failed else "")
+
+        with rows([]), mock.patch.object(plugincache.util, "run", run):
+            status, _ = plugincache.install("/planes/a")
+        self.assertEqual(status, "installed")
+        self.assertEqual(len(calls), 2, "the install step must still run")
+
+    def test_both_steps_failing_names_the_install_error_first(self):
+        """The two failures are not equally informative: "already registered" and "offline"
+        fail the marketplace step identically, so the install's own error is the verdict —
+        and the reader is told a second command was unhappy rather than left to guess."""
+        calls: list = []
+        with rows([]), spawns(calls, code=1, err="offline"):
+            _status, detail = plugincache.install("/planes/a")
+        self.assertLess(detail.index("plugin install"), detail.index("marketplace add"),
+                        detail)
+
+
+class InstallationHappensWhereSomebodyAskedForIt(PersonaIso):
+    """#857's rule, one level up: `charter workspace list` must not install software.
+
+    `init` and `doctor --fix` are the two doors, and `reinit` — which re-runs the wiring
+    into the same plane — is deliberately not one of them. Asserted through
+    `Harness.provision`, which is the only thing that can reach `plugincache.install`, so a
+    new caller has to pass this file rather than merely avoid the two commands it names.
+    """
+
+    def _provisions(self, fn) -> int:
+        seen: list = []
+        with mock.patch.object(claude_code.ClaudeCodeHarness, "provision",
+                               side_effect=lambda root: seen.append(root) or []):
+            fn()
+        return len(seen)
+
+    def test_init_provisions(self):
+        n = self._provisions(lambda: commands.cmd_init(
+            SimpleNamespace(forge="github", owner="acme", host=None)))
+        self.assertEqual(n, 1)
+
+    def test_reinit_does_not(self):
+        commands.cmd_init(SimpleNamespace(forge="github", owner="acme", host=None))
+        n = self._provisions(lambda: commands.cmd_reinit(SimpleNamespace()))
+        self.assertEqual(n, 0, "`reinit` re-runs the WIRING; it does not install software")
+
+    def test_doctor_provisions_only_with_the_flag(self):
+        commands.cmd_init(SimpleNamespace(forge="github", owner="acme", host=None))
+        self.assertEqual(
+            self._provisions(lambda: commands.cmd_doctor(SimpleNamespace(json=True))), 0)
+        self.assertEqual(
+            self._provisions(
+                lambda: commands.cmd_doctor(SimpleNamespace(json=True, fix=True))), 1)
+
+    def test_the_flag_is_reachable_from_the_command_line(self):
+        """A flag argparse does not define is a flag nobody can type."""
+        from charter import cli
+
+        args = cli.build_parser().parse_args(["doctor", "--fix"])
+        self.assertIs(args.func, commands.cmd_doctor)
+        self.assertTrue(args.fix)
+        self.assertFalse(cli.build_parser().parse_args(["doctor"]).fix)
+
+
+class OnlyClaudeCodeHasAnArtifactCharterInstalls(unittest.TestCase):
+    """The promise is repo-scoped (#881).
+
+    opencode's plugin already arrives through `wire`; Codex's wiring is
+    `~/.codex/config.toml`, machine-global, written only by `charter harness install codex`
+    where running the command is the consent. `provision` is empty on the base class so
+    that adding a harness cannot accidentally start writing a machine-global file.
+    """
+
+    def test_every_other_harness_provisions_nothing(self):
+        for h in registry.all():
+            if h.name == claude_code.NAME:
+                continue
+            self.assertEqual(h.provision(Path("/planes/a")), [], h.name)
+
+    def test_a_machine_with_no_claude_gets_no_row_rather_than_a_warning(self):
+        """An opencode or Codex plane has no Claude Code plugin to be missing, and a
+        warning about one would be the cry-wolf failure `doctor.py` keeps returning to."""
+        with mock.patch.object(plugincache, "available", return_value=False):
+            self.assertEqual(
+                claude_code.ClaudeCodeHarness().provision(Path("/planes/a")), [])
+
+    def test_a_failed_install_is_a_sentence_init_warns_about_not_an_item_it_lists(self):
+        """`unvouched` is the bucket #433 built: a path listed under "already present" is
+        true about the filename and false about everything a reader takes from it."""
+        calls: list = []
+        with rows([]), spawns(calls, code=1, err="offline"):
+            out = claude_code.ClaudeCodeHarness().provision(Path("/planes/a"))
+        self.assertEqual([s for s, _ in out], ["unvouched"])
+        self.assertIn("charter doctor --fix", out[0][1])
+
+
+class TheDoctorRowReportsTheGapWithoutCryingWolf(PersonaIso):
+    def setUp(self) -> None:
+        super().setUp()
+        (self.tmp / "charter.toml").write_text("schema = 1\n")
+        from charter import config
+        config.use(self.tmp)
+
+    def test_an_absent_plugin_is_a_WARN_naming_the_exact_command(self):
+        with rows([]):
+            res = doctor.check_plugin_install()
+        self.assertEqual(res.status, doctor.WARN)
+        self.assertIn(doctor.PLUGIN_FIX_CMD, res.hint)
+
+    def test_it_is_never_a_FAIL(self):
+        """`cmd_doctor` exits non-zero only on FAIL, and that exit code is what makes the
+        SessionStart preflight print — so a FAIL here reddens every CLI-only install, which
+        `docs/install.md` supports and CI uses. A plane declaring `charter hook pretooluse`
+        in its own settings is guarded with no plugin at all; `plane-root guard` is the row
+        that answers whether the guard fires."""
+        for entries in ([], [{"id": "charter@charter", "scope": "user"}],
+                        [{"id": "other@thing", "scope": "user"}]):
+            with rows(entries):
+                self.assertNotEqual(doctor.check_plugin_install().status, doctor.FAIL,
+                                    entries)
+
+    def test_an_install_that_covers_this_plane_is_green_and_says_its_scope(self):
+        entry = {"id": "charter@charter", "scope": "project",
+                 "projectPath": str(self.tmp)}
+        with rows([entry]):
+            res = doctor.check_plugin_install()
+        self.assertEqual(res.status, doctor.OK)
+        self.assertIn("project", res.detail)
+
+    def test_an_unreadable_list_is_not_checked_rather_than_a_tick(self):
+        """#171: a check that silently does nothing is worse than no check, and the
+        population answering here is the one most likely to be running a stale plugin."""
+        with mock.patch.object(plugincache, "available", return_value=True), \
+                mock.patch.object(plugincache, "_claude_json", return_value=None):
+            res = doctor.check_plugin_install()
+        self.assertEqual(res.status, doctor.WARN)
+        self.assertIn("not checked", res.detail)
+
+    def test_a_raising_check_costs_one_row_and_not_the_whole_preflight(self):
+        """`doctor._checks()` is an eager list literal with no per-check guard, so one
+        raising check returns NO rows — and `hooks/hooks.json` renders a non-zero `charter
+        doctor` as "charter preflight failed" at every SessionStart. This row found that
+        out the hard way on its first full run."""
+        with mock.patch.object(plugincache, "available",
+                               side_effect=RuntimeError("something unforeseen")):
+            res = doctor.check_plugin_install()
+            rows_ = doctor.run_all()
+        self.assertEqual(res.status, doctor.WARN)
+        self.assertIn("not checked", res.detail)
+        self.assertGreater(len(rows_), 20)
+
+    def test_the_row_is_registered_so_doctor_actually_runs_it(self):
+        """A check nobody calls is a check that does not exist, and `name_width` sizes the
+        report from a second spelling of the list — so the two must agree."""
+        with rows([]):
+            self.assertIn("plugin install", [r.name for r in doctor.run_all()])
+        self.assertIn("plugin install", doctor.check_names())
+
+
+class SkewRefusesInDoctorAndOnlyWarnsInAHook(unittest.TestCase):
+    """The asymmetry #881 asked to keep, pinned so it cannot quietly become symmetric.
+
+    The two artifacts update through different channels, so skew is normal and will happen
+    mid-session. A hook that hard-failed on it would refuse every tool call in that session
+    — a cosmetic mismatch turned into an outage — so the hook speaks once and returns, and
+    `doctor` is the surface that blocks.
+    """
+
+    def _newer(self) -> str:
+        from charter import hooks
+        major, minor, patch = (int(p) for p in hooks.MIN_PLUGIN_VERSION.split(".")[:3])
+        return f"{major + 1}.{minor}.{patch}"
+
+    def test_doctor_fails_on_a_newer_plugin(self):
+        import os
+        from charter import hooks
+
+        with mock.patch.dict(os.environ, {"CLAUDE_PLUGIN_ROOT": "/plugin"}), \
+                mock.patch.object(Path, "read_text",
+                                  return_value=json.dumps({"version": self._newer()})):
+            res = doctor.check_plugin_skew()
+        self.assertEqual(res.status, doctor.FAIL)
+        self.assertIn(hooks.MIN_PLUGIN_VERSION, res.detail)
+
+    def test_the_hook_says_it_and_carries_on(self):
+        """`skew_message` returns a STRING for the hook to speak. It raises nothing and
+        denies nothing — the guard keeps guarding, which is the whole point."""
+        from charter import hooks
+
+        self.assertIsNotNone(hooks.skew_message(self._newer()))
+        self.assertIsNone(hooks.skew_message(hooks.MIN_PLUGIN_VERSION))
+
+    def test_no_hook_handler_refuses_on_skew(self):
+        """The negative half, and the one that would actually brick a session. `dispatch`
+        is where the skew check sits in front of every handler; nothing in that path may
+        turn a version mismatch into a denial."""
+        import inspect
+        from charter import hooks
+
+        src = inspect.getsource(hooks._queue_plugin_notices)
+        for banned in ("sys.exit", "return 2", "deny"):
+            self.assertNotIn(banned, src,
+                             "a hook that blocks on skew bricks every tool call")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_plugin_install.py
+++ b/tests/test_plugin_install.py
@@ -339,6 +339,31 @@ class InstallationHappensWhereSomebodyAskedForIt(PersonaIso):
             self._provisions(
                 lambda: commands.cmd_doctor(SimpleNamespace(json=True, fix=True))), 1)
 
+    def test_init_installs_the_plugin_BEFORE_it_would_write_its_own_guard_hook(self):
+        """The order is load-bearing, and getting it wrong doubles the guard.
+
+        `claude plugin install --scope project` writes `enabledPlugins` into the plane's own
+        `.claude/settings.json` — measured on a real machine, where that file holds exactly
+        `enabledPlugins`, `env` and `statusLine` and no `hooks` block. `_ensure_guard_hook`
+        then sees an enabled plugin dispatching `charter hook pretooluse` and writes
+        nothing.
+
+        Reverse the two and `init` writes its own `hooks.PreToolUse` block first, because
+        the plugin is not installed yet; the install enables it a moment later; and the
+        plane carries both, running the guard twice on every Bash call. That is what
+        `check_guard_wired` reports as *declared twice*, and nobody finds it because two
+        denials for one command read as one stubborn denial.
+        """
+        order: list = []
+        real_guard = commands._ensure_guard_hook
+        with mock.patch.object(commands, "_provision_harnesses",
+                               side_effect=lambda root: order.append("provision") or []), \
+                mock.patch.object(commands, "_ensure_guard_hook",
+                                  side_effect=lambda root: (order.append("guard"),
+                                                            real_guard(root))[1]):
+            commands.cmd_init(SimpleNamespace(forge="github", owner="acme", host=None))
+        self.assertEqual(order, ["provision", "guard"])
+
     def test_init_lists_what_it_installed_and_warns_about_what_it_could_not(self):
         """The two buckets `init` renders differently. A path under "already present" is
         true about the filename and false about everything a reader takes from it (#433),

--- a/tests/test_plugin_install.py
+++ b/tests/test_plugin_install.py
@@ -158,6 +158,33 @@ class AnInstallBelongingToSomebodyElsesCheckoutIsNotAnAnswerHere(unittest.TestCa
         with rows([entry]):
             self.assertIsNotNone(plugincache.installed_for(link))
 
+    def test_a_path_that_cannot_be_resolved_answers_no_rather_than_raising(self):
+        """A symlink loop or an unreadable ancestor makes `Path.resolve` raise, and this
+        runs inside a `doctor` row — which must render something rather than traceback, and
+        inside `init`, which must not die on the way to writing a plane."""
+        entry = {"id": "charter@charter", "scope": "project", "projectPath": "/planes/a"}
+        with rows([entry]), mock.patch.object(Path, "resolve",
+                                              side_effect=OSError("too many links")):
+            self.assertIsNone(plugincache.installed_for("/planes/a"))
+
+    def test_a_list_that_is_not_a_list_of_rows_is_UNKNOWN(self):
+        """`--json` answering an object, or rows that are not objects. Not "nothing is
+        installed", which is the confidently-wrong answer :data:`UNKNOWN` exists for."""
+        with mock.patch.object(plugincache, "available", return_value=True), \
+                mock.patch.object(plugincache, "_claude_json", return_value={"oops": 1}):
+            self.assertIs(plugincache.installed_for("/planes/a"), plugincache.UNKNOWN)
+
+    def test_rows_that_are_not_objects_are_skipped_rather_than_believed(self):
+        with rows(["nonsense", 7, None,
+                   {"id": "charter@charter", "scope": "user"}]):
+            self.assertIsNotNone(plugincache.installed_for("/planes/a"))
+
+    def test_a_scope_charter_does_not_recognise_is_not_an_install(self):
+        """The scope reaches an argv, so an entry carrying one charter would not act on is
+        not returned at all — no caller has to remember to check."""
+        with rows([{"id": "charter@charter", "scope": "global"}]):
+            self.assertIsNone(plugincache.installed_for("/planes/a"))
+
     def test_a_projectPath_that_is_not_a_string_is_not_a_match(self):
         """`claude plugin list --json` is a machine's own output, not a committed file, but
         it is still input: a row whose `projectPath` is null or a number must answer "no",
@@ -248,6 +275,25 @@ class TheInstallItself(unittest.TestCase):
         self.assertEqual(status, "installed")
         self.assertEqual(len(calls), 2, "the install step must still run")
 
+    def test_a_claude_that_hangs_or_vanishes_is_a_failure_and_not_a_traceback(self):
+        """`util.run` raises `ProcTimeout` regardless of `check`, and `shutil.which` in
+        `available` and the exec here are two moments — a `claude` removed between them is
+        a `FileNotFoundError`. Both reach `init`, which must report rather than die."""
+        for boom in (plugincache.util.ProcTimeout(["claude", "plugin", "install"], 120),
+                     FileNotFoundError("claude")):
+            with rows([]), mock.patch.object(plugincache.util, "run", side_effect=boom):
+                status, detail = plugincache.install("/planes/a")
+            self.assertEqual(status, "failed", boom)
+            self.assertTrue(detail)
+
+    def test_a_scope_charter_would_not_install_at_never_reaches_a_subprocess(self):
+        calls: list = []
+        with rows([]), spawns(calls):
+            status, detail = plugincache.install("/planes/a", scope="everywhere")
+        self.assertEqual(status, "failed")
+        self.assertEqual(calls, [])
+        self.assertIn("everywhere", detail)
+
     def test_both_steps_failing_names_the_install_error_first(self):
         """The two failures are not equally informative: "already registered" and "offline"
         fail the marketplace step identically, so the install's own error is the verdict —
@@ -292,6 +338,22 @@ class InstallationHappensWhereSomebodyAskedForIt(PersonaIso):
         self.assertEqual(
             self._provisions(
                 lambda: commands.cmd_doctor(SimpleNamespace(json=True, fix=True))), 1)
+
+    def test_init_lists_what_it_installed_and_warns_about_what_it_could_not(self):
+        """The two buckets `init` renders differently. A path under "already present" is
+        true about the filename and false about everything a reader takes from it (#433),
+        which is why an install charter could not vouch for is a warning instead."""
+        import io
+        from contextlib import redirect_stderr
+
+        for status, label, expect in (("created", "a thing", "+ a thing"),
+                                      ("unvouched", "it went wrong", "it went wrong")):
+            buf = io.StringIO()
+            with redirect_stderr(buf), \
+                    mock.patch.object(claude_code.ClaudeCodeHarness, "provision",
+                                      return_value=[(status, label)]):
+                commands.cmd_init(SimpleNamespace(forge="github", owner="acme", host=None))
+            self.assertIn(expect, buf.getvalue(), status)
 
     def test_fix_outside_a_plane_installs_nothing_and_says_where_to_go(self):
         """The plugin is installed per PROJECT, so with no plane there is no directory to
@@ -368,6 +430,23 @@ class OnlyClaudeCodeHasAnArtifactCharterInstalls(unittest.TestCase):
         with mock.patch.object(plugincache, "available", return_value=False):
             self.assertEqual(
                 claude_code.ClaudeCodeHarness().provision(Path("/planes/a")), [])
+
+    def test_an_install_that_is_already_there_is_reported_as_present(self):
+        """`init` lists it under "already present" and `--fix` says "Already there". The
+        label carries no parenthetical of its own, because both callers already say the
+        word — and because `_fold_entries` splits a label on `" ("`."""
+        with rows([{"id": "charter@charter", "scope": "user"}]):
+            out = claude_code.ClaudeCodeHarness().provision(Path("/planes/a"))
+        self.assertEqual([s for s, _ in out], ["present"])
+        self.assertNotIn("(", out[0][1])
+
+    def test_an_install_it_performed_is_reported_as_created_and_names_what_it_did(self):
+        calls: list = []
+        with rows([]), spawns(calls):
+            out = claude_code.ClaudeCodeHarness().provision(Path("/planes/a"))
+        self.assertEqual([s for s, _ in out], ["created"])
+        self.assertIn(plugincache.PLUGIN_ID, out[0][1])
+        self.assertIn(plugincache.INSTALL_SCOPE, out[0][1])
 
     def test_a_failed_install_is_a_sentence_init_warns_about_not_an_item_it_lists(self):
         """`unvouched` is the bucket #433 built: a path listed under "already present" is
@@ -486,6 +565,18 @@ class TheDoctorRowReportsTheGapWithoutCryingWolf(PersonaIso):
         self.assertEqual(res.status, doctor.WARN)
         self.assertIn("not checked", res.detail)
         self.assertGreater(len(rows_), 20)
+
+    def test_outside_a_plane_there_is_nothing_to_install_it_for(self):
+        """The plugin is installed per PROJECT, so a `charter doctor` run from a machine
+        with no plane has no directory to answer about. Green, not yellow: preflighting a
+        machine before creating a plane is what `docs/install.md` tells people to do."""
+        from charter import config
+
+        config.use(self.tmp / "somewhere-else")
+        with rows([]):
+            res = doctor.check_plugin_install()
+        self.assertEqual(res.status, doctor.OK)
+        self.assertIn("no control plane", res.detail)
 
     def test_the_row_is_registered_so_doctor_actually_runs_it(self):
         """A check nobody calls is a check that does not exist, and `name_width` sizes the

--- a/tests/test_plugin_install.py
+++ b/tests/test_plugin_install.py
@@ -145,18 +145,29 @@ class AnInstallBelongingToSomebodyElsesCheckoutIsNotAnAnswerHere(unittest.TestCa
         """Not a test-only nicety. macOS resolves `/tmp` to `/private/tmp` and `/var` to
         `/private/var`, so a plane under either is spelled one way by `claude plugin list`
         and another by the shell — and an unresolved compare would report "not installed"
-        for an install that is right there."""
+        for an install that is right there.
+
+        **Both directions, because one direction pins only one `resolve()`.** The first
+        version put the symlink on the *asking* side only, and dropping `resolve()` from
+        the `projectPath` side then changed nothing: on a Linux runner `/tmp` is a real
+        directory, so the unresolved `projectPath` already equalled the resolved query.
+        The deletion sweep found exactly that. The install can be recorded under either
+        spelling, so both are asked.
+        """
         import os
         import tempfile
 
-        real = Path(tempfile.mkdtemp(prefix="charter-samedir-"))
+        real = Path(tempfile.mkdtemp(prefix="charter-samedir-")).resolve()
         self.addCleanup(lambda: __import__("shutil").rmtree(real, ignore_errors=True))
         link = real.parent / (real.name + "-link")
         os.symlink(real, link)
         self.addCleanup(lambda: link.unlink(missing_ok=True))
-        entry = {"id": "charter@charter", "scope": "project", "projectPath": str(real)}
-        with rows([entry]):
-            self.assertIsNotNone(plugincache.installed_for(link))
+        for recorded, asked in ((real, link), (link, real)):
+            entry = {"id": "charter@charter", "scope": "project",
+                     "projectPath": str(recorded)}
+            with rows([entry]):
+                self.assertIsNotNone(plugincache.installed_for(asked),
+                                     f"recorded as {recorded}, asked about {asked}")
 
     def test_a_path_that_cannot_be_resolved_answers_no_rather_than_raising(self):
         """A symlink loop or an unreadable ancestor makes `Path.resolve` raise, and this
@@ -257,6 +268,30 @@ class TheInstallItself(unittest.TestCase):
             status, detail = plugincache.install("/planes/a")
         self.assertEqual(status, "failed")
         self.assertIn("offline", detail)
+
+    def test_the_reason_is_the_last_line_of_output_with_no_whitespace_on_it(self):
+        """`claude` writes a trailing newline, and a multi-line failure buries the useful
+        sentence at the bottom. The detail is one line of a `doctor` hint and of `init`'s
+        warning, so a trailing newline pushed into it breaks the row it lands in — which is
+        what `.strip()` before `.splitlines()` is for, and what dropping it to `.lstrip()`
+        would silently undo."""
+        def run(cmd, cwd=None, check=True, **kw):
+            failed = "install" in cmd and "marketplace" not in cmd
+            return mock.Mock(returncode=1 if failed else 0, stdout="",
+                             stderr="  setting up\nnot logged in  \n\n" if failed else "")
+
+        with rows([]), mock.patch.object(plugincache.util, "run", run):
+            _status, detail = plugincache.install("/planes/a")
+        self.assertTrue(detail.endswith("not logged in"), repr(detail))
+        self.assertNotIn("setting up", detail, "the LAST line is the reason")
+
+    def test_a_failure_with_no_output_at_all_still_names_the_exit_code(self):
+        """A `claude` that fails silently. Without the fallback the detail would end at
+        `failed: ` and say nothing at all — the shape of a report that looks delivered."""
+        calls: list = []
+        with rows([]), spawns(calls, code=3, err=""):
+            _status, detail = plugincache.install("/planes/a")
+        self.assertIn("exit 3", detail)
 
     def test_an_already_registered_marketplace_does_not_stop_the_install(self):
         """`claude plugin marketplace add` exits non-zero when the marketplace is already
@@ -364,21 +399,40 @@ class InstallationHappensWhereSomebodyAskedForIt(PersonaIso):
             commands.cmd_init(SimpleNamespace(forge="github", owner="acme", host=None))
         self.assertEqual(order, ["provision", "guard"])
 
-    def test_init_lists_what_it_installed_and_warns_about_what_it_could_not(self):
-        """The two buckets `init` renders differently. A path under "already present" is
-        true about the filename and false about everything a reader takes from it (#433),
-        which is why an install charter could not vouch for is a warning instead."""
+    def test_init_renders_each_provision_status_in_its_own_bucket(self):
+        """Three statuses, three renderings, and the difference is the whole point. A
+        sentence listed under "already present" is true about the label and false about
+        everything a reader takes from it (#433), which is why an install charter could not
+        vouch for is a warning instead.
+
+        **Each case asserts what the OTHER two would have printed is absent**, and the
+        first version did not: it looked for the label text, which every bucket prints. So
+        collapsing `created if status == "created" else present` to `created`, or forcing
+        the `unvouched` test either way, changed nothing a test could see — three sweep
+        survivors in five lines.
+        """
         import io
         from contextlib import redirect_stderr
 
-        for status, label, expect in (("created", "a thing", "+ a thing"),
-                                      ("unvouched", "it went wrong", "it went wrong")):
+        # `init` always prints an "already present:" line for its own reasons, so the
+        # question is never "does that line exist" but "is the LABEL on it".
+        def buckets(out: str) -> dict:
+            present = next((ln for ln in out.splitlines() if "already present:" in ln), "")
+            return {"created": "+ a thing" in out,
+                    "present": "a thing" in present,
+                    "unvouched": "! a thing" in out}
+
+        for status in ("created", "present", "unvouched"):
             buf = io.StringIO()
             with redirect_stderr(buf), \
                     mock.patch.object(claude_code.ClaudeCodeHarness, "provision",
-                                      return_value=[(status, label)]):
+                                      return_value=[(status, "a thing")]):
                 commands.cmd_init(SimpleNamespace(forge="github", owner="acme", host=None))
-            self.assertIn(expect, buf.getvalue(), status)
+            out = buf.getvalue()
+            self.assertEqual(buckets(out), {"created": status == "created",
+                                            "present": status == "present",
+                                            "unvouched": status == "unvouched"},
+                             f"{status} did not land in its own bucket:\n{out}")
 
     def test_fix_outside_a_plane_installs_nothing_and_says_where_to_go(self):
         """The plugin is installed per PROJECT, so with no plane there is no directory to
@@ -409,20 +463,32 @@ class InstallationHappensWhereSomebodyAskedForIt(PersonaIso):
             commands._run_doctor_fix()
         self.assertIn("nothing to install", buf.getvalue())
 
-    def test_fix_warns_about_an_install_it_could_not_vouch_for(self):
-        """`unvouched` carries a sentence, and a `--fix` that failed must not read as a
-        `--fix` that worked — the row it did not turn green is the verdict, but the reason
-        is only here."""
+    def test_fix_says_which_of_the_three_things_happened(self):
+        """A `--fix` that failed must not read as a `--fix` that worked, and one that had
+        nothing to do must not read as one that installed something.
+
+        **The glyph is the assertion, not the label.** `util.warn`/`ok`/`info` each print a
+        different mark, and the label is the same string in all three — so the first
+        version of this test, which looked for the label, passed with the whole dispatch
+        forced to any one branch. The sweep found it as three survivors.
+        """
         import io
         from contextlib import redirect_stderr
 
         commands.cmd_init(SimpleNamespace(forge="github", owner="acme", host=None))
-        buf = io.StringIO()
-        with redirect_stderr(buf), \
-                mock.patch.object(commands, "_provision_harnesses",
-                                  return_value=[("unvouched", "it did not work because X")]):
-            commands._run_doctor_fix()
-        self.assertIn("it did not work because X", buf.getvalue())
+        cases = (("unvouched", "! it did not work", ("Installed", "Already there")),
+                 ("created", "✓ Installed it did not work", ("Already there",)),
+                 ("present", "• Already there: it did not work", ("Installed",)))
+        for status, expect, absent in cases:
+            buf = io.StringIO()
+            with redirect_stderr(buf), \
+                    mock.patch.object(commands, "_provision_harnesses",
+                                      return_value=[(status, "it did not work")]):
+                commands._run_doctor_fix()
+            out = buf.getvalue()
+            self.assertIn(expect, out, f"{status}: {out!r}")
+            for gone in absent:
+                self.assertNotIn(gone, out, f"{status} rendered as {gone!r}: {out!r}")
 
     def test_the_flag_is_reachable_from_the_command_line(self):
         """A flag argparse does not define is a flag nobody can type."""
@@ -494,7 +560,25 @@ class TheDoctorRowReportsTheGapWithoutCryingWolf(PersonaIso):
         with rows([]):
             res = doctor.check_plugin_install()
         self.assertEqual(res.status, doctor.WARN)
-        self.assertIn(doctor.PLUGIN_FIX_CMD, res.hint)
+        self.assertIn("charter doctor --fix", res.hint)
+
+    def test_the_remedy_is_a_command_the_parser_actually_accepts(self):
+        """`assertIn(doctor.PLUGIN_FIX_CMD, res.hint)` was the whole of this, and it is a
+        sentence comparing itself: respell the constant and the hint respells with it, so
+        the sweep respelled it to `dibsufs epdups --gjy` and nothing noticed.
+
+        Asked of `cli.build_parser` instead, which is the property that actually matters —
+        a hint naming a command charter does not have is worse than no hint, because the
+        reader types it, gets `unrecognized arguments`, and stops trusting the row. The
+        parser answers for the verb, the flag and the handler at once.
+        """
+        from charter import cli
+
+        argv = doctor.PLUGIN_FIX_CMD.split()
+        self.assertEqual(argv[0], "charter", doctor.PLUGIN_FIX_CMD)
+        args = cli.build_parser().parse_args(argv[1:])
+        self.assertIs(args.func, commands.cmd_doctor)
+        self.assertTrue(args.fix)
 
     def test_it_is_never_a_FAIL(self):
         """`cmd_doctor` exits non-zero only on FAIL, and that exit code is what makes the
@@ -577,6 +661,14 @@ class TheDoctorRowReportsTheGapWithoutCryingWolf(PersonaIso):
             res = doctor.check_plugin_install()
         self.assertEqual(res.status, doctor.WARN)
         self.assertIn("not checked", res.detail)
+        # The REASON, not merely the status — the trap `test_plugin_freshness` records
+        # verbatim for its own copy of this branch, and which the deletion sweep found
+        # here: delete `if entry is UNKNOWN` and the sentinel falls through, `entry.get`
+        # raises on a bare `object()`, and the row-level crash guard turns it into a WARN
+        # reading "not checked ('object' object has no attribute 'get')". A test that
+        # stopped at the status would accept that as this branch working — a guard passing
+        # because a different guard caught it.
+        self.assertIn("claude plugin list", res.detail)
 
     def test_a_raising_check_costs_one_row_and_not_the_whole_preflight(self):
         """`doctor._checks()` is an eager list literal with no per-check guard, so one


### PR DESCRIPTION
The README asked an operator to install two things and hope they ran all three
commands. It asks for one now.

```bash
uv tool install charter-cp
```

`charter init` installs Claude Code's charter plugin for the plane it creates;
`charter doctor --fix` installs it for a plane that already exists.

## The CLI is the front door

The CLI is what sits on `PATH`, what all twelve hooks in `hooks/hooks.json`
shell out to, and what already writes `.claude/settings.json` — so it exists
before a harness session does. The inverse shape, a plugin that bootstraps a
CLI, has to guess at a Python environment it does not own.

`ClaudeCodeHarness.provision` is the new seam, beside `wire`, and
`Harness.provision` is empty on the base class. That is a statement about the
other harnesses rather than an unfinished method: only Claude Code ships an
artifact charter can install without touching a machine-global file. opencode's
plugin already arrives through `wire`; Codex's wiring is `~/.codex/config.toml`,
which charter writes only from `charter harness install codex`, where running
the command is the consent. **No code here writes either global file.**

## Nothing self-heals

`charter init` and `charter doctor --fix` install. Nothing else — not
`charter reinit`, which re-runs the *wiring*, which is why `provision` is a
second loop beside `_wire_harnesses` rather than a line inside it.
`InstallationHappensWhereSomebodyAskedForIt` pins all three answers through
`Harness.provision`, so a new caller has to pass that class rather than merely
avoid the two commands it names.

## The doctor row

```
  !  plugin install   charter's Claude Code plugin is not installed for this plane, so
                      none of its hooks run here — no session context, no plane-root
                      guard, no auto-save
        → Run: charter doctor --fix  (installs `charter@charter` at project scope from
          `diazoxide/charter`; `charter init` does the same thing on a fresh plane). The
          plugin loads at the NEXT session, so restart afterwards.
```

**WARN, never FAIL.** `cmd_doctor` exits non-zero only on FAIL, and that exit
code is what makes the SessionStart preflight print — so a FAIL would redden
every CLI-only install, which `docs/install.md` supports and CI uses. It would
also be wrong about protection: a plane declaring `charter hook pretooluse` in
its own `.claude/settings.json` is guarded with no plugin at all, and
`plane-root guard` is the row that answers whether the guard fires.

Scoped to the **plane**, not the machine. `installed_charter_plugin` answers
"which install may charter refresh", where any project-scoped install will do
because they share one cache directory; `installed_for` answers "is THIS plane
covered", and reading a stranger's install as an answer would print "installed"
over a plane with no plugin — #168's defect in a new row.

## Version skew: `doctor` refuses, hooks only warn

Unchanged, and now pinned and written down. `SkewRefusesInDoctorAndOnlyWarnsInAHook`
holds both halves, including the negative one: nothing in `_queue_plugin_notices`
may turn a version mismatch into a denial. A hook that hard-failed on skew would
refuse every tool call in the session — a cosmetic mismatch turned into an
outage — and `doctor.py:780` already ruled on version-checking the plugin,
because it *"would warn on planes that are genuinely protected"*.

## Project scope, never `user`

The plugin is what carries a plane's pinned version, so two planes on one laptop
can sit on different charters. A machine-wide install collapses that, and puts
charter's hooks into repositories nobody pointed charter at.

## Two facts moved out of prose and into code

`tests/test_docs.py` was pinning real mechanisms to README text: the plugin id
built from both manifests, and `marketplace add` running before `plugin install`.
The README no longer types those commands, so both assertions moved onto
`plugincache.install_argvs`, against the same two manifests. `MARKETPLACE_SOURCE`
is pinned to `pyproject.toml`'s own `Repository` URL — the wheel ships no
`.claude-plugin/` to read it from.

Its fence matcher also paired only a bare ` ``` ` as an opener, so the new
` ```bash ` block above the paste-in prompt put the whole document out of phase
and four cases failed for a document that still said the right thing. Both ends
are now anchored at line start.

## The first full run found two real defects

* `test_cli_smoke` runs `charter init` as a **real subprocess**, where an
  in-process stub cannot reach — so it installed `charter@charter` into the
  operator's own Claude Code, scoped to temp directories that no longer existed.
  Five such rows were in `claude plugin list` afterwards. `tests/_claudeguard.py`
  now puts a fake `claude` first on `$PATH` for the whole suite and answers what
  CI answers in-process.
* `check_plugin_install` had no row-level guard, so `plugincache.available`
  raising took every row of the preflight with it — caught by
  `test_a_raising_check_costs_one_row_and_not_the_whole_preflight`, which exists
  for exactly that.

## Two things found while building it

**`init` installs the plugin before it would write its own guard hook.** Measured
on a real machine: `claude plugin install --scope project` writes
`enabledPlugins` into the plane's own `.claude/settings.json`, which then holds
exactly `enabledPlugins`, `env` and `statusLine` and no `hooks` block. So
`_ensure_guard_hook` runs after the install, finds an enabled plugin dispatching
`charter hook pretooluse`, and correctly writes nothing. Reversed, the plane
carries both and the guard runs twice on every Bash call — what
`check_guard_wired` reports as *declared twice*, and the ordinary outcome of the
old two-step install. The order is pinned; moving the loop turns the test red
with `['guard', 'provision']`.

**An installed plugin that is DISABLED is not a tick.** `claude plugin list
--json` carries `enabled`, and installed is not enabled (#177). charter names
`claude plugin enable charter@charter --scope project` and stops there —
`--fix` does not enable it, because turning a plugin off is a choice and charter
does not revert a deliberate edit. Absent is read as enabled, so an older
`claude` that omits the field does not have every plane told its plugin is off.

## Docs

`README.md`, `docs/install.md`, `docs/harnesses.md`, `docs/hooks.md`, and a
staged `docs/news/` entry carrying `adopt: doctor --fix`.

Closes #881

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Us4MbwkSCJCxwt1CjAd1sf
