### PR TITLE
0.56.0 gets the two notes it was about to ship without

### DIFF
--- a/docs/news/0.56.0-a-command-run-anywhere-reaches-every-frame.md
+++ b/docs/news/0.56.0-a-command-run-anywhere-reaches-every-frame.md
@@ -1,0 +1,13 @@
+---
+version: 0.56.0
+headline: a `charter` command run in any terminal — or by a harness inside a chat — now refreshes every frame that would draw it differently, instead of leaving panels contradicting the plane until a restart
+---
+
+`charter clone` wrote the clones and told nobody, so `repos` went on showing the old list
+until charter restarted. The gap was wider than the report: `notify.plane_changed` bumps
+only the frame named in `$CHARTER_SESSION_ID`, so a clone inside `alpha.1` left sibling
+`alpha.2` stale too, though both draw the same workspace.
+
+The fan-out runs one `gather.scan` per distinct **workspace**, not per frame — frames
+sharing a workspace produce the same repo list — and refreshes every cache before moving
+any version, because a panel reads the version first and the cache second.

--- a/docs/news/0.56.0-the-persona-switcher-sorts-by-use.md
+++ b/docs/news/0.56.0-the-persona-switcher-sorts-by-use.md
@@ -1,0 +1,7 @@
+---
+version: 0.56.0
+headline: the persona switcher stops lifting the selected persona to the top — the default is pinned first and the rest sort by dispatch count, in the `F2` picker and the sidebar column alike, which until now disagreed with each other
+---
+
+A memory count only ever grows, so ordering by it ossifies: a persona used heavily one
+month outranks one used daily the next, permanently. Dispatch count measures use.


### PR DESCRIPTION
#885 (the persona switcher) and #888 (a command run anywhere reaches every frame) both merged into 0.56.0 **with no `docs/news/` entry**. The release was about to publish with two user-visible changes absent from its notes.

The cause is mine: the briefs that produced those two PRs did not ask for an entry, while the briefs before and after them did.

## Measured, with both entries in

| | |
|---|---|
| entries | 25 |
| whole | 122,461 bytes |
| `_BODY_BUDGET` | 122,000 |
| rendered | 118,987 bytes — the tail elides |
| `test_release_notes_fit_the_release` | 46 cases, all pass |

**Elision here is correct, not a regression.** It is the designed response to a release carrying more notes than the budget holds, and an elided note is a headline and a link to the full text in the repo — strictly more than the nothing these two changes had. The alternative considered and rejected was trimming the prose of both entries until the body fit whole: that makes the notes worse to satisfy a number, and the guards do not ask for it.

The tag has not been pushed and nothing is published, so these land before `v0.56.0` exists rather than after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Us4MbwkSCJCxwt1CjAd1sf
