### PR TITLE
Two writers for one file stop publishing each other's half (#893)

### DIFF
--- a/charter/config.py
+++ b/charter/config.py
@@ -512,9 +512,10 @@ def write_for(p, data) -> None:
 
 #: What every temp file this module publishes through is called, appended to a name that
 #: already carries its target and this writer. ``.tmp`` and not something charter-shaped,
-#: because the one sweep that looks for litter beside an atomic write
-#: (`TheWriteIsAtomic.test_no_temporary_file_is_left_beside_it`) looks for this suffix, and
-#: a rename here that left that test looking for a name nothing writes would report a clean
+#: because the two suites that look for litter beside an atomic write ask for this suffix —
+#: `TheWriteIsAtomic.test_no_temporary_file_is_left_beside_it` and the ``glob("*.tmp")`` in
+#: `test_the_state_directory_is_charters_to_choose` — and both assert they find NONE, so a
+#: rename here would leave them looking for a name nothing writes and reporting a clean
 #: directory forever.
 TEMP_SUFFIX = ".tmp"
 
@@ -545,11 +546,12 @@ def temp_beside(p) -> Path:
     crashed mid-publish. `os.urandom` and not `random`, because the latter is seeded per
     process and a `fork` hands both sides the same stream.
 
-    NOT `tempfile.mkstemp`, which `frame/reopen.py` uses for this same job and is right to.
-    Its 0600 is the mode charter's own state wants and the wrong one for a *committed*
-    file: `workspace._write_manifest` publishes ``workspaces/<n>/workspace.json`` through
-    this, and creating the source at 0600 would carry 0600 onto a file in the operator's
-    own git tree — charter tightening what is not its own, which is #331's whole finding.
+    NOT `tempfile.mkstemp`, which `frame/reopen.py` reached for when it found this defect
+    on its own file (#845) and which `inflight` still uses for a file it names rather than
+    publishes. Its 0600 is the mode charter's own state wants and the wrong one for a
+    *committed* file: `workspace._write_manifest` publishes ``workspaces/<n>/workspace.json``
+    through this, and creating the source at 0600 would carry 0600 onto a file in the
+    operator's own git tree — charter tightening what is not its own, which is #331.
     The mode is left to :func:`write_for`, which asks the one question that decides it
     (*where is this path*) and asks it of the temp file, which is the file `os.replace`
     carries. So the naming is here and the mode is there, and neither one guesses.
@@ -562,12 +564,14 @@ def replace_for(p, data) -> None:
     """Write *data* to *p* **whole or not at all** — through a temp file of this writer's
     own (:func:`temp_beside`) and one ``os.replace``.
 
-    The single atomic writer for this package. There were twenty spellings of it before
-    #893 — seventeen in `frame/state.py`, `gather.save`, `toolgate.snapshot`,
-    `workspace._write_manifest` — and every one of them was the same four lines with the
-    same defect in them, which is the argument for one function rather than twenty edits:
-    the next writer that needs "a reader must never see half of this" calls this instead
-    of copying the shape, and it has nowhere to copy the shape from.
+    The single atomic writer for this package. There were twenty-one spellings of it before
+    #893 — seventeen in `frame/state.py`, plus `gather.save`, `toolgate.snapshot`,
+    `workspace._write_manifest` and `reopen.write` — and twenty of them were the same four
+    lines with the same defect in them, which is the argument for one function rather than
+    twenty edits: the next writer that needs "a reader must never see half of this" calls
+    this instead of copying the shape, and it has nowhere to copy the shape from. (The
+    twenty-first, `reopen.write`, had already answered it for itself and is here so there
+    is one rule rather than two.)
 
     Two guarantees, and they are different guarantees. ``os.replace`` gives the second: the
     destination is the old content or the new one, never a prefix of either. The temp

--- a/charter/config.py
+++ b/charter/config.py
@@ -510,6 +510,97 @@ def write_for(p, data) -> None:
         f.write(data)
 
 
+#: What every temp file this module publishes through is called, appended to a name that
+#: already carries its target and this writer. ``.tmp`` and not something charter-shaped,
+#: because the one sweep that looks for litter beside an atomic write
+#: (`TheWriteIsAtomic.test_no_temporary_file_is_left_beside_it`) looks for this suffix, and
+#: a rename here that left that test looking for a name nothing writes would report a clean
+#: directory forever.
+TEMP_SUFFIX = ".tmp"
+
+
+def temp_beside(p) -> Path:
+    """A name for the temp file :func:`replace_for` will publish *p* through — **beside
+    *p*, and private to the process asking**.
+
+    Beside it, because ``os.replace`` cannot cross filesystems: an atomic write into
+    ``.charter/`` has to be written in ``.charter/`` for the rename to be a rename.
+
+    Private to the asker, and that is the whole of #893. The pid and the random tail are
+    not decoration and not debugging aid — they are what makes the *name* unshared, which
+    is the property ``os.replace`` is unable to supply on its own. ``os.replace`` is atomic
+    about the moment the destination changes; it says nothing about the file being renamed,
+    so while every writer for one target agreed on one temp name, two of them wrote into
+    one inode: A's ``open(tmp, "w")`` truncated it to zero, B renamed those zero bytes over
+    the destination, and A's own rename then published a file B had already moved. That is
+    reachable in one ``open()`` and it *was* reached — a `frame/gather.py` cache came out
+    of CI existing and empty, read as truth by `gather.cached`, which deliberately has no
+    freshness check.
+
+    `os.getpid` **and** a random tail rather than either alone. The pid separates processes
+    and nothing else: a frame process writes a gather cache from a thread while
+    `notify.plane_changed_everywhere` bumps every frame on the plane from another, so two
+    writers for one target inside one process is ordinary rather than exotic. The random
+    tail separates those, and separates a pid the kernel has recycled onto a writer that
+    crashed mid-publish. `os.urandom` and not `random`, because the latter is seeded per
+    process and a `fork` hands both sides the same stream.
+
+    NOT `tempfile.mkstemp`, which `frame/reopen.py` uses for this same job and is right to.
+    Its 0600 is the mode charter's own state wants and the wrong one for a *committed*
+    file: `workspace._write_manifest` publishes ``workspaces/<n>/workspace.json`` through
+    this, and creating the source at 0600 would carry 0600 onto a file in the operator's
+    own git tree — charter tightening what is not its own, which is #331's whole finding.
+    The mode is left to :func:`write_for`, which asks the one question that decides it
+    (*where is this path*) and asks it of the temp file, which is the file `os.replace`
+    carries. So the naming is here and the mode is there, and neither one guesses.
+    """
+    p = Path(p)
+    return p.with_name(f"{p.name}.{os.getpid()}.{os.urandom(6).hex()}{TEMP_SUFFIX}")
+
+
+def replace_for(p, data) -> None:
+    """Write *data* to *p* **whole or not at all** — through a temp file of this writer's
+    own (:func:`temp_beside`) and one ``os.replace``.
+
+    The single atomic writer for this package. There were twenty spellings of it before
+    #893 — seventeen in `frame/state.py`, `gather.save`, `toolgate.snapshot`,
+    `workspace._write_manifest` — and every one of them was the same four lines with the
+    same defect in them, which is the argument for one function rather than twenty edits:
+    the next writer that needs "a reader must never see half of this" calls this instead
+    of copying the shape, and it has nowhere to copy the shape from.
+
+    Two guarantees, and they are different guarantees. ``os.replace`` gives the second: the
+    destination is the old content or the new one, never a prefix of either. The temp
+    file's *name* gives the first: no other writer is inside this file, so what lands is
+    one writer's whole content rather than a splice of two. `write_for` for the temp and
+    never `Path.write_text`, because `os.replace` carries the SOURCE's mode onto the
+    target (#582), so the dispatch has to happen on the file that moves.
+
+    **The temp file is removed when the rename does not happen**, on every failure and not
+    only on `OSError` — a name nothing can predict is a name nothing can collect, and none
+    of the directories this writes into has a sweep that would find one. The removal is
+    itself best-effort: a temp that cannot be unlinked is litter, and raising *that* at a
+    caller which was told its write failed would replace the real reason with a tidying-up
+    one.
+
+    Raises exactly what `write_for` and `os.replace` raise — `OSError` for every way a
+    filesystem says no, and whatever the content itself is (a `str` this cannot encode).
+    Callers keep their own answer to a failed write, because they do not agree on one: a
+    hook swallows it, `workspace._write_manifest` lets it out.
+    """
+    p = Path(p)
+    tmp = temp_beside(p)
+    try:
+        write_for(tmp, data)
+        os.replace(tmp, p)
+    except BaseException:
+        try:
+            tmp.unlink()
+        except OSError:
+            pass
+        raise
+
+
 def touch_for(p) -> None:
     """`Path.touch` for a path that may be charter's own state.
 

--- a/charter/config.py
+++ b/charter/config.py
@@ -587,8 +587,12 @@ def replace_for(p, data) -> None:
     filesystem says no, and whatever the content itself is (a `str` this cannot encode).
     Callers keep their own answer to a failed write, because they do not agree on one: a
     hook swallows it, `workspace._write_manifest` lets it out.
+
+    A ``str`` destination is as good as a `Path`, like everywhere else in this module — and
+    there is no ``p = Path(p)`` here to make that true, because there is nothing left for it
+    to do: :func:`temp_beside` takes either and ``os.replace`` takes either. A line whose
+    removal changes no outcome is a line the deletion sweep is right to call equivalent.
     """
-    p = Path(p)
     tmp = temp_beside(p)
     try:
         write_for(tmp, data)

--- a/charter/frame/gather.py
+++ b/charter/frame/gather.py
@@ -368,18 +368,22 @@ def scan(workspace: str | None = None, cwd: str | None = None) -> dict:
 def save(fid: str, data: dict) -> None:
     """Write *data* (from :func:`scan`) as JSON under *fid*'s frame directory.
 
-    Atomic — a temp file plus ``os.replace``, the same shape ``state.bump`` uses
-    and for the same reason: a reader must never observe a half-written cache.
+    Atomic — `config.replace_for`, the same call ``state.bump`` makes and for the same
+    reason: a reader must never observe a half-written cache. **Nor another writer's
+    half**, which is the part ``os.replace`` alone never gave and #893 is. While the temp
+    file was named after its target and nothing else, two savers for one *fid* wrote into
+    one inode, and this cache is where that surfaced: a frame's ``gather.json`` came out
+    of CI existing and zero bytes, and :func:`cached` hands back whatever parses, so an
+    empty scan is read as a true one rather than as a file to distrust.
+
     Never raises: this runs from a hook (Task 2), where a failure here must
     degrade to "the cache did not update" rather than cost the session its turn.
     """
     f = _cache_file(fid, create=True)
     if f is None:
         return
-    tmp = f.with_name(f.name + ".tmp")
     try:
-        config.write_for(tmp, json.dumps(data))
-        os.replace(tmp, f)
+        config.replace_for(f, json.dumps(data))
     except OSError:
         return
 

--- a/charter/frame/reopen.py
+++ b/charter/frame/reopen.py
@@ -38,7 +38,6 @@ from __future__ import annotations
 
 import json
 import os
-import tempfile
 import time
 from pathlib import Path
 from typing import NamedTuple
@@ -209,20 +208,23 @@ def write(frames, *, focus: str, at: int | None = None) -> bool:
     `Path.write_text`, because `os.replace` carries the SOURCE's mode onto the target
     (#582) and this is a state path.
 
-    **The temp file's NAME is `tempfile.mkstemp`'s and not this module's, and #845 is why.**
-    ``os.replace`` is atomic; the file it renames is not. While there was one temp name,
-    two writers wrote into the same bytes and the first to rename put the SECOND writer's
-    content in place — reporting, to the first, that its own record had landed. That was
-    already reachable (a quit races another quit; `_forget_transcript` races either), and
-    #845 makes it ordinary: the frame process now records on a debounce, from a thread, in
-    the same process as `cmd_reopen`'s own `_consume`. `mkstemp` is unique across processes
-    and threads by construction, which is a property to borrow rather than to re-derive out
-    of a pid and a counter — and it creates at 0600, which is the mode a state path wants
-    and the one `os.replace` will carry.
+    **The temp file's NAME is `config.temp_beside`'s and not this module's, and #845 is
+    why.** ``os.replace`` is atomic; the file it renames is not. While there was one temp
+    name, two writers wrote into the same bytes and the first to rename put the SECOND
+    writer's content in place — reporting, to the first, that its own record had landed.
+    That was already reachable (a quit races another quit; `_forget_transcript` races
+    either), and #845 makes it ordinary: the frame process now records on a debounce, from
+    a thread, in the same process as `cmd_reopen`'s own `_consume`. This was `mkstemp`
+    here first, alone in the package; #893 found the same defect in the other twenty
+    atomic writers and answered all of them in `config.replace_for`, so what was a rule
+    this module kept for itself is now the one every writer gets — a pid and a random tail,
+    unique across processes and threads by construction rather than re-derived out of a
+    counter, at the mode `config.write_for` picks for where the path is.
 
     **Removed when the rename does not happen**, because a name nothing can predict is a
     name nothing can collect: `prune_transcripts` is the only sweep the frame root has and
-    it touches nothing but `*.transcript`, so a temp left behind would stay for good.
+    it touches nothing but `*.transcript`, so a temp left behind would stay for good. That
+    removal is `replace_for`'s now, and it is the reason this module no longer spells one.
 
     ``False`` for every way it can fail to land — no frame root, a filesystem that refuses
     the write, a value `json` cannot serialise. One answer, because the caller does the same
@@ -242,19 +244,9 @@ def write(frames, *, focus: str, at: int | None = None) -> bool:
                     "chats": [c._asdict() for c in f.chats]} for f in frames],
     }
     try:
-        fd, name = tempfile.mkstemp(dir=root, prefix=f"{MANIFEST}.", suffix=".tmp")
-        os.close(fd)
-    except OSError:
-        return False
-    tmp = Path(name)
-    try:
-        config.write_for(tmp, json.dumps(payload, indent=2, sort_keys=True) + "\n")
-        os.replace(tmp, root / MANIFEST)
+        config.replace_for(root / MANIFEST,
+                           json.dumps(payload, indent=2, sort_keys=True) + "\n")
     except (OSError, TypeError, ValueError):
-        try:
-            tmp.unlink(missing_ok=True)
-        except OSError:
-            pass
         return False
     return True
 

--- a/charter/frame/state.py
+++ b/charter/frame/state.py
@@ -314,20 +314,24 @@ def frame_dir(fid: str, *, create: bool = False) -> Path | None:
 def bump(fid: str) -> None:
     """Record that the frame changed. A caller on a must-not-crash path (a hook).
 
-    Written to a temp file and moved into place with ``os.replace``. A failed write is
-    swallowed (see below), not raised — which is exactly why the atomic replace matters
-    more here than it would if a failure were still visible: ``os.replace`` only ever
-    touches the target file by fully replacing it, never partially, so a write that
-    cannot complete leaves the previous version exactly as a reader last saw it rather
-    than corrupting it silently.
+    Published through `config.replace_for` — a temp file of this writer's own, then one
+    ``os.replace``. A failed write is swallowed (see below), not raised — which is exactly
+    why the atomic replace matters more here than it would if a failure were still
+    visible: ``os.replace`` only ever touches the target file by fully replacing it, never
+    partially, so a write that cannot complete leaves the previous version exactly as a
+    reader last saw it rather than corrupting it silently.
 
-    **The temp file goes through `config.write_for`, and that is what settles the mode of
-    the destination too.** ``os.replace`` carries the SOURCE's mode onto the target, so
-    while this was `Path.write_text` it wrote a 0644 temp file and then moved 0644 onto
-    ``version`` — with nothing in the directory ever looking wrong. Ten writers in this
-    module share that shape (#582). ``os.replace`` itself needs no dispatch: a rename
-    cannot cross filesystems, so an atomic write into ``.charter/`` is written beside its
-    destination and is a state path by construction.
+    **The temp file's mode and its NAME are both settled there, and each closed a defect
+    of its own.** ``os.replace`` carries the SOURCE's mode onto the target, so while this
+    was `Path.write_text` it wrote a 0644 temp file and then moved 0644 onto ``version`` —
+    with nothing in the directory ever looking wrong (#582); `config.write_for`, which
+    `replace_for` writes through, is what asks where the path is. And while every writer
+    for one frame shared one temp NAME, two of them wrote into one inode and published
+    each other's half-written file — #893, and the reason the seventeen writers in this
+    module are seventeen calls to one function rather than seventeen copies of four lines.
+    ``os.replace`` itself needs no dispatch: a rename cannot cross filesystems, so an
+    atomic write into ``.charter/`` is written beside its destination and is a state path
+    by construction.
 
     Does nothing for an *fid* :func:`frame_dir` refuses, and
     nothing for a write that fails after the directory exists (a full filesystem, say) —
@@ -337,10 +341,8 @@ def bump(fid: str) -> None:
     d = frame_dir(fid, create=True)
     if d is None:
         return
-    tmp = d / "version.tmp"
     try:
-        config.write_for(tmp, f"{time.time_ns()}\n")
-        os.replace(tmp, d / "version")
+        config.replace_for(d / "version", f"{time.time_ns()}\n")
     except OSError:
         # The directory existing doesn't guarantee the write does too (a filesystem
         # that fills up between the two calls above, say) — same must-not-raise
@@ -419,9 +421,9 @@ def say(fid: str, message: str, *, seconds: float = NOTICE_SECONDS) -> None:
       not a message aimed at a server.
 
     Best effort, never raises: the callers are switch outcomes, and one that cannot write
-    its notice must still return the exit status it owes tmux. Same atomic
-    `write_for`-then-`os.replace` shape as :func:`bump`, so a reader never sees half a
-    line, and a failed write leaves the previous notice exactly as it was.
+    its notice must still return the exit status it owes tmux. Same `config.replace_for`
+    as :func:`bump`, so a reader never sees half a line, never sees another writer's half
+    either (#893), and a failed write leaves the previous notice exactly as it was.
 
     The expiry is stored, not the duration, so a reader needs only the clock and never
     has to know when the write happened. `time.time()` rather than `time.monotonic()`:
@@ -447,10 +449,8 @@ def say(fid: str, message: str, *, seconds: float = NOTICE_SECONDS) -> None:
     text = contain.one_line(message).strip()
     if not text:
         return
-    tmp = d / "notice.tmp"
     try:
-        config.write_for(tmp, f"{time.time() + float(seconds)}\n{text}\n")
-        os.replace(tmp, d / "notice")
+        config.replace_for(d / "notice", f"{time.time() + float(seconds)}\n{text}\n")
     except OSError:
         # `OSError` alone, exactly as `bump` and `record_exit` above — one shape for the
         # three writers in this module rather than a wider net here. `ValueError` and
@@ -529,10 +529,8 @@ def record_exit(fid: str, code: int) -> None:
     d = frame_dir(fid, create=True)
     if d is None:
         return
-    tmp = d / "exit.tmp"
     try:
-        config.write_for(tmp, f"{int(code)}\n")
-        os.replace(tmp, d / "exit")
+        config.replace_for(d / "exit", f"{int(code)}\n")
     except OSError:
         return
 
@@ -632,10 +630,8 @@ def record_harness_pane(fid: str, pane: str) -> None:
     d = frame_dir(fid, create=True)
     if d is None:
         return
-    tmp = d / "harness.tmp"
     try:
-        config.write_for(tmp, f"{pane}\n")
-        os.replace(tmp, d / "harness")
+        config.replace_for(d / "harness", f"{pane}\n")
     except OSError:
         return
 
@@ -695,10 +691,8 @@ def record_harness_session(fid: str, sid: str) -> bool:
     d = frame_dir(fid, create=True)
     if d is None:
         return False
-    tmp = d / "session.tmp"
     try:
-        config.write_for(tmp, f"{sid}\n")
-        os.replace(tmp, d / "session")
+        config.replace_for(d / "session", f"{sid}\n")
     except OSError:
         return False
     _record_kept_session(d, sid)
@@ -771,10 +765,8 @@ def _record_kept_session(d: Path, sid: str) -> None:
     cannot be resumed later. Returning nothing rather than a bool is the same statement —
     there is no caller that could do anything with the answer.
     """
-    tmp = d / "session.durable.tmp"
     try:
-        config.write_for(tmp, f"{sid}\n")
-        os.replace(tmp, d / _KEPT_SESSION_FILE)
+        config.replace_for(d / _KEPT_SESSION_FILE, f"{sid}\n")
     except OSError:
         return
 
@@ -822,10 +814,8 @@ def record_server(fid: str, server: str) -> None:
     d = frame_dir(fid, create=True)
     if d is None:
         return
-    tmp = d / "server.tmp"
     try:
-        config.write_for(tmp, f"{server}\n")
-        os.replace(tmp, d / "server")
+        config.replace_for(d / "server", f"{server}\n")
     except OSError:
         return
 
@@ -890,10 +880,8 @@ def record_workspace(fid: str, name: str) -> None:
     d = frame_dir(fid, create=True)
     if d is None:
         return
-    tmp = d / "workspace.tmp"
     try:
-        config.write_for(tmp, f"{name}\n")
-        os.replace(tmp, d / "workspace")
+        config.replace_for(d / "workspace", f"{name}\n")
     except OSError:
         return
 
@@ -1215,10 +1203,8 @@ def record_density(fid: str, level: str) -> None:
     d = frame_dir(fid, create=True)
     if d is None:
         return
-    tmp = d / "density.tmp"
     try:
-        config.write_for(tmp, f"{level}\n")
-        os.replace(tmp, d / "density")
+        config.replace_for(d / "density", f"{level}\n")
     except OSError:
         return
 
@@ -1271,10 +1257,8 @@ def record_bar_rows(fid: str, rows: int) -> None:
     d = frame_dir(fid, create=True)
     if d is None:
         return
-    tmp = d / "bar_rows.tmp"
     try:
-        config.write_for(tmp, f"{int(rows)}\n")
-        os.replace(tmp, d / "bar_rows")
+        config.replace_for(d / "bar_rows", f"{int(rows)}\n")
     except OSError:
         return
 
@@ -1331,10 +1315,8 @@ def record_chrome(fid: str, level: str) -> None:
     d = frame_dir(fid, create=True)
     if d is None:
         return
-    tmp = d / "chrome.tmp"
     try:
-        config.write_for(tmp, f"{level}\n")
-        os.replace(tmp, d / "chrome")
+        config.replace_for(d / "chrome", f"{level}\n")
     except OSError:
         return
 
@@ -1380,10 +1362,8 @@ def record_change(fid: str, slug: str) -> None:
     d = frame_dir(fid, create=True)
     if d is None:
         return
-    tmp = d / "change.tmp"
     try:
-        config.write_for(tmp, f"{slug}\n")
-        os.replace(tmp, d / "change")
+        config.replace_for(d / "change", f"{slug}\n")
     except OSError:
         return
 
@@ -1443,10 +1423,8 @@ def record_selection(fid: str, name: str) -> None:
     d = frame_dir(fid, create=True)
     if d is None:
         return
-    tmp = d / "selection.tmp"
     try:
-        config.write_for(tmp, f"{name}\n")
-        os.replace(tmp, d / "selection")
+        config.replace_for(d / "selection", f"{name}\n")
     except OSError:
         return
 
@@ -1495,10 +1473,8 @@ def record_hidden(fid: str, names) -> None:
     d = frame_dir(fid, create=True)
     if d is None:
         return
-    tmp = d / "hidden.tmp"
     try:
-        config.write_for(tmp, "".join(f"{n}\n" for n in names))
-        os.replace(tmp, d / "hidden")
+        config.replace_for(d / "hidden", "".join(f"{n}\n" for n in names))
     except OSError:
         return
 
@@ -1656,10 +1632,8 @@ def record_identity(fid: str, values: dict[str, str]) -> None:
     d = frame_dir(fid, create=True)
     if d is None:
         return
-    tmp = d / "identity.tmp"
     try:
-        config.write_for(tmp, json.dumps(dict(values)))
-        os.replace(tmp, d / "identity")
+        config.replace_for(d / "identity", json.dumps(dict(values)))
     except (OSError, TypeError, ValueError):
         return
 
@@ -1726,10 +1700,8 @@ def record_panes(fid: str, *, panels: dict[str, str]) -> None:
     d = frame_dir(fid, create=True)
     if d is None:
         return
-    tmp = d / "panes.tmp"
     try:
-        config.write_for(tmp, json.dumps(dict(panels)))
-        os.replace(tmp, d / "panes")
+        config.replace_for(d / "panes", json.dumps(dict(panels)))
     except (OSError, TypeError, ValueError):
         return
 
@@ -1807,10 +1779,8 @@ def record_cwd(fid: str, path: str) -> None:
     d = frame_dir(fid, create=True)
     if d is None:
         return
-    tmp = d / "cwd.tmp"
     try:
-        config.write_for(tmp, f"{path}\n")
-        os.replace(tmp, d / _CWD_FILE)
+        config.replace_for(d / _CWD_FILE, f"{path}\n")
     except OSError:
         return
 

--- a/charter/frame/state.py
+++ b/charter/frame/state.py
@@ -345,7 +345,7 @@ def bump(fid: str) -> None:
         config.replace_for(d / "version", f"{time.time_ns()}\n")
     except OSError:
         # The directory existing doesn't guarantee the write does too (a filesystem
-        # that fills up between the two calls above, say) — same must-not-raise
+        # that fills up between the `mkdir` and the write, say) — same must-not-raise
         # promise as the mkdir guard in frame_dir, covering the step after it.
         return
 

--- a/charter/toolgate.py
+++ b/charter/toolgate.py
@@ -806,9 +806,11 @@ def snapshot(session_id: str | None = None) -> dict:
         f = _ceiling_file(sid)
         config.private_mkdir(f.parent)
         config.touch_for(_marker_file(sid))   # before the ceiling: see `_marker_file`
-        tmp = f.with_name(f.name + ".tmp")
-        config.write_for(tmp, json.dumps(data, sort_keys=True))
-        os.replace(tmp, f)
+        # `replace_for` and not a temp name of this function's own: two harnesses can
+        # reach a snapshot for one session id — a SessionStart hook and a first gated
+        # Bash call under trust-on-first-use — and a shared temp name is how the second
+        # publishes the first's zero bytes as a ceiling that approves nothing (#893).
+        config.replace_for(f, json.dumps(data, sort_keys=True))
     except OSError:
         return {}
     return data

--- a/charter/workspace.py
+++ b/charter/workspace.py
@@ -1134,12 +1134,16 @@ def _write_manifest(name: str, data: dict) -> None:
     """:func:`write_manifest` without the `ensure` — the writer this module calls, because
     `ensure` scaffolds and scaffolding is what calls this.
 
-    **Atomic**: a temp file plus ``os.replace``, the shape `state.bump` and `gather.save`
-    already use, for a reason a committed file sharpens — one of this file's readers is
-    `git add`, so half a manifest is not a glitch somebody re-runs past, it is half a
-    manifest a teammate pulls. The temp file goes through `config.write_for` for
-    `state.bump`'s stated reason: ``os.replace`` carries the SOURCE's mode onto the target,
-    so the dispatch has to happen on the file that is moved rather than the one it lands on.
+    **Atomic**: `config.replace_for`, the call `state.bump` and `gather.save` make, for a
+    reason a committed file sharpens — one of this file's readers is `git add`, so half a
+    manifest is not a glitch somebody re-runs past, it is half a manifest a teammate pulls.
+    It writes through `config.write_for` for `state.bump`'s stated reason: ``os.replace``
+    carries the SOURCE's mode onto the target, so the dispatch has to happen on the file
+    that is moved rather than the one it lands on — and that is also why the temp file is
+    not `tempfile.mkstemp`'s, whose 0600 would land on a file in the operator's own git
+    tree. The temp NAME carries this writer's pid, which is #893: `ensure` scaffolds a
+    manifest and `record_members` rewrites one, and two commands doing that at once for one
+    workspace used to share a single ``workspace.json.tmp``.
 
     `contain.writable` first and by itself: a manifest path redirected out of the plane by a
     symlink is refused here rather than followed (#328), and the refusal RAISES, because
@@ -1149,9 +1153,7 @@ def _write_manifest(name: str, data: dict) -> None:
     p = contain.writable(manifest_path(name))
     doc = dict(data)
     doc[MANIFEST_MARKER] = content_digest(_manifest_body(doc))
-    tmp = p.with_name(p.name + ".tmp")
-    config.write_for(tmp, json.dumps(doc, indent=2) + "\n")
-    os.replace(tmp, p)
+    config.replace_for(p, json.dumps(doc, indent=2) + "\n")
 
 
 def _now() -> str:

--- a/docs/news/unreleased-two-writers-for-one-file-stop-publishing-each-others-half.md
+++ b/docs/news/unreleased-two-writers-for-one-file-stop-publishing-each-others-half.md
@@ -1,0 +1,62 @@
+---
+version: unreleased
+headline: two charter processes writing the same file stop publishing each other's half — every atomic write now uses a temp file of its own
+---
+
+**A frame's gather cache came out of CI existing and zero bytes.** The panel that reads it
+drew a frame with no branch on it, on one interpreter out of four, on a branch that touched
+none of this code. It is a race, so it passed on the rerun.
+
+`os.replace` is atomic. The file it renames is not — and that is the half twenty writers in
+charter were missing.
+
+## One name, two writers
+
+Every atomic writer in the package published through a temp file named after its target and
+nothing else: `version` through `version.tmp`, `gather.json` through `gather.json.tmp`,
+`workspace.json` through `workspace.json.tmp`. Two processes writing one target therefore
+wrote into **one inode**, and the sequence needs no unusual timing:
+
+1. A opens the shared temp with `"w"` — which truncates it to zero bytes.
+2. B, a step ahead, renames that same path onto the target. The target is now A's empty
+   file, and B has been told its own content landed.
+3. A writes its bytes into an inode that is already the target, so a reader between here and
+   A's own rename sees whatever has been flushed so far.
+
+Every reader of these files was written to trust them. `gather.cached` *"hands back whatever
+parses"* — deliberately, because a frame panel calls it on every repaint and a freshness
+check there would cost the property the frame was built for. A truncated cache is read as
+truth.
+
+## Why it stopped being theoretical
+
+0.56.0 added `notify.plane_changed_everywhere()`, which writes a gather cache for **every
+frame on the plane** and then bumps every version file. Hooks, panels and CLI commands can
+all be doing that at once, and the frame process records the plane from a debounce thread
+while everything else in that process writes too. Concurrency on one target went from rare
+to ordinary, and the CI failure followed.
+
+## One writer, and its temp file is its own
+
+`config.replace_for` is now the only atomic writer in charter — seventeen call sites in
+`frame/state.py`, plus the frame's gather cache, the reopen manifest, the tool ceiling and
+the workspace manifest. Its temp file carries the target's name, the writing process's pid
+and a random tail, beside the target so the rename stays a rename. It is removed on every
+failure, because a name nothing can predict is a name nothing can collect: `.charter/frame/`
+has one sweep and it touches nothing but `*.transcript`.
+
+Not `tempfile.mkstemp`, which `frame/reopen.py` reached for when it found this defect on its
+own file. mkstemp creates at 0600, which is the right mode for `.charter/` and the wrong one
+for `workspaces/<name>/workspace.json` — a committed file in your own git tree. The mode
+stays `config.write_for`'s answer, which is to ask where the path is.
+
+There is nothing to adopt. The files are the same files, at the same paths, with the same
+contents; what changed is that two writers can no longer be inside one of them.
+
+## Pinned by a race, not by a name
+
+The test that holds this runs four writers at one target with a reader watching throughout,
+and asserts the property — the target always holds one writer's whole content, never empty
+and never a splice. A case that read the temp file's name and looked for a pid in it would
+have passed against the defect verbatim: the bug was never that the name lacked a pid, it
+was that two writers shared a file.

--- a/tests/_statedirscan.py
+++ b/tests/_statedirscan.py
@@ -102,6 +102,11 @@ this scan already sees (an ``os.replace`` cannot cross filesystems, so an atomic
 0600 by construction. Both are pinned behaviourally in
 `TheDispatchOnWhereTheFileIs.test_the_atomic_writers_temp_file_is_private_by_construction`,
 so the reasoning is measured rather than assumed.
+
+Since #893 the first of those two is what nearly every atomic writer in the package is:
+`config.replace_for` is the one that names the temp file and hands it to `write_for`, so
+the source is a path this scan sees, beside a destination it already judged. `inflight` is
+the remaining `mkstemp` caller and the second clause is still for it.
 """
 
 from __future__ import annotations
@@ -129,7 +134,12 @@ THE_WALK = ("config.private_mkdir", "config._mkdir_0700", "config.mkdir_for",
 #: The routed spellings for a FILE (#505). Same shape as `ROUTED`, and the same reason it
 #: is documentation rather than a filter: none of these is named ``write_text``/``open``/
 #: ``touch``, so a routed call is simply not a site.
-ROUTED_WRITE = ("write_for", "open_for", "touch_for")
+#:
+#: ``replace_for`` is `write_for` plus a rename and a temp name of the writer's own (#893).
+#: It is here because it is the spelling an atomic writer should reach for and this list is
+#: where a reader looks for that; the scan needs no entry for it, since what it writes
+#: through is `write_for` one frame down.
+ROUTED_WRITE = ("write_for", "open_for", "touch_for", "replace_for")
 
 #: `config`'s own file writers, exempt for the reason `THE_WALK` is: they **are** the
 #: routing. ``_open_private``/``_private_fd`` are the private opener itself; ``open_for``'s

--- a/tests/test_a_key_cycles_the_tab_strips_height.py
+++ b/tests/test_a_key_cycles_the_tab_strips_height.py
@@ -224,7 +224,10 @@ class TheHeightIsRememberedForThisFrameAndNoLonger(PersonaIso, unittest.TestCase
         d = state.frame_dir(self.FID)
         self.assertTrue((d / "bar_rows").is_file())
         self.assertEqual((d / "bar_rows").read_text(), "2\n")
-        self.assertFalse((d / "bar_rows.tmp").exists(),
+        # A GLOB and not `d / "bar_rows.tmp"`, which is #893: the temp file's name carries
+        # the writing process's pid and a random tail, so a case naming one fixed spelling
+        # would be asserting the absence of a file nothing ever writes.
+        self.assertEqual(list(d.glob("bar_rows.*")), [],
                          "the atomic write left its temp file behind")
 
 

--- a/tests/test_charter_records_the_plane_as_it_changes.py
+++ b/tests/test_charter_records_the_plane_as_it_changes.py
@@ -353,11 +353,20 @@ class TheRecordIsWrittenAtomically(PersonaIso, unittest.TestCase):
         self.assertEqual([c.resume for c in reopen.read().all_chats()], ["conv-1"])
 
     def test_a_temp_file_that_cannot_be_made_is_a_record_that_did_not_land(self):
-        """A full filesystem answers here rather than at the write, and the caller does the
-        same thing with either: tell the operator the plane was not recorded."""
+        """A full filesystem answers here rather than at the rename, and the caller does
+        the same thing with either: tell the operator the plane was not recorded.
+
+        **Injected at `config.write_for`, and #893 is why it is no longer
+        `tempfile.mkstemp`.** Making the temp file and writing it are one event now —
+        `config.replace_for` names a path and hands it to the state-file dispatch, which
+        creates it — so a mock aimed at `mkstemp` was aimed at a call nobody makes and this
+        case went green having exercised nothing. Repointed rather than deleted: "the temp
+        file could not be made" is still a real way for this to fail, and it is still not
+        the rename below.
+        """
         reopen.write([_frame("alpha", "alpha.1", resume="conv-1")], focus="alpha")
 
-        with mock.patch("tempfile.mkstemp", side_effect=OSError("no space")):
+        with mock.patch.object(config, "write_for", side_effect=OSError("no space")):
             self.assertFalse(reopen.write([_frame("beta", "beta.1")], focus="beta"))
 
         self.assertEqual([c.resume for c in reopen.read().all_chats()], ["conv-1"])

--- a/tests/test_frame_surface_live.py
+++ b/tests/test_frame_surface_live.py
@@ -205,7 +205,11 @@ class TheTwoNewStateAccessorsRefuseRatherThanRaise(PersonaIso, unittest.TestCase
         real = state.config.write_for
 
         def refuse(path, data):
-            if pathlib.Path(path).name == "chrome.tmp":
+            # `startswith` and not `== "chrome.tmp"`, which is #893: the temp file carries
+            # the writing process's pid and a random tail now, so the one name this used to
+            # match is a name nothing writes — and a mock aimed at it lets the write
+            # succeed and the case go green having refused nothing.
+            if pathlib.Path(path).name.startswith("chrome."):
                 raise OSError("no space left on device")
             return real(path, data)
 

--- a/tests/test_two_writers_never_publish_each_others_half.py
+++ b/tests/test_two_writers_never_publish_each_others_half.py
@@ -1,0 +1,354 @@
+"""What `os.replace` gives an atomic write, and what only the temp file's NAME can.
+
+``os.replace`` is atomic about the moment the destination changes: a reader sees the whole
+old file or the whole new one, never a prefix of either. It says nothing whatever about the
+file being renamed. While every writer for one target agreed on one temp name — ``version``
+published through ``version.tmp``, ``gather.json`` through ``gather.json.tmp`` — two writers
+for that target were writing into ONE inode, and the sequence needs no unusual timing:
+
+1. A opens the shared temp with ``"w"``, which truncates it to zero bytes.
+2. B, a step ahead, ``os.replace``\\ s that same path onto the target. The target is now A's
+   empty file, and B has been told its own content landed.
+3. A writes its bytes into an inode that is already the target, so a reader between here
+   and A's own rename sees whatever prefix has been flushed.
+
+That is #893, and it was reached rather than reasoned about: on CI run 33854599000 a
+frame's ``gather.json`` came out of `gather.refresh` existing and **zero bytes**, on a
+branch touching none of this code, on one interpreter of four. `gather.cached` hands back
+whatever parses and deliberately has no freshness check, so an empty scan is read as a true
+one.
+
+**These cases race rather than assert a name.** A case that read the temp file's name and
+looked for a pid in it would pass against the defect verbatim — the bug is not that the name
+lacks a pid, it is that two writers share a file — so what is asserted here is the property:
+the target always holds ONE writer's whole content. Never empty, never a splice of two, at
+every moment a reader can look and once the writers have stopped.
+
+Threads and not processes, for what that buys and costs. It buys the interleaving being
+inside one interpreter, where `sys.setswitchinterval` can make the scheduler switch on
+almost every bytecode and turn a window measured in microseconds into one this suite hits
+in under a second; it costs nothing in fidelity, because the shared-name defect is between
+two *file descriptors* and does not care which process holds them. #845 already found this
+shape from threads alone: `frame/record.py` writes the reopen manifest from a debounce
+thread in the same process as everything else that writes it.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import stat
+import sys
+import threading
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from charter import config, workspace
+from charter.frame import gather, state
+
+from tests._isolation import PersonaIso
+
+#: How many writers go at one target at once. Two is the defect's own shape and the number
+#: the issue names; four is what a contended CI runner looks like and finds the window
+#: sooner without making a green run slower in any way anyone notices.
+WRITERS = 4
+
+#: How many times each writer publishes. Chosen against the defect rather than for a round
+#: number: with the shared temp name hand-applied, `charter/config.py`'s writer fails these
+#: cases on every run measured at this depth, and the whole class costs well under a second
+#: green.
+ROUNDS = 60
+
+
+def _payloads(n: int = WRITERS) -> list[str]:
+    """One distinct, self-describing payload per writer, each a different LENGTH.
+
+    Different lengths matter more than different values: a splice of two equal-length
+    payloads can land on a byte boundary that still reads as one of them, and a short
+    writer's content sitting inside a long writer's file is exactly what a shared temp
+    inode produces. Trailing newline included, because every writer in `frame/state.py`
+    writes one and a reader that strips is a reader that cannot see a truncation.
+    """
+    return [json.dumps({"writer": i, "pad": "p" * (256 * (i + 1))}) + "\n"
+            for i in range(n)]
+
+
+class _Race:
+    """WRITERS threads publishing to one target, and one reader watching it throughout.
+
+    The reader is the half that catches step 3 above — a reader between the wrong rename
+    and the writer that is still filling the inode — and the final assertion is the half
+    that catches step 2. Neither subsumes the other: a defect that only ever published
+    empty files would be invisible to a run that happened to end on a good write.
+    """
+
+    def __init__(self, target: Path, publish, payloads: list[str]) -> None:
+        self.target, self.publish, self.payloads = target, publish, payloads
+        self.bad: list[str] = []
+        self.errors: list[BaseException] = []
+        self.stop = threading.Event()
+        self.start = threading.Barrier(WRITERS + 1)
+
+    def _write(self, i: int) -> None:
+        self.start.wait()
+        try:
+            for _ in range(ROUNDS):
+                self.publish(self.payloads[i])
+        except BaseException as exc:       # noqa: BLE001 — reported, not swallowed
+            self.errors.append(exc)
+
+    def _read(self) -> None:
+        self.start.wait()
+        while not self.stop.is_set():
+            try:
+                text = self.target.read_text()
+            except FileNotFoundError:
+                continue                    # before the first publish lands
+            except OSError as exc:
+                self.errors.append(exc)
+                return
+            if text not in self.payloads:
+                self.bad.append(text)
+                return                      # one witness is the whole finding
+
+    def run(self) -> None:
+        # An aggressive switch interval, restored afterwards. The window this is about is
+        # one `open()` wide, and the default 5ms interval means a thread usually runs
+        # straight through it; at a microsecond the interpreter yields inside the window
+        # instead. It changes how OFTEN the defect is hit and nothing about whether it is
+        # there — a test that needed a `sleep` to find a race would be a test that stops
+        # finding it (`reopen.write`'s own note, and the issue's).
+        old = sys.getswitchinterval()
+        sys.setswitchinterval(1e-6)
+        threads = [threading.Thread(target=self._write, args=(i,))
+                   for i in range(WRITERS)]
+        reader = threading.Thread(target=self._read)
+        try:
+            for t in (*threads, reader):
+                t.start()
+            for t in threads:
+                t.join()
+            self.stop.set()
+            reader.join()
+        finally:
+            sys.setswitchinterval(old)
+
+
+class TwoWritersForOneTarget(PersonaIso):
+    """`config.replace_for` under concurrency, on both sides of its own dispatch."""
+
+    def _assert_whole(self, race: _Race, target: Path) -> None:
+        self.assertEqual(race.errors, [], "a writer raised rather than publishing")
+        self.assertEqual(race.bad, [],
+                         "a reader saw a file that is no writer's content — two writers "
+                         "shared one temp inode, which is what a private temp NAME is for")
+        self.assertIn(target.read_text(), race.payloads,
+                      "the target ended up holding something no writer wrote whole")
+
+    def test_the_target_only_ever_holds_one_writers_whole_content(self) -> None:
+        target = Path(config.STATE_DIR) / "frame" / "alpha.1" / "gather.json"
+        config.private_mkdir(target.parent)
+        payloads = _payloads()
+        race = _Race(target, lambda text: config.replace_for(target, text), payloads)
+        race.run()
+        self._assert_whole(race, target)
+
+    def test_it_holds_for_a_committed_target_too(self) -> None:
+        """The other side of `config.write_for`'s dispatch — `workspace._write_manifest`
+        publishes ``workspaces/<n>/workspace.json`` through this, and that file's readers
+        include `git add`. A race that only ever ran under `.charter/` would leave the
+        branch a committed file takes unmeasured."""
+        target = self.tmp / "committed" / "workspace.json"
+        target.parent.mkdir(parents=True)
+        payloads = _payloads()
+        race = _Race(target, lambda text: config.replace_for(target, text), payloads)
+        race.run()
+        self._assert_whole(race, target)
+
+    def test_no_temp_file_survives_the_race(self) -> None:
+        """Every publish that landed took its temp file with it. Asserted after the race
+        rather than during it, because during it there ARE temp files — that is the point
+        of them — and a case that could not tell the two apart would be asserting that the
+        writer does not work."""
+        target = Path(config.STATE_DIR) / "frame" / "alpha.1" / "gather.json"
+        config.private_mkdir(target.parent)
+        race = _Race(target, lambda text: config.replace_for(target, text), _payloads())
+        race.run()
+        self.assertEqual(sorted(p.name for p in target.parent.iterdir()),
+                         ["gather.json"])
+
+
+class TwoSaversForOneFrame(PersonaIso):
+    """The same property through the function the defect was OBSERVED in.
+
+    `config.replace_for` being correct is not the same claim as `gather.save` calling it:
+    the cache file that came out of CI empty is this one, and a case that only exercised
+    the shared writer would go green with `gather.save` still spelling its own temp name.
+    """
+
+    FID = "alpha.1"
+
+    def test_a_cache_read_during_a_race_always_parses_and_is_never_empty(self) -> None:
+        """The reader reads the FILE, not `gather.cached`, and the difference is the whole
+        CI failure. `cached` answers ``None`` for a file that is missing and for one that
+        does not parse — it cannot tell them apart and does not try — so a reader watching
+        through it sees the zero-byte cache as "no cache yet" and reports nothing. What the
+        panel then draws is a frame with no branch on it, which is what run 33854599000
+        actually asserted against. So the witness is the bytes on disk: every reading of
+        this file, at every moment, is one saver's whole JSON.
+        """
+        state.frame_dir(self.FID, create=True)
+        scans = [{"repos": [{"name": f"r{j}"} for j in range(i + 1)], "worktrees": [],
+                  "writer": i} for i in range(WRITERS)]
+        # `json.dumps` is deterministic for one dict within one process, so this is the
+        # exact byte string `gather.save` will write for each scan — which is what lets the
+        # race compare a raw read against "what some writer wrote whole".
+        payloads = [json.dumps(s) for s in scans]
+        target = Path(config.STATE_DIR) / "frame" / self.FID / "gather.json"
+
+        race = _Race(target, lambda text: gather.save(self.FID, json.loads(text)), payloads)
+        race.run()
+
+        self.assertEqual(race.errors, [], "a saver raised rather than saving")
+        self.assertEqual(race.bad, [],
+                         "a panel repaint read a cache nobody saved — an empty file among "
+                         "these is the CI failure this issue was filed from, verbatim")
+        self.assertNotEqual(target.read_bytes(), b"", "the cache file is zero bytes")
+        self.assertIn(gather.cached(self.FID), scans)
+
+
+class TheTempFileIsThisWritersOwn(PersonaIso):
+    """`config.temp_beside` on its own. These cases cannot replace the racing ones above —
+    a name carrying a pid is not the property, it is one way of getting it — but a name
+    that stopped being unique would fail here first and say why in one line."""
+
+    def test_two_asks_for_one_target_never_name_the_same_file(self) -> None:
+        target = Path(config.STATE_DIR) / "frame" / "alpha.1" / "gather.json"
+        names = {config.temp_beside(target) for _ in range(200)}
+        self.assertEqual(len(names), 200)
+
+    def test_it_is_beside_the_target_so_the_rename_stays_a_rename(self) -> None:
+        """``os.replace`` cannot cross filesystems, and `.charter/` may be a mount of its
+        own (`$CHARTER_HOME` puts it anywhere on the machine). A temp file in the system
+        temp directory would turn every atomic write into an `EXDEV`."""
+        target = Path(config.STATE_DIR) / "frame" / "alpha.1" / "gather.json"
+        tmp = config.temp_beside(target)
+        self.assertEqual(tmp.parent, target.parent)
+        self.assertNotEqual(tmp.name, target.name)
+        self.assertTrue(tmp.name.startswith(f"{target.name}."),
+                        "a temp file that does not say which target it belongs to is one "
+                        "nobody can attribute when it is found beside four of them")
+        self.assertTrue(tmp.name.endswith(config.TEMP_SUFFIX))
+
+    def test_it_carries_the_writing_process(self) -> None:
+        """The pid separates processes and the random tail separates threads within one.
+        Both are needed and neither is decoration: `notify.plane_changed_everywhere` writes
+        a gather cache for every frame on the plane, from hooks, panels and CLI commands
+        that run at once."""
+        target = Path(config.STATE_DIR) / "frame" / "alpha.1" / "gather.json"
+        self.assertIn(str(os.getpid()), config.temp_beside(target).name)
+
+
+class AFailedPublishLeavesNothingBehind(PersonaIso):
+    """A temp name nothing can predict is a temp name nothing can collect. None of the
+    directories charter publishes into has a sweep that would find one: `.charter/frame/`
+    has `reopen.prune_transcripts`, which touches nothing but `*.transcript`, and
+    `workspaces/<n>/` has `git status`, where litter is a teammate's problem."""
+
+    def test_a_rename_that_fails_removes_the_temp_file(self) -> None:
+        target = Path(config.STATE_DIR) / "frame" / "alpha.1" / "version"
+        config.private_mkdir(target.parent)
+        with mock.patch("os.replace", side_effect=OSError("no")):
+            with self.assertRaises(OSError):
+                config.replace_for(target, "1\n")
+        self.assertEqual(list(target.parent.iterdir()), [])
+
+    def test_a_write_that_fails_removes_the_temp_file(self) -> None:
+        """The earlier half of the same clause. `write_for` can create the file and then
+        fail filling it — a full filesystem answers at the `write`, not at the `open` —
+        and the temp file exists at that point exactly as it does after a failed rename."""
+        target = Path(config.STATE_DIR) / "frame" / "alpha.1" / "version"
+        config.private_mkdir(target.parent)
+        real = config.open_for
+
+        class _Full:
+            def __init__(self, f):
+                self._f = f
+
+            def write(self, _data):
+                raise OSError(28, "No space left on device")
+
+        import contextlib
+
+        @contextlib.contextmanager
+        def refusing(p, mode="w", **kw):
+            with real(p, mode, **kw) as f:
+                yield _Full(f)
+
+        with mock.patch.object(config, "open_for", refusing):
+            with self.assertRaises(OSError):
+                config.replace_for(target, "1\n")
+        self.assertEqual(list(target.parent.iterdir()), [])
+
+    def test_a_temp_file_that_cannot_be_removed_is_still_the_real_failure(self) -> None:
+        """The filesystem that refused the rename can refuse the tidy-up too. What the
+        caller is owed is why its WRITE failed; replacing that with the unlink's error
+        would send every reader of the traceback after the wrong fault."""
+        target = Path(config.STATE_DIR) / "frame" / "alpha.1" / "version"
+        config.private_mkdir(target.parent)
+        with mock.patch("os.replace", side_effect=OSError(28, "No space left on device")), \
+                mock.patch("pathlib.Path.unlink", side_effect=OSError(13, "read-only")):
+            with self.assertRaises(OSError) as caught:
+                config.replace_for(target, "1\n")
+        self.assertEqual(caught.exception.errno, 28)
+
+    def test_a_failed_publish_leaves_the_previous_content_whole(self) -> None:
+        target = Path(config.STATE_DIR) / "frame" / "alpha.1" / "version"
+        config.private_mkdir(target.parent)
+        config.replace_for(target, "first\n")
+        with mock.patch("os.replace", side_effect=OSError("no")):
+            with self.assertRaises(OSError):
+                config.replace_for(target, "second\n")
+        self.assertEqual(target.read_text(), "first\n")
+
+
+class ThePublishedFileKeepsTheModeItsPlaceAsksFor(PersonaIso):
+    """``os.replace`` carries the SOURCE's mode onto the target (#582), so the temp file
+    decides what the destination comes out at — and the temp file is created by
+    `config.write_for`, which asks where the path is rather than assuming.
+
+    This is why `config.replace_for` does NOT use `tempfile.mkstemp`, which
+    `frame/reopen.py` used to and every other atomic writer in the wild does: mkstemp
+    creates at 0600 unconditionally, which is the right mode for `.charter/` and the wrong
+    one for a file in the operator's own git tree. Charter tightens what is its own and
+    reports what is not (#331); a manifest that came back 0600 from a `charter workspace`
+    command would be charter tightening somebody's committed file without being asked.
+    """
+
+    def test_a_state_file_is_private_however_loose_the_umask(self) -> None:
+        target = Path(config.STATE_DIR) / "frame" / "alpha.1" / "version"
+        config.private_mkdir(target.parent)
+        old = os.umask(0o000)
+        try:
+            config.replace_for(target, "1\n")
+        finally:
+            os.umask(old)
+        self.assertEqual(stat.S_IMODE(target.stat().st_mode) & 0o077, 0)
+
+    def test_a_committed_file_is_left_at_the_umasks_answer(self) -> None:
+        workspace.ensure("alpha")
+        old = os.umask(0o022)
+        try:
+            workspace.write_manifest("alpha", {"name": "alpha", "repos": []})
+            control = self.tmp / "control"
+            control.write_text("x")
+        finally:
+            os.umask(old)
+        self.assertEqual(stat.S_IMODE(workspace.manifest_path("alpha").stat().st_mode),
+                         stat.S_IMODE(control.stat().st_mode),
+                         "a committed manifest was tightened; it is the operator's")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_two_writers_never_publish_each_others_half.py
+++ b/tests/test_two_writers_never_publish_each_others_half.py
@@ -249,6 +249,26 @@ class TheTempFileIsThisWritersOwn(PersonaIso):
         target = Path(config.STATE_DIR) / "frame" / "alpha.1" / "gather.json"
         self.assertIn(str(os.getpid()), config.temp_beside(target).name)
 
+    def test_the_suffix_is_the_one_the_litter_sweeps_look_for(self) -> None:
+        """``.tmp`` is load-bearing rather than decorative, which is the only reason a case
+        asserts a constant. Two suites look for a temp file left beside an atomic write by
+        that suffix — `TheWriteIsAtomic.test_no_temporary_file_is_left_beside_it` and the
+        `glob("*.tmp")` in `test_the_state_directory_is_charters_to_choose` — and both
+        assert that they find NONE, so a rename here would leave them looking for a name
+        nothing writes and reporting a clean directory forever."""
+        self.assertEqual(config.TEMP_SUFFIX, ".tmp")
+
+    def test_a_target_spelled_as_a_string_is_the_same_target(self) -> None:
+        """`config.write_for` and `config.open_for` both take either, and a writer that
+        took only one of the two would be a trap laid for the next caller rather than a
+        contract — the paths in this package come from `contain.child`, from a `/` join and
+        out of `os.environ`, and the last of those is a `str`."""
+        target = Path(config.STATE_DIR) / "frame" / "alpha.1" / "version"
+        config.private_mkdir(target.parent)
+        config.replace_for(str(target), "1\n")
+        self.assertEqual(target.read_text(), "1\n")
+        self.assertEqual(config.temp_beside(str(target)).parent, target.parent)
+
 
 class AFailedPublishLeavesNothingBehind(PersonaIso):
     """A temp name nothing can predict is a temp name nothing can collect. None of the
@@ -289,6 +309,20 @@ class AFailedPublishLeavesNothingBehind(PersonaIso):
         with mock.patch.object(config, "open_for", refusing):
             with self.assertRaises(OSError):
                 config.replace_for(target, "1\n")
+        self.assertEqual(list(target.parent.iterdir()), [])
+
+    def test_a_content_that_cannot_be_encoded_removes_the_temp_file_too(self) -> None:
+        """``except BaseException`` and not ``except OSError``, which is what a reader of
+        this function will want to narrow. A failed write is not always a filesystem
+        saying no: a lone surrogate in a value charter read off disk is a
+        `UnicodeEncodeError` at the `write`, and `reopen.write` catches `TypeError` and
+        `ValueError` for its own `json.dumps` for the same reason. Narrow the clause and
+        every one of those leaves its temp file behind, in a directory with no collector.
+        """
+        target = Path(config.STATE_DIR) / "frame" / "alpha.1" / "identity"
+        config.private_mkdir(target.parent)
+        with self.assertRaises(UnicodeEncodeError):
+            config.replace_for(target, "a lone surrogate: \ud800\n")
         self.assertEqual(list(target.parent.iterdir()), [])
 
     def test_a_temp_file_that_cannot_be_removed_is_still_the_real_failure(self) -> None:


### PR DESCRIPTION
`os.replace` is atomic. The file it renames is not — and that is the half twenty writers
in charter were missing.

Closes #893.

## The defect

Every atomic writer in the package published through a temp file named after its target
and nothing else. Two writers for one target therefore wrote into **one inode**:

1. A opens the shared temp with `"w"`, which truncates it to zero bytes.
2. B, a step ahead, `os.replace`s that same path onto the target. The target is now A's
   empty file, and B has been told its own content landed.
3. A writes into an inode that is already the target, so a reader between here and A's own
   rename sees whatever has been flushed.

It was reached, not reasoned about: on CI run 33854599000 a frame's `gather.json` came out
of `gather.refresh` existing and **zero bytes**, on one interpreter of four, on a branch
touching none of this code. `gather.cached` deliberately hands back whatever parses — a
panel calls it on every repaint — so a truncated cache is read as truth.

#888's `notify.plane_changed_everywhere()` writes a gather cache for every frame on the
plane and bumps every version file, from hooks, panels and CLI commands at once. The
concurrency went from rare to ordinary.

## The sites — 21, where the issue named 10

The issue names `gather.save` and "nine in `frame/state.py`". There are **seventeen** in
`frame/state.py`, and three more the issue does not mention:

| file | sites |
| --- | --- |
| `charter/frame/state.py` | 17 — `version`, `notice`, `exit`, `harness`, `session`, `session.durable`, `server`, `workspace`, **`density`, `bar_rows`, `chrome`, `change`, `selection`, `hidden`, `identity`, `panes`, `cwd`** |
| `charter/frame/gather.py` | `save` — the one CI caught |
| `charter/toolgate.py` | `snapshot` — the per-session tool ceiling. Two harnesses reach it for one session id (a SessionStart hook, and a first gated Bash call under trust-on-first-use), and a ceiling that reads back empty **approves nothing** |
| `charter/workspace.py` | `_write_manifest` — `workspaces/<n>/workspace.json`, whose readers include `git add`. `ensure` scaffolds one and `record_members` rewrites one |
| `charter/frame/reopen.py` | already unique-named (`mkstemp`, #845) — folded into the shared writer so there is one rule rather than two |

Checked and **not** defects: `commands_frame._restore_recorded_chat` (`os.replace` of a
transcript onto its new id — not a publish), `config._migrate_state_dir` (a directory
rename), `inflight` and `commands_secrets` (already `mkstemp`).

## The fix

`config.replace_for` is the one atomic writer; `config.temp_beside` names its temp file —
the target's name, the writing process's pid, and a random tail, beside the target so the
rename stays a rename. The temp is removed on **every** failure, not only `OSError`,
because a name nothing can predict is a name nothing can collect: `.charter/frame/` has one
sweep and it touches nothing but `*.transcript`.

**Not `tempfile.mkstemp`**, which `reopen.py` was right to use for itself. mkstemp creates
at 0600, which is the mode `.charter/` wants and the wrong one for a committed
`workspace.json` — charter tightening a file in the operator's own git tree is #331's
finding. The mode stays `config.write_for`'s answer, asked of the temp file, which is the
file `os.replace` carries (#582).

Nothing lands in a directory a reader scans that was not already landing there: every
temp file is written inside a frame's own directory, `sessions/`, or a workspace
directory. `state._root()` itself is written only by `reopen.write`, which was already
unique-named, and `own_workspace`/`frame_workspace` answer `None` for a loose file there.

## The test races

Four writers at one target, sixty rounds each, with a reader watching throughout, and
`sys.setswitchinterval(1e-6)` for the duration so the interpreter yields inside a window
that is one `open()` wide. What is asserted is the property — the target always holds one
writer's whole content, never empty and never a splice — because a case that read the temp
file's name and looked for a pid in it would pass against the defect verbatim.

Measured: with the shared temp name hand-applied to `temp_beside`, all three racing cases
fail on every one of five runs, including the one that goes through `gather.save`.
Reverted, the file survives **50 consecutive runs** with no failure.

The gather reader reads the FILE and not `gather.cached`, and that is the CI failure
itself: `cached` answers `None` for a cache that is missing and for one that does not
parse, so a zero-byte cache reads to it as "nothing saved yet".

## `state.bump` is on a 5 Hz path, so it was measured

Median of 7 × 20,000 bumps, same machine, back to back:

```
before (origin/main): median 212.41 us/bump   min 211.13   max 215.48
after  (this branch): median 217.14 us/bump   min 214.96   max 272.55
before (origin/main): median 212.25 us/bump   min 209.00   max 213.99
after  (this branch): median 216.53 us/bump   min 212.73   max 220.66
```

+4.5 µs, +2.1% — one `os.urandom(6)` and an f-string. At the panel's 5 Hz that is 22 µs a
second.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Us4MbwkSCJCxwt1CjAd1sf
