### PR TITLE
`workspace reinit --all` counts repairs and workspaces apart (#876)

### DIFF
--- a/charter/commands_workspace.py
+++ b/charter/commands_workspace.py
@@ -1235,12 +1235,27 @@ def cmd_workspace_reinit(args) -> int:
     if not names:
         util.info("No workspaces to reinitialize.")
         return 0
-    healed = 0
-    #: Workspaces whose manifest `reinit` was asked for and could not write. Counted
-    #: separately from `healed` so the closing line does not say "nothing to do" over an
-    #: error two lines above it — a repair command that contradicts itself is one nobody
-    #: trusts the next time.
-    blocked = 0
+    #: How many individual repairs were applied, and WHICH workspaces got at least one.
+    #: Two counters because they are two units, and #876 is what one counter cost: a
+    #: workspace can need several repairs — the harness layer is a row per file, the
+    #: structure bump is another — so a single `healed` incremented per repair and then
+    #: printed against `len(names)` said *"Healed 32 of 17 workspace(s); the rest were
+    #: current."* on a 17-workspace plane. A numerator above its own denominator, and a
+    #: "rest" that is negative, in the one line an operator reads to confirm a bulk
+    #: mutation landed.
+    #:
+    #: `repaired` is a SET OF NAMES drawn from `names`, and that is the fix rather than a
+    #: subtraction that happens to come out right: `len(repaired) <= len(names)` holds
+    #: because a set of members of `names` cannot be bigger than `names`, so no arithmetic
+    #: below is in a position to state a count greater than the total. The per-repair
+    #: number is not thrown away — it is named as what it is.
+    repairs = 0
+    repaired: set[str] = set()
+    #: Workspaces whose manifest `reinit` was asked for and could not write. Kept apart
+    #: from `repaired` so the closing line does not say "nothing to do" — or, worse,
+    #: "the rest were current" — over an error two lines above it. A repair command that
+    #: contradicts itself is one nobody trusts the next time.
+    blocked: set[str] = set()
     for n in names:
         before = workspace.reinit(n)
         # The HARNESS LAYER, reported as its own line rather than folded into the
@@ -1266,7 +1281,8 @@ def cmd_workspace_reinit(args) -> int:
                 util.err(f"'{n}': {rel} could not be written — something is in the way at "
                          f"that path. charter never deletes or renames existing content.")
             else:
-                healed += 1
+                repairs += 1
+                repaired.add(n)
                 util.ok(f"Reinitialized '{n}' → "
                         f"{'wrote' if did == 'created' else 'refreshed'} {rel} "
                         f"(charter's harness layer).")
@@ -1284,14 +1300,15 @@ def cmd_workspace_reinit(args) -> int:
         # sweep found the conjunct as a survivor and it was right — an equivalent mutant
         # and dead code are one finding.
         if not workspace.manifest_path(n).exists():
-            blocked += 1
+            blocked.add(n)
             before["missing"] = [m for m in before["missing"] if m != "workspace.json"]
             before["ok"] = not before["missing"] and before["version"] >= before["target"]
             util.err(f"'{n}': workspace.json could not be written — something is in the "
                      f"way at that path. charter never deletes or renames existing content.")
         if before["ok"]:
             continue
-        healed += 1
+        repairs += 1
+        repaired.add(n)
         what = (", ".join(before["missing"]) if before["missing"]
                 else f"structure v{before['version']} → v{before['target']}")
         util.ok(f"Reinitialized '{n}' → added {what}.")
@@ -1301,10 +1318,17 @@ def cmd_workspace_reinit(args) -> int:
         # command that prints "Nothing to save".
         if workspace.is_live(n) and set(before["missing"]) & _LIVE_SHARED_COMPONENTS:
             util.info(f"  '{n}' is LIVE — commit the restored files: charter workspace save {n}")
-    if healed == 0 and blocked == 0:
+    if not repaired and not blocked:
         util.ok(f"Up to date (structure v{workspace.STRUCTURE_VERSION}) — nothing to do.")
     elif len(names) > 1:
-        util.info(f"Healed {healed} of {len(names)} workspace(s); the rest were current.")
+        # Two units, named as two. "Applied N repair(s)" is the number the per-workspace
+        # rows above add up to; "across M of T workspace(s)" is the number an operator is
+        # actually checking against the plane they know the size of. A workspace charter
+        # could not repair is called out rather than swept into "the rest were current",
+        # which would contradict the error it just printed.
+        stuck = f"{len(blocked)} could not be repaired; " if blocked else ""
+        util.info(f"Applied {repairs} repair(s) across {len(repaired)} of {len(names)} "
+                  f"workspace(s); {stuck}the rest were current.")
     return 0
 
 

--- a/docs/news/unreleased-a-bulk-repair-counts-repairs-and-workspaces-apart.md
+++ b/docs/news/unreleased-a-bulk-repair-counts-repairs-and-workspaces-apart.md
@@ -1,0 +1,65 @@
+---
+version: unreleased
+headline: '`charter workspace reinit --all` counts repairs and workspaces apart, so its closing line can no longer report healing more workspaces than exist'
+adopt: workspace reinit --all
+---
+
+Run on a 17-workspace plane, the bulk repair ended like this:
+
+```
+• Healed 32 of 17 workspace(s); the rest were current.
+```
+
+**32 of 17.** The numerator was bigger than its own denominator, and "the rest were
+current" was then a claim about −15 workspaces.
+
+## One counter, two units
+
+A workspace needs more than one repair routinely rather than exceptionally. The harness
+layer is reported as a row per file charter writes, and the structure bump is a separate
+row on top of it, so a workspace that predates both prints two lines:
+
+```
+✓ Reinitialized 'todos' → wrote .claude/settings.json (charter's harness layer).
+✓ Reinitialized 'todos' → added structure v3 → v5.
+```
+
+The counter behind the summary was incremented once per row and then printed against the
+number of workspaces, which is a different quantity. `workspace.json` becoming a required
+component moved the structure version to 5, so on any plane that predates it most
+workspaces need a manifest *and* a bump — the two-repairs shape is the common case, not
+the exotic one, and every one of them contributed 2 to a number labelled "workspaces".
+
+That line matters more than its size suggests: it is the only part of the report that
+survives the run, because the per-workspace rows scroll away. It is what an operator reads
+to confirm a bulk mutation landed, and a number that cannot be true there discredits
+everything above it.
+
+## Both numbers, each named
+
+```
+Applied 32 repair(s) across 15 of 17 workspace(s); the rest were current.
+```
+
+Nothing is thrown away. Deduping to a workspace count alone would have been correct and
+would have lost the per-repair number, which is the one that says how much work the run
+actually did; naming both says more than either.
+
+The bound is structural rather than arithmetic. The workspaces repaired are accumulated as
+a **set of names drawn from the list being iterated**, so a count above the total is not
+something the summary avoids by getting a subtraction right — it is something it cannot
+express.
+
+A workspace charter could not repair is named rather than folded into "the rest were
+current", which would have contradicted the error printed two lines above it:
+
+```
+✗ 'api': workspace.json could not be written — something is in the way at that path.
+• Applied 4 repair(s) across 2 of 3 workspace(s); 1 could not be repaired; the rest were current.
+```
+
+## Nothing to adopt
+
+The repair itself is unchanged — same components, same idempotence, same additive
+promise. Only the sentence that closes it is different, so `charter workspace reinit --all`
+is worth re-running only if you stopped believing the last report.

--- a/tests/test_a_bulk_repair_counts_repairs_and_workspaces_apart.py
+++ b/tests/test_a_bulk_repair_counts_repairs_and_workspaces_apart.py
@@ -1,0 +1,255 @@
+"""`charter workspace reinit --all` counts repairs and workspaces as two different things.
+
+Reported from a 17-workspace plane (#876):
+
+```
+• Healed 32 of 17 workspace(s); the rest were current.
+```
+
+**32 of 17.** One counter was incremented once per REPAIR and then printed against
+``len(names)``, which counts WORKSPACES — so the numerator outran its own denominator and
+"the rest were current" described a negative number. A workspace needs more than one
+repair routinely, not exceptionally: the harness layer is a row per file it writes and the
+structure bump is another, so every workspace on a plane that predates `STRUCTURE_VERSION`
+5 emits two `✓ Reinitialized` lines and contributes 2 to a counter labelled "workspaces".
+
+That line is the only summary that survives the run — the per-workspace rows scroll away —
+so it is what an operator reads to confirm a bulk mutation landed. A number that cannot be
+true there discredits the whole report.
+
+**Every fixture in this file gives at least one workspace TWO repairs**, and that is the
+point rather than an accident of setup. A plane where every workspace needs exactly one
+repair reads identically under both spellings, which is precisely why the defect shipped
+past the tests that existed.
+
+The invariant is structural, not arithmetic: `cmd_workspace_reinit` accumulates a SET OF
+NAMES drawn from the list it is iterating, so ``len(repaired) <= len(names)`` holds by
+construction and there is no subtraction in a position to get it wrong.
+`ACountNeverExceedsItsTotal` reads the printed sentence back and checks the numbers
+against each other, so the promise is pinned on the output rather than on the variable.
+
+Sentences are spelled out by hand rather than rebuilt from the code that prints them: a
+test assembled from the same f-string agrees with whatever wording that f-string takes,
+including the wording this file exists to have replaced.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import re
+import unittest
+from contextlib import redirect_stderr
+from pathlib import Path
+from types import SimpleNamespace
+
+from charter import config, workspace
+from charter import commands_workspace as cw
+from tests._isolation import PersonaIso
+
+#: The summary's shape, read back so a case can compare the numbers in it. Deliberately
+#: loose about the wording and strict about the arithmetic — this is the guard against a
+#: numerator above its denominator, whatever sentence the numbers end up inside.
+_SUMMARY = re.compile(r"Applied (\d+) repair\(s\) across (\d+) of (\d+) workspace\(s\)")
+
+
+class BulkRepairCase(PersonaIso):
+    """A plane whose workspaces can be made to need one repair, two, or none."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        # The tripwire every fixture that writes a plane runs under: `PersonaIso` repoints
+        # the derived paths at a throwaway tree, and if it ever stops doing so the writes
+        # below land in somebody's real plane.
+        self.assertIn("edm-test-", str(config.STATE_DIR))
+        self._plane_settings()
+
+    def _plane_settings(self) -> None:
+        """The plane's own `.claude/settings.json`, shaped like this repo's committed one.
+
+        Without it there is no harness layer to write into a workspace at all, and the
+        two-repairs case — the only one that separates the two spellings — cannot exist.
+        """
+        d = config.ROOT / ".claude"
+        d.mkdir(parents=True, exist_ok=True)
+        (d / "settings.json").write_text(json.dumps({
+            "env": {"CHARTER_HARNESS": "claude-code"},
+            "statusLine": {"type": "command", "command": "charter statusline",
+                           "padding": 0, "refreshInterval": 10},
+            "enabledPlugins": {"charter@charter": True},
+            "permissions": {"allow": ["Bash(ls:*)"]},
+        }, indent=2) + "\n")
+
+    def current(self, name: str) -> None:
+        """A workspace with nothing to repair."""
+        workspace.ensure(name)
+
+    def one_repair(self, name: str) -> None:
+        """Stale STRUCTURE only — the layer is current, so exactly one row is printed."""
+        workspace.ensure(name)
+        (workspace.workspace_dir(name) / ".charter-structure").write_text("3\n")
+
+    def two_repairs(self, name: str) -> None:
+        """Stale layer AND stale structure — the shape a plane older than #884 is in.
+
+        Two `✓ Reinitialized` lines, one workspace. Removing the generated marker with the
+        file is what makes the layer read `created` rather than `foreign`: charter vouches
+        for a path by digest, and a settings.json it has no digest for is the operator's.
+        """
+        workspace.ensure(name)
+        (workspace.workspace_dir(name) / ".claude" / "settings.json").unlink()
+        (workspace.workspace_dir(name) / workspace.GENERATED_MARKER).unlink()
+        (workspace.workspace_dir(name) / ".charter-structure").write_text("3\n")
+
+    def reinit_all(self) -> str:
+        buf = io.StringIO()
+        with redirect_stderr(buf):
+            cw.cmd_workspace_reinit(SimpleNamespace(name=None, all=True))
+        return buf.getvalue()
+
+    def rows(self, said: str) -> list[str]:
+        return [ln for ln in said.splitlines() if "Reinitialized" in ln]
+
+    def summary(self, said: str) -> tuple[int, int, int]:
+        """``(repairs, workspaces repaired, workspaces looked at)`` off the printed line."""
+        m = _SUMMARY.search(said)
+        self.assertIsNotNone(m, f"no summary line in:\n{said}")
+        return int(m.group(1)), int(m.group(2)), int(m.group(3))
+
+
+class ACountNeverExceedsItsTotal(BulkRepairCase):
+    """The bug, stated as the property it violated."""
+
+    def test_the_workspace_count_does_not_outrun_the_workspace_total(self):
+        """`Healed 6 of 3`, before. Three workspaces, two repairs each."""
+        for n in ("alpha", "beta", "gamma"):
+            self.two_repairs(n)
+        said = self.reinit_all()
+        repairs, across, total = self.summary(said)
+        self.assertEqual(total, 3)
+        self.assertLessEqual(across, total,
+                             f"more workspaces repaired than exist:\n{said}")
+        self.assertEqual(across, 3)
+        self.assertEqual(repairs, 6)
+
+    def test_the_rest_is_never_a_negative_number_of_workspaces(self):
+        """"the rest were current" is a claim about ``total - across``. It has to be a
+        count of workspaces somebody could go and look at."""
+        for n in ("alpha", "beta"):
+            self.two_repairs(n)
+        self.current("gamma")
+        repairs, across, total = self.summary(self.reinit_all())
+        self.assertGreaterEqual(total - across, 0)
+        self.assertEqual(total - across, 1, "the one workspace that needed nothing")
+
+    def test_a_workspace_repaired_twice_is_one_workspace_and_two_repairs(self):
+        """The two numbers must DIFFER here, or a test proves nothing about which of them
+        the sentence is naming. One workspace, two `✓ Reinitialized` rows."""
+        self.two_repairs("alpha")
+        self.current("beta")
+        said = self.reinit_all()
+        self.assertEqual(len(self.rows(said)), 2, said)
+        repairs, across, total = self.summary(said)
+        self.assertEqual((repairs, across, total), (2, 1, 2))
+
+    def test_the_repair_count_is_the_number_of_rows_printed_above_it(self):
+        """The summary adds up the report it closes: whatever the mix, the first number is
+        exactly how many `✓ Reinitialized` lines an operator scrolled past."""
+        self.two_repairs("alpha")
+        self.two_repairs("beta")
+        self.one_repair("gamma")
+        self.current("delta")
+        said = self.reinit_all()
+        repairs, across, total = self.summary(said)
+        self.assertEqual(repairs, len(self.rows(said)))
+        self.assertEqual((repairs, across, total), (5, 3, 4))
+
+
+class TheSentenceNamesWhatItCounts(BulkRepairCase):
+    """Both numbers are kept and each is labelled — deduping to one would have thrown the
+    per-repair number away, and it is the one that says how much work the run did."""
+
+    def test_the_wording_says_repairs_and_workspaces_in_the_same_breath(self):
+        self.two_repairs("alpha")
+        self.two_repairs("beta")
+        self.current("gamma")
+        self.assertIn(
+            "Applied 4 repair(s) across 2 of 3 workspace(s); the rest were current.",
+            self.reinit_all())
+
+    def test_it_does_not_still_say_healed_n_of_m(self):
+        """The old sentence had one unit for two quantities. Named here so a revert to it
+        fails rather than passing on a substring the new wording happens to share."""
+        self.two_repairs("alpha")
+        self.two_repairs("beta")
+        self.assertNotIn("Healed", self.reinit_all())
+
+    def test_a_plane_with_nothing_to_repair_says_so_instead(self):
+        """No summary at all when there was no repair — "Applied 0 repair(s) across 0 of
+        3" is a true sentence and a worse one than the sentence that already existed."""
+        for n in ("alpha", "beta", "gamma"):
+            self.current(n)
+        said = self.reinit_all()
+        self.assertIn(f"Up to date (structure v{workspace.STRUCTURE_VERSION}) — "
+                      f"nothing to do.", said)
+        self.assertNotIn("Applied", said)
+
+    def test_one_workspace_gets_no_summary_line(self):
+        """`--all` on a plane of one: the row above IS the summary, and a second sentence
+        restating it as "1 of 1" is noise. The boundary is >1, not >=1."""
+        self.two_repairs("alpha")
+        said = self.reinit_all()
+        self.assertEqual(len(self.rows(said)), 2, said)
+        self.assertNotIn("Applied", said)
+
+    def test_two_workspaces_do_get_one(self):
+        """The other side of the same boundary, so a fixture of one is never the only
+        witness to it."""
+        self.two_repairs("alpha")
+        self.current("beta")
+        self.assertIn("Applied 2 repair(s) across 1 of 2 workspace(s)", self.reinit_all())
+
+
+class AWorkspaceCharterCouldNotRepairIsNotCurrent(BulkRepairCase):
+    """The other half of the same honesty. `blocked` exists so the closing line does not
+    contradict an error two lines above it; "the rest were current" is a claim about the
+    workspaces NOT repaired, and a blocked one is not current either."""
+
+    def blocked(self, name: str) -> None:
+        """A manifest path charter refuses to write, and a stale structure besides.
+
+        A dangling symlink out of the plane: `contain.writable` refuses the write (#328)
+        and `Path.exists` answers False through it, so the manifest is reported blocked
+        while everything else in the workspace stays repairable.
+        """
+        workspace.ensure(name)
+        workspace.manifest_path(name).unlink()
+        workspace.manifest_path(name).symlink_to(self.tmp / "nowhere.json")
+
+    def test_a_blocked_workspace_is_called_out_rather_than_counted_current(self):
+        self.two_repairs("alpha")
+        self.blocked("beta")
+        said = self.reinit_all()
+        self.assertIn("workspace.json could not be written", said)
+        self.assertIn("1 could not be repaired; the rest were current.", said)
+
+    def test_the_clause_is_absent_when_nothing_was_blocked(self):
+        """It reports a fact, so it says nothing when there is no fact to report."""
+        self.two_repairs("alpha")
+        self.current("beta")
+        self.assertNotIn("could not be repaired", self.reinit_all())
+
+    def test_a_plane_where_only_a_blocked_workspace_exists_never_says_up_to_date(self):
+        """The reason `blocked` was split off `healed` in the first place, kept working
+        now that both are sets: nothing was repaired, and "nothing to do" over an error is
+        the report nobody trusts again."""
+        self.blocked("alpha")
+        self.blocked("beta")
+        said = self.reinit_all()
+        self.assertNotIn("Up to date", said)
+        self.assertIn("Applied 0 repair(s) across 0 of 2 workspace(s); 2 could not be "
+                      "repaired; the rest were current.", said)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_a_bulk_repair_counts_repairs_and_workspaces_apart.py
+++ b/tests/test_a_bulk_repair_counts_repairs_and_workspaces_apart.py
@@ -89,6 +89,18 @@ class BulkRepairCase(PersonaIso):
         workspace.ensure(name)
         (workspace.workspace_dir(name) / ".charter-structure").write_text("3\n")
 
+    def layer_only(self, name: str) -> None:
+        """Stale LAYER only — current layout, one row, from the other of the two loops.
+
+        The mirror of `one_repair`, and it exists so neither place that records a
+        workspace as repaired is the only one a fixture ever exercises: with every
+        one-repair workspace stale in the same half, dropping the record from the OTHER
+        half changes no number any case here reads.
+        """
+        workspace.ensure(name)
+        (workspace.workspace_dir(name) / ".claude" / "settings.json").unlink()
+        (workspace.workspace_dir(name) / workspace.GENERATED_MARKER).unlink()
+
     def two_repairs(self, name: str) -> None:
         """Stale layer AND stale structure — the shape a plane older than #884 is in.
 
@@ -154,15 +166,40 @@ class ACountNeverExceedsItsTotal(BulkRepairCase):
 
     def test_the_repair_count_is_the_number_of_rows_printed_above_it(self):
         """The summary adds up the report it closes: whatever the mix, the first number is
-        exactly how many `✓ Reinitialized` lines an operator scrolled past."""
+        exactly how many `✓ Reinitialized` lines an operator scrolled past.
+
+        Both one-repair shapes appear, and on purpose. A workspace is recorded as repaired
+        in two separate places — the harness-layer loop and the structure branch — and a
+        mix that is stale in only one half leaves the other half unmeasured.
+        """
         self.two_repairs("alpha")
         self.two_repairs("beta")
         self.one_repair("gamma")
-        self.current("delta")
+        self.layer_only("delta")
+        self.current("epsilon")
         said = self.reinit_all()
         repairs, across, total = self.summary(said)
         self.assertEqual(repairs, len(self.rows(said)))
-        self.assertEqual((repairs, across, total), (5, 3, 4))
+        self.assertEqual((repairs, across, total), (6, 4, 5))
+
+    def test_a_workspace_whose_only_gap_is_the_layer_still_counts_as_one(self):
+        """The layer loop's own record, isolated. Its layout is current — the ONLY thing
+        stale about it is `.claude/settings.json`, so nothing but that loop can put it in
+        the count, and `1 of 2` is the whole assertion."""
+        self.layer_only("alpha")
+        self.current("beta")
+        said = self.reinit_all()
+        self.assertEqual(len(self.rows(said)), 1, said)
+        self.assertEqual(self.summary(said), (1, 1, 2))
+
+    def test_a_workspace_whose_only_gap_is_the_structure_still_counts_as_one(self):
+        """And the structure branch's, isolated the same way — the two are asserted as a
+        pair so neither can be the one nothing measures."""
+        self.one_repair("alpha")
+        self.current("beta")
+        said = self.reinit_all()
+        self.assertEqual(len(self.rows(said)), 1, said)
+        self.assertEqual(self.summary(said), (1, 1, 2))
 
 
 class TheSentenceNamesWhatItCounts(BulkRepairCase):


### PR DESCRIPTION
`charter workspace reinit --all` ended a run on a 17-workspace plane with:

```
• Healed 32 of 17 workspace(s); the rest were current.
```

The numerator was bigger than its own denominator, and "the rest were current" was then a claim about −15 workspaces.

## The cause, confirmed

The reported reading was right, and reproduced before anything was changed. `cmd_workspace_reinit` kept one counter, `healed`, incremented once per **repair** — once inside the harness-layer loop, which runs a row per file charter writes, and once again for the structure bump — and then printed it against `len(names)`, which counts **workspaces**. Three workspaces needing two repairs each produced, verbatim, `Healed 6 of 3 workspace(s); the rest were current.`

`workspace.json` becoming a required component moved `STRUCTURE_VERSION` to 5, so on any plane that predates it most workspaces need a manifest *and* a bump. The two-repairs shape is the common case, not the exotic one.

The line matters more than its size: it is the only part of the report that survives, because the per-workspace rows scroll away. It is what an operator reads to confirm a bulk mutation landed.

## The fix

Both numbers are kept and each is named:

```
Applied 32 repair(s) across 15 of 17 workspace(s); the rest were current.
```

Deduping to a workspace count alone would also have been correct and would have thrown away the per-repair number — the one that says how much work the run did.

**The bound is structural, not arithmetic.** `repaired` is a `set[str]` of names drawn from the list being iterated, so `len(repaired) <= len(names)` holds by construction: a count above the total is not something the summary avoids by getting a subtraction right, it is something it cannot express.

`blocked` becomes a set of names for the reason it was split off `healed` in the first place. A workspace charter could not repair is called out rather than swept into "the rest were current", which would contradict the error two lines above it:

```
✗ 'api': workspace.json could not be written — something is in the way at that path.
• Applied 4 repair(s) across 2 of 3 workspace(s); 1 could not be repaired; the rest were current.
```

## The tests

`tests/test_a_bulk_repair_counts_repairs_and_workspaces_apart.py`, 14 cases. **Every fixture gives at least one workspace two repairs** — a plane where each needs exactly one reads identically under both spellings, which is why this shipped past the tests that existed. 11 of the 14 fail against `origin/main`; the other 3 pin adjacent behaviour that must not regress (the `Up to date` branch, the `>1` boundary, the absent blocked clause).

`ACountNeverExceedsItsTotal` parses the printed sentence back and compares the numbers to each other, so the promise is pinned on the output rather than on a variable name.

A workspace is recorded as repaired in two separate places — the harness-layer loop and the structure branch — so a one-repair fixture exists for each. Verified by hand: deleting either `repaired.add(n)` fails two cases.

Full suite: `Ran 11410 tests … OK (skipped=9)`. Deletion sweep: **no survivors** — 6 mutations charged, 6 pinned.

Closes #876

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Us4MbwkSCJCxwt1CjAd1sf
