### PR TITLE
The sweep sandbox says what the machine said when it cannot be built (#905)

### DIFF
--- a/docs/news/unreleased-a-sweep-sandbox-that-cannot-be-built-says-what-the-machine-said.md
+++ b/docs/news/unreleased-a-sweep-sandbox-that-cannot-be-built-says-what-the-machine-said.md
@@ -1,0 +1,69 @@
+---
+version: unreleased
+headline: a sweep sandbox that cannot be built now quotes what the machine said, instead of reporting a full disk as a failed deletion sweep
+---
+
+`tests/test_sweep.py::…::test_no_shard_at_all_still_means_the_whole_plan` failed on CI, on
+a branch whose diff touches no sweep file, and the whole of the report was this:
+
+```
+subprocess.CalledProcessError: Command '['git', 'clone', '--quiet', '--no-hardlinks',
+'--no-checkout', '/tmp/sweep-gate-yfa6_l8t',
+'/tmp/sweep-gate-yfa6_l8t/wd/run-2274/w0']' returned non-zero exit status 128.
+```
+
+Commit `d220a7c` passed `test (3.14)` on its `pull_request` run and failed it on its `push`
+run — same tree, same Python — and a re-run of the failed job on the unchanged tree passed.
+
+## What it was
+
+`Sandbox.__init__` ran `git clone` and then `git checkout` with `check=True` and
+`stderr=subprocess.PIPE`. That pairing looks like care and is the opposite of it:
+`CalledProcessError.__str__` prints the argv and the exit status and **nothing else**. The
+stderr it is constructed with rides along on the exception object and is never shown. So a
+command that failed *for a stated reason* arrived as a command that failed.
+
+Reproduced against a 20 MiB filesystem with 250 KiB left on it. The traceback is
+character-for-character the one CI printed, and what `git` had actually written — collected
+by this code and dropped — was:
+
+```
+fatal: failed to create directory '…/w0/.git/objects/82': No space left on device
+```
+
+None of that is charter's doing, and that is the other half of why the sentence has to
+survive. Without it the only available reading is *the deletion sweep is broken*. With it,
+the reader is told the box ran out of disk and the sweep never got as far as having an
+opinion about anybody's code.
+
+## The first hypothesis, and why it is refuted rather than unconfirmed
+
+The obvious suspect was #893/#894, which landed the same day: many writers publishing
+through a **shared temp name**, where `os.replace` was atomic but the name was not private.
+A fixed `/tmp/sweep-gate-…` under concurrency is that shape one directory up.
+
+It is not that, and this is a proof rather than a shrug. `tempfile.mkdtemp` creates with
+`O_EXCL` and holds the directory for the life of the test, the sweep's workdir lives inside
+it, and `run_dir` puts *this process's pid* under that — so no two concurrent invocations
+can be handed the same sandbox path. Measured as well as argued: **1600 runs of the failing
+test across 16 concurrent processes, 1600 passes.** The same 1600 pass after this change.
+
+## What changed
+
+Both calls go through `Sandbox._must`, which raises `NoSandbox` — a category of its own,
+because every other way this tool ends badly is a statement about the branch and this one
+is a statement about the machine, made before a single mutation has been measured:
+
+```
+tools.sweep.NoSandbox: the sandbox at /tmp/…/w0 could not be built — cloning the tree:
+`git clone --quiet --no-hardlinks --no-checkout /tmp/… /tmp/…/w0` exited 128 — fatal:
+failed to create directory '/tmp/…/objects/ad': No space left on device. That is the
+machine this sweep is running on, not a verdict about any mutation: nothing had been
+measured yet when it happened.
+```
+
+**No retry, no skip, no broadened `except`.** A full disk is the environment's business and
+charter does not get a vote on it; being able to tell a full disk from a failed sweep is
+charter's business entirely, and that is the only thing this fixes. If the next occurrence
+turns out to be inodes, or a fork that would not, or something nobody has thought of, it now
+names itself on the first run instead of costing a day.

--- a/tests/test_sweep.py
+++ b/tests/test_sweep.py
@@ -6175,5 +6175,125 @@ class ABranchIsNotChargedForWhatMainGainedWhileItWasOpen(unittest.TestCase):
         self.assertIn("charter/theirs.py", {m.path for m in inflated})
 
 
+class ASandboxThatCannotBeBuiltSaysWhatTheMachineSaid(unittest.TestCase):
+    """#905, and the whole of it is one discarded sentence.
+
+    `test_no_shard_at_all_still_means_the_whole_plan` failed on CI as
+
+        subprocess.CalledProcessError: Command '['git', 'clone', '--quiet',
+        '--no-hardlinks', '--no-checkout', '/tmp/sweep-gate-yfa6_l8t',
+        '/tmp/sweep-gate-yfa6_l8t/wd/run-2274/w0']' returned non-zero exit status 128.
+
+    and that is the entire report. Same commit, same Python: `pull_request` green,
+    `push` red, a re-run of the red one green. The first hypothesis was the shape #893
+    and #894 had just fixed — concurrent writers through a shared temp name — and it is
+    **refuted**, structurally and by measurement. The sandbox path cannot collide:
+    `tempfile.mkdtemp` hands out a directory no other process holds, the workdir lives
+    inside it, and `run_dir` puts this process's pid under that. 1600 runs of the failing
+    test across 16 concurrent processes produced 1600 passes.
+
+    What it is instead was reproduced against a 20 MiB filesystem with 250 KiB left on
+    it: the traceback is character-for-character CI's, and `git clone` had written
+
+        fatal: failed to create directory '…/objects/82': No space left on device
+
+    onto a stderr this code piped, collected, and threw away. `check=True` builds the
+    exception with that text attached and never prints it, so a machine that ran out of
+    disk was reported as a deletion sweep that failed.
+
+    These cases hold the sentence to surviving. Not the disk — the disk is the
+    environment's business and charter does not get a vote — but the reader's ability to
+    tell which of the two happened, which is the thing #905 asked for.
+    """
+
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp(prefix="charter-sweep-nobox-")).resolve()
+        self.addCleanup(lambda: __import__("shutil").rmtree(self.tmp, ignore_errors=True))
+        self.repo = self.tmp / "repo"
+        (self.repo / "charter").mkdir(parents=True)
+        (self.repo / "charter" / "m.py").write_text("x = 1\n")
+        env = dict(os.environ, GIT_CONFIG_GLOBAL=os.devnull, GIT_CONFIG_SYSTEM=os.devnull,
+                   GIT_CONFIG_NOSYSTEM="1", GIT_TERMINAL_PROMPT="0")
+
+        def run(*a):
+            subprocess.run(("git", "-c", "core.hooksPath=", "-c", "commit.gpgsign=false")
+                           + a, cwd=self.repo, check=True, env=env, timeout=60,
+                           stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+
+        run("init", "-q", "-b", "main")
+        run("config", "user.email", "sweep@example.invalid")
+        run("config", "user.name", "sweep")
+        run("add", "-A")
+        run("commit", "-qm", "base")
+        self.head = sweep.git("rev-parse", "HEAD", cwd=self.repo).strip()
+
+    def test_a_clone_that_cannot_happen_carries_gits_own_sentence(self):
+        """The failing half of #905, in the one shape a test can force on any machine: a
+        source that is not a repository. The reason differs from CI's — the *losing* of
+        it is what this pins, and every `fatal:` is lost by the same line."""
+        not_a_repo = self.tmp / "not-a-repo"
+        not_a_repo.mkdir()
+        with self.assertRaises(sweep.NoSandbox) as caught:
+            sweep.Sandbox(not_a_repo, self.tmp / "w0", self.head, {})
+        said = str(caught.exception)
+        self.assertIn("fatal", said)                    # git's, not this code's
+        self.assertIn("exited 128", said)
+        self.assertIn(str(self.tmp / "w0"), said)
+        self.assertIn("cloning the tree", said)
+
+    def test_the_failure_says_it_is_the_machine_and_not_a_mutation(self):
+        """The sentence that would have saved the day of diagnosis. A sweep reports about
+        a branch; this one reports about the box, and it happens before any mutation is
+        measured, so nothing in it is a finding about anybody's code."""
+        with self.assertRaises(sweep.NoSandbox) as caught:
+            sweep.Sandbox(self.tmp / "nothing-here", self.tmp / "w0", self.head, {})
+        self.assertIn("not a verdict about any mutation", str(caught.exception))
+
+    def test_a_checkout_that_cannot_happen_names_the_ref_it_wanted(self):
+        """The second `check=True` on the way in, and it swallowed stderr identically. A
+        sandbox at the wrong ref is `NotApplied` for every mutation in the shard — a
+        whole file of guards reported unmeasurable — so which ref was asked for is the
+        first thing the reader needs."""
+        with self.assertRaises(sweep.NoSandbox) as caught:
+            sweep.Sandbox(self.repo, self.tmp / "w1", "no-such-ref", {})
+        said = str(caught.exception)
+        self.assertIn("checking out no-such-ref", said)
+        self.assertIn("fatal", said)
+
+    def test_a_command_that_fails_mutely_says_that_too(self):
+        """`_must` directly, with a stderr this case chooses to the byte, because the two
+        things a git version could vary are the exact wording and the surrounding
+        whitespace. The status is interpolated rather than assumed to be 128, and the
+        text is stripped on both sides: an error message with a newline dropped into the
+        middle of it is the same unreadability one notch quieter.
+        """
+        noisy = [sys.executable, "-c",
+                 "import sys; sys.stderr.write('  boom  \\n'); raise SystemExit(9)"]
+        with self.assertRaises(sweep.NoSandbox) as caught:
+            sweep.Sandbox._must(noisy, self.tmp / "w2", None, "trying it")
+        self.assertIn("exited 9 — boom. That is", str(caught.exception))
+
+        mute = [sys.executable, "-c", "raise SystemExit(7)"]
+        with self.assertRaises(sweep.NoSandbox) as caught:
+            sweep.Sandbox._must(mute, self.tmp / "w2", None, "trying it")
+        self.assertIn("exited 7 without saying why.", str(caught.exception))
+
+    def test_a_command_that_works_is_not_an_error(self):
+        """The other half of the branch, and the reason it is written down: a guard that
+        raises on everything is indistinguishable from this one until something passes
+        through it."""
+        self.assertIsNone(sweep.Sandbox._must([sys.executable, "-c", ""],
+                                              self.tmp / "w3", None, "trying it"))
+
+    def test_the_sandbox_path_no_two_runs_can_share(self):
+        """The refuted hypothesis, kept as a measurement rather than as a paragraph. If
+        `run_dir` ever stopped being per-process — a fixed name, a shared scratch — this
+        would be #894 one directory up, and the failure it produced would look exactly
+        like the environment failure above."""
+        seen = sweep.run_dir(Path("/w"))
+        self.assertEqual(seen, Path("/w") / f"run-{os.getpid()}")
+        self.assertNotEqual(seen, sweep.run_dir(Path("/w")).parent / "run-0")
+
+
 if __name__ == "__main__":      # pragma: no cover
     unittest.main()

--- a/tools/sweep.py
+++ b/tools/sweep.py
@@ -2009,8 +2009,54 @@ class NotApplied(Exception):
     """The mutant tree is not a mutant. See :meth:`Sandbox.apply`."""
 
 
+class NoSandbox(Exception):
+    """The sandbox could not be built, and here is what the machine said.
+
+    A category of its own, and the category is the point. Every other way this tool ends
+    badly is a statement about the branch — a mutation survived, a suite went red, an
+    edit would not apply to the tree it was read from. This one is a statement about the
+    machine, made before a single mutation has been measured, and reading it as the
+    first kind is how #905 cost a day.
+
+    See :meth:`Sandbox._must` for what was actually lost.
+    """
+
+
 class Sandbox:
     """A private clone of the tree. The operator's checkout is never written to."""
+
+    @staticmethod
+    def _must(argv: list[str], where: Path, cwd: Path | None, doing: str) -> None:
+        """Run one setup command, and **keep what git said** when it will not run.
+
+        `check=True` raises a :class:`subprocess.CalledProcessError`, and that exception's
+        `__str__` is the argv and the exit status and nothing else. The stderr it was
+        constructed with is carried on the object and never printed by it. So a command
+        that failed for a stated reason arrives as a command that failed.
+
+        **Measured (#905).** A `git clone … → exit 128` reached CI as exactly that line
+        and no more, from a test that touches no sweep code, on a tree that had passed
+        the same job minutes earlier. Reproduced here against a filesystem with 250 KiB
+        left on it: the traceback is character-for-character the one CI printed, and what
+        git had written — and this code had collected and dropped — was
+        `fatal: failed to create directory '…/objects/82': No space left on device`.
+
+        Nothing about that sentence is charter's doing, which is the other half of why it
+        has to survive. Without it the only reading available is that the deletion sweep
+        is broken; with it, the reader is told the disk filled up and the sweep never got
+        as far as having an opinion.
+        """
+        done = subprocess.run(argv, cwd=None if cwd is None else str(cwd), check=False,
+                              stdout=subprocess.DEVNULL, stderr=subprocess.PIPE)
+        if not done.returncode:
+            return
+        said = done.stderr.decode("utf-8", "replace").strip()
+        raise NoSandbox(
+            f"the sandbox at {where} could not be built — {doing}: "
+            f"`{' '.join(argv)}` exited {done.returncode}"
+            + (f" — {said}" if said else " without saying why") + ". "
+            "That is the machine this sweep is running on, not a verdict about any "
+            "mutation: nothing had been measured yet when it happened.")
 
     def __init__(self, root: Path, where: Path, ref: str, dirty: dict[str, bytes]):
         # Resolved on the way in, once. Everything downstream hangs off this path — the
@@ -2025,12 +2071,10 @@ class Sandbox:
         # read the repository, and a tree with no `.git` costs a dozen errors that have
         # nothing to do with any mutation. `--no-hardlinks` so a sandbox cannot reach back
         # into the objects of the checkout it came from.
-        subprocess.run(["git", "clone", "--quiet", "--no-hardlinks", "--no-checkout",
-                        str(root), str(where)], check=True,
-                       stdout=subprocess.DEVNULL, stderr=subprocess.PIPE)
-        subprocess.run(["git", "checkout", "--quiet", "--detach", ref],
-                       cwd=str(where), check=True,
-                       stdout=subprocess.DEVNULL, stderr=subprocess.PIPE)
+        self._must(["git", "clone", "--quiet", "--no-hardlinks", "--no-checkout",
+                    str(root), str(where)], where, None, "cloning the tree")
+        self._must(["git", "checkout", "--quiet", "--detach", ref], where, where,
+                   f"checking out {ref}")
         for rel, blob in dirty.items():
             target = where / rel
             target.parent.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
Closes #905.

`test_no_shard_at_all_still_means_the_whole_plan` failed on CI with this, and this is the
whole of what it said:

```
subprocess.CalledProcessError: Command '['git', 'clone', '--quiet', '--no-hardlinks',
'--no-checkout', '/tmp/sweep-gate-yfa6_l8t',
'/tmp/sweep-gate-yfa6_l8t/wd/run-2274/w0']' returned non-zero exit status 128.
```

## The mechanism, established

`Sandbox.__init__` ran `git clone` and then `git checkout` with `check=True` **and**
`stderr=subprocess.PIPE`. That pairing looks like care and is the opposite of it:
`CalledProcessError.__str__` is the argv and the exit status and nothing else. The stderr
it is constructed with rides along on the exception object and is never printed by it. A
command that failed *for a stated reason* therefore arrives as a command that failed.

**Reproduced.** A 20 MiB HFS+ RAM disk, filled until 250 KiB were left, `TMPDIR` pointed
at it, the real test method run once:

```
[iter 0] subprocess.CalledProcessError: Command '['git', 'clone', '--quiet',
'--no-hardlinks', '--no-checkout', '/Volumes/i905tiny/sweep-gate-pk3j_o6s',
'/Volumes/i905tiny/sweep-gate-pk3j_o6s/wd/run-6415/w0']' returned non-zero exit status 128.
```

Character-for-character CI's failure, deterministically, on demand. Spying on the
subprocess call to recover the piped stderr shows what this code had collected and thrown
away:

```
fatal: failed to create directory '…/wd/run-7823/w0/.git/objects/82': No space left on device
```

At 400 KiB free it passes; at 300 KiB it passes; at 250 KiB the clone dies; at 150 KiB even
`setUp`'s own `git commit` dies. The cliff is real and narrow, which is exactly the profile
of something that fires once in twenty-five CI runs.

## The first hypothesis is refuted, not merely unconfirmed

#905 and its reviewer both pointed at #893/#894 — many writers publishing through a
**shared temp name**, `os.replace` atomic but the name not private — and a fixed
`/tmp/sweep-gate-…` under concurrency is that shape one directory up. It is not that, and
this is a proof rather than a shrug:

* `tempfile.mkdtemp` creates with `O_EXCL` and **holds** the directory for the life of the
  test, so no other process is ever handed that name;
* the sweep's workdir is `…/wd`, inside it;
* `run_dir` puts `run-{os.getpid()}` under that.

Two concurrent invocations cannot select the same sandbox path. Measured as well as
argued — **1600 runs of the failing test across 16 concurrent processes, 1600 passes**,
before the change and again after it. Concurrency is not the variable.

## The fix

Both calls go through `Sandbox._must`, which raises `NoSandbox` — its own category,
because every other way this tool ends badly is a statement about the *branch* and this
one is a statement about the *machine*, made before a single mutation has been measured:

```
tools.sweep.NoSandbox: the sandbox at /Volumes/i905tiny/…/w0 could not be built —
cloning the tree: `git clone --quiet --no-hardlinks --no-checkout /Volumes/i905tiny/…
/Volumes/i905tiny/…/w0` exited 128 — fatal: failed to create directory
'…/w0/.git/objects/ad': No space left on device. That is the machine this sweep is
running on, not a verdict about any mutation: nothing had been measured yet when it
happened.
```

Same failure, same disk, same exit code — now legible on the first read.

**No skip, no retry loop, no broadened `except`.** A full disk is the environment's
business and charter does not get a vote on it. Telling a full disk apart from a broken
deletion sweep is charter's business entirely, and it is the only thing changed here. If
the next occurrence turns out to be inodes, or a fork that would not, or something nobody
has thought of, it names itself on the first run instead of costing a day.

## Tests

`ASandboxThatCannotBeBuiltSaysWhatTheMachineSaid`, six cases: the clone leg and the
checkout leg each carrying git's own `fatal:` and the exit status; the sentence saying it
is the machine and not a mutation; a command that fails **mutely** saying that too (a
stderr chosen to the byte, so the strip on both sides and the interpolated status are
pinned rather than assumed to be `128`); a command that succeeds not being an error; and
the refuted collision hypothesis kept as a measurement of `run_dir` rather than as a
paragraph — if that ever stopped being per-process it would be #894 one directory up, and
it would look exactly like the environment failure above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Us4MbwkSCJCxwt1CjAd1sf
