### PR TITLE
0.58.0 — a dragged tab strip keeps its height and leads with your working set

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "charter",
   "description": "Personas, workspaces and memory for coding agents across many repos \u2014 Claude Code, opencode and Codex",
-  "version": "0.57.0",
+  "version": "0.58.0",
   "author": {
     "name": "Aaron Yordanyan"
   },

--- a/charter/__init__.py
+++ b/charter/__init__.py
@@ -7,4 +7,4 @@ Run it as ``python3 -m charter`` (from the control plane root) or via the
 installed ``charter`` console script.
 """
 
-__version__ = "0.57.0"
+__version__ = "0.58.0"

--- a/docs/news/0.58.0-a-quoted-news-headline-is-refused-not-published.md
+++ b/docs/news/0.58.0-a-quoted-news-headline-is-refused-not-published.md
@@ -1,5 +1,5 @@
 ---
-version: unreleased
+version: 0.58.0
 headline: A news headline wrapped in quotes is refused at the release gate, instead of publishing its quotes inside the heading
 ---
 

--- a/docs/news/0.58.0-a-sweep-sandbox-that-cannot-be-built-says-what-the-machine-said.md
+++ b/docs/news/0.58.0-a-sweep-sandbox-that-cannot-be-built-says-what-the-machine-said.md
@@ -1,5 +1,5 @@
 ---
-version: unreleased
+version: 0.58.0
 headline: a sweep sandbox that cannot be built now quotes what the machine said, instead of reporting a full disk as a failed deletion sweep
 ---
 

--- a/docs/news/0.58.0-the-readme-pictures-are-taken-again.md
+++ b/docs/news/0.58.0-the-readme-pictures-are-taken-again.md
@@ -1,5 +1,5 @@
 ---
-version: unreleased
+version: 0.58.0
 headline: the frame in the README is a picture of the strip charter draws today, and all four captures are stamped at the version they were taken at
 ---
 

--- a/docs/news/0.58.0-the-second-tmux-client-is-waited-for-rather-than-assumed.md
+++ b/docs/news/0.58.0-the-second-tmux-client-is-waited-for-rather-than-assumed.md
@@ -1,5 +1,5 @@
 ---
-version: unreleased
+version: 0.58.0
 headline: the open-or-focus test waits for the second tmux client to arrive instead of for the first one to still be there, and the module stops claiming CI has no tmux
 ---
 

--- a/docs/news/0.58.0-the-tab-strips-keep-a-drag-lead-with-your-work-and-get-out-of-the-way.md
+++ b/docs/news/0.58.0-the-tab-strips-keep-a-drag-lead-with-your-work-and-get-out-of-the-way.md
@@ -1,6 +1,7 @@
 ---
-version: unreleased
+version: 0.58.0
 headline: dragging a tab strip taller now sticks, the workspace tabs lead with the workspaces you have been in, the active tab gets an edge, and the strip spends five cells between tabs where it spent eight
+lead: true
 ---
 
 Four changes to the tab strips, reported together from a running plane and made together

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -14,7 +14,7 @@
           },
           {
             "type": "command",
-            "command": "charter hook sessionstart --plugin-version 0.57.0",
+            "command": "charter hook sessionstart --plugin-version 0.58.0",
             "timeout": 5
           },
           {
@@ -35,7 +35,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook userpromptsubmit --plugin-version 0.57.0",
+            "command": "charter hook userpromptsubmit --plugin-version 0.58.0",
             "timeout": 5
           }
         ]
@@ -47,7 +47,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse --plugin-version 0.57.0",
+            "command": "charter hook pretooluse --plugin-version 0.58.0",
             "timeout": 10
           }
         ]
@@ -57,7 +57,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse-read --plugin-version 0.57.0",
+            "command": "charter hook pretooluse-read --plugin-version 0.58.0",
             "timeout": 5
           }
         ]
@@ -67,7 +67,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse-dispatch --plugin-version 0.57.0"
+            "command": "charter hook pretooluse-dispatch --plugin-version 0.58.0"
           }
         ]
       },
@@ -76,7 +76,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse-edit --plugin-version 0.57.0",
+            "command": "charter hook pretooluse-edit --plugin-version 0.58.0",
             "timeout": 5
           }
         ]
@@ -88,7 +88,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse-bash --plugin-version 0.57.0",
+            "command": "charter hook posttooluse-bash --plugin-version 0.58.0",
             "timeout": 5
           }
         ]
@@ -98,7 +98,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse --plugin-version 0.57.0",
+            "command": "charter hook posttooluse --plugin-version 0.58.0",
             "timeout": 5
           }
         ]
@@ -108,7 +108,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse-skill --plugin-version 0.57.0",
+            "command": "charter hook posttooluse-skill --plugin-version 0.58.0",
             "timeout": 5
           }
         ]
@@ -118,7 +118,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse-dispatch --plugin-version 0.57.0",
+            "command": "charter hook posttooluse-dispatch --plugin-version 0.58.0",
             "timeout": 5
           }
         ]
@@ -128,7 +128,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse-message --plugin-version 0.57.0",
+            "command": "charter hook posttooluse-message --plugin-version 0.58.0",
             "timeout": 5
           }
         ]
@@ -139,7 +139,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook stop --plugin-version 0.57.0",
+            "command": "charter hook stop --plugin-version 0.58.0",
             "timeout": 5
           },
           {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "charter-cp"
-version = "0.57.0"
+version = "0.58.0"
 description = "Personas, workspaces and memory for coding agents across many repos — Claude Code, opencode and Codex"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Cuts 0.58.0. Minor, because the tab strips change alters what the strip draws by default.

## The four version sites move together

`pyproject.toml`, `charter/__init__.py`, `.claude-plugin/plugin.json`, and all **12**
`--plugin-version` flags in `hooks/hooks.json` — count re-grepped rather than taken from a
doc, and `grep 0.57.0` across the four comes back empty.
`tests/test_plugin.py::TestVersionsMoveInLockstep` passes.

## Five entries, stamped

`charter news stamp 0.58.0` renamed all five and rewrote each `version:`; no
`unreleased-*.md` remains. `charter news --for 0.58.0` exits 0 — the same call the
pre-publish guard and the Release body both use.

`lead: true` goes on the tab strips entry, and it is the only entry that claims it. It is
the one operator-visible change of the five, and the one an operator reported; the other
four are a test fix, a CI diagnostic, a docs capture refresh, and the release gate that
landed this session. Rendered order:

1. **(lead)** dragging a tab strip taller now sticks, the workspace tabs lead with the workspaces you have been in, the active tab gets an edge, and the strip spends five cells between tabs where it spent eight
2. A news headline wrapped in quotes is refused at the release gate, instead of publishing its quotes inside the heading
3. a sweep sandbox that cannot be built now quotes what the machine said, instead of reporting a full disk as a failed deletion sweep
4. the frame in the README is a picture of the strip charter draws today, and all four captures are stamped at the version they were taken at
5. the open-or-focus test waits for the second tmux client to arrive instead of for the first one to still be there, and the module stops claiming CI has no tmux

## Gates checked rather than assumed

**Body budget.** Measured on the **whole** body — `"\n\n".join(_part(e) for e in
for_version("0.58.0"))` — not on `render_body`'s return, which elides and so can never
exceed the budget by construction. 26,622 encoded bytes against a `_BODY_BUDGET` of
122,000: 22% used, and `render_body` returns the whole body unelided.

**Quoted headlines.** #902's gate passes on all five. The one `headline: '…'` line that
looks like a violation is inside a fenced block in the quoted-headline entry's own body,
demonstrating the bug it fixes — `persona.parse` splits frontmatter from body, so it is
never read as a field.

**Asset freshness.** All four captures are stamped `0.57.0` from #907, which is one minor
behind and passes at 0.58.0. Nothing regenerated.

**Every merged PR has an entry.** The five PRs since `v0.57.0` — #904, #907, #909, #908,
#911 — map one-to-one onto the five entries. The two other commits are `charter save` of
persona memory and carry no user-visible change.

`python3 -m unittest discover -s tests` passes locally on this tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Us4MbwkSCJCxwt1CjAd1sf
