### PR TITLE
A plane declares a format version a reader can refuse, and charter stops rather than guesses (#913)

### DIFF
--- a/charter/cli.py
+++ b/charter/cli.py
@@ -1908,6 +1908,20 @@ def _bare_launch(argv: list[str]) -> tuple[list[str], int | None]:
         return argv, None
     from . import config
 
+    # *The plane's format version is one charter cannot place.* Reported here for the same
+    # reason the refused-default arm below is: a plane charter has refused declares nothing
+    # charter can read, `[harness] default` included — `config.HARNESS` derives from the
+    # empty config every time — so falling through hands the operator argparse's usage
+    # message, byte-identical to what a plane that declared no default gets. Bare `charter`
+    # would then look like a plane with no harness rather than one charter refused. The
+    # gate in `main` cannot cover this: it reads the typed subcommand, and a bare argv has
+    # none. Both call the same :func:`_plane_refusal`, so there is one message and one
+    # exemption rule between them.
+    refusal = _plane_refusal(None)
+    if refusal:
+        util.err(refusal)
+        return argv, 1
+
     declared = config.HARNESS
     # Truthiness, not `is not None`, and the same test `doctor` makes of the same key.
     # `contain.readable` never returns a blank string, so on anything `harness_of` produced
@@ -1963,6 +1977,25 @@ def _bare_launch(argv: list[str]) -> tuple[list[str], int | None]:
 _DESPITE_REFUSAL = frozenset({"doctor", "update", "version", "_version-check"})
 
 
+def _plane_refusal(typed: str | None) -> str | None:
+    """What to print instead of running *typed*, or ``None`` to carry on.
+
+    One function for the two callers — `_bare_launch` (which has no subcommand to pass) and
+    the gate in :func:`main` (which passes the typed token) — so the message and the
+    exemption rule cannot come to differ between the bare form and the typed one.
+
+    ``None`` is never exempt, and that is deliberate rather than incidental: it is what a
+    bare ``charter`` passes, and opening a frame over a plane charter cannot place is the
+    most expensive guess available to it.
+    """
+    from . import config
+    refusal = config.PLANE_REFUSAL
+    if not refusal or typed in _DESPITE_REFUSAL:
+        return None
+    return (f"{refusal} Nothing was run. `charter doctor` reports it; "
+            f"`charter update` is the way out.")
+
+
 def main(argv=None) -> int:
     argv = list(sys.argv[1:] if argv is None else argv)
     # First, so what it returns is then hoisted, split and parsed exactly as the same
@@ -1981,16 +2014,24 @@ def main(argv=None) -> int:
         # gap signal needs catching here rather than a third `except` down there.
         _hint_gap_if_unknown_command(parser, argv)
         raise
-    # The refusal, and it is read HERE for two reasons. It is after `parse_args`, so charter
-    # has understood the command before declining it and `--version`/`--help` have already
-    # exited from inside argparse. And it is before the two rewrites below: `secret exec`
-    # overwrites `args.command` with the command line to run, so the subcommand's own name
-    # is only readable on this side of that line.
-    from . import config as _config
-    refusal = _config.PLANE_REFUSAL
-    if refusal and args.command not in _DESPITE_REFUSAL:
-        util.err(f"{refusal} Nothing was run. `charter doctor` reports it; "
-                 f"`charter update` is the way out.")
+    # The refusal, and both halves of where it sits are load-bearing.
+    #
+    # *After `parse_args`*, so charter has understood the command before declining it and,
+    # more to the point, so `--version` and `--help` are already gone: both are argparse
+    # actions that exit from inside `parse_args`, which is what keeps them working on a
+    # plane charter will not otherwise touch. A gate above this line would have to
+    # re-implement that, and would refuse the two questions an operator asks first.
+    #
+    # *Reading `argv[0]` and not `args.command`.* They agree for almost every command and
+    # then do not: `charter secret exec` gives its own positional the dest `command`
+    # (`_sa_exec`), so argparse overwrites the subparser name with the child command line
+    # and `args.command` is a LIST there — unhashable, and a `not in` against a frozenset
+    # raises rather than refuses. `argv[0]` is the token the operator typed, `_bare_launch`
+    # has already rewritten a bare `charter` into it, and the root parser carries no flag
+    # that survives to this line, so it is the subcommand every time.
+    refusal = _plane_refusal(argv[0] if argv else None)
+    if refusal:
+        util.err(refusal)
         return 1
     if exec_command is not None:
         args.command = exec_command

--- a/charter/cli.py
+++ b/charter/cli.py
@@ -2029,7 +2029,12 @@ def main(argv=None) -> int:
     # raises rather than refuses. `argv[0]` is the token the operator typed, `_bare_launch`
     # has already rewritten a bare `charter` into it, and the root parser carries no flag
     # that survives to this line, so it is the subcommand every time.
-    refusal = _plane_refusal(argv[0] if argv else None)
+    #
+    # Subscripted with no emptiness guard because `parse_args` has already made one: the
+    # subparsers are `required=True`, so an empty argv exits from inside it and never
+    # arrives here. A guard would be an unreachable branch, which is the shape this
+    # repository deletes.
+    refusal = _plane_refusal(argv[0])
     if refusal:
         util.err(refusal)
         return 1

--- a/charter/cli.py
+++ b/charter/cli.py
@@ -1938,6 +1938,31 @@ def _bare_launch(argv: list[str]) -> tuple[list[str], int | None]:
     return [default, *argv], None
 
 
+#: The commands that still run on a plane charter has refused (`config.PLANE_REFUSAL`).
+#:
+#: Three of them, and each earns its place by being about CHARTER rather than about the
+#: plane's contents: `doctor` is where the refusal is reported, `version`/`_version-check`
+#: answer "which charter is this" — the first question anyone asks on reading the refusal —
+#: and `update` is the only remedy, since nothing but a newer charter can understand a
+#: newer plane. Refusing the remedy would leave a plane with no way out but a hand edit.
+#:
+#: `--version`, `-h` and `--help` need no entry: argparse's own actions exit from inside
+#: `parse_args`, above the gate, so help still works on a plane charter will not operate on.
+#:
+#: **`init` and `reinit` are NOT here.** Both write into the plane, and writing into a
+#: layout you have been told you do not understand is the guess in its most damaging form.
+#:
+#: **Neither is `hook`, and that is the deliberate half.** charter's hooks are the session
+#: briefing and the PreToolUse guard, and on a refused plane the guard is *already* covering
+#: nothing: `forge.registry.known_forges_report` opens `charter.toml` through
+#: `instance.load`, gets the refusal, and returns an empty forge set — a guard that looks
+#: present and denies nothing. Refusing out loud turns a silent fail-open into a visible
+#: one. It costs the session its briefing and not its turn, which is the standing rule for
+#: a charter hook: the exit code below is 1, never `hooks.DENY_EXIT`, so Claude Code shows
+#: the line and carries on.
+_DESPITE_REFUSAL = frozenset({"doctor", "update", "version", "_version-check"})
+
+
 def main(argv=None) -> int:
     argv = list(sys.argv[1:] if argv is None else argv)
     # First, so what it returns is then hoisted, split and parsed exactly as the same
@@ -1956,6 +1981,17 @@ def main(argv=None) -> int:
         # gap signal needs catching here rather than a third `except` down there.
         _hint_gap_if_unknown_command(parser, argv)
         raise
+    # The refusal, and it is read HERE for two reasons. It is after `parse_args`, so charter
+    # has understood the command before declining it and `--version`/`--help` have already
+    # exited from inside argparse. And it is before the two rewrites below: `secret exec`
+    # overwrites `args.command` with the command line to run, so the subcommand's own name
+    # is only readable on this side of that line.
+    from . import config as _config
+    refusal = _config.PLANE_REFUSAL
+    if refusal and args.command not in _DESPITE_REFUSAL:
+        util.err(f"{refusal} Nothing was run. `charter doctor` reports it; "
+                 f"`charter update` is the way out.")
+        return 1
     if exec_command is not None:
         args.command = exec_command
     if frame_rest is not None:

--- a/charter/config.py
+++ b/charter/config.py
@@ -668,11 +668,27 @@ def derive(root: Path, start: Path | None = None) -> dict:
     #: --version``), so a malformed ``charter.toml`` or a too-new schema must never crash
     #: import — ``instance.load`` keeps raising (its own tests pin that); here the failure
     #: is caught and recorded instead of propagated. ``doctor`` surfaces it to the user.
+    #: A plane whose format version this charter cannot place — the message, or ``None``.
+    #:
+    #: **Split out of `CONFIG_ERROR` because the two failures deserve opposite answers.**
+    #: A malformed `charter.toml` is a file the operator can fix, and charter carrying on
+    #: with empty defaults while `doctor` names it is a reasonable trade. A plane declaring
+    #: a format version from the future is not that: every default charter would carry on
+    #: with is a GUESS about a layout it has already been told it does not understand, and
+    #: git's one rule for a program reading a repository it did not write is that it "MUST
+    #: NOT operate" (`instance.SCHEMA`). `cli.main` reads this and declines the command.
+    #:
+    #: `CONFIG_ERROR` is set as well, and deliberately: `doctor`'s ``charter.toml`` row and
+    #: `channel.channel`'s documented fallback both key off it, and neither becomes wrong
+    #: because a second, narrower name now exists beside it.
     try:
         cfg = _instance.load(root)
-        d["CONFIG_ERROR"] = None
-    except Exception as e:            # malformed TOML, schema too new, unreadable file
-        cfg, d["CONFIG_ERROR"] = {}, str(e)
+        d["CONFIG_ERROR"] = d["PLANE_REFUSAL"] = None
+    except _instance.PlaneFormatUnknown as e:      # a format version we cannot place
+        cfg = {}
+        d["CONFIG_ERROR"] = d["PLANE_REFUSAL"] = str(e)
+    except Exception as e:            # malformed TOML, unreadable file
+        cfg, d["CONFIG_ERROR"], d["PLANE_REFUSAL"] = {}, str(e), None
 
     #: The group/org whose repos this control plane tracks — from charter.toml, not baked in.
     d["GROUP"] = _instance.group_of(cfg, GROUP_FALLBACK)

--- a/charter/config.py
+++ b/charter/config.py
@@ -668,9 +668,11 @@ def derive(root: Path, start: Path | None = None) -> dict:
     #: --version``), so a malformed ``charter.toml`` or a too-new schema must never crash
     #: import — ``instance.load`` keeps raising (its own tests pin that); here the failure
     #: is caught and recorded instead of propagated. ``doctor`` surfaces it to the user.
-    #: A plane whose format version this charter cannot place — the message, or ``None``.
     #:
-    #: **Split out of `CONFIG_ERROR` because the two failures deserve opposite answers.**
+    #: **``PLANE_REFUSAL`` is the narrower half, and it is split out because the two
+    #: failures deserve opposite answers.** It carries the message when the plane declares
+    #: a format version this charter cannot place, and ``None`` otherwise.
+    #:
     #: A malformed `charter.toml` is a file the operator can fix, and charter carrying on
     #: with empty defaults while `doctor` names it is a reasonable trade. A plane declaring
     #: a format version from the future is not that: every default charter would carry on

--- a/charter/doctor.py
+++ b/charter/doctor.py
@@ -253,9 +253,17 @@ def check_ssh() -> Result:
 
 
 def check_control_plane_config() -> Result:
-    """``charter.toml`` failed to parse (malformed TOML, or a schema newer than this
-    charter understands). ``config`` swallows the exception so the CLI stays usable
-    (see ``config.CONFIG_ERROR``); this is where a user would look to find out why.
+    """``charter.toml`` failed to parse (malformed TOML, or a format version this charter
+    cannot place). ``config`` swallows the exception so the CLI stays usable (see
+    ``config.CONFIG_ERROR``); this is where a user would look to find out why.
+
+    **The hint differs by which failure it was**, because only one of them is survivable.
+    Malformed TOML is a file the operator edits, and charter carries on with empty defaults
+    while this row names it. A plane declaring a format version from the future is not
+    survivable and charter does not carry on at all (`config.PLANE_REFUSAL`, `cli.main`) —
+    promising a fallback there would describe behaviour that no longer exists. The
+    ``schema`` row carries the detail; this one must simply stop lying about what happens
+    next.
 
     A DIFFERENT, narrower failure lives one level down: the file parses fine but one
     ``[[forge]]`` block doesn't (a typo'd ``kind``, a missing field). ``registry.
@@ -271,8 +279,10 @@ def check_control_plane_config() -> Result:
             "charter.toml",
             FAIL,
             detail=_first_line(_config.CONFIG_ERROR),
-            hint="Fix or remove charter.toml, then re-run. Falling back to empty "
-                 "group/exclude/workspace defaults until it does.",
+            hint=("charter refuses to operate on this plane at all — see the `schema` row. "
+                  "`charter update`, then re-run.") if _config.PLANE_REFUSAL else
+                 ("Fix or remove charter.toml, then re-run. Falling back to empty "
+                  "group/exclude/workspace defaults until it does."),
         )
     # A committed `[plane] worktrees` that points outside the plane is IGNORED rather than
     # honoured (`config.worktrees_root_for`, #339) — and a setting silently ignored is a
@@ -374,11 +384,29 @@ def check_control_plane_schema() -> Result:
     the *detect* half of the same stamp/detect/heal pattern ``workspace reinit`` already
     proves for a single workspace's layout — lifted one level up to the whole control
     plane, healed by ``charter reinit`` — surfaced here so a stale control plane is
-    visible without running ``reinit`` first."""
+    visible without running ``reinit`` first.
+
+    **And, first, the refusal.** This row is named after the number, so it is where anyone
+    who has just read a refused command looks next. Until #913 it reported ``up to date
+    (schema 1)`` over a plane declaring schema 99 — ``drift`` only counts directories, and
+    a plane from the future has all three — so the one row that could have named the
+    declared version said the opposite of the truth. FAIL rather than WARN because every
+    other command now stops outright: a row scoring a hard stop as a warning is a row
+    disagreeing with the tool it reports on."""
     from . import config as _config, instance as _instance
 
     if not _config.HAS_CONTROL_PLANE:
         return Result("schema", OK, detail="no control plane found")
+    if _config.PLANE_REFUSAL:
+        return Result(
+            "schema",
+            FAIL,
+            detail=_first_line(_config.PLANE_REFUSAL),
+            hint="charter refuses to operate on a plane whose format version it cannot "
+                 "place, rather than guess at a layout it has been told it does not "
+                 "understand. `charter update` is the way out; every other command "
+                 "declines until it runs.",
+        )
     found = _instance.drift(_config.ROOT)
     if not found:
         return Result("schema", OK, detail=f"up to date (schema {_instance.SCHEMA})")

--- a/charter/frame/state.py
+++ b/charter/frame/state.py
@@ -149,6 +149,41 @@ _CHAT_ORDINAL_MAX = 10_000
 #: surface for a second caller to reach for.
 _CLAIM_FILE = "launcher"
 
+#: **What `.charter/frame/` promises a program that is not charter: nothing.**
+#:
+#: #913 gave the PLANE a format version a reader can refuse on (`instance.SCHEMA`) and
+#: asked the same question of the frame state underneath it: version it too, or say in
+#: code that it is private. This is the answer, and it is "private", for a reason narrower
+#: than "it is internal" — everything in charter is internal until somebody reads it.
+#:
+#: **A format version buys exactly one thing: the ability to refuse. Refusal is only worth
+#: anything when the writer and the reader can be different charters.** For a plane they
+#: routinely are: `charter.toml`, `personas/`, `inventory/` are committed, shared with a
+#: team, and outlive any install. Nothing here is. Every path under this directory is
+#: written by a frame launcher and read by the panels of the same frame — one process
+#: tree, one machine, one charter, one tmux session — and the residue of any *other* charter
+#: is :func:`reap`'d rather than read, because liveness here is a pid or a tmux window and
+#: both die with the install that made them. A version stamped here could never fire, and
+#: the issue's own rule is that a version nobody refuses on is decoration.
+#:
+#: Two consequences, and they are the whole of the promise:
+#:
+#: * charter may change the shape of anything under `.charter/frame/` in a patch release,
+#:   without bumping `instance.SCHEMA` and without a migration.
+#: * a program reading it has no contract to hold charter to. `charter frame …` is the
+#:   interface; this is the scratch underneath it.
+#:
+#: Stated as a value rather than left in prose so the claim has a name a test can hold and
+#: a future author has somewhere to change it. If frame state ever gains a durable reader
+#: — anything that survives the launcher — this constant is what must change first, and
+#: `tests/test_a_plane_declares_a_format_a_reader_can_refuse.py` is where it is pinned.
+NO_FORMAT_PROMISE = (
+    "`.charter/frame/` is charter's own scratch: per-frame, per-machine, gitignored, "
+    "reaped when the frame dies, and written and read by one charter within one process "
+    "tree. It carries no format version and no promise to any program outside charter. "
+    "Read `charter frame` instead; these files may change shape in any release."
+)
+
 
 def _root() -> Path:
     return Path(config.STATE_DIR) / "frame"

--- a/charter/instance.py
+++ b/charter/instance.py
@@ -17,19 +17,100 @@ from typing import NamedTuple
 from . import contain
 from .root import MARKER
 
-#: Layout version this engine understands.
+#: **The plane format version** — the layout of a control plane, as a single integer, in
+#: the one place a program that did not write the plane can read it: ``schema`` in
+#: ``charter.toml``. ``cmd_init`` stamps it (`commands._render_charter_toml`); :func:`load`
+#: reads it on the way into every command, because `config.derive` opens the plane through
+#: this function and nothing else does.
+#:
+#: **It buys exactly one thing: the ability to refuse.** It is not a schema and it is not a
+#: spec — the shape of `gather.json`, of `workspace.json`, of anything else charter writes
+#: is charter's own business and is documented to nobody. What this number says is what
+#: git's `core.repositoryformatversion` says, and no more: *an implementation that does not
+#: understand the version advertised on disk MUST NOT operate on that plane.* A consumer
+#: with no way to refuse guesses, and guessing is the failure this exists to prevent.
+#:
+#: **How it relates to `workspace.STRUCTURE_VERSION` — nested, and only the outer one
+#: refuses.** A workspace lives inside a plane, so this is the outer of the two numbers,
+#: but it does not subsume the inner one's *value* and is never compared against it:
+#:
+#: * This one is the REFUSAL number. It answers "may this charter operate on this plane at
+#:   all?" and the only answers are yes and no. Nothing heals a refusal but a newer charter.
+#: * `workspace.STRUCTURE_VERSION` is the REPAIR number. It answers "is this one
+#:   workspace's interior current?", and a stale answer is *healed* — flagged on the status
+#:   line, fixed by `charter workspace reinit`. A workspace an older charter can still read
+#:   is exactly what makes that repair additive.
+#:
+#: So a change to a workspace's layout that an older charter SURVIVES is, by definition,
+#: not a change that requires refusal, and it bumps `STRUCTURE_VERSION` alone. Two numbers
+#: can only come to disagree if something compares them; nothing does, and
+#: `tests/test_a_plane_declares_a_format_a_reader_can_refuse.py` is what keeps it that way.
 SCHEMA = 1
 
+#: What an ABSENT ``schema`` key means: **1** — the layout every plane had before planes
+#: declared one. Definite, and true: there has only ever been one plane format, so an
+#: unstamped plane is a version-1 plane and every charter can read it.
+#:
+#: **Deliberately not "whatever this charter is".** That was the old reading
+#: (``cfg.get("schema", SCHEMA)``), and it is the choice that makes the whole feature
+#: useless the first time it is needed: the day :data:`SCHEMA` moves to 2, every unstamped
+#: version-1 plane on disk would start claiming to be a version-2 plane, and a charter that
+#: understands 2 would read a version-1 layout with version-2 rules — the guess, arrived at
+#: through the version number that exists to prevent it.
+#:
+#: The two readings are indistinguishable today, because ``SCHEMA == 1``. That is why the
+#: test that pins this moves :data:`SCHEMA` before it looks.
+UNSTAMPED = 1
 
-class SchemaTooNew(Exception):
+
+class PlaneFormatUnknown(Exception):
+    """This charter cannot vouch for the plane's on-disk format, so it will not operate.
+
+    Raised by :func:`load`, recorded by `config.derive` as ``PLANE_REFUSAL``, reported by
+    `doctor`'s ``schema`` row, and acted on by `cli.main`, which declines to run the
+    command. A warning here would be decoration: a version nobody refuses on is a number.
+    """
+
+
+class SchemaTooNew(PlaneFormatUnknown):
     """The control plane was written by a newer charter than this one."""
+
+
+def plane_version(cfg: dict) -> int | None:
+    """The plane format version *cfg* declares — or ``None`` when it declares one this
+    charter cannot even compare against.
+
+    Three answers, and the third is the point:
+
+    * **absent** → :data:`UNSTAMPED`. See that constant for why it is 1 and not ``SCHEMA``.
+    * **an integer** → itself, whether or not this charter understands it. Reporting it is
+      not accepting it; :func:`load` decides that.
+    * **anything else** → ``None``. ``schema = "2"``, ``schema = 1.5``, ``schema = true``:
+      a plane that declares a version in a spelling this charter cannot read is a plane
+      this charter cannot place, which is the same position as one declaring a version from
+      the future. It used to pass straight through the ``isinstance`` test and be treated
+      as understood.
+
+    ``bool`` is excluded explicitly because ``isinstance(True, int)`` is ``True`` in
+    Python: ``schema = true`` in TOML would otherwise compare as 1 and read as current.
+    """
+    if "schema" not in cfg:
+        return UNSTAMPED
+    found = cfg["schema"]
+    if isinstance(found, bool) or not isinstance(found, int):
+        return None
+    return found
 
 
 def load(root: Path) -> dict:
     """Parse ``<root>/charter.toml``. Returns ``{}`` when there is no such file.
 
-    A *newer* schema raises rather than being read on a best-effort basis: silently
-    misreading a persona or workspace layout is worse than refusing to run.
+    A version this charter does not understand raises rather than being read on a
+    best-effort basis: silently misreading a persona or workspace layout is worse than
+    refusing to run. See :data:`SCHEMA` for what the number is and what it is not.
+
+    ``found > SCHEMA`` and not ``>=``: a plane declaring exactly the version this charter
+    understands is the ordinary case, and refusing it would refuse every plane there is.
     """
     p = Path(root) / MARKER
     try:
@@ -40,8 +121,15 @@ def load(root: Path) -> dict:
         cfg = tomllib.loads(raw.decode("utf-8"))
     except (tomllib.TOMLDecodeError, UnicodeDecodeError) as e:
         raise ValueError(f"{p} is not valid TOML: {e}") from None
-    found = cfg.get("schema", SCHEMA)
-    if isinstance(found, int) and found > SCHEMA:
+    found = plane_version(cfg)
+    if found is None:
+        raise PlaneFormatUnknown(
+            f"{p} declares schema {cfg['schema']!r}, which is not a plane format version "
+            f"this charter can compare against {SCHEMA}. charter will not operate on a "
+            f"plane whose format it cannot place. Fix the `schema` line, or upgrade "
+            f"charter: `uv tool install charter-cp --force --refresh`."
+        )
+    if found > SCHEMA:
         raise SchemaTooNew(
             f"{p} declares schema {found}, but this charter understands {SCHEMA}. "
             f"Upgrade charter: `uv tool install charter-cp --force --refresh`."

--- a/docs/control-plane.md
+++ b/docs/control-plane.md
@@ -528,14 +528,50 @@ update`.
 
 ## Schema drift and healing
 
-`schema` is a stamp, not just a version number: a control plane written by a *newer*
-charter than the one you have installed refuses to load (`charter --version` still
-works; every command that needs the control plane fails with a clear "upgrade charter"
-message) rather than silently misreading a layout it doesn't fully understand. Going the
-other way — an *older* control plane opened by a newer charter — is always fine: newer
-charter versions can add baseline directories (`personas/`, `inventory/`, `workspaces/`)
-a control plane predates, and `charter reinit` creates whatever's missing, additively,
-never touching what's already there.
+`schema` is the plane's **format version**, and the one thing it buys is the ability to
+refuse. It is the same contract git states for a program reading a repository it did not
+write — *"an implementation which does not understand a particular version advertised by
+an on-disk repository MUST NOT operate on that repository"* — and no more than that. It is
+not a schema and not a spec: the shape of the files charter writes is charter's own
+business and is free to change. The commands are the interface.
+
+So a control plane written by a *newer* charter than the one you have installed is not
+operated on. Every command declines with the "upgrade charter" message and exits 1, except
+four, each of which is a question about charter rather than a read of the plane's contents:
+
+| still runs | why |
+|---|---|
+| `charter doctor` | where the refusal is reported — the `schema` row names both versions |
+| `charter --version`, `charter version`, `charter _version-check` | which charter is this |
+| `charter update` | the only remedy; nothing but a newer charter can understand a newer plane |
+
+`charter init` and `charter reinit` are deliberately **not** exempt: writing into a layout
+charter has been told it does not understand is the most damaging guess available to it.
+A `schema` charter cannot compare against at all — `schema = "2"`, `1.5`, `true` — is
+refused on the same terms as one from the future.
+
+**Omitting `schema` means 1**, not "whatever charter you are running". A plane created
+before planes declared a version *is* a version-1 plane, so it stays readable by every
+charter forever; reading it as "current" would be the same guess, arrived at through the
+number that exists to prevent it.
+
+Going the other way — an *older* control plane opened by a newer charter — is always fine:
+newer charter versions can add baseline directories (`personas/`, `inventory/`,
+`workspaces/`) a control plane predates, and `charter reinit` creates whatever's missing,
+additively, never touching what's already there.
+
+**`schema` and a workspace's own structure version are nested, and only `schema` refuses.**
+`charter workspace reinit` repairs a workspace whose interior an older charter laid out;
+that is a *repair* number, and a workspace charter can still read is exactly what makes the
+repair additive. `schema` is the *refusal* number, and nothing heals it but a newer charter.
+The two are never compared against each other.
+
+**`.charter/` carries no such promise, on purpose.** Everything under `.charter/frame/` is
+charter's own scratch — per frame, per machine, gitignored, reaped when the frame dies, and
+written and read by one charter inside one process tree. It has no format version and never
+will: a version is only worth stamping where the writer and the reader can be different
+charters. Read it through `charter frame`; the files themselves may change shape in any
+release.
 
 ## The plane, rendered
 

--- a/docs/news/unreleased-a-plane-declares-a-format-version-a-reader-can-refuse.md
+++ b/docs/news/unreleased-a-plane-declares-a-format-version-a-reader-can-refuse.md
@@ -1,0 +1,114 @@
+---
+version: unreleased
+headline: A plane declares a format version a reader can refuse, and charter stops rather than guesses
+---
+
+charter is about to grow consumers that are not the frame. Today any of them would guess.
+
+The research that led here (`docs/research/2026-09-05-interface-agnostic-cores.md`) went
+looking for what git — charter's closest sibling — actually promises a program reading its
+files directly, and found one sentence:
+
+> An implementation of git which does not understand a particular version advertised by an
+> on-disk repository **MUST NOT operate on that repository**.
+> — `Documentation/technical/repository-version.adoc`
+
+That is the whole contract. Not a schema and not a spec: a way to know you are out of your
+depth and stop. `gitformat-index(5)` and `gitformat-pack(5)` carry no stability language at
+all, and the loose-ref format is specified only in C — gitoxide shipped subtly wrong refs
+for years because git silently `rtrim`s on read. A consumer with no way to refuse guesses.
+
+## The number already existed. The refusal did not
+
+`charter init` has stamped `schema = 1` into `charter.toml` since the beginning, and
+`instance.load` has raised on a version from the future for just as long. Two things kept
+that from being a refusal:
+
+**`config.derive` caught the exception and carried on.** It recorded the message as
+`CONFIG_ERROR`, set the config to `{}`, and handed every command a plane made of fallback
+defaults — a fallback group, a fallback workspace, an empty forge set. So a plane declaring
+`schema = 99` did not stop charter; it made charter quietly act on a plane it had already
+been told it could not read. The guard was the sharpest case: `known_forges_report` opens
+`charter.toml` through the same `load`, got the refusal, and returned nothing — a
+PreToolUse guard that looks present and denies nothing.
+
+`config.PLANE_REFUSAL` is now recorded apart from `CONFIG_ERROR`, and `cli.main` declines
+the command. Four commands still run, and each is a question about *charter* rather than a
+read of the plane's contents: `doctor` (where the refusal is reported), `version` and
+`_version-check` ("which charter is this?"), and `update` — the only remedy, since nothing
+but a newer charter can understand a newer plane. `--version` and `--help` need no
+exemption: argparse's own actions exit before the gate.
+
+`init` and `reinit` are deliberately not exempt. Writing into a layout you have been told
+you do not understand is the guess at its most damaging.
+
+**An absent stamp meant "whatever this charter is".** `cfg.get("schema", SCHEMA)` — and
+that is the reading which makes the whole feature useless the first time it is needed. The
+day `SCHEMA` moves to 2, every unstamped version-1 plane on disk would start claiming to be
+a version-2 plane, and a charter that understands 2 would read a version-1 layout with
+version-2 rules. The guess, arrived at through the number that exists to prevent it.
+
+Absent now means `UNSTAMPED = 1` — the layout every plane had before planes declared one.
+Definite, and true: there has only ever been one plane format, so every plane created before
+this release is a version-1 plane and stays readable by every charter forever. The two
+readings are indistinguishable today, because `SCHEMA` is 1; the test that pins it moves
+`SCHEMA` before it looks, or it would be pinning nothing.
+
+A `schema` charter cannot compare against at all — `"2"`, `1.5`, `true` — used to fall
+straight through the `isinstance` check and read as understood. It is refused on the same
+terms. `true` is the sharp one: `isinstance(True, int)` is `True` in Python, so without an
+explicit exclusion a plane declaring `schema = true` compares as 1 and reads as current.
+
+## Two numbers, and the rule that keeps them from disagreeing
+
+`workspace.STRUCTURE_VERSION` moved 4 → 5 this week. Adding a second version number beside
+a warm one is how two numbers come to contradict each other, so the relationship is stated
+rather than left to be inferred. They are **nested, and only the outer one refuses**:
+
+- **`instance.SCHEMA` is the refusal number.** May this charter operate on this plane at
+  all? Yes or no, and nothing heals a no but a newer charter.
+- **`workspace.STRUCTURE_VERSION` is the repair number.** Is this one workspace's interior
+  current? A stale answer is flagged on the status line and healed by `charter workspace
+  reinit`. A workspace an older charter can still *read* is exactly what makes that repair
+  additive.
+
+So a workspace-layout change an older charter survives is, by definition, not a change that
+requires refusal, and it moves `STRUCTURE_VERSION` alone. Two numbers can only come to
+disagree if something compares them, and nothing does — pinned in both directions: moving
+`SCHEMA` must not change a workspace's staleness verdict, and moving `STRUCTURE_VERSION`
+must not change the plane's.
+
+## `.charter/frame/` is private, and says so in code
+
+The issue offered two defensible answers — version the frame state too, or state plainly
+that it carries no promise — and asked for one of them rather than the ambiguity.
+
+It is private. Not because it is internal (everything in charter is internal until somebody
+reads it) but because **a format version buys the ability to refuse, and refusal is worth
+something only when the writer and the reader can be different charters.** A plane's files
+are committed, shared with a team and outlive any install. Nothing under `.charter/frame/`
+is: every path there is written by a frame launcher and read by the panels of that same
+frame — one process tree, one machine, one charter — and any residue of another charter is
+reaped rather than read, because liveness there is a pid or a tmux window. A version stamped
+there could never fire, which is the definition of decoration.
+
+`frame.state.NO_FORMAT_PROMISE` is the statement, as a value rather than a comment so a test
+can hold it, and a tripwire keeps any module under `charter/frame/` from quietly gaining a
+format version beside it. Two consequences, and they are the whole promise: charter may
+change the shape of anything under `.charter/frame/` in a patch release with no bump and no
+migration, and a program reading it has no contract to hold charter to. `charter frame` is
+the interface.
+
+## What this is not
+
+Not a schema and not a spec. The shape of `gather.json`, of `workspace.json`, of anything
+else charter writes is documented to nobody and is free to change. git's lesson, which this
+rests on, is that the *format* is truth and the *commands* are interface. This buys exactly
+one thing: a consumer's ability to know it must stop.
+
+## Nothing to adopt
+
+A plane created by an earlier charter has no `schema` line and needs none — absent means 1,
+which is what it is. `charter init` goes on stamping the current version. The refusal fires
+only on a plane written by a charter newer than the one reading it, and the way out of it is
+`charter update`.

--- a/tests/test_a_plane_declares_a_format_a_reader_can_refuse.py
+++ b/tests/test_a_plane_declares_a_format_a_reader_can_refuse.py
@@ -226,6 +226,25 @@ class TheCliDeclinesRatherThanGuesses(PlaneIso):
         self.assertEqual(rc, 0)
         self.assertEqual(self.ran, ["cmd_update"])
 
+    def test_it_is_the_first_token_that_decides_and_not_some_other_one(self):
+        """The gate subscripts `argv`, so which end it reads is the whole of its meaning
+        and every case above is blind to it: `["status"]` and `["doctor"]` are one token
+        long, so `argv[0]` and `argv[-1]` agree on all of them. An exempt command carrying
+        a flag is where they part — `argv[-1]` would see `0.59.0`, find it nowhere in the
+        exempt set, and refuse the one command that is the way out of the refusal."""
+        self.declare_schema(str(instance.SCHEMA + 1))
+        rc, _ = self.run_cli(["update", "--to", "0.59.0"])
+        self.assertEqual(rc, 0)
+        self.assertEqual(self.ran, ["cmd_update"])
+
+    def test_an_exempt_word_in_a_later_position_exempts_nothing(self):
+        """The other direction, because "reads the first token" needs both halves: a
+        refused command must stay refused however its own arguments are spelled."""
+        self.declare_schema(str(instance.SCHEMA + 1))
+        rc, _ = self.run_cli(["status", "--workspace", "doctor"])
+        self.assertEqual(rc, 1)
+        self.assertEqual(self.ran, [])
+
     def test_every_exempt_command_is_about_charter_and_not_about_the_plane(self):
         """The exemptions, one case, by name. Each runs; each is a question about which
         charter this is or how to get a newer one — never a read of the plane's contents."""

--- a/tests/test_a_plane_declares_a_format_a_reader_can_refuse.py
+++ b/tests/test_a_plane_declares_a_format_a_reader_can_refuse.py
@@ -1,0 +1,456 @@
+"""A plane's format version, and the refusal that is the only thing it buys (#913).
+
+`instance.SCHEMA` is stamped into `charter.toml` by `charter init` and read on the way into
+every command by `config.derive`. What #913 added is not the number — that existed — but
+the two properties that make it worth having:
+
+* **a refusal.** A plane declaring a format version this charter cannot place is not
+  operated on. `config.PLANE_REFUSAL` records it, `cli.main` declines the command,
+  `doctor`'s `schema` row reports it. A version nobody refuses on is decoration.
+* **a definite meaning for an absent stamp.** :data:`instance.UNSTAMPED` is 1, not
+  "whatever this charter is" — see the class that pins it for why the difference is the
+  whole feature.
+
+And the relationship to the other number, which is the thing two version numbers most
+easily get wrong: `instance.SCHEMA` refuses, `workspace.STRUCTURE_VERSION` repairs, and
+nothing compares them. `ThePlaneVersionAndTheStructureVersionAreNeverCompared` is the pin.
+"""
+
+from __future__ import annotations
+
+import io
+import unittest
+from contextlib import redirect_stderr
+from unittest import mock
+
+from charter import cli, commands, commands_update, config, doctor, instance, workspace
+from charter.frame import state as frame_state
+
+from tests._isolation import PersonaIso
+
+
+class PlaneIso(PersonaIso):
+    """A tmp plane whose `charter.toml` this case writes, re-derived after every write."""
+
+    def declare(self, body: str) -> None:
+        (self.tmp / "charter.toml").write_text(body)
+        config.use(self.tmp)
+
+    def declare_schema(self, value: str) -> None:
+        self.declare(f"schema = {value}\n")
+
+
+class TheAbsentStampMeansVersionOne(PlaneIso):
+    """A plane created before planes declared a version is a version-1 plane.
+
+    **This is the case that has to move `SCHEMA` to prove anything.** `SCHEMA` is 1 today,
+    so "absent means 1" and the reading it replaced — "absent means whatever this charter
+    is" — agree on every plane in existence. They part company exactly once: on the release
+    that bumps the number, which is the first time the feature is ever needed. A test that
+    read an unstamped plane against the shipped `SCHEMA` would pass under either rule and
+    would therefore be pinning nothing at all.
+    """
+
+    def test_an_unstamped_plane_reads_as_one_however_far_charter_has_moved(self):
+        with mock.patch.object(instance, "SCHEMA", 7):
+            self.assertEqual(instance.plane_version({}), 1)
+
+    def test_absent_is_not_read_as_the_current_version(self):
+        """The negative half, stated on its own: a bumped charter must not adopt an
+        unstamped plane as its own. Doing so reads a version-1 layout with version-7 rules
+        — the guess this whole number exists to prevent, arrived at through the number."""
+        with mock.patch.object(instance, "SCHEMA", 7):
+            self.assertNotEqual(instance.plane_version({}), instance.SCHEMA)
+
+    def test_the_constant_says_one_and_the_reader_uses_it(self):
+        self.assertEqual(instance.UNSTAMPED, 1)
+        with mock.patch.object(instance, "UNSTAMPED", 4):
+            self.assertEqual(instance.plane_version({}), 4)
+
+    def test_an_unstamped_plane_is_loaded_rather_than_refused(self):
+        """Definite is not the same as refused. Every plane on disk older than #913 is
+        unstamped, and refusing them would be a charter that cannot open its own planes."""
+        self.declare('[[forge]]\nkind = "gitlab"\nowner = "acme"\n')
+        self.assertIsNone(config.PLANE_REFUSAL)
+        self.assertEqual(instance.load(self.tmp)["forge"][0]["owner"], "acme")
+
+
+class TheBoundaryBetweenUnderstoodAndRefused(PlaneIso):
+    """`found > SCHEMA`, and both sides of that comparison get a case at the boundary.
+
+    A version comparison is what a shift-boundary mutation attacks: `>` re-spelled `>=`
+    refuses every plane there is, and `>=` re-spelled `>` accepts one version from the
+    future. Neither is catchable by a case that tests `SCHEMA - 5` against `SCHEMA + 5`, so
+    the three cases below sit on `SCHEMA - 1`, `SCHEMA` and `SCHEMA + 1`.
+    """
+
+    def test_exactly_the_version_this_charter_understands_is_accepted(self):
+        self.declare_schema(str(instance.SCHEMA))
+        self.assertIsNone(config.PLANE_REFUSAL)
+        self.assertEqual(instance.load(self.tmp)["schema"], instance.SCHEMA)
+
+    def test_one_version_older_is_accepted(self):
+        with mock.patch.object(instance, "SCHEMA", 7):
+            self.declare_schema("6")
+            self.assertIsNone(config.PLANE_REFUSAL)
+
+    def test_one_version_newer_is_refused(self):
+        self.declare_schema(str(instance.SCHEMA + 1))
+        self.assertIsNotNone(config.PLANE_REFUSAL)
+        with self.assertRaises(instance.SchemaTooNew):
+            instance.load(self.tmp)
+
+    def test_the_refusal_names_both_numbers(self):
+        """The operator's next question is "how far ahead is it", and the answer is two
+        integers. A message carrying only one of them cannot be acted on."""
+        self.declare_schema(str(instance.SCHEMA + 1))
+        self.assertIn(str(instance.SCHEMA + 1), config.PLANE_REFUSAL)
+        self.assertIn(str(instance.SCHEMA), config.PLANE_REFUSAL)
+
+
+class AVersionCharterCannotCompareIsAlsoRefused(PlaneIso):
+    """`schema = "2"` is not a version this charter can place, so it is not operated on.
+
+    It used to fall straight through `isinstance(found, int)` and be treated as understood
+    — the plane most likely to have been written by something charter has never seen,
+    silently accepted. `schema = true` is the sharp one: `isinstance(True, int)` is `True`
+    in Python, so without the explicit `bool` exclusion it compares as 1 and reads as
+    current.
+    """
+
+    def test_a_string_version_is_refused(self):
+        self.declare_schema('"2"')
+        self.assertIsNone(instance.plane_version({"schema": "2"}))
+        self.assertIsNotNone(config.PLANE_REFUSAL)
+
+    def test_a_fractional_version_is_refused(self):
+        self.declare_schema("1.5")
+        self.assertIsNone(instance.plane_version({"schema": 1.5}))
+        self.assertIsNotNone(config.PLANE_REFUSAL)
+
+    def test_a_boolean_version_is_refused_rather_than_read_as_one(self):
+        self.declare_schema("true")
+        self.assertIsNone(instance.plane_version({"schema": True}))
+        self.assertIsNotNone(config.PLANE_REFUSAL)
+
+    def test_the_refusal_is_the_same_kind_the_cli_gate_reads(self):
+        """One exception family, so `config.derive` and `cli.main` need one branch and not
+        two — and `SchemaTooNew` keeps working for everything that already caught it."""
+        self.assertTrue(issubclass(instance.SchemaTooNew, instance.PlaneFormatUnknown))
+        self.declare_schema('"2"')
+        with self.assertRaises(instance.PlaneFormatUnknown):
+            instance.load(self.tmp)
+
+
+class TheRefusalIsRecordedApartFromAParseError(PlaneIso):
+    """Two failures of one file, and only one of them stops charter.
+
+    Malformed TOML is a typo the operator fixes, and carrying on with empty defaults while
+    `doctor` names it is the trade charter already made. A plane from the future is not
+    that: every default charter would carry on with is a guess about a layout it has been
+    told it does not understand.
+    """
+
+    def test_a_too_new_plane_sets_both_names(self):
+        """`CONFIG_ERROR` stays set as well, deliberately: `doctor`'s `charter.toml` row
+        and `channel.channel`'s documented fallback both key off it."""
+        self.declare_schema(str(instance.SCHEMA + 1))
+        self.assertIsNotNone(config.PLANE_REFUSAL)
+        self.assertEqual(config.CONFIG_ERROR, config.PLANE_REFUSAL)
+
+    def test_malformed_toml_is_an_error_and_not_a_refusal(self):
+        self.declare("this is not = valid = toml\n")
+        self.assertIsNotNone(config.CONFIG_ERROR)
+        self.assertIsNone(config.PLANE_REFUSAL)
+
+    def test_a_healthy_plane_sets_neither(self):
+        self.declare_schema(str(instance.SCHEMA))
+        self.assertIsNone(config.CONFIG_ERROR)
+        self.assertIsNone(config.PLANE_REFUSAL)
+
+    def test_the_refusal_is_one_of_the_settings_the_test_harness_isolates(self):
+        """`config.DERIVED` is the source of truth for what `config.use` swaps. A setting
+        absent from it leaks the developer's own plane into every case that reads it."""
+        self.assertIn("PLANE_REFUSAL", config.DERIVED)
+
+
+class TheCliDeclinesRatherThanGuesses(PlaneIso):
+    """The refusal, where it is worth something: charter does not run the command.
+
+    A warning would leave the command running against a layout charter cannot place, which
+    is the state #913 exists to end — and is what the code did before it, since
+    `config.derive` swallowed the exception and handed every command an empty config.
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.ran: list[str] = []
+        for mod, name in ((commands, "cmd_status"), (commands, "cmd_doctor"),
+                          (commands, "cmd_version"), (commands, "cmd_version_check"),
+                          (commands_update, "cmd_update")):
+            self.enterContext(mock.patch.object(
+                mod, name, lambda args, _n=name: self.ran.append(_n) or 0))
+
+    def run_cli(self, argv: list[str]) -> tuple[int, str]:
+        err = io.StringIO()
+        with redirect_stderr(err):
+            rc = cli.main(argv)
+        return rc, err.getvalue()
+
+    def test_an_ordinary_command_does_not_run_on_a_plane_charter_refuses(self):
+        self.declare_schema(str(instance.SCHEMA + 1))
+        rc, err = self.run_cli(["status"])
+        self.assertEqual(rc, 1)
+        self.assertEqual(self.ran, [])
+        self.assertIn(str(instance.SCHEMA + 1), err)
+
+    def test_the_same_command_runs_on_a_plane_charter_understands(self):
+        """The precondition. A gate that refused everything would pass the case above
+        while making charter useless, and the two are indistinguishable without this."""
+        self.declare_schema(str(instance.SCHEMA))
+        rc, _ = self.run_cli(["status"])
+        self.assertEqual(rc, 0)
+        self.assertEqual(self.ran, ["cmd_status"])
+
+    def test_doctor_still_runs_because_it_is_where_the_refusal_is_reported(self):
+        self.declare_schema(str(instance.SCHEMA + 1))
+        rc, _ = self.run_cli(["doctor"])
+        self.assertEqual(rc, 0)
+        self.assertEqual(self.ran, ["cmd_doctor"])
+
+    def test_update_still_runs_because_it_is_the_only_way_out(self):
+        """Nothing but a newer charter can understand a newer plane. Refusing the remedy
+        leaves an operator with a hand edit of `charter.toml` as their only move."""
+        self.declare_schema(str(instance.SCHEMA + 1))
+        rc, _ = self.run_cli(["update"])
+        self.assertEqual(rc, 0)
+        self.assertEqual(self.ran, ["cmd_update"])
+
+    def test_every_exempt_command_is_about_charter_and_not_about_the_plane(self):
+        """The exemptions, one case, by name. Each runs; each is a question about which
+        charter this is or how to get a newer one — never a read of the plane's contents."""
+        self.assertEqual(set(cli._DESPITE_REFUSAL),
+                         {"doctor", "update", "version", "_version-check"})
+        for argv, handler in ((["version"], "cmd_version"),
+                              (["_version-check"], "cmd_version_check")):
+            with self.subTest(argv=argv):
+                self.declare_schema(str(instance.SCHEMA + 1))
+                self.ran.clear()
+                self.assertEqual(self.run_cli(argv)[0], 0)
+                self.assertEqual(self.ran, [handler])
+
+    def test_a_command_that_writes_into_the_plane_is_not_exempt(self):
+        """`init` and `reinit` are the tempting exemptions and the wrong ones: writing into
+        a layout charter has been told it does not understand is the guess at its most
+        damaging."""
+        self.assertNotIn("init", cli._DESPITE_REFUSAL)
+        self.assertNotIn("reinit", cli._DESPITE_REFUSAL)
+
+    def test_the_hook_dispatcher_is_not_exempt_either(self):
+        """A hook on a refused plane already covers nothing — `known_forges_report` opens
+        `charter.toml` through `instance.load`, gets the refusal and returns an empty forge
+        set, so the PreToolUse guard looks present and denies nothing. Refusing out loud
+        turns a silent fail-open into a visible one, at the cost of the session's briefing
+        and never its turn: the gate returns 1, not `hooks.DENY_EXIT`."""
+        self.assertNotIn("hook", cli._DESPITE_REFUSAL)
+        self.declare_schema(str(instance.SCHEMA + 1))
+        with mock.patch("charter.hooks.dispatch") as dispatched:
+            rc, _ = self.run_cli(["hook", "sessionstart"])
+        self.assertEqual(rc, 1)
+        dispatched.assert_not_called()
+
+    def test_the_gate_survives_a_subcommand_that_owns_the_command_dest(self):
+        """`charter secret exec` gives its own positional the dest `command` (`_sa_exec`),
+        so argparse overwrites the subparser name with the child command line and
+        `args.command` is a LIST there. A gate reading it would raise `TypeError: unhashable
+        type: 'list'` out of `not in` — a crash report filed against charter, on the one
+        plane charter had already decided not to touch. `argv[0]` is the typed token."""
+        self.declare_schema(str(instance.SCHEMA + 1))
+        rc, err = self.run_cli(["secret", "exec", "myvault", "--", "echo", "hi"])
+        self.assertEqual(rc, 1)
+        self.assertIn("Nothing was run", err)
+
+    def test_a_bare_charter_does_not_launch_a_harness_on_a_refused_plane(self):
+        """`_bare_launch` rewrites bare `charter` into `[<default harness>]` before the
+        gate, so the rewritten token is what gets refused. Opening a frame over a plane
+        charter cannot place is the most expensive guess of the lot."""
+        self.declare(f"schema = {instance.SCHEMA + 1}\n[harness]\ndefault = \"claude\"\n")
+        with mock.patch("sys.stdout.isatty", return_value=True), \
+             mock.patch.object(cli.commands_frame, "cmd_launch") as launched:
+            rc, _ = self.run_cli([])
+        self.assertEqual(rc, 1)
+        launched.assert_not_called()
+
+
+class DoctorReportsTheRefusalOnTheRowNamedAfterTheNumber(PlaneIso):
+    """`doctor`'s `schema` row said `up to date (schema 1)` over a plane declaring 99.
+
+    `instance.drift` counts baseline directories and a plane from the future has all three,
+    so the one row an operator would read to find out which version was declared reported
+    the opposite of the truth.
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+        for name in instance.BASELINE_DIRS:
+            (self.tmp / name).mkdir(parents=True, exist_ok=True)
+
+    def test_the_schema_row_fails_and_names_the_declared_version(self):
+        self.declare_schema(str(instance.SCHEMA + 1))
+        row = doctor.check_control_plane_schema()
+        self.assertEqual(row.status, doctor.FAIL)
+        self.assertIn(str(instance.SCHEMA + 1), row.detail)
+
+    def test_the_hint_says_charter_stopped_and_what_moves_it(self):
+        self.declare_schema(str(instance.SCHEMA + 1))
+        self.assertIn("charter update", doctor.check_control_plane_schema().hint)
+
+    def test_a_plane_charter_understands_still_reports_up_to_date(self):
+        self.declare_schema(str(instance.SCHEMA))
+        row = doctor.check_control_plane_schema()
+        self.assertEqual(row.status, doctor.OK)
+        self.assertIn("up to date", row.detail)
+
+    def test_the_charter_toml_row_stops_promising_a_fallback_that_does_not_happen(self):
+        """Its hint says charter falls back to empty defaults, which is true of malformed
+        TOML and false of a refusal — nothing carries on to fall back."""
+        self.declare_schema(str(instance.SCHEMA + 1))
+        refused = doctor.check_control_plane_config()
+        self.assertEqual(refused.status, doctor.FAIL)
+        self.assertNotIn("Falling back", refused.hint)
+        self.declare("this is not = valid = toml\n")
+        broken = doctor.check_control_plane_config()
+        self.assertEqual(broken.status, doctor.FAIL)
+        self.assertIn("Falling back", broken.hint)
+
+    def test_the_row_keeps_its_name(self):
+        """`doctor._FIXED_CHECK_NAMES` is pinned by equality against what `run_all`
+        produces. The refusal reuses the `schema` row rather than adding a second one —
+        two rows about one number are two places for an operator to read a different
+        answer."""
+        self.assertIn("schema", doctor._FIXED_CHECK_NAMES)
+        self.declare_schema(str(instance.SCHEMA + 1))
+        self.assertEqual(doctor.check_control_plane_schema().name, "schema")
+
+
+class ThePlaneVersionAndTheStructureVersionAreNeverCompared(PlaneIso):
+    """Two version numbers, and the rule that keeps them from disagreeing.
+
+    They are nested — a workspace lives inside a plane — and only the outer one refuses:
+
+    * `instance.SCHEMA` is the REFUSAL number. Yes or no; nothing heals a no but a newer
+      charter.
+    * `workspace.STRUCTURE_VERSION` is the REPAIR number. Stale is flagged and healed by
+      `charter workspace reinit`, and a workspace an older charter can still read is
+      exactly what makes that repair additive.
+
+    So a workspace-layout change an older charter SURVIVES is, by definition, not a change
+    that requires refusal, and it moves `STRUCTURE_VERSION` alone. Two numbers can only
+    come to disagree if something compares them, and the four cases below are what says
+    nothing does.
+    """
+
+    def test_a_stale_workspace_is_repaired_and_never_refused(self):
+        self.declare_schema(str(instance.SCHEMA))
+        workspace.scaffold("ws")
+        (workspace.workspace_dir("ws") / ".charter-structure").write_text(
+            str(workspace.STRUCTURE_VERSION - 1))
+        self.assertTrue(workspace.needs_reinit("ws"))
+        self.assertIsNone(config.PLANE_REFUSAL)
+
+    def test_a_refused_plane_is_refused_however_current_its_workspaces_are(self):
+        self.declare_schema(str(instance.SCHEMA))
+        workspace.scaffold("ws")
+        self.assertFalse(workspace.needs_reinit("ws"))
+        self.declare_schema(str(instance.SCHEMA + 1))
+        self.assertIsNotNone(config.PLANE_REFUSAL)
+
+    def test_moving_the_plane_version_does_not_move_the_workspace_verdict(self):
+        """The refusal number is not an input to the repair question. `structure_status`
+        must answer identically with `SCHEMA` anywhere at all."""
+        self.declare_schema(str(instance.SCHEMA))
+        workspace.scaffold("ws")
+        before = workspace.structure_status("ws")
+        with mock.patch.object(instance, "SCHEMA", 99):
+            self.assertEqual(workspace.structure_status("ws"), before)
+
+    def test_moving_the_workspace_version_does_not_move_the_plane_verdict(self):
+        """And the repair number is not an input to the refusal. The plane's answer is a
+        fact about `charter.toml` alone."""
+        self.declare_schema(str(instance.SCHEMA))
+        with mock.patch.object(workspace, "STRUCTURE_VERSION", 99):
+            config.use(self.tmp)
+            self.assertIsNone(config.PLANE_REFUSAL)
+            self.assertEqual(instance.plane_version(instance.load(self.tmp)),
+                             instance.SCHEMA)
+
+    def test_the_two_numbers_hold_different_values_today(self):
+        """5 and 1. Not a requirement — they may collide by coincidence — but a number
+        that tracked the other would be a second spelling of one fact, and the day they
+        were made equal by hand is the day somebody starts comparing them."""
+        self.assertNotEqual(workspace.STRUCTURE_VERSION, instance.SCHEMA)
+
+
+class FrameStateCarriesNoFormatPromise(PlaneIso):
+    """#913's third question, answered "private" rather than "versioned".
+
+    A format version buys the ability to refuse, and refusal is worth something only when
+    the writer and the reader can be different charters. A plane's files are committed,
+    shared and outlive any install; nothing under `.charter/frame/` is. It is written by a
+    launcher, read by that frame's own panels, and any residue of another charter is
+    reaped rather than read — so a version stamped there could never fire, which is the
+    definition of decoration.
+    """
+
+    def test_the_promise_is_stated_as_a_value_rather_than_left_in_prose(self):
+        self.assertIn("no format version", frame_state.NO_FORMAT_PROMISE)
+        self.assertIn("no promise", frame_state.NO_FORMAT_PROMISE)
+
+    def test_the_promise_names_the_interface_it_points_a_reader_at(self):
+        """"Private" with nothing offered in its place is a refusal to answer. The
+        commands are the interface — git's own split, and the one this issue rests on."""
+        self.assertIn("charter frame", frame_state.NO_FORMAT_PROMISE)
+
+    def test_nothing_under_frame_stamps_or_reads_a_format_version(self):
+        """The tripwire, and the reason the claim is worth more than a comment. Frame state
+        carrying a version would mean somebody outside charter had come to depend on its
+        shape — at which point the promise above has changed and this test is where to say
+        so, rather than a version quietly appearing beside one that already exists.
+
+        **Tokenised, not grepped.** Comments and docstrings under `charter/frame/` name
+        `instance.SCHEMA` freely — the constant above does it at length, to explain why the
+        frame does not carry one — and a substring search would call every one of those an
+        offence. `tokenize` keeps only NAME tokens, so this reads what the module *does*.
+        """
+        import tokenize
+        from pathlib import Path
+
+        forbidden = {"SCHEMA", "STRUCTURE_VERSION", "UNSTAMPED"}
+        offenders = []
+        for p in sorted(Path(frame_state.__file__).resolve().parent.glob("*.py")):
+            with tokenize.open(p) as fh:
+                names = {t.string for t in tokenize.generate_tokens(fh.readline)
+                         if t.type == tokenize.NAME}
+            if names & forbidden:
+                offenders.append(p.name)
+        self.assertEqual(offenders, [], (
+            "a module under charter/frame/ now names a format version in code. "
+            "`.charter/frame/` is declared private and unversioned "
+            "(frame.state.NO_FORMAT_PROMISE); if that changed, change the promise first."))
+
+    def test_the_tripwire_can_actually_fire(self):
+        """A source scan that matched nothing would pass the case above forever. This runs
+        the same scan over a module that DOES carry the number — `charter/instance.py`,
+        where the plane's own version lives — so "no offenders" is a finding rather than a
+        scanner that lost its way to the files."""
+        import tokenize
+        from pathlib import Path
+
+        with tokenize.open(Path(instance.__file__).resolve()) as fh:
+            names = {t.string for t in tokenize.generate_tokens(fh.readline)
+                     if t.type == tokenize.NAME}
+        self.assertIn("SCHEMA", names)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #913.

charter is about to grow consumers that are not the frame, and today any of them would
guess. This gives a program that opens a plane a way to know it is out of its depth and
**stop**.

## The number already existed. The refusal did not

`charter init` has stamped `schema = 1` into `charter.toml` since the beginning
(`commands._render_charter_toml`), and `instance.load` has raised on a version from the
future for just as long. **So this does not add a second plane-level version number** — the
issue's own "two version numbers that can disagree is worse than one" is answered by not
minting one. What was missing was the two properties that make the number worth having.

**1. `config.derive` caught the exception and carried on.** It recorded the message as
`CONFIG_ERROR`, set `cfg = {}` and handed every command a plane made of fallback defaults.
A plane declaring `schema = 99` did not stop charter; it made charter quietly act on a plane
it had already been told it could not read. The sharpest case is the guard:
`known_forges_report` opens `charter.toml` through the same `load`, got the refusal and
returned an empty forge set — a PreToolUse guard that looks present and denies nothing.

`config.PLANE_REFUSAL` is now recorded apart from `CONFIG_ERROR` (which stays set, because
`doctor`'s `charter.toml` row and `channel.channel`'s documented fallback key off it), and
`cli.main` declines the command. Four commands still run, each a question about *charter*
rather than a read of the plane's contents: `doctor` (where it is reported), `version` and
`_version-check`, and `update` — the only remedy, since nothing but a newer charter can
understand a newer plane. `--version` and `--help` need no exemption; argparse's own actions
exit before the gate. `init` and `reinit` are deliberately **not** exempt: writing into a
layout you have been told you do not understand is the guess at its most damaging. Neither
is `hook`, which turns that silent guard fail-open into a visible one, at the cost of the
session's briefing and never its turn (rc 1, never `hooks.DENY_EXIT`).

**2. An absent stamp meant "whatever this charter is".** `cfg.get("schema", SCHEMA)` — the
reading that makes the feature useless the first time it is needed. The day `SCHEMA` moves
to 2, every unstamped version-1 plane would claim to be a version-2 plane, and a charter
that understands 2 would read a version-1 layout with version-2 rules.

Absent now means `instance.UNSTAMPED = 1`: the layout every plane had before planes declared
one. Definite, and *true* — there has only ever been one plane format, so every plane that
exists today is a version-1 plane and stays readable forever. Refusing them was never on the
table; the choice was only between "1" and "current", and "current" is the one that lies
later. The two readings are indistinguishable today (`SCHEMA` is 1), which is why the test
that pins it moves `SCHEMA` before it looks.

A `schema` charter cannot compare against at all (`"2"`, `1.5`, `true`) used to fall through
`isinstance(found, int)` and read as understood. Refused on the same terms. `true` is the
sharp one: `isinstance(True, int)` is `True`, so it would otherwise compare as 1.

## How the plane version relates to `STRUCTURE_VERSION`

**Nested, and only the outer one refuses.** Stated at `instance.SCHEMA` and pinned in both
directions.

| | `instance.SCHEMA` | `workspace.STRUCTURE_VERSION` |
|---|---|---|
| asks | may this charter operate on this plane at all? | is this one workspace's interior current? |
| answers | yes / no | current / stale |
| a bad answer is | refused — nothing heals it but a newer charter | repaired, additively, by `charter workspace reinit` |

A workspace-layout change an older charter *survives* is, by definition, not a change that
requires refusal, so it moves `STRUCTURE_VERSION` alone — which is exactly what 4 → 5 was.
Two numbers can only come to disagree if something compares them; nothing does, and
`ThePlaneVersionAndTheStructureVersionAreNeverCompared` is what keeps it that way: moving
`SCHEMA` must not change a workspace's staleness verdict, and moving `STRUCTURE_VERSION`
must not change the plane's.

## `.charter/frame/` is private, and says so in code

`frame.state.NO_FORMAT_PROMISE`. Not "because it is internal" — everything in charter is
internal until somebody reads it — but because **a format version buys the ability to
refuse, and refusal is worth something only when the writer and the reader can be different
charters.** A plane's files are committed, shared and outlive any install. Nothing under
`.charter/frame/` is: it is written by a frame launcher and read by that same frame's
panels — one process tree, one machine, one charter — and residue from any other charter is
`reap`ed rather than read, because liveness there is a pid or a tmux window. A version
stamped there could never fire, and the issue's own rule is that a version nobody refuses on
is decoration. Two consequences, and they are the whole promise: charter may change the
shape of anything under `.charter/frame/` in a patch release with no bump and no migration,
and a program reading it has no contract to hold charter to. A tokenised tripwire (not a
grep — the constant itself discusses `instance.SCHEMA` at length) fails if any module under
`charter/frame/` gains a format version in *code*.

## Two findings out of writing the tests

- **`args.command` is not the subcommand.** The `exec` subcommand under `charter secret`
  gives its own positional the dest `command` (`_sa_exec`), so argparse overwrites the
  subparser name with the child command line. A gate reading it got `TypeError: unhashable
  type: 'list'` out of `not in` — a crash report filed against charter, on the one plane
  charter had decided not to touch. The gate reads `argv[0]`.
- **Bare `charter` fell through to argparse's usage message**, which is byte-identical to
  what a plane declaring no harness gets, so a refused plane looked like an unconfigured
  one. `_bare_launch` refuses it through the same `_plane_refusal` helper the gate uses, so
  the bare form and the typed one cannot come to differ.

## Not a schema and not a spec

The shape of `gather.json`, of `workspace.json`, of anything else charter writes is
documented to nobody and stays free to change. git's lesson is that the format is truth and
the *commands* are interface. This buys exactly one thing: a consumer's ability to know it
must stop.

## Verification

`python3 -m unittest discover -s tests -q` — **`Ran 11610 tests in 629.286s` / `OK
(skipped=11)`**, trailer read rather than the exit code. 39 of them are new.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Us4MbwkSCJCxwt1CjAd1sf
