### PR TITLE
0.57.0 — charter stops putting a status line in Claude Code

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "charter",
   "description": "Personas, workspaces and memory for coding agents across many repos \u2014 Claude Code, opencode and Codex",
-  "version": "0.56.0",
+  "version": "0.57.0",
   "author": {
     "name": "Aaron Yordanyan"
   },

--- a/charter/__init__.py
+++ b/charter/__init__.py
@@ -7,4 +7,4 @@ Run it as ``python3 -m charter`` (from the control plane root) or via the
 installed ``charter`` console script.
 """
 
-__version__ = "0.56.0"
+__version__ = "0.57.0"

--- a/docs/news/0.57.0-a-bulk-repair-counts-repairs-and-workspaces-apart.md
+++ b/docs/news/0.57.0-a-bulk-repair-counts-repairs-and-workspaces-apart.md
@@ -1,6 +1,6 @@
 ---
-version: unreleased
-headline: '`charter workspace reinit --all` counts repairs and workspaces apart, so its closing line can no longer report healing more workspaces than exist'
+version: 0.57.0
+headline: `charter workspace reinit --all` counts repairs and workspaces apart, so its closing line can no longer report healing more workspaces than exist
 adopt: workspace reinit --all
 ---
 

--- a/docs/news/0.57.0-a-month-file-is-read-once-per-version.md
+++ b/docs/news/0.57.0-a-month-file-is-read-once-per-version.md
@@ -1,5 +1,5 @@
 ---
-version: unreleased
+version: 0.57.0
 headline: the persona column stops re-reading the whole dispatch log on every repaint — a month file is now parsed once per version of that file, so the cost stops growing with the age of the plane
 ---
 

--- a/docs/news/0.57.0-charter-stops-putting-a-status-line-in-claude-code.md
+++ b/docs/news/0.57.0-charter-stops-putting-a-status-line-in-claude-code.md
@@ -1,5 +1,5 @@
 ---
-version: unreleased
+version: 0.57.0
 headline: charter stops putting a status line in Claude Code — `init` writes no `statusLine` key, and a plane that already has one keeps it
 lead: true
 ---

--- a/docs/news/0.57.0-every-workspace-has-a-manifest.md
+++ b/docs/news/0.57.0-every-workspace-has-a-manifest.md
@@ -1,5 +1,5 @@
 ---
-version: unreleased
+version: 0.57.0
 headline: every workspace has a `workspace.json` — written when the workspace is made, kept in step when a repo is cloned into it, and backfilled for the ones that predate it
 adopt: workspace reinit --all
 ---

--- a/docs/news/0.57.0-installing-charter-installs-charter.md
+++ b/docs/news/0.57.0-installing-charter-installs-charter.md
@@ -1,5 +1,5 @@
 ---
-version: unreleased
+version: 0.57.0
 headline: Installing charter installs charter — `uv tool install charter-cp`, and `charter init` brings Claude Code's plugin with it
 adopt: doctor --fix
 ---

--- a/docs/news/0.57.0-the-repo-shows-you-the-frame.md
+++ b/docs/news/0.57.0-the-repo-shows-you-the-frame.md
@@ -1,5 +1,5 @@
 ---
-version: unreleased
+version: 0.57.0
 headline: the repo shows you the frame — a capture of charter's real surface, and it is what a shared link previews now
 ---
 

--- a/docs/news/0.57.0-the-tab-strips-lose-their-headings-and-gain-a-count.md
+++ b/docs/news/0.57.0-the-tab-strips-lose-their-headings-and-gain-a-count.md
@@ -1,5 +1,5 @@
 ---
-version: unreleased
+version: 0.57.0
 headline: the tab strips drop their headings, launch one row deep with F3 to grow them, and every workspace tab says how many chats it holds
 ---
 

--- a/docs/news/0.57.0-two-writers-for-one-file-stop-publishing-each-others-half.md
+++ b/docs/news/0.57.0-two-writers-for-one-file-stop-publishing-each-others-half.md
@@ -1,5 +1,5 @@
 ---
-version: unreleased
+version: 0.57.0
 headline: two charter processes writing the same file stop publishing each other's half — every atomic write now uses a temp file of its own
 ---
 

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -14,7 +14,7 @@
           },
           {
             "type": "command",
-            "command": "charter hook sessionstart --plugin-version 0.56.0",
+            "command": "charter hook sessionstart --plugin-version 0.57.0",
             "timeout": 5
           },
           {
@@ -35,7 +35,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook userpromptsubmit --plugin-version 0.56.0",
+            "command": "charter hook userpromptsubmit --plugin-version 0.57.0",
             "timeout": 5
           }
         ]
@@ -47,7 +47,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse --plugin-version 0.56.0",
+            "command": "charter hook pretooluse --plugin-version 0.57.0",
             "timeout": 10
           }
         ]
@@ -57,7 +57,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse-read --plugin-version 0.56.0",
+            "command": "charter hook pretooluse-read --plugin-version 0.57.0",
             "timeout": 5
           }
         ]
@@ -67,7 +67,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse-dispatch --plugin-version 0.56.0"
+            "command": "charter hook pretooluse-dispatch --plugin-version 0.57.0"
           }
         ]
       },
@@ -76,7 +76,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse-edit --plugin-version 0.56.0",
+            "command": "charter hook pretooluse-edit --plugin-version 0.57.0",
             "timeout": 5
           }
         ]
@@ -88,7 +88,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse-bash --plugin-version 0.56.0",
+            "command": "charter hook posttooluse-bash --plugin-version 0.57.0",
             "timeout": 5
           }
         ]
@@ -98,7 +98,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse --plugin-version 0.56.0",
+            "command": "charter hook posttooluse --plugin-version 0.57.0",
             "timeout": 5
           }
         ]
@@ -108,7 +108,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse-skill --plugin-version 0.56.0",
+            "command": "charter hook posttooluse-skill --plugin-version 0.57.0",
             "timeout": 5
           }
         ]
@@ -118,7 +118,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse-dispatch --plugin-version 0.56.0",
+            "command": "charter hook posttooluse-dispatch --plugin-version 0.57.0",
             "timeout": 5
           }
         ]
@@ -128,7 +128,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse-message --plugin-version 0.56.0",
+            "command": "charter hook posttooluse-message --plugin-version 0.57.0",
             "timeout": 5
           }
         ]
@@ -139,7 +139,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook stop --plugin-version 0.56.0",
+            "command": "charter hook stop --plugin-version 0.57.0",
             "timeout": 5
           },
           {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "charter-cp"
-version = "0.56.0"
+version = "0.57.0"
 description = "Personas, workspaces and memory for coding agents across many repos — Claude Code, opencode and Codex"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Cuts **0.57.0**, a minor: the release drops a key `charter init` had written for
charter's whole life, and ships seven other user-visible changes.

## The four version sites move together

`0.56.0` → `0.57.0` in `pyproject.toml`, `charter/__init__.py`,
`.claude-plugin/plugin.json`, and all **twelve** `--plugin-version` flags in
`hooks/hooks.json`. No `0.56.0` remains in any of the four;
`TestVersionsMoveInLockstep` pins it.

## Eight entries, stamped

`charter news stamp 0.57.0` moved every `docs/news/unreleased-*.md` onto this version —
eight of them, one per user-visible PR merged since `v0.56.0`, with no merged PR left
without an entry:

| PR | entry |
| --- | --- |
| #897 | charter stops putting a status line in Claude Code **(lead)** |
| #896 | a bulk repair counts repairs and workspaces apart |
| #899 | a month file is read once per version |
| #889 | every workspace has a manifest |
| #891 | installing charter installs charter |
| #900 | the repo shows you the frame |
| #890 | the tab strips lose their headings and gain a count |
| #894 | two writers for one file stop publishing each other's half |

`charter-stops-putting-a-status-line-in-claude-code` is the only entry claiming
`lead: true`, and it renders first. No entry claims `security:`.

The rendered body is **33,306 encoded bytes of the 122,000 `_BODY_BUDGET`** — measured on
the whole unelided body, not on `render_body`'s return, which already elides and so can
never exceed the budget. `render_body('0.57.0')` returns that whole body unchanged: nothing
is elided at this size.

## One headline loses a pair of quotes it was never going to shed

`0.57.0-a-bulk-repair-counts-repairs-and-workspaces-apart.md` had its headline wrapped in
single quotes, YAML-style. charter's frontmatter is **not** YAML — `persona.parse` reads
flat `key: value` and does not unquote — so the quotes were part of the headline, and the
release notes would have rendered:

```
### '`charter workspace reinit --all` counts repairs and workspaces apart…exist'
```

Changing the entry is the sanctioned way to change what the Release says, so the entry
changed. The heading now starts at the backtick.

This is not new and not confined to this entry: **0.56.0 shipped six headlines with the
same stray quotes**, and nothing in the suite or the guard notices. Filed separately — this
PR fixes only the entry that ships now.

## Assets

Not regenerated, deliberately. All four captures are stamped `0.56.0` and `MAX_MINOR_LAG`
is 1, so 0.57.0 is exactly the one release of slack the gate is designed to allow.
`tests/test_asset_freshness.py` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Us4MbwkSCJCxwt1CjAd1sf
