### PR TITLE
A month file is read once per version, not once per repaint (#887)

### DIFF
--- a/charter/dispatch.py
+++ b/charter/dispatch.py
@@ -202,23 +202,78 @@ def handoffs_since_first_advice() -> int:
                if o.get("agent") and (t := _ts(o)) and t >= since)
 
 
+#: Month files already parsed, keyed by path → ``((mtime_ns, size), rows)``.
+#: Read and written only by :func:`_rows_of`, whose docstring is the argument for it.
+_PARSED: dict[str, tuple[tuple[int, int], list[dict]]] = {}
+
+
+def _rows_of(f: Path) -> list[dict]:
+    """The rows of one month file, parsed at most once per version of that file.
+
+    :func:`_read_all` walks EVERY month file ever written, and :func:`tally` sits on a
+    per-turn repaint path: `persona.by_use` calls it for the switcher's order,
+    `statusline._persona_chip_cells` draws that column, and `frame/panel.run` holds a
+    process repainting it for as long as the frame lives. The cost of that walk is
+    monotonic in the AGE of the plane and in nothing an operator does — measured at this
+    plane's ~225 dispatches a month: 0.37 ms today, 2.10 ms after a year, 10.71 ms after
+    five. It degrades silently, and only on the planes that have been used longest, whose
+    operators would least expect it (#887).
+
+    A month file that is not the current one is **closed**: :func:`path_for` only ever
+    writes ``<this month>.<host>.jsonl``, and nothing reopens an earlier one. So every
+    month but one is a permanent hit here, and the walk is bounded by the current month
+    however old the plane is.
+
+    **The key is the invalidation, not a summary.** Nothing derived from a row is kept —
+    only the rows the jsonl already holds, discarded the instant the file they came from
+    is not the file that was read. That is what stops this becoming a second source of
+    truth for something the log answers, and ``(path, mtime, size)`` is the same shape
+    `statusline._usage_stamp` and `frame/gather` already invalidate on.
+
+    **Size is in the key because mtime alone is a filesystem's promise, not a fact.**
+    APFS keeps nanoseconds, but some ext4 configurations report whole seconds, and
+    :func:`record` appends to the current month file many times inside one such tick. Two
+    versions of an append-only log always differ in length, so the size catches precisely
+    what a coarse clock hides.
+
+    **The stat is taken BEFORE the read, and that order is the correctness.** A row
+    appended between the two is then memoised under the OLDER stamp and the next call
+    re-reads it; taken after, that same row would be memoised under the NEWER stamp and
+    stay invisible for the life of the process.
+
+    Rows are shared rather than copied — every caller in this module only reads them, and
+    a copy per call would hand back most of what the memo saves. A caller that wants to
+    mutate a row must copy it first.
+    """
+    key = str(f)
+    st = f.stat()
+    stamp = (st.st_mtime_ns, st.st_size)
+    hit = _PARSED.get(key)
+    if hit is not None and hit[0] == stamp:
+        return hit[1]
+    rows: list[dict] = []
+    for ln in f.read_text(errors="replace").splitlines():
+        ln = ln.strip()
+        if not ln:
+            continue
+        try:
+            o = json.loads(ln)
+        except ValueError:
+            continue
+        if isinstance(o, dict) and (o.get("agent") or o.get("event")):
+            rows.append(o)
+    _PARSED[key] = (stamp, rows)
+    return rows
+
+
 def _read_all() -> list[dict]:
+    out: list[dict] = []
     d = _dir()
     if not d.exists():
-        return []
-    out = []
+        return out
     for f in sorted(d.glob("*.jsonl")):
         try:
-            for ln in f.read_text(errors="replace").splitlines():
-                ln = ln.strip()
-                if not ln:
-                    continue
-                try:
-                    o = json.loads(ln)
-                except ValueError:
-                    continue
-                if isinstance(o, dict) and (o.get("agent") or o.get("event")):
-                    out.append(o)
+            out.extend(_rows_of(f))
         except OSError:
             continue
     return out

--- a/charter/dispatch.py
+++ b/charter/dispatch.py
@@ -253,10 +253,12 @@ def _rows_of(f: Path) -> list[dict]:
         return hit[1]
     rows: list[dict] = []
     for ln in f.read_text(errors="replace").splitlines():
-        ln = ln.strip()
-        if not ln:
-            continue
         try:
+            # No blank-line guard above this: `json.loads` raises ValueError on an empty
+            # or whitespace-only line exactly as it does on a truncated one, so the pair
+            # of lines that used to check for it here was a branch nothing could go red
+            # without. It tolerates surrounding whitespace on a real row, too, and
+            # `splitlines` has already taken the line endings off.
             o = json.loads(ln)
         except ValueError:
             continue
@@ -267,10 +269,10 @@ def _rows_of(f: Path) -> list[dict]:
 
 
 def _read_all() -> list[dict]:
-    out: list[dict] = []
     d = _dir()
     if not d.exists():
-        return out
+        return []
+    out = []
     for f in sorted(d.glob("*.jsonl")):
         try:
             out.extend(_rows_of(f))

--- a/charter/persona.py
+++ b/charter/persona.py
@@ -1002,6 +1002,13 @@ def _dispatches() -> dict:
     would re-walk the same files once for each. Swallowed like every other number a
     switcher draws: an unreadable log is a roster in alphabetical order, never a frame
     that will not paint.
+
+    That "handful" is the count TODAY, and it is one file per month per host forever
+    after: the store only grows, this sits on a per-turn repaint path, and the walk was
+    therefore monotonic in the age of the plane rather than in anything an operator does
+    (#887). `dispatch._rows_of` memoises each file's rows on ``(path, mtime, size)``, so a
+    closed month is parsed once per process and the reading is bounded by the current
+    month. Nothing about the number this returns changed.
     """
     from . import dispatch
     try:

--- a/docs/news/unreleased-a-month-file-is-read-once-per-version.md
+++ b/docs/news/unreleased-a-month-file-is-read-once-per-version.md
@@ -1,0 +1,66 @@
+---
+version: unreleased
+headline: the persona column stops re-reading the whole dispatch log on every repaint — a month file is now parsed once per version of that file, so the cost stops growing with the age of the plane
+---
+
+**The measurement came first and the cache came second, a release apart.** #882 made the
+persona switcher sort by use, which put `dispatch.tally()` on a path that repaints every
+turn. The implementer measured what that cost, found it growing with nothing an operator
+does, and filed it rather than fixing it — a cache invented inside an ordering change is a
+cache nobody asked for. This is that issue.
+
+## A cost that grows with the age of the plane
+
+`personas/_dispatch/` holds one jsonl file per month per host, and it only ever grows: a
+month file that is not the current one is closed forever, because the writer only ever
+opens `<this month>.<host>.jsonl`. `tally()` read **all of them**, every call, and parsed
+every line.
+
+`persona.by_use` calls it for the switcher's order, `statusline._persona_chip_cells` draws
+that column, and a frame panel is a held process that repaints it for as long as the frame
+lives. So the reading was monotonic in **how long the plane has existed** and in nothing
+anybody did. Re-measured on charter's own plane, at its ~225 dispatches a month, against
+synthesized stores of that shape:
+
+| log age | rows | before | after a first read |
+|---|---|---|---|
+| today | 450 | 0.37 ms | 0.06 ms |
+| 1 year | 2 700 | 2.06 ms | 0.26 ms |
+| 2 years | 5 400 | 4.14 ms | 0.52 ms |
+| 5 years | 13 500 | 11.12 ms | 1.27 ms |
+
+Nothing was slow today. The point is the column on the left: it degrades silently, and
+only on the planes that have been used longest — the ones whose operators would least
+expect it.
+
+## The key is the invalidation, not a summary
+
+`dispatch._rows_of` memoises one file's parsed rows on `(path, mtime, size)`. It stores
+**nothing derived** — not a count, not an order, not a total — only the rows the jsonl
+already holds, discarded the instant the file they came from is not the file that was
+read. That is what keeps it from becoming a second answer to a question the log already
+answers, and it is the same shape `statusline._usage_stamp` and the frame's gather cache
+already invalidate on.
+
+**Size is in the key because mtime alone is a filesystem's promise rather than a fact.**
+APFS keeps nanoseconds; some ext4 configurations report whole seconds, and a dispatch is
+appended to the current month many times inside one such tick. The test that holds this
+forges the mtime back to its old value with `os.utime`, changes the file's length, and
+demands the new tally — then asserts the forgery actually took, so it cannot pass because
+the filesystem quietly refused to hold the value the case is about.
+
+**And the stat is taken before the read, which is the direction that errs safe.** A row
+appended between the two is memoised under the older stamp and re-read on the next call.
+Taken after, that same row would be memoised under the newer stamp and stay invisible for
+the whole life of the process.
+
+## What was deliberately not done
+
+Nothing is cached in the caller, and no ordering is cached. #882's tie-break is a second
+pass over runs of tied dispatch counts rather than a term in one sort key, precisely so
+the per-persona memory glob is paid only by names that tie — on charter's own plane,
+never. Caching the output of that would have replaced a structure that is already free
+with one that has to be invalidated.
+
+The tally itself is unchanged: the same rows, the same counts, the same file format.
+There is nothing to adopt.

--- a/docs/news/unreleased-a-month-file-is-read-once-per-version.md
+++ b/docs/news/unreleased-a-month-file-is-read-once-per-version.md
@@ -22,16 +22,26 @@ lives. So the reading was monotonic in **how long the plane has existed** and in
 anybody did. Re-measured on charter's own plane, at its ~225 dispatches a month, against
 synthesized stores of that shape:
 
-| log age | rows | before | after a first read |
+| log age | rows | before | after, every repaint |
 |---|---|---|---|
 | today | 450 | 0.37 ms | 0.06 ms |
-| 1 year | 2 700 | 2.06 ms | 0.26 ms |
-| 2 years | 5 400 | 4.14 ms | 0.52 ms |
-| 5 years | 13 500 | 11.12 ms | 1.27 ms |
+| 1 year | 2 700 | 2.10 ms | 0.27 ms |
+| 2 years | 5 400 | 4.22 ms | 0.54 ms |
+| 5 years | 13 500 | 10.71 ms | 1.32 ms |
 
 Nothing was slow today. The point is the column on the left: it degrades silently, and
 only on the planes that have been used longest — the ones whose operators would least
 expect it.
+
+**The FIRST call in a process still costs the left column**, to within measurement noise,
+and that is the honest shape of this: the memo removes a repeated read, not a read. A
+panel is a held process that repaints for the life of the frame, so it pays that once.
+What is left in the right-hand column is no longer file reading — it is walking the rows
+already in memory to add them up, which at five years is 1.32 ms of which the reading is
+0.28 ms. That term is still linear in the age of the plane, and deliberately left alone:
+it is a smaller and different thing from the one this fixed, and inventing a cache of
+counts to chase it is exactly the move that got this issue filed instead of folded into
+#882.
 
 ## The key is the invalidation, not a summary
 

--- a/tests/test_a_month_file_is_read_once_per_version.py
+++ b/tests/test_a_month_file_is_read_once_per_version.py
@@ -1,0 +1,209 @@
+"""`dispatch.tally` stops re-reading every month file ever written — #887.
+
+The tally is on a per-turn repaint path: `persona.by_use` calls it for the persona
+switcher's order (#882), `statusline._persona_chip_cells` draws that column, and
+`frame/panel.run` holds a process repainting it for as long as the frame lives. Behind it
+`_read_all` walked EVERY month file under `personas/_dispatch/` and parsed every line —
+a cost monotonic in the age of the plane and in nothing an operator does. Measured on
+charter's own plane at its ~225 dispatches a month: 0.37 ms today, 2.10 ms after a year,
+11.12 ms after five.
+
+`dispatch._rows_of` now memoises each file's parsed rows on ``(path, mtime_ns, size)``.
+A month file that is not the current one is closed — `path_for` only ever writes
+``<this month>.<host>.jsonl`` — so every month but one is a permanent hit and the reading
+is bounded by the current month however old the plane is.
+
+**Every case here is an invalidation, not a hit.** A cache that returns the right answer
+is not evidence of anything; deleting it entirely leaves every value assertion passing.
+What has to be pinned is that a file which changed after being memoised is read again —
+and each case forges exactly one half of the key so that dropping the other half from it
+goes red:
+
+* :meth:`~SizeIsInTheKey.test_a_rewrite_inside_one_mtime_tick_is_seen` holds the mtime
+  still and changes the size. Without ``size`` in the key this reads a stale tally, and
+  mtime granularity is a filesystem's promise rather than a fact: APFS keeps nanoseconds,
+  some ext4 configurations report whole seconds, and `record` appends many times inside
+  one such tick.
+* :meth:`~MtimeIsInTheKey.test_a_rewrite_at_the_same_size_is_seen` holds the size still
+  and moves the mtime. Without ``mtime`` in the key that one reads stale too.
+
+Both forge the stamp through `os.utime` and then **assert the forgery took**, so neither
+can pass because the filesystem quietly refused to hold the value the case is about.
+"""
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import tempfile
+import unittest
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+from charter import dispatch
+from tests._isolation import PersonaIso, point_config_at
+
+
+class MonthStore(PersonaIso):
+    """A plane holding month files, and the two ways to change one behind charter's back."""
+
+    def month(self, *agents: str) -> Path:
+        """One month file, written by the real writer — `dispatch.record`."""
+        for a in agents:
+            self.assertIsNotNone(dispatch.record(a), f"{a}: nothing was recorded")
+        files = sorted(dispatch._dir().glob("*.jsonl"))
+        self.assertEqual(len(files), 1, "this fixture writes exactly one month file")
+        return files[0]
+
+    def rewrite(self, p: Path, old: str, new: str, *, keep_mtime: bool) -> os.stat_result:
+        """Replace *old* with *new* throughout *p*, optionally putting the mtime back.
+
+        The stamp is read before the write and re-asserted after it: a filesystem that
+        cannot hold the nanoseconds `os.utime` is handed would otherwise turn a case about
+        one half of the key into a case about neither half, and it would pass.
+        """
+        before = p.stat()
+        p.write_text(p.read_text().replace(old, new))
+        if keep_mtime:
+            os.utime(p, ns=(before.st_atime_ns, before.st_mtime_ns))
+            self.assertEqual(p.stat().st_mtime_ns, before.st_mtime_ns,
+                             "this filesystem would not hold the forged mtime")
+        return before
+
+
+class SizeIsInTheKey(MonthStore):
+    """``size``, because a coarse clock hides a rewrite that a length does not."""
+
+    def test_a_rewrite_inside_one_mtime_tick_is_seen(self):
+        p = self.month("aaa", "aaa", "aaa")
+        self.assertEqual(dispatch.tally()["aaa"], 3)      # memoises this version
+        before = self.rewrite(p, '"aaa"', '"bbbb"', keep_mtime=True)
+        self.assertNotEqual(p.stat().st_size, before.st_size,
+                            "the case needs the size to move and nothing else")
+        self.assertEqual(dispatch.tally()["bbbb"], 3,
+                         "a file rewritten inside one mtime tick was served from the memo")
+        self.assertEqual(dispatch.tally()["aaa"], 0)
+
+
+class MtimeIsInTheKey(MonthStore):
+    """``mtime``, because a rewrite can leave a file exactly as long as it was."""
+
+    def test_a_rewrite_at_the_same_size_is_seen(self):
+        p = self.month("aaa", "aaa", "aaa")
+        self.assertEqual(dispatch.tally()["aaa"], 3)
+        before = p.stat()
+        p.write_text(p.read_text().replace('"aaa"', '"bbb"'))
+        os.utime(p, ns=(before.st_atime_ns, before.st_mtime_ns + 1_000_000_000))
+        self.assertEqual(p.stat().st_size, before.st_size,
+                         "the case needs the mtime to move and nothing else")
+        self.assertNotEqual(p.stat().st_mtime_ns, before.st_mtime_ns)
+        self.assertEqual(dispatch.tally()["bbb"], 3,
+                         "a file whose mtime moved was served from the memo")
+        self.assertEqual(dispatch.tally()["aaa"], 0)
+
+
+class TheMemoIsUsedAtAll(MonthStore):
+    """The one case that goes red when the memo is removed rather than weakened.
+
+    It changes a file's CONTENT while holding both halves of the key still — the one
+    change charter is entitled not to notice, because no filesystem produces it — and
+    demands the old answer. Every other case here demands the new one.
+    """
+
+    def test_an_unchanged_stamp_is_not_read_again(self):
+        p = self.month("aaa", "aaa", "aaa")
+        self.assertEqual(dispatch.tally()["aaa"], 3)
+        before = self.rewrite(p, '"aaa"', '"bbb"', keep_mtime=True)
+        self.assertEqual(p.stat().st_size, before.st_size,
+                         "the rewrite has to leave the length alone to say anything")
+        self.assertEqual(dispatch.tally()["aaa"], 3,
+                         "the file was parsed again although its stamp had not moved")
+        self.assertEqual(dispatch.tally()["bbb"], 0)
+
+
+class TheCurrentMonthStaysLive(MonthStore):
+    """The invalidation that happens every day, through the writer rather than a forgery.
+
+    A closed month is a permanent hit; the current one is appended to by `record` many
+    times a turn, and every one of those has to be visible to the next repaint.
+    """
+
+    def test_a_dispatch_recorded_after_a_read_is_counted(self):
+        dispatch.record("devops")
+        self.assertEqual(dispatch.tally()["devops"], 1)
+        dispatch.record("devops")
+        self.assertEqual(dispatch.tally()["devops"], 2,
+                         "a dispatch appended after a read was hidden by the memo")
+
+    def test_a_closed_month_and_a_live_one_are_both_counted(self):
+        old = datetime.now(timezone.utc) - timedelta(days=95)
+        dispatch.record("devops", when=old)
+        self.assertEqual(dispatch.tally()["devops"], 1)
+        dispatch.record("devops")
+        self.assertEqual(dispatch.tally()["devops"], 2)
+        self.assertEqual(len({f.name for f in dispatch._dir().glob("*.jsonl")}), 2,
+                         "the case needs two month files to be saying anything")
+
+    def test_the_other_readers_see_the_same_appends(self):
+        """`tally` is the one on the repaint path, but every reader shares `_read_all`,
+        so a memo that went stale would go stale for all of them at once."""
+        dispatch.record_advice()
+        dispatch.record_resume("devops")
+        self.assertEqual((dispatch.advice_tally(), dispatch.resume_tally()), (1, 1))
+        dispatch.record_advice()
+        dispatch.record_resume("devops")
+        self.assertEqual((dispatch.advice_tally(), dispatch.resume_tally()), (2, 2))
+        self.assertIsNotNone(dispatch.last_seen("devops"))
+
+
+class TheKeyIsAWholePath(MonthStore):
+    """Two planes name their month files identically — the same month, the same host.
+
+    The memo is keyed on the full path for that reason. Keyed on the file's NAME, the
+    second plane would be handed the first plane's tally, and every other case here would
+    still pass: they only ever look at one plane.
+    """
+
+    def test_two_planes_do_not_share_one_months_rows(self):
+        dispatch.record("aaa")
+        name = sorted(dispatch._dir().glob("*.jsonl"))[0].name
+        self.assertEqual(dispatch.tally(), {"aaa": 1})
+
+        first = dispatch._dir() / name
+        other = Path(tempfile.mkdtemp(prefix="edm-test-other-"))
+        self.addCleanup(shutil.rmtree, other, True)
+        point_config_at(self, other)
+        d = dispatch._dir()
+        d.mkdir(parents=True, exist_ok=True)
+        (d / name).write_text(json.dumps(
+            {"agent": "bbb", "ts": datetime.now(timezone.utc).isoformat(timespec="seconds")},
+            sort_keys=True) + "\n")
+        self.assertNotEqual(d / name, first,
+                            "the case needs two planes, not one read twice")
+        self.assertEqual((d / name).name, first.name,
+                         "the two month files have to be identically NAMED to say anything")
+        self.assertEqual(dispatch.tally(), {"bbb": 1},
+                         "a second plane was answered out of the first plane's memo")
+
+
+class AMonthFileThatGoesAway(MonthStore):
+    """A memo entry is not a reason to keep counting a file that is no longer there.
+
+    `_read_all` decides WHICH files exist by globbing the store, every time, and asks the
+    memo only about files it just found. Iterating the memo instead would resurrect rows
+    the directory no longer holds — and a backfill run deletes and rewrites every
+    `*.backfill.jsonl` it owns, so this is a path charter actually walks.
+    """
+
+    def test_a_deleted_month_stops_being_counted(self):
+        old = datetime.now(timezone.utc) - timedelta(days=95)
+        dispatch.record("devops", when=old)
+        dispatch.record("qa")
+        self.assertEqual(dispatch.tally(), {"devops": 1, "qa": 1})
+        dispatch.path_for(old).unlink()
+        self.assertEqual(dispatch.tally(), {"qa": 1},
+                         "a deleted month file was still counted out of the memo")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_a_month_file_is_read_once_per_version.py
+++ b/tests/test_a_month_file_is_read_once_per_version.py
@@ -6,7 +6,8 @@ switcher's order (#882), `statusline._persona_chip_cells` draws that column, and
 `_read_all` walked EVERY month file under `personas/_dispatch/` and parsed every line —
 a cost monotonic in the age of the plane and in nothing an operator does. Measured on
 charter's own plane at its ~225 dispatches a month: 0.37 ms today, 2.10 ms after a year,
-11.12 ms after five.
+4.22 ms after two, 10.71 ms after five — against 0.06 / 0.27 / 0.54 / 1.32 ms once each
+closed month has been read once.
 
 `dispatch._rows_of` now memoises each file's parsed rows on ``(path, mtime_ns, size)``.
 A month file that is not the current one is closed — `path_for` only ever writes
@@ -37,6 +38,7 @@ import os
 import shutil
 import tempfile
 import unittest
+from unittest import mock
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
@@ -166,24 +168,109 @@ class TheKeyIsAWholePath(MonthStore):
 
     def test_two_planes_do_not_share_one_months_rows(self):
         dispatch.record("aaa")
-        name = sorted(dispatch._dir().glob("*.jsonl"))[0].name
+        first = sorted(dispatch._dir().glob("*.jsonl"))[0]
         self.assertEqual(dispatch.tally(), {"aaa": 1})
 
-        first = dispatch._dir() / name
         other = Path(tempfile.mkdtemp(prefix="edm-test-other-"))
         self.addCleanup(shutil.rmtree, other, True)
         point_config_at(self, other)
         d = dispatch._dir()
         d.mkdir(parents=True, exist_ok=True)
-        (d / name).write_text(json.dumps(
-            {"agent": "bbb", "ts": datetime.now(timezone.utc).isoformat(timespec="seconds")},
-            sort_keys=True) + "\n")
-        self.assertNotEqual(d / name, first,
-                            "the case needs two planes, not one read twice")
-        self.assertEqual((d / name).name, first.name,
-                         "the two month files have to be identically NAMED to say anything")
+        second = d / first.name
+        second.write_text(first.read_text().replace('"aaa"', '"bbb"'))
+        # The two files are made INDISTINGUISHABLE except by path: same name, same
+        # length, same mtime to the nanosecond. Anything less and the stamps differ, the
+        # memo misses for a reason that has nothing to do with the key, and a name-keyed
+        # memo passes this case while still being wrong — which is how it passed the
+        # first time this was written. `cp -p`, `rsync -a` and an unpacked tarball all
+        # carry an mtime across, so two clones of one plane really can reach this.
+        st = first.stat()
+        os.utime(second, ns=(st.st_atime_ns, st.st_mtime_ns))
+        self.assertNotEqual(second, first, "the case needs two planes, not one read twice")
+        self.assertEqual((second.stat().st_mtime_ns, second.stat().st_size),
+                         (st.st_mtime_ns, st.st_size),
+                         "the two month files have to be stamped alike to say anything")
         self.assertEqual(dispatch.tally(), {"bbb": 1},
                          "a second plane was answered out of the first plane's memo")
+
+
+class TheStatComesBeforeTheRead(MonthStore):
+    """The order of two statements, and it is the difference between late and never.
+
+    `record` opens the current month file ``O_APPEND`` from any process on the machine, so
+    a row can land between the stat and the read. Stamped BEFORE, that row is memoised
+    under the older stamp and the next call re-reads the file — the row is one repaint
+    late. Stamped AFTER, the SAME row is memoised under the newer stamp, so every later
+    call is a hit and the row is invisible for the whole life of the process — and a frame
+    panel is a process that lives as long as the frame does.
+
+    The race is made deterministic rather than waited for: `Path.read_text` appends the
+    row itself, once, at the exact instant the window is open.
+    """
+
+    def test_a_row_that_lands_during_the_read_is_not_lost(self):
+        p = self.month("aaa")
+        real, fired = Path.read_text, []
+
+        def racing(self_, *a, **kw):
+            text = real(self_, *a, **kw)
+            if self_ == p and not fired:
+                fired.append(True)
+                with open(p, "a") as fh:
+                    fh.write(json.dumps(
+                        {"agent": "bbb",
+                         "ts": datetime.now(timezone.utc).isoformat(timespec="seconds")},
+                        sort_keys=True) + "\n")
+            return text
+
+        with mock.patch.object(Path, "read_text", racing):
+            self.assertEqual(dispatch.tally()["aaa"], 1)
+        self.assertTrue(fired, "the case needs the append to have happened mid-read")
+        self.assertEqual(dispatch.tally()["bbb"], 1,
+                         "a row appended during the read was memoised away for good")
+
+
+class ACorruptLineIsSkippedAndNotTheFile(MonthStore):
+    """A half-written line costs its own row and no other — and now costs it once.
+
+    The store is append-only from any process (`record` uses ``O_APPEND``), so a machine
+    that dies mid-append leaves a truncated line behind forever; the file is also
+    committed, so a bad merge can leave anything at all in it. Parsing is now MEMOISED,
+    which is why these belong here rather than only beside the writer: whatever the parse
+    decides about a line, it decides once and every later repaint inherits.
+    """
+
+    def rows(self, *lines: str) -> None:
+        p = dispatch.path_for()
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text("".join(f"{ln}\n" for ln in lines))
+
+    def test_a_truncated_line_costs_only_itself(self):
+        good = json.dumps({"agent": "devops", "ts": "2026-09-01T00:00:00+00:00"},
+                          sort_keys=True)
+        self.rows(good, '{"agent": "qa", "ts', good)
+        self.assertEqual(dispatch.tally(), {"devops": 2})
+
+    def test_a_blank_line_is_not_a_row(self):
+        good = json.dumps({"agent": "devops", "ts": "2026-09-01T00:00:00+00:00"},
+                          sort_keys=True)
+        self.rows(good, "", "   ", good)
+        self.assertEqual(dispatch.tally(), {"devops": 2})
+
+    def test_a_line_that_is_valid_json_but_not_an_object_is_not_a_row(self):
+        good = json.dumps({"agent": "devops", "ts": "2026-09-01T00:00:00+00:00"},
+                          sort_keys=True)
+        self.rows(good, '["devops", 3]', "7", '"devops"', good)
+        self.assertEqual(dispatch.tally(), {"devops": 2},
+                         "a JSON array or scalar was read as a dispatch row")
+
+    def test_an_object_carrying_neither_an_agent_nor_an_event_is_not_a_row(self):
+        good = json.dumps({"agent": "devops", "ts": "2026-09-01T00:00:00+00:00"},
+                          sort_keys=True)
+        self.rows(good, '{"ts": "2026-09-01T00:00:00+00:00"}', "{}", good)
+        self.assertEqual(sum(dispatch.tally().values()), 2)
+        self.assertEqual(len(dispatch._rows_of(dispatch.path_for())), 2,
+                         "a row with neither an agent nor an event was kept")
 
 
 class AMonthFileThatGoesAway(MonthStore):


### PR DESCRIPTION
Closes #887.

`dispatch.tally()` read **every month file ever written** under `personas/_dispatch/` and
parsed every line. Since #882 it sits on a per-turn repaint path: `persona.by_use` calls it
for the persona switcher's order, `statusline._persona_chip_cells` draws that column, and
`frame/panel.run` is a held process that repaints it for as long as the frame lives.

## The premise, re-measured before it was fixed

Measured here against synthesized stores at this plane's real rate (~225 dispatches a month,
one file per month), median of 40 calls. The issue's table was modelled; this one was run.

| log age | rows | before | issue's model | after, every repaint |
|---|---|---|---|---|
| today | 450 | 0.37 ms | 0.38 ms | 0.06 ms |
| 1 year | 2 700 | 2.10 ms | 2.36 ms | 0.27 ms |
| 2 years | 5 400 | 4.22 ms | 4.52 ms | 0.54 ms |
| 5 years | 13 500 | 10.71 ms | 11.55 ms | 1.32 ms |

The shape is exactly what #887 says it is — linear in rows, and rows are linear in the age
of the plane. On this plane's real store: 456 rows, `tally()` 0.36 ms, `_persona_chip_cells`
4.88 ms, which also matches.

**One thing the issue does not say, and this PR does.** The FIRST call in a process still
costs the left-hand column, to within noise: the memo removes a repeated read, not a read.
A panel pays it once and then repaints for free. What remains in the right-hand column is
no longer file reading — at five years it is 1.32 ms of which reading is 0.28 ms; the rest
is walking rows already in memory to add them up. That term is still linear in log age, and
it is left alone deliberately: it is a smaller and different thing than the one filed, and a
cache of counts is the invention #887 exists because #882 refused to make.

## The fix

`dispatch._rows_of` memoises one file's parsed rows on `(path, mtime_ns, size)`, inside
`dispatch`, below `_read_all` — so `advice_tally`, `resume_tally`, `first_advice`,
`handoffs_since_first_advice` and `last_seen` get it too. A month file that is not the
current one is closed: `path_for` only ever writes `<this month>.<host>.jsonl`. So every
month but one is a permanent hit and the reading is bounded by the current month.

**The key is the invalidation, not a summary.** Nothing derived is stored — no count, no
order, no total — only the rows the jsonl already holds, discarded the instant the file they
came from is not the file that was read. Same shape `statusline._usage_stamp` and the frame's
gather cache already invalidate on.

Nothing is cached in the caller and no ordering is cached. #882's tie-break stays a second
pass over runs of tied counts, so the per-persona memory glob is still paid only by names
that tie.

## The invalidation, and the test that pins each half

Every case demands the NEW answer after a change, except the one that exists to prove the
memo is consulted at all. Each forges exactly one half of the key, through `os.utime`, and
then asserts the forgery took — so none can pass because the filesystem quietly refused to
hold the value the case is about.

* `SizeIsInTheKey` — mtime held still to the nanosecond, length changed. This is the
  `drop-conjunct` survivor on `size`, and it is why `size` is in the key: mtime alone is a
  filesystem's promise rather than a fact. APFS keeps nanoseconds; some ext4 configurations
  report whole seconds, and `record` appends many times inside one such tick.
* `MtimeIsInTheKey` — length held still, mtime moved.
* `TheMemoIsUsedAtAll` — both halves held still, content changed, OLD answer demanded.
* `TheKeyIsAWholePath` — two planes, identically named month files made indistinguishable
  except by path (same name, same length, same mtime). A name-keyed memo answers the second
  plane out of the first plane's rows.
* `TheStatComesBeforeTheRead` — `Path.read_text` appends a row itself, once, at the instant
  the window between the stat and the read is open. Stamped before, that row is one repaint
  late; stamped after, it is invisible for the life of the process.
* `TheCurrentMonthStaysLive` — the everyday invalidation, through `record` rather than a
  forgery, for `tally`, `advice_tally`, `resume_tally` and `last_seen`.
* `AMonthFileThatGoesAway` — `_read_all` decides which files exist by globbing, every time,
  and asks the memo only about files it just found.
* `ACorruptLineIsSkippedAndNotTheFile` — the parse is memoised, so what it decides about a
  half-written line it decides once.

## Deletion sweep, hand-applied first

Twelve mutations applied by hand, `__pycache__` cleared on both transitions, RED watched,
reverted. All twelve are RED. Two survivors were found and fixed rather than argued with:
`key on the file's name` (the case passed against it because the two files differed in mtime
— now stamped alike), and the blank-line guard, which is **deleted**: `json.loads` raises
`ValueError` on an empty or whitespace-only line exactly as it does on a truncated one, so
`ln = ln.strip()` / `if not ln: continue` was a branch nothing could go red without — the
verdict #882 reached about two lines in its own ordering.

`python3 -m unittest discover -s tests -q` → `Ran 11448 tests ... OK (skipped=9)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Us4MbwkSCJCxwt1CjAd1sf
