### PR TITLE
A news headline wrapped in quotes is refused at the release gate, instead of publishing its quotes inside the heading (#902)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -234,15 +234,25 @@ jobs:
           # second copy of the limit in shell would be a second answer to one question, and
           # it is the announce-side answer that decides whether the release exists.
           #
-          # So the annotation names the three SHAPES — no entry; something the entries
-          # declare that charter cannot honour; or a body GitHub would refuse — and defers
-          # to the command's own stderr for which, since that stderr is already one
-          # sentence per finding. `>/dev/null` keeps it, dropping only stdout. Prescribing
-          # `news stamp` for any shape but the first would be prescribing a no-op for a
-          # failure stamping cannot fix.
+          # And for a fourth, which is the quietest of the lot (#902). charter's frontmatter
+          # opens and closes with `---` and is not YAML: it is flat `key: value`, so a
+          # headline an author wrapped in quotes — correctly, if it were YAML, because a
+          # headline usually starts with a backtick — keeps both quotes, and they render
+          # inside the `###` heading of the published Release. 0.56.0 shipped six of those
+          # and nothing here objected; 0.57.0's one was caught by a human reading the diff.
+          # The entries are well-formed, so it is not "cannot honour" and gets its own
+          # clause: the file is right about everything except what it thought the format
+          # was.
+          #
+          # So the annotation names the four SHAPES — no entry; something the entries
+          # declare that charter cannot honour; a value they quoted that charter does not
+          # unquote; or a body GitHub would refuse — and defers to the command's own stderr
+          # for which, since that stderr is already one sentence per finding. `>/dev/null`
+          # keeps it, dropping only stdout. Prescribing `news stamp` for any shape but the
+          # first would be prescribing a no-op for a failure stamping cannot fix.
           version=$(python -c 'import tomllib;print(tomllib.load(open("pyproject.toml","rb"))["project"]["version"])')
           if ! python -m charter news --for "$version" >/dev/null; then
-            echo "::error::the release notes for $version are not publishable: either no docs/news/$version-<slug>.md (every published version ships an entry, including a patch — run: charter news stamp $version), or something those entries declare that charter cannot honour — an ordering, a frontmatter key, or a file in docs/news that is not an entry — or a body GitHub would refuse as too long, which is a failure this step exists to catch before the upload rather than after it. See the error above for which."
+            echo "::error::the release notes for $version are not publishable: either no docs/news/$version-<slug>.md (every published version ships an entry, including a patch — run: charter news stamp $version), or something those entries declare that charter cannot honour — an ordering, a frontmatter key, or a file in docs/news that is not an entry — or a value one of them quotes that charter does not unquote, because this frontmatter is flat key: value and not YAML, so the quotes would publish inside the heading — or a body GitHub would refuse as too long, which is a failure this step exists to catch before the upload rather than after it. See the error above for which."
             exit 1
           fi
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -113,6 +113,16 @@ command.
   to the release, which is the only vantage point from which "first" means anything.
   Without either, entries sort by filename as they always have.
 
+  **The frontmatter is flat `key: value`, and it is not YAML — do not quote the value.**
+  It opens and closes with `---`, so it looks exactly like YAML frontmatter, and a headline
+  usually starts with a backtick, which real YAML would need quoted. charter takes
+  everything after the first colon verbatim and unquotes nothing, so `headline: 'a thing'`
+  publishes as `### 'a thing'`, quotes and all. 0.56.0 shipped six of those before anything
+  checked. A backtick needs no quoting here; a value that must really begin and end with a
+  quote has to be reworded, because a flat format has no way to say which pair is yours.
+  The suite asks this of every entry in the tree, and `charter news --for` refuses at the
+  release gate (#902).
+
   **Those six keys are the whole set, and they are matched exactly.** `version`,
   `headline`, `check`, `adopt`, `lead`, `security` — anything else in an entry's
   frontmatter is reported at the release gate rather than ignored, `Security:` and

--- a/charter/commands.py
+++ b/charter/commands.py
@@ -2900,6 +2900,22 @@ def cmd_news(args) -> int:
             for why in problems:
                 util.info(f"  {why}")
             return 1
+        # A second refusal rather than six more lines in the first, because the reader is
+        # being told a different thing. Everything above is a declaration charter could not
+        # read; this is one it read exactly as written, from an author who believed the
+        # frontmatter was YAML — it opens and closes with `---`, so believing that is
+        # reasonable — and whose quotes would otherwise be published inside the heading.
+        # 0.56.0 shipped six of those and this gate was silent for all six (#902).
+        #
+        # Its own sentence for the same reason `_EMPTY_VALUE` has one: "charter cannot
+        # honour this" would send the release engineer looking for a malformed entry, and
+        # every entry here is well-formed. The fix is in the file's text, not its shape.
+        quoted = news.quoted_values(news.for_version(version))
+        if quoted:
+            util.err(f"the news for {version} quotes a value charter does not unquote:")
+            for why in quoted:
+                util.info(f"  {why}")
+            return 1
         body = news.render_body(version)
         if not body:
             util.err(f"no news entry for {version}.")

--- a/charter/news.py
+++ b/charter/news.py
@@ -41,6 +41,17 @@ sentence is assembled (`contain.sentence`) rather than at the spans somebody was
 about: the ordering VALUE was contained and the committed FILENAME beside it was not, so a
 filename holding a newline forged an extra line of charter's report (#502).
 
+**And the frontmatter is not YAML, which is said rather than half-implemented.** It opens
+and closes with ``---`` and `persona.parse` reads flat ``key: value``, so an author who
+quotes a headline — correctly, if this were YAML, because a headline usually starts with a
+backtick — gets both quotes published inside the ``###`` heading. 0.56.0 shipped six of
+those. :func:`quoted_values` reports them; nothing unquotes them, because unquoting would
+honour one YAML habit while :func:`_flag` goes on reporting another (a value on the
+continuation line) rather than reading it — half a spec, with nothing to tell the next
+author which half (#902). This is the one report that is NOT `entry_errors`': a quoted
+value is honoured exactly as written, so the consequence belongs at the release gate and in
+the suite, not in the range view where a reader would be scolded about a shipped file.
+
 **It ships in the wheel.** Entries travel with the code that implements them, resolved the
 way :mod:`charter.docsrc` resolves documentation — packaged copy first, the repo's
 ``docs/news/`` as the checkout fallback. A control plane has no reason to vendor a copy and

--- a/charter/news.py
+++ b/charter/news.py
@@ -366,6 +366,56 @@ def _flag(raw: str | None) -> bool | None:
     return folded == "true" if folded in ("true", "false") else None
 
 
+#: The two characters a YAML habit wraps a scalar in. A backtick is deliberately not one:
+#: a headline that is entirely one code span opens and closes with a backtick and is
+#: *right* to, because that pair renders as markdown in the Release body rather than as
+#: itself. These two render as themselves.
+_QUOTES = ("'", '"')
+
+#: The text fields, derived from :data:`_KNOWN_FIELDS` rather than listed again. The two
+#: ordering fields are excluded because they are not text: ``lead: 'true'`` is already a
+#: value :func:`_flag` cannot read and :func:`entry_errors` already names it, and reporting
+#: it twice in two vocabularies would send an author looking for two mistakes.
+_TEXT_FIELDS = tuple(f for f in _KNOWN_FIELDS if f not in _ORDERING_FIELDS)
+
+
+def quoted(value: str) -> str | None:
+    """The quote character *value* is wrapped in — ``'`` or ``"`` — or ``None``.
+
+    **charter's frontmatter is not YAML, and this is the question that says so.** It opens
+    and closes with ``---``, which is exactly what YAML frontmatter looks like, so an author
+    who knows YAML is *correct* to quote a headline that starts with a backtick — a
+    reserved indicator there. `persona.parse` is flat ``key: value`` and takes everything
+    after the first colon verbatim, so both quotes are part of the value, and the value is
+    what `render_body` puts after ``### `` in a published GitHub Release (#902).
+
+    The rule is the whole of the matched pair and nothing narrower, and the corpus is why.
+    The tempting refinement — "and the same quote does not appear inside" — would model
+    YAML's own single-quoted scalar, where an inner ``'`` is written ``''``. One of the six
+    headlines 0.56.0 published is exactly that: ``'`charter doctor`''s `session root` row
+    …'``. The refinement drops it, so the narrower rule would have missed a sixth of the
+    entries this exists for while looking more precise.
+
+    What the broad rule costs is a headline that legitimately opens and closes with a quote
+    — ``"found" means "missing"`` — which is reported and has to be reworded. That cost is
+    accepted rather than engineered around, because this format genuinely cannot tell those
+    apart: there is no escape, and inventing one is how a flat parser becomes a YAML parser
+    a line at a time. Today's corpus holds three headlines that start *or* end with a quote
+    and none that does both, so the ambiguity is rarer than the mistake.
+
+    **Reporting rather than stripping is the decision, and it is the module's own.**
+    :func:`_flag` refuses to widen a truthy set because "which words mean yes" is a guard
+    against a spelling, and its ``_EMPTY_VALUE`` sentence already answers a *different* YAML
+    habit — a value on the continuation line — by naming the habit rather than by learning
+    to read it. Unquoting here would honour one YAML habit and go on dropping continuation
+    lines, anchors and backslash escapes, which is a format that is half a spec and tells
+    nobody which half. It would also make a headline that really does end in a quote
+    unwritable *silently*, where refusing at least says so.
+    """
+    v = value.strip()
+    return v[0] if len(v) >= 2 and v[0] in _QUOTES and v[-1] == v[0] else None
+
+
 def rank(e: Entry) -> int:
     """Where *e* sits among its own version's entries: 0 leads, 1 is a security fix, 2 is
     everything else. Lower first."""
@@ -480,6 +530,60 @@ def entry_errors(entries: list[Entry]) -> list[str]:
         if len(claimants) > 1:
             out.append(contain.sentence(_TWO_LEADS, version=version, count=len(claimants),
                                         names=sorted(c.path.name for c in claimants)))
+    return out
+
+
+#: A value the file wrapped in quotes and charter did not unwrap. Names the character, the
+#: field and the file, and not the value: the author already knows what they typed, the
+#: mistake is at both ends of it, and a 150-character headline quoted back and clipped at
+#: `contain.DISPLAY_LIMIT` would hide the two characters this sentence is about.
+_QUOTED_VALUE = ("{name}: `{field}:` opens and closes with {quote} and charter kept both. "
+                 "This frontmatter is not YAML — it is flat `key: value`, and everything "
+                 "after the first colon is the value — so {quote}…{quote} publishes as "
+                 "{quote}…{quote}, quotes and all, in the GitHub Release and in `charter "
+                 "news` alike. Write the value unquoted; a backtick needs no quoting here, "
+                 "and a value that must really begin and end with {quote} has to be "
+                 "reworded, because a flat format has no way to say which pair is yours.")
+
+
+def quoted_values(entries: list[Entry]) -> list[str]:
+    """Every value in *entries* that was written wrapped in quotes, as sentences.
+
+    Empty is the ordinary answer, and 257 entries deep it was the answer for 251 of them:
+    the dominant convention is unquoted and always rendered correctly. Six 0.56.0 entries
+    are the exception, and they are the reason this exists — they published with the quotes
+    in the heading, in the Release GitHub still holds, and neither the suite nor the release
+    gate said a word (#902).
+
+    **Its own function rather than a fourth branch of :func:`entry_errors`, and the split
+    is not cosmetic.** That function reports what an entry declared that charter *cannot
+    honour* — a value it could not read, a key it never looked up, two entries claiming one
+    position. A quoted headline is honoured perfectly: charter reads it, renders it, and
+    ships exactly the bytes the file holds. What went wrong is upstream of charter, in what
+    the author believed the format was. Folding the two together would put this in the range
+    view as well, where `cmd_news` warns rather than refuses — so every reader catching up
+    across 0.56.0 would be scolded, forever, about six files that cannot be corrected
+    without forking the repo's copy from the Release that was published from it.
+
+    So the consequence lands only at ``charter news --for``, which is `release.yml`'s
+    pre-publish guard and the one call that becomes something permanent — the same place
+    :func:`entry_errors` and :func:`unreadable` land, and the place that was silent while
+    0.56.0 went out. The *earlier* catch, the one that matters most because it is the one an
+    author meets, is `tests/test_news_frontmatter_is_not_yaml.py`, which asks this of the
+    whole committed corpus on every PR.
+
+    Asked of the :class:`Entry` rather than of the file, so it reads the same values every
+    other consumer reads and needs no second parse; and over :data:`_TEXT_FIELDS`, derived
+    from :data:`_KNOWN_FIELDS`, so a field added there is asked about here without anyone
+    remembering to.
+    """
+    out: list[str] = []
+    for e in sorted(entries, key=lambda e: e.path.name):
+        for field in _TEXT_FIELDS:
+            mark = quoted(getattr(e, field))
+            if mark is not None:
+                out.append(contain.sentence(_QUOTED_VALUE, name=e.path.name,
+                                            field=field, quote=mark))
     return out
 
 

--- a/docs/news/unreleased-a-quoted-news-headline-is-refused-not-published.md
+++ b/docs/news/unreleased-a-quoted-news-headline-is-refused-not-published.md
@@ -46,9 +46,12 @@ So charter says what the format is:
 ```
 $ charter news --for 0.58.0
 ✗ the news for 0.58.0 quotes a value charter does not unquote:
-  0.58.0-a-thing.md: `headline:` opens and closes with ' and charter kept both. This
-  frontmatter is not YAML — it is flat `key: value`, and everything after the first colon
-  is the value — so '…' publishes as '…', quotes and all…
+•   0.58.0-a-thing.md: `headline:` opens and closes with ' and charter kept both. This
+frontmatter is not YAML — it is flat `key: value`, and everything after the first colon is
+the value — so '…' publishes as '…', quotes and all, in the GitHub Release and in `charter
+news` alike. Write the value unquoted; a backtick needs no quoting here, and a value that
+must really begin and end with ' has to be reworded, because a flat format has no way to
+say which pair is yours.
 ```
 
 ## Where it is asked

--- a/docs/news/unreleased-a-quoted-news-headline-is-refused-not-published.md
+++ b/docs/news/unreleased-a-quoted-news-headline-is-refused-not-published.md
@@ -1,0 +1,81 @@
+---
+version: unreleased
+headline: A news headline wrapped in quotes is refused at the release gate, instead of publishing its quotes inside the heading
+---
+
+`docs/news/` frontmatter opens with `---` and closes with `---`, which is exactly what YAML
+frontmatter looks like. It is not YAML. `persona.parse` reads flat `key: value` and takes
+everything after the first colon verbatim, so an entry written like this:
+
+```
+headline: '`charter workspace reinit --all` counts repairs and workspaces apart'
+```
+
+published like this:
+
+```
+### '`charter workspace reinit --all` counts repairs and workspaces apart'
+```
+
+## The author was not being careless
+
+A headline in this repo usually starts with a backtick, and a backtick is a reserved
+indicator in real YAML. Anyone who believes this frontmatter is YAML — and everything about
+how it looks says so — is *correct* to quote that headline. The format punished knowing
+YAML, and it punished quietly: the file is well-formed, the entry sorts correctly,
+`charter news --for` exited 0, and the only person who ever saw the quotes was a reader of
+the published notes.
+
+**0.56.0 shipped six of them.** Nobody noticed until 0.57.0 was being cut, when one entry
+was caught by hand by somebody who happened to look. Neither the suite nor the release
+guard had an opinion.
+
+## Refused, not silently unquoted
+
+The other candidate was to strip a matched pair of quotes when reading the value. It is
+cheaper and it would have fixed the six retroactively — and it is the wrong half of the
+trade. Stripping honours exactly one YAML habit while charter goes on dropping continuation
+lines, ignoring anchors and keeping backslashes: half a spec, with nothing to tell the next
+author which half they have. `news._flag` already refused this shape once, for a different
+YAML habit — a value indented onto the line below — and answered it with a sentence naming
+the habit rather than by learning to read it. And a headline that legitimately ends in a
+quote would become unwritable *silently*, where a refusal at least says so.
+
+So charter says what the format is:
+
+```
+$ charter news --for 0.58.0
+✗ the news for 0.58.0 quotes a value charter does not unquote:
+  0.58.0-a-thing.md: `headline:` opens and closes with ' and charter kept both. This
+  frontmatter is not YAML — it is flat `key: value`, and everything after the first colon
+  is the value — so '…' publishes as '…', quotes and all…
+```
+
+## Where it is asked
+
+Three surfaces, one function — `news.quoted_values`, so they cannot disagree:
+
+- **the suite**, over every entry committed to the tree, which is the one an author meets
+  and the only one that runs before merge;
+- **`charter news --for <version>`**, which is `release.yml`'s pre-publish guard and the
+  call whose stdout becomes the Release body — the last place 0.56.0 could have been
+  stopped;
+- **not the range view.** `charter news` warns a reader catching up about entries charter
+  cannot honour, and this is not one of those: charter reads a quoted headline perfectly
+  and ships exactly the bytes the file holds. Warning there would scold every user whose
+  upgrade spans 0.56.0, on every run, about six files nobody is going to change.
+
+## The six 0.56.0 entries are reported, not rewritten
+
+They are what the published 0.56.0 Release says. Correcting them in the repo would fork
+this tree's copy of a stamped release's notes from the notes themselves, leaving two
+documents that claim to be the same one. `news.quoted_values` names all six to anyone who
+asks — `charter news --for 0.56.0` refuses today, which is the proof the gate would have
+caught them — and the suite pins exactly those six by name, so a seventh goes red and a
+correction to one of the six goes red too, as a decision about the published Release rather
+than a tidy-up.
+
+## Nothing to adopt
+
+The check runs in this repo's own CI and release guard. A plane that consumes charter has
+nothing to take up.

--- a/personas/release/memory/a-news-entry-s-headline-wrapped-in-yaml-style-si.md
+++ b/personas/release/memory/a-news-entry-s-headline-wrapped-in-yaml-style-si.md
@@ -2,4 +2,4 @@
 
 _2026-09-04 17:50 · persistent_
 
-A news entry's headline: wrapped in YAML-style single quotes ships those quotes into the rendered release-note heading — charter's frontmatter is flat key: value (persona.parse), not YAML, so nothing unquotes it. 0.56.0 published six such headlines unnoticed. Before tagging, grep "^headline: '" docs/news/<version>-*.md and fix the entry, never the rendered notes. Tracked as #902.
+A news entry's headline: wrapped in YAML-style single quotes ships those quotes into the rendered release-note heading — charter's frontmatter is flat key: value (persona.parse), not YAML, so nothing unquotes it. 0.56.0 published six such headlines unnoticed. #902 moved the check into code, so the pre-tag grep is no longer yours to remember: the suite asks it of every entry (tests/test_news_frontmatter_is_not_yaml.py) and `charter news --for <version>` — the release guard — refuses a version whose entries quote a value. Fix the entry, never the rendered notes. The six 0.56.0 entries are deliberately NOT corrected: they are what the published Release says, and quoted_values still reports them, so `charter news --for 0.56.0` refuses on purpose.

--- a/tests/test_a_news_entry_cannot_forge_a_report_line.py
+++ b/tests/test_a_news_entry_cannot_forge_a_report_line.py
@@ -274,6 +274,17 @@ class EverySpanInEverySentence(NewsDir):
         self.assertOneLine(why, "the unrecognised-key sentence")
         self.assertShown(why)
 
+    def test_the_filename_in_the_quoted_value_sentence(self):
+        """#902's sentence, and the shape #502 predicted in as many words: a further
+        untrusted span turning up in a report line written long after the fix. This one
+        deliberately does not quote the value back — the mistake is the two characters at
+        its ends and the author knows what they typed — so the ONLY thing it carries out
+        of the entry is the committed filename, which is the span #502 was about."""
+        self.write(f"{_V}-{_HOSTILE}.md", _entry(headline="'important'"))
+        why, = news.quoted_values(news.all())
+        self.assertOneLine(why, "the quoted-value sentence")
+        self.assertShown(why)
+
     def test_the_reason_a_file_is_not_an_entry(self):
         """`unreadable()` names files, and a file that is not an entry is the one whose
         name nobody has ever looked at."""

--- a/tests/test_news_frontmatter_is_not_yaml.py
+++ b/tests/test_news_frontmatter_is_not_yaml.py
@@ -168,6 +168,18 @@ class AMatchedPairIsFound(unittest.TestCase):
         self.assertIsNone(news.quoted("'"))
         self.assertIsNone(news.quoted('"'))
 
+    def test_a_value_that_is_nothing_but_the_pair(self):
+        """The other side of that boundary, and the deletion sweep is what asked for it:
+        ``len(v) >= 2`` re-spelled ``> 2`` survived every other test in this file.
+
+        Two characters is not a corner case, it is an entry. ``headline: ''`` is a matched
+        pair and nothing else — the emptiest headline there is — and it publishes as
+        ``### ''``, which is the defect at its most visible. Under ``> 2`` charter would
+        read it as unquoted and say nothing at all.
+        """
+        self.assertEqual(news.quoted("''"), "'")
+        self.assertEqual(news.quoted('""'), '"')
+
     def test_nothing_at_all(self):
         self.assertIsNone(news.quoted(""))
         self.assertIsNone(news.quoted("   "))

--- a/tests/test_news_frontmatter_is_not_yaml.py
+++ b/tests/test_news_frontmatter_is_not_yaml.py
@@ -1,0 +1,418 @@
+"""#902: `docs/news/` frontmatter looks exactly like YAML and is not, and the quotes an
+author adds because of that get published.
+
+It opens with ``---`` and closes with ``---``. Everything a reader knows about frontmatter
+says the next thing is YAML. `persona.parse` is flat ``key: value`` — it takes everything
+after the first colon verbatim and unquotes nothing — so::
+
+    headline: '`charter workspace reinit --all` counts repairs and workspaces apart'
+
+renders into the published GitHub Release as::
+
+    ### '`charter workspace reinit --all` counts repairs and workspaces apart'
+
+**The author is not being careless.** A headline in this repo usually *starts with a
+backtick*, and a backtick is a reserved indicator in real YAML: anyone who believes this is
+YAML is correct to quote it. The format punishes knowing YAML, and it punishes quietly —
+the file is well-formed, `charter news --for` exits 0, and the only person who ever sees
+the quotes is a reader of the published notes.
+
+**Which is how six of them shipped.** 0.56.0 published six quoted headlines and nobody
+noticed until 0.57.0 was being cut, when one entry was caught by hand, by someone who
+happened to look. Neither this suite nor the release gate had an opinion.
+
+Refusing rather than unquoting, and the module's own reasoning is what decided it.
+`news._flag` already answers a *different* YAML habit — a value indented onto the
+continuation line — and it answers it with a sentence naming the habit rather than by
+learning to read it, because "which spellings do we accept" is a guard against a spelling
+and the property is whether the value was understood. `news._KNOWN_FIELDS` refuses to fold
+keys for the same reason, and `persona.misspelled_key` says in as many words that charter
+never guesses which field an author meant. Teaching the reader to strip one pair of quotes
+would honour exactly one YAML habit while going on dropping continuation lines, anchors and
+backslash escapes — half a spec, with nothing to tell an author which half — and would make
+a headline that really does end in a quote unwritable *silently*. Refusing says so.
+
+Three surfaces, and the earliest is the one that matters. This file asks the whole
+committed corpus on every PR, which is before merge. `charter news --for` asks the version
+being cut, which is the release gate that was silent for 0.56.0. `news.quoted_values` is
+where the answer lives, so the two ask the same question of the same parser.
+
+**And the six are reported, not rewritten.** They are the record of a Release GitHub
+already holds; editing them would fork the repo's copy from the published notes, so that
+the thing you read in `docs/news/` and the thing readers of the Release see would no longer
+be the same document. :data:`_SHIPPED_QUOTED` pins them by name and
+:class:`WhatShippedIsReportedRatherThanRewritten` asserts both directions of it.
+"""
+
+from __future__ import annotations
+
+import io
+import shutil
+import tempfile
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
+
+from charter import commands, news
+
+_V = "0.60.0"
+
+#: The six headlines 0.56.0 published with their quotes, named rather than described.
+#:
+#: Frozen on purpose, and in the test rather than in `charter/news.py`. In the module it
+#: would be an exemption — `quoted_values` would stop naming them, and the defect would
+#: become invisible in the surface built to make it visible. Here it is a *pin*: the
+#: function still reports all six to anyone who asks, and this file says that reporting
+#: exactly these six is the expected state of the tree.
+#:
+#: Both directions have teeth. A seventh quoted entry makes this set too small and the
+#: assertion names the new file — which is the check #902 asked for. Correcting one of the
+#: six makes it too big, and that is deliberate: these files are what the 0.56.0 Release
+#: says, and a repo whose copy of a stamped release's notes differs from the notes
+#: themselves has two answers to one question. Correcting them is a decision about the
+#: published Release, not about this tree, and it edits this set in the same commit.
+_SHIPPED_QUOTED = frozenset({
+    "0.56.0-a-green-doctor-row-keeps-nothing-back.md",
+    "0.56.0-a-release-body-spends-what-github-allows.md",
+    "0.56.0-charter-save-refuses-from-a-workspace-clone-that-is-a-plane.md",
+    "0.56.0-doctor-answers-for-the-directory-it-is-running-in.md",
+    "0.56.0-the-plane-init-creates-is-one-init-can-see.md",
+    "0.56.0-the-session-root-row-stops-contradicting-the-row-below-it.md",
+})
+
+
+def _entry(headline: str, version: str = _V, **fields) -> str:
+    lines = [f"version: {version}", f"headline: {headline}"]
+    lines += [f"{k}: {v}" for k, v in fields.items()]
+    return "---\n" + "\n".join(lines) + "\n---\n\nbody text\n"
+
+
+class NewsDir(unittest.TestCase):
+    """Entries read from a throwaway directory, so a test never depends on what shipped —
+    the same isolation `tests/test_news_ordering.py` establishes, for the same reason."""
+
+    def setUp(self):
+        self.dir = Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, self.dir, ignore_errors=True)
+        patch = mock.patch.object(news, "_PACKAGED", self.dir)
+        patch.start()
+        self.addCleanup(patch.stop)
+
+    def write(self, text: str, name: str = f"{_V}-z-important.md") -> None:
+        (self.dir / name).write_text(text)
+
+    def said(self, text: str) -> list[str]:
+        self.write(text)
+        return news.quoted_values(news.all())
+
+
+class AMatchedPairIsFound(unittest.TestCase):
+    """`news.quoted` on values, with nothing else in the way.
+
+    The rule is "starts and ends with the same ``'`` or ``\"``" and nothing narrower. Every
+    case below is either one of the shapes the corpus actually holds or one of the shapes a
+    narrower rule would have got wrong.
+    """
+
+    def test_the_shape_the_issue_was_filed_about(self):
+        self.assertEqual(news.quoted("'`charter workspace reinit --all` counts'"), "'")
+
+    def test_double_quotes_too(self):
+        """The issue is about the six single-quoted ones because those are what shipped.
+        A YAML author reaches for either, and a rule that knew only one would leave the
+        other exactly as silent as before."""
+        self.assertEqual(news.quoted('"a headline"'), '"')
+
+    def test_an_inner_quote_of_the_same_kind_does_not_excuse_the_pair(self):
+        """The refinement that looks more precise and is wrong. YAML writes an inner ``'``
+        as ``''`` inside a single-quoted scalar, so "the same quote appears inside, this is
+        prose rather than a wrapper" is a rule with a real YAML pedigree — and one of the
+        six 0.56.0 headlines is exactly that shape:
+
+            '`charter doctor`''s `session root` row stops telling you…'
+
+        The narrower rule drops it. A guard that misses a sixth of the corpus it was
+        written for, while reading as though it understood the format better, is the
+        trade this test exists to refuse.
+        """
+        self.assertEqual(news.quoted("'`charter doctor`''s `session root` row'"), "'")
+
+    def test_a_backtick_is_not_a_quote(self):
+        """The commonest headline in this repo is a code span, and a headline that IS one
+        opens and closes with a backtick. It renders as markdown in the Release body
+        rather than as itself, which is the whole difference: the pair disappears into
+        formatting instead of into the heading."""
+        self.assertIsNone(news.quoted("`charter workspace reinit --all`"))
+
+    def test_the_dominant_convention_is_left_alone(self):
+        """251 of 257 entries. A check that had an opinion about these would be a check
+        nobody could keep."""
+        self.assertIsNone(news.quoted(
+            "`charter save` from a workspace clone refuses, instead of committing"))
+
+    def test_a_quote_at_one_end_only(self):
+        """Three shipped headlines start or end with a `"` and none does both — a quoted
+        phrase at the start of a sentence, or at the end of one. Flagging those would fail
+        CI on prose that renders exactly as written."""
+        self.assertIsNone(news.quoted('charter trace answers "which command got the token"'))
+        self.assertIsNone(news.quoted('"gathering" is what the frame says now'))
+
+    def test_two_different_quote_characters_are_not_a_pair(self):
+        self.assertIsNone(news.quoted("\"mixed'"))
+
+    def test_one_quote_is_not_two(self):
+        """``len >= 2``, or a value of a single ``'`` starts and ends with the same
+        character and reads as its own wrapper."""
+        self.assertIsNone(news.quoted("'"))
+        self.assertIsNone(news.quoted('"'))
+
+    def test_nothing_at_all(self):
+        self.assertIsNone(news.quoted(""))
+        self.assertIsNone(news.quoted("   "))
+
+    def test_surrounding_whitespace_does_not_hide_the_pair(self):
+        """`persona.parse` strips, so this is belt to braces — but `quoted` is public and
+        the next caller may not hand it a parsed value."""
+        self.assertEqual(news.quoted("  'a headline'  "), "'")
+
+
+class EveryTextFieldIsAsked(NewsDir):
+    """Not the headline alone.
+
+    `headline:` is what shipped wrong and what the issue is named for, so it is also the
+    field a fix written from the issue alone would check by itself. `check:` and `adopt:`
+    are read the same way by the same parser: a quoted `check:` is a probe naming a
+    command that does not exist, and a quoted `adopt:` prints `adopt: charter 'workspace
+    reinit'` into the suggestion a reader is meant to paste.
+
+    The set is derived from `news._KNOWN_FIELDS` rather than listed, so a seventh field
+    is asked about without anyone remembering to add it here.
+    """
+
+    def test_the_headline(self):
+        why, = self.said(_entry("'important'"))
+        self.assertIn("headline", why)
+
+    def test_the_probe(self):
+        why, = self.said(_entry("important", check="'workspace reinit'"))
+        self.assertIn("check", why)
+
+    def test_the_adopt_line(self):
+        why, = self.said(_entry("important", adopt="'workspace reinit'"))
+        self.assertIn("adopt", why)
+
+    def test_the_version(self):
+        """A quoted `version:` is the loudest of them — the entry lands in a release
+        called `'0.60.0'` that no other view of the tree agrees exists."""
+        why, = self.said(_entry("important", version=f"'{_V}'"))
+        self.assertIn("version", why)
+
+    def test_the_ordering_fields_are_not_asked_twice(self):
+        """`lead: 'true'` is already a value `_flag` cannot read, and `entry_errors`
+        already names it with the vocabulary of ordering fields. Reporting it here as well
+        would send an author looking for two mistakes where they made one."""
+        self.assertEqual(self.said(_entry("important", security="'true'")), [])
+        self.assertEqual(
+            [f for f in news._TEXT_FIELDS if f in news._ORDERING_FIELDS], [])
+
+    def test_every_text_field_is_a_field_of_an_entry(self):
+        """`quoted_values` reaches them with `getattr`, so a name in `_KNOWN_FIELDS` that
+        is not an `Entry` field would be an `AttributeError` at the release gate — the one
+        call where an exception is worst."""
+        for field in news._TEXT_FIELDS:
+            with self.subTest(field=field):
+                self.assertIn(field, news.Entry._fields)
+
+    def test_an_unquoted_entry_says_nothing(self):
+        """The counterfactual. Without it every assertion above passes on a function that
+        always reports."""
+        self.assertEqual(self.said(_entry("important", check="doctor")), [])
+
+
+class TheSentenceSaysWhatToDo(NewsDir):
+    """A refusal an author cannot act on is a failed CI run and nothing else."""
+
+    def _why(self, headline: str) -> str:
+        why, = self.said(_entry(headline))
+        return why
+
+    def test_it_names_the_file(self):
+        self.assertIn("0.60.0-z-important.md", self._why("'important'"))
+
+    def test_and_the_field(self):
+        self.assertIn("`headline:`", self._why("'important'"))
+
+    def test_and_the_character_the_author_typed(self):
+        """Not "a quote". The author typed one of two characters and the sentence shows
+        which, so the line is greppable and the fix is unambiguous."""
+        self.assertIn("'", self._why("'important'"))
+        self.assertIn('"', self._why('"important"'))
+
+    def test_and_says_the_format_is_not_yaml(self):
+        """The sentence has to correct the belief, not just the file. An author told only
+        "remove the quotes" learns a rule; an author told the frontmatter is flat `key:
+        value` stops reaching for the next YAML habit too."""
+        why = self._why("'important'")
+        self.assertIn("not YAML", why)
+        self.assertIn("key: value", why)
+
+    def test_and_that_a_backtick_needs_no_quoting(self):
+        """The specific thing the author was working around. A headline starting with a
+        backtick is why the quotes went on, so a sentence that does not answer that sends
+        them back to the same fix."""
+        self.assertIn("backtick", self._why("'`charter doctor` does a thing'"))
+
+    def test_and_names_the_one_value_it_cannot_represent(self):
+        """The cost of refusing rather than stripping, said out loud rather than
+        discovered. A headline that must really begin and end with a quote has to be
+        reworded, and the author is told that instead of being left to guess whether they
+        have found a bug."""
+        self.assertIn("reworded", self._why("'important'"))
+
+    def test_it_is_one_line(self):
+        """`contain.sentence`, like every other sentence this module assembles: the
+        filename is committed data and a `\\n` in it would forge a second line of
+        charter's own report (#502)."""
+        self.assertEqual(len(self._why("'important'").splitlines()), 1)
+
+
+class TheReleaseGateRefusesIt(NewsDir):
+    """`charter news --for <version>` is `release.yml`'s pre-publish guard and the same
+    call whose stdout `announce` pipes into `gh release create`. It was the last place
+    0.56.0 could have been stopped, and it exited 0 six times."""
+
+    def _for(self, version: str = _V) -> tuple[int, str, str]:
+        out, err = io.StringIO(), io.StringIO()
+        args = SimpleNamespace(for_version=version, pending=False, since=None, until=None)
+        with redirect_stdout(out), redirect_stderr(err):
+            rc = commands.cmd_news(args)
+        return rc, out.getvalue(), err.getvalue()
+
+    def test_a_quoted_headline_stops_the_release(self):
+        self.write(_entry("'important'"))
+        rc, _out, err = self._for()
+        self.assertEqual(rc, 1)
+        self.assertIn("0.60.0-z-important.md", err)
+
+    def test_and_the_notes_are_not_printed(self):
+        """stdout is what `announce` redirects into `--notes-file`. A gate that refused
+        and printed the body anyway would have the exit code and the artefact disagree,
+        and only one of them is read by a human."""
+        self.write(_entry("'important'"))
+        _rc, out, _err = self._for()
+        self.assertNotIn("### ", out)
+
+    def test_an_unquoted_release_publishes(self):
+        """The counterfactual, and the one this gate cannot afford to get wrong: it runs
+        on every release, and a check that refused them all would be found by the first
+        one rather than by a test."""
+        self.write(_entry("important"))
+        rc, out, _err = self._for()
+        self.assertEqual(rc, 0)
+        self.assertIn("### important", out)
+
+
+class TheRangeViewSaysNothingAboutIt(NewsDir):
+    """A reader catching up is not an author, and the six cannot be corrected without
+    forking the repo's copy of 0.56.0's notes from the Release published from them.
+
+    So this deliberately does NOT go through `entry_errors`, which `cmd_news` prints as a
+    warning in the range view: every user whose upgrade spans 0.56.0 would be warned, on
+    every run, forever, about six files nobody is going to change. The consequence belongs
+    at the release gate, where a fix is still possible, and in the suite, where it is
+    cheap.
+    """
+
+    def test_a_reader_catching_up_is_not_warned(self):
+        self.write(_entry("'important'"))
+        out, err = io.StringIO(), io.StringIO()
+        args = SimpleNamespace(for_version=None, pending=False, since="0.59.0", until=_V)
+        with mock.patch.object(news, "probe", return_value=(news.INFORMATIONAL, "")), \
+             redirect_stdout(out), redirect_stderr(err):
+            self.assertEqual(commands.cmd_news(args), 0)
+        self.assertIn("important", out.getvalue())
+        self.assertNotIn("unquote", err.getvalue())
+
+    def test_and_entry_errors_keeps_its_own_vocabulary(self):
+        """The other half: a quoted value is not something charter *cannot honour*. It
+        reads it, renders it and ships exactly the bytes the file holds. Folding the two
+        reports together would make that sentence false for a sixth of what it covers."""
+        self.write(_entry("'important'"))
+        self.assertEqual(news.entry_errors(news.all()), [])
+
+
+class WhatShippedIsReportedRatherThanRewritten(unittest.TestCase):
+    """Over the real `docs/news`, not a fixture.
+
+    This is the check that would have caught 0.56.0 on the PR that wrote the entries, and
+    it is the one that keeps the seventh from happening. It is also what says the six are
+    *reported* without being *changed*: `news.quoted_values` names all six every time it is
+    asked, and this asserts that the set it names is exactly the six that shipped.
+    """
+
+    def setUp(self):
+        self.entries = news.all()
+        self.assertTrue(self.entries, "no news entries found — this test proves nothing")
+
+    def _flagged(self) -> set[str]:
+        return {e.path.name for e in self.entries
+                if any(news.quoted(getattr(e, f)) for f in news._TEXT_FIELDS)}
+
+    def test_no_entry_carries_a_quoted_value_except_the_six_that_shipped(self):
+        self.assertEqual(
+            self._flagged(), set(_SHIPPED_QUOTED),
+            "an entry in docs/news wraps a frontmatter value in quotes. This frontmatter "
+            "is flat `key: value`, not YAML — nothing unquotes it, so both quotes are part "
+            "of the value and both render into the published GitHub Release heading. "
+            "Remove them; a backtick needs no quoting here. If a file went the other way "
+            "and one of the six 0.56.0 entries was corrected, that is a change to what a "
+            "stamped release's notes say and it belongs in the same commit as the edit to "
+            "`_SHIPPED_QUOTED` and to the published Release.")
+
+    def test_the_six_are_reported_by_name(self):
+        """Not merely counted. The release engineer's memory note says to grep for them by
+        hand before tagging; the point of putting the question in code is that the answer
+        is specific enough to replace that grep."""
+        named = " ".join(news.quoted_values(self.entries))
+        for name in sorted(_SHIPPED_QUOTED):
+            with self.subTest(entry=name):
+                self.assertIn(name, named)
+
+    def test_and_they_still_say_on_disk_what_the_release_says(self):
+        """The other half of "reported, not rewritten", asserted against the bytes. The
+        published 0.56.0 Release has those quotes in its headings; a repo whose copy
+        quietly lost them would leave two documents claiming to be the same notes."""
+        for name in sorted(_SHIPPED_QUOTED):
+            path = next(e.path for e in self.entries if e.path.name == name)
+            with self.subTest(entry=name):
+                self.assertIsNotNone(
+                    news.quoted(next(e.headline for e in self.entries
+                                     if e.path.name == name)),
+                    f"{name} no longer carries the quotes 0.56.0 published")
+                self.assertTrue(path.is_file())
+
+    def test_and_the_version_being_prepared_would_publish(self):
+        """The staged entries, through the real gate. `--for unreleased` is not a release,
+        but it renders through the same `quoted_values` call `--for 0.58.0` will make
+        after `news stamp` — so a staged entry that would stop the next release stops this
+        PR instead."""
+        staged = news.for_version(news.UNRELEASED)
+        self.assertEqual(news.quoted_values(staged), [])
+
+    def test_and_0_56_0_is_the_release_that_would_not_publish_today(self):
+        """Said as a fact rather than left implicit. The gate now refuses the version that
+        shipped these, which is the proof that it would have refused them in September —
+        and the reason the fix is a report rather than an edit: charter cannot un-publish
+        a Release, so the honest thing is to keep saying so.
+        """
+        out, err = io.StringIO(), io.StringIO()
+        args = SimpleNamespace(for_version="0.56.0", pending=False, since=None, until=None)
+        with redirect_stdout(out), redirect_stderr(err):
+            self.assertEqual(commands.cmd_news(args), 1)
+        self.assertIn("unquote", err.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_news_frontmatter_is_not_yaml.py
+++ b/tests/test_news_frontmatter_is_not_yaml.py
@@ -230,6 +230,25 @@ class EveryTextFieldIsAsked(NewsDir):
         always reports."""
         self.assertEqual(self.said(_entry("important", check="doctor")), [])
 
+    def test_two_quoted_fields_in_one_entry_are_two_sentences(self):
+        """One line per finding, the way `entry_errors` reports. An author fixes fields,
+        not files, and a sentence naming an entry that has two mistakes in it leaves the
+        second to be discovered by the next CI run."""
+        said = self.said(_entry("'important'", adopt="'workspace reinit'"))
+        self.assertEqual(len(said), 2)
+
+    def test_and_the_report_is_in_filename_order(self):
+        """`sorted` on the path name, like `entry_errors` immediately above it. Asked of
+        a list handed over REVERSED rather than of `all()`'s output: `all()` already sorts
+        within a version, so a fixture that fed this function that list would prove the
+        sort of a function one layer up and nothing about this one."""
+        self.write(_entry("'first'"), name=f"{_V}-a-first.md")
+        self.write(_entry("'second'"), name=f"{_V}-z-second.md")
+        said = news.quoted_values(list(reversed(news.all())))
+        self.assertEqual(len(said), 2)
+        self.assertIn("a-first", said[0])
+        self.assertIn("z-second", said[1])
+
 
 class TheSentenceSaysWhatToDo(NewsDir):
     """A refusal an author cannot act on is a failed CI run and nothing else."""

--- a/tests/test_news_ordering.py
+++ b/tests/test_news_ordering.py
@@ -570,13 +570,16 @@ class TheGateAnnotationNamesWhatTheGateNowCatches(NewsDir):
     that as fact and prescribe `charter news stamp $version`. #486 gave it two more: an
     ordering value charter cannot read, and two entries both claiming `lead: true`; #503
     gave it two after that, a frontmatter key charter does not read (`Security:`,
-    `securiy:`) and a file in `docs/news` that is not an entry at all. Against any of
-    them, an annotation naming only the missing entry names a cause that is not the cause
-    and prescribes a command that changes nothing — and stamping a version that is already
-    stamped is a no-op, so the operator's next move produces no new information either.
+    `securiy:`) and a file in `docs/news` that is not an entry at all. #902 gave it one
+    more, and that one is not a "cannot honour" at all: a value the author wrapped in
+    quotes, which charter reads perfectly and publishes with the quotes inside the
+    heading. Against any of them, an annotation naming only the missing entry names a
+    cause that is not the cause and prescribes a command that changes nothing — and
+    stamping a version that is already stamped is a no-op, so the operator's next move
+    produces no new information either.
 
     Which is also why the vocabulary the two texts share is no longer the word "ordering".
-    Four of the five causes are not orderings, and a shared word that is true of one cause
+    Five of the six causes are not orderings, and a shared word that is true of one cause
     is the same narrowing that put #486 back through the field added to prevent it.
 
     Three properties, in ascending order of teeth.
@@ -633,6 +636,25 @@ class TheGateAnnotationNamesWhatTheGateNowCatches(NewsDir):
         explains it. `tests/test_release_notes_fit_the_release.py` holds the other end.
         """
         self.assertIn("too long", self.annotation)
+
+    def test_and_the_cause_where_the_entry_is_right_about_everything_but_the_format(self):
+        """#902's shape, and it needs its own clause for the mirror image of #665's
+        reason. There, nothing was wrong with the entries; here, nothing is wrong with
+        them *as charter reads them* — the value parses, renders, and ships. What is wrong
+        is that the author believed the frontmatter was YAML, which it looks exactly like,
+        and the quotes they added in good faith end up inside the published `###` heading.
+
+        An operator sent to look for "something charter cannot honour" would read six
+        well-formed entries and find nothing, which is how 0.56.0 published six of these.
+        So the annotation carries the word the command prints — `unquote` — and the pair
+        is asserted here rather than each against a hand-written string.
+        """
+        self.assertIn("unquote", self.annotation)
+
+    def test_a_quoted_value_prints_the_word_the_annotation_sends_a_reader_to_find(self):
+        self.three()
+        self.write(f"{_V}-z-important.md", _entry(_V, "'important'"))
+        self.assertIn("unquote", self._stderr_of(_V))
 
     def test_and_defers_to_the_command_for_which_of_them_it_was(self):
         """Rather than diagnosing. Two causes named in one line is only an improvement if
@@ -700,13 +722,17 @@ class TheGateAnnotationNamesWhatTheGateNowCatches(NewsDir):
         that a workflow annotation two directories away enumerates them. So the count is
         pinned here: raise it and this test names the file to update, in the same PR that
         creates the obligation.
+
+        It has already paid for itself once. #902 added the fourth — a value the entry
+        quoted — and this is the test that said the annotation had to grow a clause for it
+        in the same commit.
         """
         import inspect
 
         src = inspect.getsource(commands.cmd_news)
         branch = src.split("if version:", 1)[1].split("if getattr(args, \"pending\"", 1)[0]
         self.assertEqual(
-            branch.count("return 1"), 3,
+            branch.count("return 1"), 4,
             "`charter news --for` has a number of ways to refuse that this test no "
             "longer expects. That call is release.yml's pre-publish guard, and its "
             "`::error::` annotation enumerates the causes for an operator who has only "


### PR DESCRIPTION
## The defect

`docs/news/` frontmatter opens with `---` and closes with `---`, which is exactly what YAML
frontmatter looks like. **It is not YAML.** `persona.parse` reads flat `key: value` and takes
everything after the first colon verbatim, so:

```
headline: '`charter workspace reinit --all` counts repairs and workspaces apart'
```

publishes as:

```
### '`charter workspace reinit --all` counts repairs and workspaces apart'
```

A headline in this repo usually *starts with a backtick*, and a backtick is a reserved
indicator in real YAML — so an author who believes this is YAML is **correct** to quote it.
The format punishes knowing YAML, and it punishes quietly: the file is well-formed, the entry
sorts correctly, `charter news --for` exited 0, and the only person who ever saw the quotes was
a reader of the published notes.

**0.56.0 shipped six of them.** 0.57.0's one was caught by hand during the cut, by somebody who
happened to look. Neither the suite nor the release guard had an opinion.

## Refuse, not unquote — and the repo's own reasoning is what decided it

The issue offered two candidates and leaned toward refusing. The existing code agrees, in three
places:

- **`news._flag`** already answers a *different* YAML habit — a value indented onto the
  continuation line — and answers it with `_EMPTY_VALUE`, a sentence naming the habit rather
  than by learning to read it. Its docstring states the principle: the property is not "which
  words mean yes" but "was this value understood?", because accepting more spellings is *a guard
  against a spelling*.
- **`news._KNOWN_FIELDS`** refuses to case-fold keys for the same reason, spelled out at length.
- **`persona.misspelled_key`** says in as many words that charter never guesses which field the
  author meant, and records that #573 refused exactly the folding-the-lookup move.

Unquoting would honour exactly one YAML habit while charter goes on dropping continuation lines,
ignoring anchors and keeping backslash escapes — half a spec, with nothing to tell the next
author which half. It would also make a headline that legitimately ends in a quote unwritable
*silently*, where refusing at least says so.

## What landed

**`news.quoted(value)`** — the quote character a value is wrapped in, or `None`. The rule is the
whole matched pair and nothing narrower. The tempting refinement ("…and the same quote does not
appear inside") models YAML's own `''` escape and would drop
`0.56.0-the-session-root-row-stops-contradicting-the-row-below-it.md`, whose headline is
`'`charter doctor`''s `session root` row …'` — a sixth of the corpus this exists for, missed by
a rule that reads as though it understood the format better. A backtick is deliberately *not* a
quote: a headline that is one code span opens and closes with one and is right to.

**`news.quoted_values(entries)`** — sentences naming the file, the field and the character. Its
own function rather than a fourth branch of `entry_errors`, and the split is not cosmetic: that
function reports what charter *cannot honour*, and a quoted headline is honoured perfectly —
charter reads it, renders it, ships exactly the bytes. Folding them together would put this in
the **range view**, where `cmd_news` warns rather than refuses, so every reader catching up
across 0.56.0 would be scolded forever about six files nobody can correct.

**Three surfaces, one function:**

| surface | behaviour |
|---|---|
| `tests/test_news_frontmatter_is_not_yaml.py` | asks the whole committed corpus, on every PR — before merge, which is the catch that matters |
| `charter news --for <version>` | refuses; this is `release.yml`'s pre-publish guard and the last place 0.56.0 could have been stopped |
| the range view (`charter news --since`) | says nothing, deliberately, and there is a test for that |

The gate is a **fourth `return 1`** in `cmd_news`'s `--for` branch, which
`test_a_new_refusal_is_a_new_sentence` pins at the source precisely so the workflow annotation
two directories away cannot be forgotten. It went red, as designed: `release.yml`'s `::error::`
grew a clause for the new cause, the pinned count went 3 → 4, and the annotation and the
command are asserted against each other on the shared word `unquote`.

## The six 0.56.0 entries are reported, not rewritten

They are what the published 0.56.0 Release says. Editing them would fork this tree's copy of a
stamped release's notes from the notes themselves, leaving two documents claiming to be the same
one. So:

- `news.quoted_values` names **all six**, every time it is asked;
- `charter news --for 0.56.0` **refuses today** — asserted, as the proof the gate would have
  caught them in September;
- the suite pins exactly those six by name in `_SHIPPED_QUOTED`, so a **seventh** goes red *and
  a correction to one of the six goes red too* — as a decision about the published Release rather
  than a tidy-up. The pin lives in the test, not in `charter/news.py`: in the module it would be
  an exemption, and the defect would go invisible in the surface built to make it visible.

Not one byte of `docs/news/0.56.0-*.md` changed.

## Also

- `CONTRIBUTING.md` says the frontmatter is flat and not YAML, where an author is reading.
- The release persona's memory note recorded the manual pre-tag grep as a thing to remember;
  it now points at the code that asks it instead.
- `tests/test_a_news_entry_cannot_forge_a_report_line.py` gains the new sentence's span — the
  filename, which is the only thing this line carries out of the entry (#502's predicted shape).
- A `docs/news/unreleased-*.md` entry, whose own headline is unquoted and which the new corpus
  check reads.

Closes #902

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Us4MbwkSCJCxwt1CjAd1sf
