### PR TITLE
The second tmux client is waited for, instead of the first one being counted twice (#910)

### DIFF
--- a/docs/news/unreleased-the-second-tmux-client-is-waited-for-rather-than-assumed.md
+++ b/docs/news/unreleased-the-second-tmux-client-is-waited-for-rather-than-assumed.md
@@ -1,0 +1,94 @@
+---
+version: unreleased
+headline: the open-or-focus test waits for the second tmux client to arrive instead of for the first one to still be there, and the module stops claiming CI has no tmux
+---
+
+`test_a_second_launch_focuses_instead_of_dragging.TwoPlanesOnOneMachine` went red once on
+`test (3.13)` and green on the re-run — `AssertionError: 1 != 2` counting tmux clients
+(#910). The property under test was never in doubt. The wait before the measurement was.
+
+## A wait for something already true is not a wait
+
+`_attach` starts a client with `pty.fork()` and then waits for it. The question it asked
+was *is there any client at all*:
+
+```python
+_await(lambda: _tmux("list-clients", "-t", SHARED,
+                     "-F", "#{client_name}").stdout.strip() != "")
+```
+
+That is the right question exactly once. On the first attach the list starts empty, so any
+client is the new one. `test_a_second_client_attaching_by_session_id_does_not_move_the_first`
+is the only test in the module that attaches **twice**, and on the second call the first
+client is still attached — so the predicate is already true when `_await` is entered, and
+the wait ends on its opening poll, before the forked child has exec'd `tmux`.
+
+**Counted rather than argued.** Instrumenting the predicate: the first attach runs it
+**twice** (empty, sleep 50ms, present). The second runs it **once**, every time.
+
+## The margin was under five milliseconds
+
+Between that opening poll and `len(self._clients())` there is exactly one thing: another
+`tmux list-clients` subprocess, about 5ms. That is the entire safety margin, and it is
+made of nothing but incidental subprocess overhead.
+
+Measured by injecting the delay a loaded runner supplies for free — the forked child sleeps
+before `os.execvp`, modelling a child that was descheduled:
+
+```
+child delay   old predicate            new predicate
+    0 ms      0/10 saw 1 client        0/30
+    5 ms     10/10                     0/30
+   10 ms      9/10                     0/30
+   20 ms     10/10                     0/30
+   50 ms     10/10                     0/30
+```
+
+Five milliseconds of lateness in the child is enough to turn it from green to *always*
+red. That is the whole of what stood between this assertion and the CI failure it produced.
+
+**It would not reproduce on its own here, and that is worth stating plainly.** 200 runs of
+the affected test on an idle 14-core machine: **0 failures**. 20 more under 48-way CPU load:
+0, because load slows the observing subprocesses just as much as it slows the child, so it
+widens nothing. A two-core shared runner losing 5ms in a fork is a likelier thing than this
+machine reproducing it, which is why one CI red and no local one is exactly the shape this
+defect should have. The mechanism is established by the poll counts and the injection, not
+by a local red.
+
+## What it waits for now
+
+The set of clients is taken **before** the fork, and the wait is for one that is not in it.
+The second attach now waits as long as the first, and the assertion measures a settled
+server. No sleep was lengthened; a longer sleep would have made this rarer and no less real.
+
+It is a set difference rather than `len(now) > len(before)` for two reasons. A count cannot
+tell an arrival from a departure-and-arrival. And the count had quietly killed something
+else:
+
+**`_TERM_CANDIDATES` had stopped being a fallback.** `_attach` tries `xterm-256color`,
+`screen`, `vt100` in turn, and advances only when `_await` returns **False**. Under *any
+client* it could never return False after the first attach — so on every later attach a
+TERM tmux refused was reported as a successful one, with a dead child's file descriptor
+handed back. Waiting for a client that actually arrived restores the fallback, and costs
+nothing on a machine where the first candidate works, which is every machine where the
+first attach succeeded at all.
+
+## The half of it CI can decide
+
+A real-tmux test can only ever catch this *probabilistically* — both predicates come true a
+few milliseconds later, so a red needs the runner to lose a race it usually wins. The
+predicate itself is not a timing question. `TheAttachWaitAsksAboutTheClientItStarted` asks
+it as four fixed client lists, with one right answer on every machine and no server to
+attach to. The first case is the #910 state exactly: a client that was already there does
+not count as the new one.
+
+## And the module stops saying CI has no tmux
+
+The docstring closed with the claim that this class is skipped *"where the machine has none
+— which per §2.12 is every CI job charter has"*. It is not. `.github/workflows/test.yml`
+installs no tmux, but `ubuntu-latest` ships one, so `TwoPlanesOnOneMachine` runs on every
+`test (3.x)` job — which the #910 traceback proves, since it has a line number in it.
+
+0.55.0's news had already measured and published this correction against the design's
+§2.12. It did not reach this module, and a module written as if CI could only ever skip it
+is a module whose timing bugs get found by CI instead of by its author. That is twice now.

--- a/docs/news/unreleased-the-second-tmux-client-is-waited-for-rather-than-assumed.md
+++ b/docs/news/unreleased-the-second-tmux-client-is-waited-for-rather-than-assumed.md
@@ -82,6 +82,26 @@ it as four fixed client lists, with one right answer on every machine and no ser
 attach to. The first case is the #910 state exactly: a client that was already there does
 not count as the new one.
 
+## What the sweep found, hand-run
+
+The diff is tests-only and the deletion sweep charges `charter/`, so CI reported **nothing
+to sweep**. Hand-run against the two lines that carry the logic, by `file:line` rather than
+by description — the file holds several similar-looking client-list expressions:
+
+* `tests/…_dragging.py:469`, `_arrived`'s body — seven mutations (operands swapped,
+  negated, `-`→`&`, `-`→`|`, always-true, always-false, and *the #910 predicate itself*,
+  `bool(set(now))`). **All seven killed.**
+* `tests/…_dragging.py:539`, `before = set(self._clients())` — **one survivor on the first
+  pass**, `before = set()`. That is #910 put back at the call site instead of in the
+  predicate: `_arrived` stays correct and cannot see it, and the real-tmux test can only
+  catch it by losing the same 5ms race that made #910 a once-per-CI-run red.
+
+A survivor there is the defect itself sitting unguarded, so it was killed rather than
+pinned. `TheAttachHelperWaitsOnTheSetItTookBeforeForking` runs the real `_attach` against a
+scripted client list — `pty.fork` forking nothing, `_reap_pty` killing nothing, `_await`
+giving up in 50ms — and pins the refusal property. Both mutations of `:539` die on it.
+**Zero survivors.**
+
 ## And the module stops saying CI has no tmux
 
 The docstring closed with the claim that this class is skipped *"where the machine has none

--- a/tests/test_a_second_launch_focuses_instead_of_dragging.py
+++ b/tests/test_a_second_launch_focuses_instead_of_dragging.py
@@ -19,7 +19,13 @@ are minted by the server and cannot be two planes' at once.
 `TwoPlanesOnOneMachine` is the test §7 asks for and the only one here that can fail for
 §3.3's reason: a single plane cannot be confused with anybody, so a single-plane test is
 structurally blind to it. It runs against a REAL tmux and is skipped, never failed, where
-the machine has none — which per §2.12 is every CI job charter has.
+the machine has none.
+
+**Where that is, is not "CI".** §2.12 says CI never runs a real tmux; 0.55.0's news already
+corrected it — `.github/workflows/test.yml` installs no tmux, but `ubuntu-latest` ships one,
+so this class RUNS on every `test (3.x)` job. #910 is the second time that correction was
+paid for: the class went red on `test (3.13)` alone, and a module written as if CI could
+only skip it is a module whose timing bugs are found by CI rather than by its author.
 """
 
 from __future__ import annotations
@@ -441,6 +447,27 @@ def _await(predicate, timeout: float = _DEADLINE) -> bool:
     return predicate()
 
 
+def _arrived(before: set[str], now: list[str]) -> bool:
+    """Is a client in `now` that `before` did not have — the question `_attach` waits on.
+
+    **The question it replaces was "is there ANY client", and that is #910.** On the first
+    attach the two agree, because the list starts empty and any client is the new one. On
+    the SECOND they do not: the first client is still there, so "any client" is already
+    true when `_await` is entered and the wait ends on its opening poll — measured, one
+    poll against the first attach's two — before the new `pty.fork()` has exec'd `tmux`.
+    `test_a_second_client_attaching_by_session_id_does_not_move_the_first` then counted
+    clients on a server the second one had not reached yet, and the only thing standing
+    between that and a red was the ~5ms a `list-clients` subprocess happens to cost.
+
+    Asked as a DIFFERENCE rather than as a count, because a count cannot tell an arrival
+    from a departure-and-arrival, and because it restores something the count had also
+    taken: `_attach`'s `_TERM_CANDIDATES` fallback only advances when `_await` returns
+    False, which under "any client" it could never do after the first attach. A refused
+    TERM was reported as a successful attach, with a dead child's fd handed back.
+    """
+    return bool(set(now) - before)
+
+
 @unittest.skipUnless(_HAS_TMUX, "no tmux on this machine")
 class TwoPlanesOnOneMachine(unittest.TestCase):
     """§7's acceptance shape, reduced to the one question this stage decides.
@@ -500,9 +527,15 @@ class TwoPlanesOnOneMachine(unittest.TestCase):
                 pass
 
     def _attach(self):
-        """A real client on `SHARED`, or a skip naming what tmux refused."""
+        """A real client on `SHARED`, or a skip naming what tmux refused.
+
+        The wait is for the client THIS call started — `_arrived` against the set that was
+        there before the fork — so the second attach waits as long as the first does
+        instead of returning on a precondition the first attach already made true (#910).
+        """
         refusals = []
         for term in _TERM_CANDIDATES:
+            before = set(self._clients())
             pid, fd = pty.fork()
             if pid == 0:
                 try:
@@ -510,8 +543,7 @@ class TwoPlanesOnOneMachine(unittest.TestCase):
                     os.execvp("tmux", ["tmux", "-L", SOCKET, "attach", "-t", SHARED])
                 finally:
                     os._exit(127)
-            if _await(lambda: _tmux("list-clients", "-t", SHARED,
-                                    "-F", "#{client_name}").stdout.strip() != ""):
+            if _await(lambda: _arrived(before, self._clients())):
                 self.addCleanup(self._reap_pty, pid, fd)
                 return fd
             refusals.append(f"TERM={term}")
@@ -707,6 +739,39 @@ class ALaunchThatIsNotTheTerminalNeverFocuses(PersonaIso, unittest.TestCase):
             commands_frame.cmd_launch(args)
         self.assertEqual(fake.asked("attach"), 1)
         self.assertEqual(fake.asked("new-window"), 0)
+
+
+class TheAttachWaitAsksAboutTheClientItStarted(unittest.TestCase):
+    """#910, as data rather than as timing — and this is the half of it CI can decide.
+
+    `TwoPlanesOnOneMachine` needs a real tmux and, needing one, can only ever catch this
+    wait *probabilistically*: the bad predicate and the good one both end up true a few
+    milliseconds later, so a red depends on the runner losing a race it usually wins. Once
+    in a fail-fast CI run is what that looked like. The predicate itself is not a timing
+    question at all, and asked here as three fixed client lists it has one right answer
+    every time, on every machine, with no server to attach to.
+    """
+
+    def test_a_client_that_was_already_there_does_not_count_as_the_new_one(self):
+        """The #910 state exactly: the first client is still attached when the second
+        `_attach` starts waiting, and waiting for it to be there is waiting for nothing."""
+        self.assertFalse(_arrived({"/dev/ttys001"}, ["/dev/ttys001"]))
+
+    def test_the_client_that_just_arrived_counts(self):
+        self.assertTrue(_arrived({"/dev/ttys001"}, ["/dev/ttys001", "/dev/ttys002"]))
+
+    def test_the_first_attach_is_the_same_question(self):
+        """Nothing was there, so any client is the new one — which is why the old
+        predicate was right once and wrong every time after."""
+        self.assertFalse(_arrived(set(), []))
+        self.assertTrue(_arrived(set(), ["/dev/ttys001"]))
+
+    def test_a_client_leaving_is_not_a_client_arriving(self):
+        """Why it is a set difference and not `len(now) > len(before)`: a count cannot
+        tell a departure-and-arrival from neither, and both leave the total unmoved."""
+        self.assertFalse(_arrived({"/dev/ttys001", "/dev/ttys002"}, ["/dev/ttys001"]))
+        self.assertTrue(_arrived({"/dev/ttys001", "/dev/ttys002"},
+                                 ["/dev/ttys001", "/dev/ttys003"]))
 
 
 if __name__ == "__main__":

--- a/tests/test_a_second_launch_focuses_instead_of_dragging.py
+++ b/tests/test_a_second_launch_focuses_instead_of_dragging.py
@@ -36,6 +36,7 @@ import os
 import pty
 import shutil
 import subprocess
+import sys
 import tempfile
 import time
 import unittest
@@ -772,6 +773,57 @@ class TheAttachWaitAsksAboutTheClientItStarted(unittest.TestCase):
         self.assertFalse(_arrived({"/dev/ttys001", "/dev/ttys002"}, ["/dev/ttys001"]))
         self.assertTrue(_arrived({"/dev/ttys001", "/dev/ttys002"},
                                  ["/dev/ttys001", "/dev/ttys003"]))
+
+
+class TheAttachHelperWaitsOnTheSetItTookBeforeForking(unittest.TestCase):
+    """`_attach` itself, with no tmux and no fork — the half `_arrived` cannot pin alone.
+
+    A correct predicate handed the wrong `before` is the same defect one line over, and
+    `TwoPlanesOnOneMachine` can only catch that by losing a race. So `_attach` is run here
+    against a scripted client list: `pty.fork` patched to fork nothing, `_reap_pty` to kill
+    nothing — nothing here may send a signal to a pid this process did not make — and
+    `_await` to give up in 50ms rather than `_DEADLINE`'s 20 seconds.
+
+    The property is the one the old predicate had quietly repealed: **an attach that never
+    produces a client is a refusal, not a success.** With `before` taken after the fork, or
+    not taken at all, the client already on the server answers for the one that never came.
+    """
+
+    def _run_attach(self, lists):
+        """`_attach` against `lists` — one client list per `_clients()` call, last repeating."""
+        case = TwoPlanesOnOneMachine("test_the_plane_that_opened_it_focuses_it")
+        seen = list(lists)
+        case._clients = lambda: seen.pop(0) if len(seen) > 1 else seen[0]
+        case._reap_pty = lambda pid, fd: None
+        module = sys.modules[TwoPlanesOnOneMachine.__module__]
+        # Bound to the function OBJECT, not to the module name `_await` is about to stop
+        # meaning — the name would resolve back to the patch and recurse until the stack
+        # ran out, which is what it did the first time this was written.
+        waiting = _await
+        with mock.patch.object(pty, "fork", return_value=(4321, 9)), \
+             mock.patch.object(module, "_await",
+                               lambda pred, timeout=None: waiting(pred, 0.05)):
+            return case._attach()
+
+    def test_a_client_list_that_never_grows_is_a_refusal(self):
+        """The first client is there throughout and no second one ever arrives. Every TERM
+        candidate is tried and the helper skips, naming them — which is only reachable
+        because `_await` can still return False after the first attach."""
+        with self.assertRaises(unittest.SkipTest) as raised:
+            self._run_attach([["/dev/ttys001"]])
+        for term in _TERM_CANDIDATES:
+            self.assertIn(f"TERM={term}", str(raised.exception))
+
+    def test_the_client_that_arrives_is_the_one_it_returns_on(self):
+        """The control: the same list, plus an arrival. Without it the test above is
+        satisfied by a helper that can only ever skip."""
+        self.assertEqual(
+            self._run_attach([["/dev/ttys001"],
+                              ["/dev/ttys001", "/dev/ttys002"]]), 9)
+
+    def test_an_empty_server_still_attaches(self):
+        """The first attach, unchanged by any of this."""
+        self.assertEqual(self._run_attach([[], ["/dev/ttys001"]]), 9)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
`TwoPlanesOnOneMachine` went red once on `test (3.13)` and green on the re-run —
`AssertionError: 1 != 2` counting tmux clients. Filed as #910 from that one red.

## The mechanism, confirmed rather than assumed

The issue's reading is right, and it is provable by counting rather than by argument.

`_attach` waits for its client with `_await`, and the predicate was *is there any client at
all*. `_await` calls its predicate **before** its first sleep, so on the second `_attach` —
the first client still being attached — it returns on the opening poll, before the new
`pty.fork()` has exec'd `tmux`.

Instrumented, on a real server:

```
attach#1: 2 poll(s) -> 1 client(s)     # empty, sleep 50ms, present: a real wait
attach#2: 1 poll(s) -> 2 client(s)     # already true; waits for nothing
```

Three runs, identical every time. `test_a_second_client_attaching_by_session_id_does_not_move_the_first`
is the only test in the module that attaches twice, which is why it is the only one that flakes.

## The margin is under five milliseconds

Between that opening poll and `len(self._clients())` there is exactly one `tmux list-clients`
subprocess — about 5ms of incidental overhead, and that is the entire safety margin.

Measured by injecting the lateness a loaded runner supplies for free (the forked child
sleeps before `os.execvp`, modelling a descheduled child):

| child delay | old predicate | new predicate |
|---|---|---|
| 0 ms | 0/10 saw 1 client | 0/30 |
| 5 ms | **10/10** | 0/30 |
| 10 ms | **9/10** | 0/30 |
| 20 ms | **10/10** | 0/30 |
| 50 ms | **10/10** | 0/30 |

5ms of lateness flips it from never-red to always-red.

## It did not reproduce naturally here, and that is stated plainly

* **200 runs** of the affected test, idle 14-core machine: **0 failures**.
* **20 runs** under 48-way CPU load: **0 failures** — load slows the observing subprocesses
  as much as the child, so it widens nothing. That is also why a longer sleep would not have
  been a fix.

A two-core shared runner losing 5ms in a fork is likelier than this machine reproducing it.
The mechanism rests on the poll counts and the injection, not on a local red.

## The fix

The client set is taken **before** the fork; the wait is for one that is not in it. The
second attach now waits as long as the first does. No sleep was lengthened, nothing is
retried, nothing is skipped.

A set difference rather than `len(now) > len(before)` for two reasons — a count cannot tell
an arrival from a departure-and-arrival, and:

**`_TERM_CANDIDATES` had silently stopped being a fallback.** It advances only when `_await`
returns **False**, which under *any client* it could never do after the first attach. So on
every later attach a TERM tmux refused was reported as success, with a dead child's fd
handed back. Waiting for a client that actually arrived restores it, at no cost where the
first candidate works — which is every machine where the first attach succeeded at all.

## The half of it CI can decide deterministically

A real-tmux test catches this only probabilistically. `TheAttachWaitAsksAboutTheClientItStarted`
asks the predicate as four fixed client lists — one right answer on every machine, with no
server to attach to. Its first case is the #910 state exactly.

## The module stops claiming CI has no tmux

The docstring said this class is skipped *"where the machine has none — which per §2.12 is
every CI job charter has"*. It is not: the workflow installs no tmux but `ubuntu-latest`
ships one, which the #910 traceback proves by having a line number in it. 0.55.0's news had
already measured and published that correction against §2.12; it never reached this module.
That is twice this has been paid for.

## Verification

`python3 -m unittest discover -s tests -q` → `Ran 11568 tests in 634.853s` / `OK (skipped=9)`.

Closes #910

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Us4MbwkSCJCxwt1CjAd1sf
