### PR TITLE
The deletion sweep sizes a shard by what its mutations cost, not by how many there are (#915)

### DIFF
--- a/docs/news/unreleased-the-deletion-sweep-sizes-a-shard-by-what-it-costs.md
+++ b/docs/news/unreleased-the-deletion-sweep-sizes-a-shard-by-what-it-costs.md
@@ -1,0 +1,136 @@
+---
+version: unreleased
+headline: The deletion sweep sizes a shard by what its mutations cost, not by how many there are
+---
+
+`tools/sweep.py --plan` decides how many machines a branch's deletion sweep needs. It did
+that by dividing the mutation count by a per-shard count, and cost is not a function of
+count.
+
+On #914 that produced a check named `no verdict: 5 of 22 measured, 17 out of time`, after
+one shard burned the runner's full hour:
+
+```
+$ python3 tools/sweep.py --plan
+  22 mutations → 1 shard(s) of at most 28 each
+    charged: charter/cli.py, charter/config.py, charter/doctor.py,
+             charter/frame/state.py, charter/instance.py
+
+Sweep shard 1 of 1   started 20:11:51Z   completed 21:12:08Z   cancelled
+```
+
+One shard, because 22 is less than 28. Eight of those 22 mutations were in
+`charter/config.py` — the module every other module imports — and the shard spent its hour
+on them. It never reached `charter/instance.py`, where that branch's refusal logic lives.
+
+## The number the plan already had and threw away
+
+The sweep does not run the whole suite for every mutation. It runs the test modules the
+**selection map** measured executing the mutated function, which is what turns a four-minute
+suite into a two-second one. That map is traced by the plan job itself — `--warm-map` is
+there so the eight shards downstream can restore it instead of measuring it eight times.
+
+So the plan job held, in the same process, the one thing that says what a mutation costs.
+Measured on this repository:
+
+| what the mutation touches | test modules it selects, of 450 |
+| --- | --- |
+| `charter/config.py::derive` | 323 |
+| `charter/instance.py::load` | 337 |
+| `charter/frame/state.py` | 105 |
+| `charter/doctor.py::check_control_plane_config` | 25 |
+| `charter/cli.py::_plane_refusal` | 6 |
+
+Two mutations in one diff, fifty-four times apart in the tests they select — and nineteen
+times apart once the fixed cost every mutation pays is added back in — dealt as equals. The
+plan job measured that, sized the fan-out off a count, and deleted the measurement.
+
+## Two terms, because the cost has two halves
+
+`seconds_for` prices one mutation as a fixed part plus a measured part:
+
+```
+SECONDS_A_MUTATION_FIXED  +  SECONDS_A_SUITE_RUN × (modules selected / modules in the suite)
+```
+
+The fixed part is the sandbox restore, the interpreter, and `unittest discover`'s own walk
+of `tests/` — the count-shaped half, and the only half a count could ever see. The second
+is the run itself.
+
+Both constants are **solved from the two runs that ran out of time**, whose selection maps
+are known and very different. #626 measured about 53 mutations of `charter/gitconfig.py`
+(13 of 450 modules) in ~2880 s; #914 measured 5 — one of `charter/cli.py` at 6 of 450, four
+of `charter/config.py` at 323 — in ~3000 s. Two runs, two unknowns, and they give 25 s and
+about 996 s. The round number is 960 because it is corroborated twice over: the unmutated
+baseline is 240 s alone on the runner, a shard runs `--jobs 4`, and `unittest` is
+single-threaded — so four concurrent whole-suite runs queue on a four-vCPU runner rather
+than overlapping. `SUBSET_TIMEOUT` is the same number from the other side, and on #914 every
+`charter/config.py` mutation reached it: `{'green': False, 'ran': 0, 'detail': 'timed out
+after 900s'}`.
+
+What the model deliberately does **not** predict is the second and third runs a verdict can
+need — the full suite that has the last word, and a survivor's confirmation. Those depend on
+the answer and not on the diff, so nothing can see them coming. They are what the twenty
+minutes between `SHARD_BUDGET` and `SHARD_REPORT_AT` are for, and that gap is not spent
+here.
+
+## #914's own plan, before and after
+
+```
+before:  22 mutations → 1 shard(s) of at most 28 each
+
+after:   22 mutations → 8 shard(s); 174 min of predicted test time over 450 test
+         modules, 1707 s on the heaviest shard (a shard is sized for 1680 s)
+           charged: charter/cli.py — 1 min predicted
+           charged: charter/config.py — 95 min predicted
+           charged: charter/doctor.py — 5 min predicted
+           charged: charter/frame/state.py — 4 min predicted
+           charged: charter/instance.py — 69 min predicted
+         ::warning::22 mutations is 174 minutes of predicted test time, and the
+         heaviest of 8 shards would carry 1707 s against the 1680 s a shard is
+         sized for…
+```
+
+The `charged:` list now carries what each file is predicted to cost, because "which file is
+making this sweep slow" is the question #914 could not answer from anything the plan
+printed — it took a person reading the map by hand.
+
+## Sized against the heaviest hand, and not against the total
+
+The plan is dealt round-robin, so a plan totalling two shards' worth of seconds can still
+put both of its expensive mutations on one shard. Dividing the total would call that a fit.
+`shards_for` instead asks for the fewest shards whose **heaviest hand** fits, and it asks
+through `shard_of` — the same function the shards deal with — rather than through a second
+copy of the dealing rule sitting beside it.
+
+The dealing itself is unchanged, and deliberately: it depends on nothing but the diff. A
+deal that consulted the map would be a slice each shard derived from its own measurement,
+and two shards that disagreed by one module would sweep one slice twice and another never,
+while the merge step added the pieces up and reported a complete sweep.
+
+## When cost wants more than eight shards
+
+`MAX_SHARDS` is 8, and #914 lands 27 seconds past what eight shards are sized for. Something
+has to give, and what gives is the **budget** — never the plan.
+
+Every mutation is still dealt to a shard. The shards carry more than they were sized for,
+stop at `SHARD_REPORT_AT`, and report what they measured, so `no verdict: N out of time`
+stays reachable and honest. The alternative — capping the plan so it always fits — would
+make the check's own name a lie, and the name is the deliverable: `no survivors` would
+become a claim about a sweep that never ran. `MAX_SHARDS` stays a limit on how much of the
+runner pool one branch may hold, which is what it always was.
+
+What changes is *when you find out*. The warning fires on the plan job, before a single
+runner is spent on measuring, and it names the predicted minutes rather than a mutation
+count — the count being exactly the thing that could not see #914 coming, since 22 is
+comfortably inside the old ceiling of 224.
+
+## Nothing to adopt
+
+This is the repository's own test harness and no part of charter's runtime. A branch gets a
+sweep sized against what its diff costs instead of against how long it is; nothing in a
+plane, a workspace or the CLI moves.
+
+`--plan` on its own still costs a second and still sizes by count — a person at a terminal
+has no map, and the plan says which of the two sizings produced the number. `sweep.yml`'s
+plan job always warms one.

--- a/tests/test_sweep.py
+++ b/tests/test_sweep.py
@@ -9,6 +9,7 @@ still passes has kept the property those rounds actually measured.
 """
 from __future__ import annotations
 
+import argparse
 import ast
 import contextlib
 import dataclasses
@@ -23,6 +24,7 @@ import sys
 import tempfile
 import textwrap
 import time
+import types
 import unittest
 from pathlib import Path
 
@@ -3972,6 +3974,15 @@ class TheSweepIsSplitAcrossMachinesAndNothingIsDropped(unittest.TestCase):
         return [sweep.Mutation(f"charter/f{i // 7}.py", i, i, "drop-if", "q?",
                                f"if x{i}: pass", "", "f") for i in range(n)]
 
+    def _costs(self, n):
+        """*n* mutations nothing has been measured about, priced through the real fallback.
+
+        Not ``[60.0] * n`` written out here: that would be a second copy of what
+        :func:`sweep.costs_for` does with no map, and the assertions below would go on
+        agreeing with a constant after the function had stopped using it.
+        """
+        return sweep.costs_for({}, self._plan(n))
+
     def test_the_shards_partition_the_plan(self):
         for total in (0, 1, 7, 62, 78, 82, 225):
             plan = self._plan(total)
@@ -4009,6 +4020,7 @@ class TheSweepIsSplitAcrossMachinesAndNothingIsDropped(unittest.TestCase):
         checkout, the sandbox clone, the selection map and the unmutated baseline. The
         literal is here rather than the arithmetic on purpose: a test that recomputed it
         from the constants would pass whatever the constants became."""
+        self.assertEqual(sweep.per_shard_seconds(), 1680)
         self.assertEqual(sweep.per_shard(), 28)
 
     def test_a_budget_smaller_than_its_own_fixed_cost_still_measures_something(self):
@@ -4016,49 +4028,56 @@ class TheSweepIsSplitAcrossMachinesAndNothingIsDropped(unittest.TestCase):
 
         Raise the fixed cost past the budget — a slower runner, a longer suite, a map that
         stops being cached — and the subtraction goes to zero or below. Without the clamp
-        the division in :func:`shards_for` is by zero, the plan job raises, and the
-        workflow gets an empty shard count: no plan, no shards, no numbers. Which is the
-        #617 failure exactly, arriving out of the arithmetic written to prevent it.
+        every candidate hand is "too big", the plan asks for the ceiling, and with the old
+        division it was a division by zero: no plan, no shards, no numbers, which is the
+        #617 failure arriving out of the arithmetic written to prevent it.
         """
         real = sweep.SHARD_FIXED
         self.addCleanup(lambda: setattr(sweep, "SHARD_FIXED", real))
         for fixed in (sweep.SHARD_BUDGET, sweep.SHARD_BUDGET + 3600):
             sweep.SHARD_FIXED = fixed
+            self.assertEqual(sweep.per_shard_seconds(), 1, fixed)
             self.assertEqual(sweep.per_shard(), 1, fixed)
-            self.assertEqual(sweep.shards_for(50), 8, fixed)   # capped, and not a crash
+            self.assertEqual(sweep.shards_for(self._costs(50)), 8, fixed)  # not a crash
 
     def test_the_two_diffs_that_ran_out_of_time_now_fit(self):
         """#608's 62 mutations were cancelled twice and #626's 78 three times, at
         `timeout-minutes: 60`, each run reaching about two thirds of its plan."""
-        self.assertEqual(sweep.shards_for(62), 3)
-        self.assertEqual(sweep.shards_for(78), 3)
+        self.assertEqual(sweep.shards_for(self._costs(62)), 3)
+        self.assertEqual(sweep.shards_for(self._costs(78)), 3)
         for total in (62, 78):
             biggest = max(len(sweep.shard_of(self._plan(total), i, 3))
                           for i in (1, 2, 3))
             self.assertLessEqual(biggest, sweep.per_shard())
 
     def test_a_branch_phase_two_would_have_produced_still_gets_one_job(self):
-        self.assertEqual(sweep.shards_for(1), 1)
-        self.assertEqual(sweep.shards_for(28), 1)
-        self.assertEqual(sweep.shards_for(29), 2)
+        self.assertEqual(sweep.shards_for(self._costs(1)), 1)
+        self.assertEqual(sweep.shards_for(self._costs(28)), 1)
+        self.assertEqual(sweep.shards_for(self._costs(29)), 2)
 
     def test_a_branch_with_nothing_to_sweep_still_gets_a_job(self):
         """"The sweep ran and found nothing to do" and "the sweep did not run" are the two
         answers this whole change is about. A plan of zero shards would make them one."""
-        self.assertEqual(sweep.shards_for(0), 1)
+        self.assertEqual(sweep.shards_for([]), 1)
 
     def test_the_fan_out_is_capped_and_the_sweep_is_not(self):
         """`MAX_SHARDS` limits how much of the runner pool one branch may hold. It does
         not limit what gets asked: past the ceiling the shards simply carry more."""
-        self.assertEqual(sweep.shards_for(10_000), 8)
+        self.assertEqual(sweep.shards_for(self._costs(10_000)), 8)
         plan = self._plan(400)
         dealt = [m for i in range(1, 9) for m in sweep.shard_of(plan, i, 8)]
         self.assertEqual(len(dealt), 400)
 
     def test_a_diff_past_the_ceiling_says_so_out_loud(self):
-        """The spec is explicit that a cap the reader cannot see is worse than the cap."""
-        self.assertEqual(sweep.over_budget(224), "")
-        loud = sweep.over_budget(225)
+        """The spec is explicit that a cap the reader cannot see is worse than the cap.
+
+        224 and 225 are the same boundary this test held before #915 — eight shards of
+        twenty-eight *average* mutations — and it survives the change of unit intact,
+        because an unmeasured mutation is still priced at :data:`sweep.SECONDS_A_MUTATION`
+        and eight hands of 28 × 60 s are exactly the 1680 s a shard is sized for.
+        """
+        self.assertEqual(sweep.over_budget(self._costs(224)), "")
+        loud = sweep.over_budget(self._costs(225))
         self.assertIn("225 mutations", loud)
         self.assertIn("nothing here is dropped", loud.lower())
 
@@ -4074,7 +4093,7 @@ class TheSweepIsSplitAcrossMachinesAndNothingIsDropped(unittest.TestCase):
         warning has to tell a reader what they will actually get. The word to look for
         is the promise of a partial answer; the words that must be GONE are the ones
         that told them to expect none."""
-        loud = sweep.over_budget(sweep.MAX_SHARDS * sweep.per_shard() + 1)
+        loud = sweep.over_budget(self._costs(sweep.MAX_SHARDS * sweep.per_shard() + 1))
         self.assertIn("PARTIAL answer", loud)
         self.assertNotIn("cancelled", loud)
         self.assertNotIn("no verdict", loud)
@@ -4563,6 +4582,41 @@ class TheWorkflowAsksTheToolAndNotTheOtherWayAround(unittest.TestCase):
                                "--github-output", str(self.outputs))
         self.assertEqual(code, 0, said)
         self.assertNotIn("::warning", said)
+
+    def test_the_plan_job_sizes_the_fan_out_off_the_map_it_warmed(self):
+        """#915's plumbing, through the CLI the workflow actually runs.
+
+        `sweep.yml` runs `--plan --warm-map`, which traces the selection map here so the
+        shards can restore it — and the job then sized the fan-out off a count with that
+        measurement sitting in the same process. Same plan, same tree, two answers: one
+        shard from the count, more than one once the map is read.
+        """
+        # `charter/m.py` is the file this fixture's branch touches, standing in for
+        # `charter/config.py`: 323 of 450 test modules, which is what `config` measures.
+        plan = [_mutation("charter/m.py", n, "close") for n in range(9)]
+        widely_imported = {"charter/m.py": _SUITE[:323], "charter/__init__.py": _SUITE}
+        real_plan_for, real_warm = sweep.plan_for, sweep._warm_map
+        self.addCleanup(lambda: setattr(sweep, "plan_for", real_plan_for))
+        self.addCleanup(lambda: setattr(sweep, "_warm_map", real_warm))
+        sweep.plan_for = lambda *a: (plan, {})
+
+        seen = {}
+        for label, selection in (("count", {}), ("cost", widely_imported)):
+            sweep._warm_map = lambda *a, _s=selection, **k: _s
+            self.outputs.unlink(missing_ok=True)
+            code, said = self._cli("--plan", "--warm-map", "--base", self.base,
+                                   "--workdir", str(self.workdir),
+                                   "--github-output", str(self.outputs))
+            self.assertEqual(code, 0, said)
+            seen[label] = (int(self._read_outputs()["shards"]), said)
+        self.assertEqual(seen["count"][0], 1)
+        self.assertEqual(seen["cost"][0], 5)
+        self.assertIn("sized by count and not by cost", seen["count"][1])
+        self.assertIn("9 mutations → 5 shard(s); 107 min of predicted test time over 450 "
+                      "test modules", seen["cost"][1])
+        # And the file the cost came from is named where a reader is already looking.
+        self.assertIn("charged: charter/m.py — 107 min predicted", seen["cost"][1])
+        self.assertIn("charged: charter/m.py\n", seen["count"][1])
 
     def test_the_matrix_names_every_shard_the_plan_asked_for(self):
         """The workflow fans out over exactly this list, so a plan of three shards that
@@ -6293,6 +6347,310 @@ class ASandboxThatCannotBeBuiltSaysWhatTheMachineSaid(unittest.TestCase):
         seen = sweep.run_dir(Path("/w"))
         self.assertEqual(seen, Path("/w") / f"run-{os.getpid()}")
         self.assertNotEqual(seen, sweep.run_dir(Path("/w")).parent / "run-0")
+
+
+#: A selection map shaped like charter's own, at the sizes #914 measured.
+#:
+#: 450 test modules, and the shares are the real ones read off the map this repository's
+#: own suite traces: `charter/config.py::derive` executes under 323 of them because `config`
+#: is the module every other module imports, `charter/instance.py::load` under 337,
+#: `charter/frame/state.py` under 105, and `charter/cli.py::_plane_refusal` under 6.
+#:
+#: A synthetic map rather than a traced one because tracing is four hundred subprocesses and
+#: two minutes; the numbers in it are not synthetic, which is the half that matters.
+_SUITE = [f"tests.test_{n:03d}" for n in range(450)]
+_MAP_914 = {
+    # Something is executed by every test module — that is what makes 450 the denominator.
+    "charter/__init__.py": list(_SUITE),
+    "charter/instance.py::load": _SUITE[:337],
+    "charter/instance.py::<module>": _SUITE[:348],
+    "charter/instance.py::plane_version": _SUITE[:123],
+    "charter/instance.py": _SUITE[:348],
+    "charter/config.py::derive": _SUITE[:323],
+    "charter/config.py": _SUITE[:332],
+    "charter/frame/state.py": _SUITE[:105],
+    "charter/doctor.py::check_control_plane_config": _SUITE[:25],
+    "charter/doctor.py": _SUITE[:159],
+    "charter/cli.py::_plane_refusal": _SUITE[:6],
+    "charter/cli.py": _SUITE[:60],
+    # #626's diff, for the other end of the range: one new file, 13 of 450.
+    "charter/gitconfig.py": _SUITE[:13],
+}
+
+
+def _mutation(path, line=1, symbol="f"):
+    return sweep.Mutation(path, line, line, "drop-if", "q?", "if x: pass", "", symbol)
+
+
+class AShardIsSizedByWhatItsMutationsCostAndNotByHowManyThereAre(unittest.TestCase):
+    """#915. `plan` divided a count by `MUTATIONS_PER_SHARD`, and cost is not a count.
+
+    The two ends of one 22-mutation diff, measured on this repository's own selection map:
+    `charter/cli.py::_plane_refusal` selects 6 test modules of 450 and
+    `charter/config.py::derive` selects 323. `plan` dealt them as equals, gave #914 one
+    shard because 22 < 28, and the runner spent its hour on five of the twenty-two —
+    `no verdict: 5 of 22 measured, 17 out of time`, on a branch whose refusal logic lives in
+    a file the shard never reached.
+
+    The cost is two terms and only one of them is count-shaped, which is why a count could
+    not see this coming: a fixed part every mutation pays, and the share of the suite its
+    subset selects.
+    """
+
+    def test_the_two_ends_of_one_diff_differ_by_more_than_an_order_of_magnitude(self):
+        """The claim the issue makes, held to the numbers rather than to the adjective —
+        and the adjective is the part the numbers correct. The *subsets* differ by 54x, but
+        the priced costs differ by 19, because :data:`sweep.SECONDS_A_MUTATION_FIXED` is a
+        floor the cheap one pays too. Nineteen is still the whole defect: dealing those two
+        as equals is what put 22 mutations on one shard."""
+        cheap = sweep.seconds_for(_MAP_914, _mutation("charter/cli.py", 1993,
+                                                      "_plane_refusal"))
+        dear = sweep.seconds_for(_MAP_914, _mutation("charter/config.py", 688, "derive"))
+        self.assertAlmostEqual(cheap, 25 + 960 * 6 / 450, places=6)
+        self.assertAlmostEqual(dear, 25 + 960 * 323 / 450, places=6)
+        self.assertEqual(len(_MAP_914["charter/config.py::derive"])
+                         // len(_MAP_914["charter/cli.py::_plane_refusal"]), 53)
+        self.assertGreater(dear / cheap, 18)
+        self.assertLess(dear / cheap, 20)
+
+    def test_the_subset_that_is_the_whole_suite_costs_a_whole_suite_run(self):
+        one = sweep.seconds_for(_MAP_914, _mutation("charter/__init__.py"))
+        self.assertAlmostEqual(
+            one, sweep.SECONDS_A_MUTATION_FIXED + sweep.SECONDS_A_SUITE_RUN, places=6)
+
+    def test_a_file_no_module_covers_is_priced_at_the_full_suite_and_not_at_nothing(self):
+        """:func:`sweep.decide` reads "no covering module" as *go straight to the full
+        suite*, so the mutation that looks cheapest in the map is the most expensive one
+        there is. Pricing an absent entry at zero — or at the average — is the same defect
+        as #915 with the sign flipped, and it is the one a `share = len(modules) / suite`
+        written without the fallback would introduce."""
+        stranger = sweep.seconds_for(_MAP_914, _mutation("charter/brand-new.py"))
+        self.assertAlmostEqual(
+            stranger, sweep.SECONDS_A_MUTATION_FIXED + sweep.SECONDS_A_SUITE_RUN, places=6)
+        self.assertGreater(stranger, sweep.seconds_for(
+            _MAP_914, _mutation("charter/config.py", 688, "derive")))
+
+    def test_the_price_is_the_subset_the_sweep_will_actually_run(self):
+        """`select_for` prefers the entry at the mutated *symbol* and falls back to the
+        file, and the price has to follow it there or the plan is sizing a different run
+        from the one the shard makes. On #914 the gap is the whole finding:
+        `charter/cli.py` is 60 modules and `_plane_refusal` inside it is 6."""
+        whole_file = sweep.seconds_for(_MAP_914, _mutation("charter/cli.py", 1, "absent"))
+        symbol = sweep.seconds_for(_MAP_914,
+                                   _mutation("charter/cli.py", 1993, "_plane_refusal"))
+        self.assertAlmostEqual(whole_file, 25 + 960 * 60 / 450, places=6)
+        self.assertAlmostEqual(symbol, 25 + 960 * 6 / 450, places=6)
+
+    def test_the_denominator_is_the_map_and_not_the_tests_directory(self):
+        """A module that would not load is absent from the map — `build_map` says so out
+        loud and falls its files back to the full suite. Counting it in the denominator
+        would make every share smaller than the run it predicts, which is #915's direction
+        of error exactly."""
+        self.assertEqual(sweep.suite_size(_MAP_914), 450)
+        self.assertEqual(sweep.suite_size({"charter/a.py": ["tests.test_a"],
+                                           "charter/b.py": ["tests.test_a", "tests.b"]}),
+                         2)
+        self.assertEqual(sweep.suite_size({}), 0)
+
+    def test_with_nothing_measured_a_mutation_is_priced_at_the_old_average(self):
+        """The fallback path, and it has to be exactly what it was: a person running
+        `--plan` at a terminal has no map, and `sweep.yml`'s plan job always warms one. A
+        different answer here would be a second sizing rule nobody asked for."""
+        self.assertEqual(sweep.costs_for({}, [_mutation("charter/config.py")] * 3),
+                         [float(sweep.SECONDS_A_MUTATION)] * 3)
+
+    def test_the_costs_arrive_in_the_order_the_shards_deal_them(self):
+        """`shards_for` deals these with the same `shard_of` the shards deal mutations
+        with, so entry *i* here has to be the cost of mutation *i* there. A sorted or
+        regrouped list would size a plan nobody runs."""
+        plan = [_mutation("charter/cli.py", 1993, "_plane_refusal"),
+                _mutation("charter/__init__.py"),
+                _mutation("charter/gitconfig.py")]
+        costs = sweep.costs_for(_MAP_914, plan)
+        self.assertEqual(costs, [sweep.seconds_for(_MAP_914, m) for m in plan])
+        self.assertLess(costs[0], costs[1])
+        self.assertLess(costs[2], costs[1])
+
+
+class TheFanOutIsSizedAgainstTheHeaviestHandAndNotTheTotal(unittest.TestCase):
+    """A plan's total says whether the work fits; only the deal says whether a *shard* does.
+
+    Round-robin spreads a file's mutations, so a plan totalling two shards' worth can still
+    put both of its expensive mutations on one shard when the count is unlucky. Dividing
+    the total would call that a fit and the shard would then run out of time — which is
+    #915 again, one level down, arriving out of the arithmetic written to fix it.
+    """
+
+    def test_the_heaviest_hand_is_the_deal_the_shards_make(self):
+        """Through `shard_of` rather than beside it: a sizing rule with its own copy of the
+        dealing is free to drift from the one that runs."""
+        costs = [7.0, 1.0, 1.0, 5.0, 1.0, 2.0]
+        self.assertEqual(sweep.heaviest_hand(costs, 3),
+                         max(sum(sweep.shard_of(costs, i, 3)) for i in (1, 2, 3)))
+        self.assertEqual(sweep.heaviest_hand(costs, 3), 12.0)  # 7+5, dealt to shard 1
+        self.assertEqual(sweep.heaviest_hand(costs, 1), 17.0)
+        self.assertEqual(sweep.heaviest_hand([], 4), 0)
+
+    def test_a_hand_of_exactly_the_budget_fits_and_one_second_more_does_not(self):
+        """The boundary, pinned on both sides. `<` where `<=` belongs here costs a shard
+        for every plan that lands exactly on its sizing target — and `<=` where `<` belongs
+        deals a shard one second past what it was sized for, which is the direction #914
+        went wrong in."""
+        budget = float(sweep.per_shard_seconds())
+        self.assertEqual(sweep.shards_for([budget]), 1)
+        self.assertEqual(sweep.shards_for([budget / 2, budget / 2]), 1)
+        self.assertEqual(sweep.shards_for([budget / 2, budget / 2 + 1]), 2)
+
+    def test_one_mutation_bigger_than_a_shard_asks_for_every_machine_and_says_so(self):
+        """No deal splits a single mutation, so a plan holding one costlier than a shard's
+        budget fits no count at all. It gets the ceiling and the warning rather than a
+        quietly rounded-down promise — which is `charter/config.py` on a slower runner, and
+        the case where the honest answer really is "expect a partial answer"."""
+        budget = float(sweep.per_shard_seconds())
+        self.assertEqual(sweep.shards_for([budget + 1]), sweep.MAX_SHARDS)
+        self.assertIn("PARTIAL answer", sweep.over_budget([budget + 1]))
+
+    def test_a_plan_that_fits_on_total_but_not_on_one_hand_gets_another_shard(self):
+        """Two mutations, each two thirds of a budget. The total is 1.33 shards' worth, so
+        dividing the total gives two — and the *deal* is what proves two is enough, since
+        round-robin puts one on each. Make it three such mutations and the total says two
+        while the deal says three: with two shards, shard 1 takes the first and the third.
+        """
+        heavy = sweep.per_shard_seconds() * 2 / 3
+        self.assertEqual(sweep.shards_for([heavy, heavy]), 2)
+        self.assertEqual(sweep.shards_for([heavy, heavy, heavy]), 3)
+        self.assertLessEqual(sweep.heaviest_hand([heavy] * 3, 3),
+                             sweep.per_shard_seconds())
+
+    def test_nothing_is_dropped_when_the_cost_wants_more_than_eight_shards(self):
+        """The trade `MAX_SHARDS` forces, and the answer this file chose: **exceed the
+        budget, loudly, and never drop.** A plan capped by dropping mutations would make
+        the verdict's own name — `no survivors` — a claim about a sweep that never ran, and
+        the check name IS the deliverable. So the cap is on machines: every mutation is
+        still dealt, the shards carry more than they were sized for, they stop at
+        `SHARD_REPORT_AT` and report what they measured, and `no verdict: N out of time`
+        stays reachable and honest.
+        """
+        costs = [float(sweep.per_shard_seconds())] * 40
+        self.assertEqual(sweep.shards_for(costs), sweep.MAX_SHARDS)
+        plan = [_mutation("charter/m.py", n) for n in range(40)]
+        dealt = [m for i in range(1, sweep.MAX_SHARDS + 1)
+                 for m in sweep.shard_of(plan, i, sweep.MAX_SHARDS)]
+        self.assertEqual(len(dealt), 40)
+        self.assertEqual(sorted(m.line for m in dealt), sorted(m.line for m in plan))
+
+    def test_the_warning_fires_on_the_heaviest_hand_and_not_on_a_count(self):
+        """The boundary again, on the other function that reads it. 224 average mutations
+        are eight hands of exactly 1680 s and say nothing; one more is 1740 s on the
+        heaviest hand and says so."""
+        budget = float(sweep.per_shard_seconds())
+        self.assertEqual(sweep.over_budget([budget / 8] * 8), "")
+        loud = sweep.over_budget([budget] * 9)
+        self.assertIn("PARTIAL answer", loud)
+        self.assertIn(f"{sweep.per_shard_seconds()} s a shard is sized for", loud)
+
+    def test_the_deliberate_headroom_between_sizing_and_the_deadline_is_not_spent(self):
+        """`SHARD_BUDGET` sizes the plan from the predictable half of the cost; the twenty
+        minutes up to `SHARD_REPORT_AT` are for the half no prediction can see — the full
+        suite `decide` runs when a subset does not kill, and a survivor's confirmation.
+        Sizing against the deadline instead would spend that headroom on arithmetic and
+        hand the partial answers back to the branches that have something to report."""
+        self.assertEqual(sweep.per_shard_seconds(), sweep.SHARD_BUDGET - sweep.SHARD_FIXED)
+        self.assertGreaterEqual(sweep.SHARD_REPORT_AT - sweep.SHARD_BUDGET, 10 * 60)
+
+
+class TheCostConstantsAreReadOffTheRunsThatRanOutOfTime(unittest.TestCase):
+    """Two runs with very different maps, two unknowns, and the numbers that solve them.
+
+    #626: about 53 mutations of `charter/gitconfig.py` (13 of 450 modules) in ~2880 s of
+    mutation time. #914: 5 mutations — one of `charter/cli.py` at 6 of 450 and four of
+    `charter/config.py` at 323 — in ~3000 s. A cost model that reproduces one of those and
+    not the other is fitted to a run rather than measured from two.
+    """
+
+    def _cost(self, modules, n=1):
+        return n * (sweep.SECONDS_A_MUTATION_FIXED
+                    + sweep.SECONDS_A_SUITE_RUN * modules / 450)
+
+    def test_the_model_reproduces_what_626_measured(self):
+        self.assertAlmostEqual(self._cost(13, 53) / 2880, 1.0, delta=0.05)
+
+    def test_the_model_reproduces_what_914_measured(self):
+        self.assertAlmostEqual((self._cost(6) + self._cost(323, 4)) / 3000, 1.0, delta=0.05)
+
+    def test_a_whole_suite_run_costs_a_shard_what_four_concurrent_ones_cost(self):
+        """`SHARD_FIXED_COSTS` states the unmutated baseline — the whole suite once, alone
+        on the runner. A shard runs `--jobs 4` and `unittest` is single-threaded, so four
+        concurrent whole-suite runs queue on a four-vCPU runner rather than overlapping.
+        The second corroboration is `SUBSET_TIMEOUT`: a subset that is the whole suite is
+        the run that reaches it, and on #914 every `charter/config.py` mutation did."""
+        self.assertEqual(sweep.SECONDS_A_SUITE_RUN,
+                         4 * sweep.SHARD_FIXED_COSTS["the unmutated baseline"])
+        self.assertGreater(sweep.SECONDS_A_SUITE_RUN, sweep.SUBSET_TIMEOUT)
+
+    def test_the_average_sits_between_the_two_halves_it_was_an_average_of(self):
+        """`SECONDS_A_MUTATION` is still the right answer for a mutation nothing has been
+        measured about, and it has to stay between the fixed floor and a whole-suite run or
+        it is not an average of anything."""
+        self.assertLess(sweep.SECONDS_A_MUTATION_FIXED, sweep.SECONDS_A_MUTATION)
+        self.assertLess(sweep.SECONDS_A_MUTATION, sweep.SECONDS_A_SUITE_RUN)
+
+
+class ThePlanSizesItselfFromTheMapItWarmed(unittest.TestCase):
+    """The plumbing half of #915: `plan` measured the map and then sized off a count.
+
+    `--warm-map` traces the selection map in the plan job so the shards can restore it
+    instead of paying for it again. The measurement was therefore already in hand and
+    already paid for, and the job threw the only copy of it away before deciding how many
+    machines the branch needed.
+    """
+
+    def setUp(self):
+        self.plan = [_mutation("charter/config.py", n, "derive") for n in range(8)]
+        self.plan += [_mutation("charter/cli.py", 1993, "_plane_refusal")]
+
+    def _sized(self, selection):
+        costs = sweep.costs_for(selection, self.plan)
+        return sweep.shards_for(costs), costs
+
+    def test_the_same_plan_is_sized_differently_once_the_map_is_read(self):
+        """The regression this whole issue is, in one assertion: nine mutations is one
+        shard by count and more than one by cost, and the difference is a file every other
+        module imports."""
+        by_count, _ = self._sized({})
+        by_cost, _ = self._sized(_MAP_914)
+        self.assertEqual(by_count, 1)
+        self.assertGreater(by_cost, by_count)
+
+    def _warmed(self, warm_map):
+        """`_warm_map` with the sandbox and the trace stubbed out — what it RETURNS is the
+        whole question, and building a real one is a `git clone` and four hundred traces."""
+        measured = {"charter/config.py": ["tests.test_a", "tests.test_b"]}
+        for name, stub in (("load_map", lambda *a, **k: measured),
+                           ("Sandbox", lambda *a, **k: types.SimpleNamespace(
+                               path=Path("/nowhere"))),
+                           ("run_dir", lambda workdir: Path("/nowhere"))):
+            real = getattr(sweep, name)
+            setattr(sweep, name, stub)
+            self.addCleanup(setattr, sweep, name, real)
+        args = argparse.Namespace(warm_map=warm_map, paths=None, jobs=1,
+                                  refresh_map=False)
+        return measured, sweep._warm_map(args, Path("/nowhere"), "HEAD", {},
+                                         Path("/nowhere"), Path("/nowhere"),
+                                         lambda *a: None)
+
+    def test_the_warm_map_hands_back_what_it_measured(self):
+        """Returned and not only written to the cache directory. `_warm_map` returning
+        `{}` on the path that warms is #915 unfixed with the plumbing in place — the plan
+        would size by count with the map sitting on disk beside it."""
+        measured, got = self._warmed(warm_map=True)
+        self.assertEqual(got, measured)
+
+    def test_no_warm_map_means_no_map_and_not_a_traced_one(self):
+        """The other half of the branch. `--plan` on its own promises to cost a second, so
+        it must not reach `load_map` — which traces the whole suite when the cache misses."""
+        _, got = self._warmed(warm_map=False)
+        self.assertEqual(got, {})
 
 
 if __name__ == "__main__":      # pragma: no cover

--- a/tests/test_sweep.py
+++ b/tests/test_sweep.py
@@ -3776,7 +3776,12 @@ class AShardThatWillNotFitReportsWhatItMeasured(unittest.TestCase):
         self.assertIn("Out of time — planned, and never measured", page)
         self.assertIn("1 of 4 mutation(s) on this branch were measured", page)
         self.assertIn("charter/b.py:2", page)
-        self.assertIn("Re-running does not help", page)
+        self.assertIn("Re-running does not help by itself", page)
+        # And why it does not, which changed with #915: the fan-out is sized against
+        # predicted cost, so a second run deals the same plan to the same machines. The
+        # old sentence blamed the plan being too long, which is what a count could see —
+        # and #914's plan was 22 mutations, well inside any count.
+        self.assertIn("what the selection map says each mutation costs", page)
         # The outcome table too, and not only the prose below it. A reader who skims one
         # skims the other, and the sweep found this row unpinned on this branch: deleting
         # it left a table whose rows all read zero above a section saying three quarters

--- a/tests/test_sweep.py
+++ b/tests/test_sweep.py
@@ -6495,6 +6495,10 @@ class TheFanOutIsSizedAgainstTheHeaviestHandAndNotTheTotal(unittest.TestCase):
         self.assertEqual(sweep.heaviest_hand(costs, 3), 12.0)  # 7+5, dealt to shard 1
         self.assertEqual(sweep.heaviest_hand(costs, 1), 17.0)
         self.assertEqual(sweep.heaviest_hand([], 4), 0)
+        # And the LAST shard counts. A range that stops one short reports the same answer
+        # whenever the worst hand is not the final one, which is most of the time — so the
+        # case that catches it has to put the expensive mutation on the last shard.
+        self.assertEqual(sweep.heaviest_hand([1.0, 1.0, 7.0], 3), 7.0)
 
     def test_a_hand_of_exactly_the_budget_fits_and_one_second_more_does_not(self):
         """The boundary, pinned on both sides. `<` where `<=` belongs here costs a shard
@@ -6538,6 +6542,13 @@ class TheFanOutIsSizedAgainstTheHeaviestHandAndNotTheTotal(unittest.TestCase):
         """
         costs = [float(sweep.per_shard_seconds())] * 40
         self.assertEqual(sweep.shards_for(costs), sweep.MAX_SHARDS)
+        # Nine mutations of exactly one budget each is the case that catches a fan-out
+        # allowed one machine past the cap: NINE shards would fit it perfectly, eight
+        # cannot fit it at all, and the answer has to be eight. `MAX_SHARDS` is a limit on
+        # how much of the runner pool one branch may hold, and a plan that wants more
+        # machines is exactly the plan that must not be given them.
+        self.assertEqual(sweep.shards_for([float(sweep.per_shard_seconds())] * 9),
+                         sweep.MAX_SHARDS)
         plan = [_mutation("charter/m.py", n) for n in range(40)]
         dealt = [m for i in range(1, sweep.MAX_SHARDS + 1)
                  for m in sweep.shard_of(plan, i, sweep.MAX_SHARDS)]

--- a/tools/sweep.py
+++ b/tools/sweep.py
@@ -4325,9 +4325,14 @@ def _plan_step(args, root: Path, ref: str, base: str, scope: dict[str, set[int]]
     # is making this sweep slow" is the question #914 could not answer from anything the
     # plan printed. Alphabetical still, and not sorted by cost: this list exists so a
     # foreign path is *findable*, and a reader looking for one wants it where it belongs.
+    #
+    # Only with a map, because on the other path the number would be the mutation count
+    # times a constant — the very figure that could not see #914 coming, restated in
+    # minutes so that it reads like a measurement.
     per_file: dict[str, float] = {}
-    for mutation, cost in zip(plan, costs):
-        per_file[mutation.path] = per_file.get(mutation.path, 0.0) + cost
+    if selection:
+        for mutation, cost in zip(plan, costs):
+            per_file[mutation.path] = per_file.get(mutation.path, 0.0) + cost
     for rel in sorted(scope)[:20]:
         spent = f" — {round(per_file[rel] / 60)} min predicted" if rel in per_file else ""
         log(f"    charged: {rel}{spent}")

--- a/tools/sweep.py
+++ b/tools/sweep.py
@@ -3167,9 +3167,11 @@ def per_shard_seconds() -> int:
 
     Clamped at 1, and :func:`per_shard` is where that clamp was found unpinned: raise the
     fixed cost past the budget — a slower runner, a longer suite, a map that stops being
-    cached — and the subtraction goes to zero or below, which makes :func:`shards_for` a
-    division by zero and the plan job an exception. No plan, no shards, no numbers, which
-    is #617's failure arriving out of the arithmetic written to prevent it.
+    cached — and the subtraction goes to zero or below. That used to be a division by zero
+    in `shards_for` and the plan job an exception: no plan, no shards, no numbers, which is
+    #617's failure arriving out of the arithmetic written to prevent it. It is a comparison
+    now rather than a division, so the clamp is what keeps a shard from being sized for
+    nothing at all while :func:`per_shard` goes on reporting a whole number of mutations.
     """
     return max(1, SHARD_BUDGET - SHARD_FIXED)
 
@@ -3199,10 +3201,10 @@ def seconds_for(selection: dict[str, list[str]], mutation: Mutation) -> float:
     """What one mutation is predicted to cost a shard, in seconds.
 
     **The whole of #915 is that this is not a constant.** A mutation costs one run of the
-    modules :func:`select_for` picks for it, and that selection spans two orders of
-    magnitude in the same diff: on #914, `charter/cli.py::_plane_refusal` selects 6 of 450
-    modules and `charter/config.py::derive` selects 323 — `config` being the module every
-    other module imports. Sizing a plan by ``count × SECONDS_A_MUTATION`` deals those two as
+    modules :func:`select_for` picks for it, and that selection spans a factor of fifty in
+    the same diff: on #914, `charter/cli.py::_plane_refusal` selects 6 of 450 modules and
+    `charter/config.py::derive` selects 323 — `config` being the module every other module
+    imports. Sizing a plan by ``count × SECONDS_A_MUTATION`` deals those two as
     equals, gives 22 mutations one shard, and spends the runner's hour reaching five of
     them.
 
@@ -3328,8 +3330,10 @@ def over_budget(costs: list[float]) -> str:
     **What it says the ceiling IS changed with #915.** It used to be a count — 224
     mutations, eight shards of twenty-eight — and a count is exactly the thing that could
     not see #914 coming: 22 mutations, comfortably inside 224, and five of them measured.
-    The ceiling is now the eight heaviest hands this plan would produce, in minutes, which
-    is the number that actually decides whether the answer arrives.
+    The ceiling is now the heaviest of the eight hands this plan would produce, in seconds
+    — the number that actually decides whether the answer arrives. Seconds and not minutes,
+    because #914 is 1707 against 1680 and rounding those to minutes prints "28 of 28",
+    which is a warning that reads like a fit.
     """
     heaviest = heaviest_hand(costs, MAX_SHARDS)
     if heaviest <= per_shard_seconds():
@@ -3770,9 +3774,13 @@ def gate_summary(gate: Gate, ref: str, base: str, elapsed: float | None,
           "measured died with it.")
         w("")
         w("**Read the counts above as a floor and not as a total.** A survivor in the "
-          "unmeasured slice looks exactly like this page. Re-running does not help — the "
-          f"plan is larger than {MAX_SHARDS} shards can measure — so either split the "
-          "branch, or raise the fan-out.")
+          "unmeasured slice looks exactly like this page. Re-running does not help by "
+          "itself: since #915 the fan-out is sized against what the selection map says "
+          "each mutation costs, not against how many there are, so a second run deals the "
+          "same plan to the same number of machines. Either the plan is past what "
+          f"{MAX_SHARDS} shards can measure — `Size the sweep` says so out loud, before a "
+          "runner is spent — or the prediction was under, which is worth reporting. Split "
+          "the branch, or raise the fan-out.")
         w("")
         for r in sorted(gate.out_of_time,
                         key=lambda r: (r.mutation.path, r.mutation.line))[:20]:
@@ -4058,10 +4066,12 @@ def main(argv: list[str] | None = None) -> int:
                         "log nobody opens.")
     p.add_argument("--plan", action="store_true",
                    help="Say how many mutations this branch offers and how many jobs "
-                        "they need, then stop. Costs one `ast` pass and no test runs.")
+                        "they need, then stop. Costs one `ast` pass and no test runs, "
+                        "and sizes by count — add --warm-map to size by measured cost.")
     p.add_argument("--warm-map", action="store_true", dest="warm_map",
                    help="Measure the selection map into --workdir and stop, so that the "
-                        "shards restore it instead of each measuring it again.")
+                        "shards restore it instead of each measuring it again — and so "
+                        "that --plan sizes the fan-out by what each mutation costs.")
     p.add_argument("--shard", default=None, metavar="N/M",
                    help="Sweep only slice N of M, dealt one mutation at a time across "
                         "the whole plan. Nothing is dropped: the other slices are other "

--- a/tools/sweep.py
+++ b/tools/sweep.py
@@ -3105,15 +3105,56 @@ SHARD_FIXED_COSTS = {
 #: hits is a budget that fails on exactly the runs nobody is watching.
 SHARD_FIXED = 12 * 60
 
-#: What one mutation costs a shard. Read off the runs that ran out of time rather than off
-#: a workstation: #626 reached about 53 of its 78 inside the hour, and the fixed cost of a
-#: run with no map cache was about 515 s, which leaves **58 s** each. A workstation
-#: measures 24 s at `--jobs 3`; CI is slower and the gate must be sized against CI.
+#: What one mutation costs a shard when nothing is known about it. Read off the runs that
+#: ran out of time rather than off a workstation: #626 reached about 53 of its 78 inside
+#: the hour, and the fixed cost of a run with no map cache was about 515 s, which leaves
+#: **58 s** each. A workstation measures 24 s at `--jobs 3`; CI is slower and the gate must
+#: be sized against CI.
 #:
-#: Together: 78 mutations over the three shards this sizing asks for is 26 each, so
-#: 515 + 26×58 ≈ 34 min with no cache and under 30 with one — inside the budget, and well
-#: inside `sweep.yml`'s hour.
+#: **It is an average, and #915 is what an average costs.** #626's 78 mutations were all in
+#: one new file whose selection map is 13 of 450 test modules, so 58 s is what a *cheap*
+#: mutation costs; #914's `charter/config.py` mutations select 323 of 450 and cost more than
+#: ten times that. Sizing a plan by this number times a count deals those two as equals.
+#: It is still the right answer for a plan whose map has not been measured — see
+#: :func:`seconds_for` — and the wrong one for a plan whose map is in hand.
 SECONDS_A_MUTATION = 60
+
+#: What one mutation costs a shard however small its subset is: restoring the sandbox,
+#: starting an interpreter, and `unittest discover`'s own walk of `tests/`.
+#:
+#: **The count-shaped half of the cost, and the only half a count could ever see.** With
+#: :data:`SECONDS_A_SUITE_RUN` it is solved from the two runs that ran out of time, whose
+#: selection maps are known and very different — #626 measured about 53 mutations of
+#: `charter/gitconfig.py` (13 of 450 modules) in ~2880 s of mutation time, and #914 measured
+#: 5 (one of `charter/cli.py` at 6 of 450, four of `charter/config.py` at 323 of 450) in
+#: ~3000 s. Two runs, two unknowns:
+#:
+#:     53×F + 53×(13/450)×S  = 2880
+#:      5×F + (6 + 4×323)/450×S = 3000
+#:
+#: which gives F ≈ 25 s and S ≈ 996 s.
+SECONDS_A_MUTATION_FIXED = 25
+
+#: What a mutation whose subset **is** the whole suite costs a shard, in seconds.
+#:
+#: The map-shaped half, and the one #915 is about. Corroborated twice, which is why the
+#: round number is 960 and not the 996 the arithmetic above lands on:
+#:
+#: * ``SHARD_FIXED_COSTS["the unmutated baseline"]`` is 240 s — the whole suite once, alone
+#:   on `ubuntu-latest`. A shard runs `--jobs 4` and `unittest` is single-threaded, so four
+#:   concurrent whole-suite runs queue on a four-vCPU runner rather than overlapping:
+#:   4 × 240 = 960 s of shard budget for four of them, one whole-suite run each.
+#: * :data:`SUBSET_TIMEOUT` is the same number seen from the other side. A subset that is
+#:   the whole suite is the run that reaches it, and on #914 every `charter/config.py`
+#:   mutation did: `{'green': False, 'ran': 0, 'detail': 'timed out after 900s'}`.
+#:
+#: What it deliberately does **not** cover is the second and third runs :func:`decide` makes
+#: — the full suite that has the last word, and a survivor's confirmation. Those depend on
+#: the verdict and not on the diff, so no prediction can see them, and they are what the
+#: twenty minutes between :data:`SHARD_BUDGET` and :data:`SHARD_REPORT_AT` are for. That gap
+#: is headroom for the unpredictable half of the cost and must not be spent closing the
+#: predictable half.
+SECONDS_A_SUITE_RUN = 960
 
 #: The most jobs one pull request may fan out to. Not a limit on what gets swept — every
 #: mutation is still dealt to a shard past this point, they just get more each — but a
@@ -3121,9 +3162,81 @@ SECONDS_A_MUTATION = 60
 MAX_SHARDS = 8
 
 
+def per_shard_seconds() -> int:
+    """How long one shard has for mutations, once its fixed costs are paid.
+
+    Clamped at 1, and :func:`per_shard` is where that clamp was found unpinned: raise the
+    fixed cost past the budget — a slower runner, a longer suite, a map that stops being
+    cached — and the subtraction goes to zero or below, which makes :func:`shards_for` a
+    division by zero and the plan job an exception. No plan, no shards, no numbers, which
+    is #617's failure arriving out of the arithmetic written to prevent it.
+    """
+    return max(1, SHARD_BUDGET - SHARD_FIXED)
+
+
 def per_shard() -> int:
-    """How many mutations one shard can measure inside :data:`SHARD_BUDGET`."""
-    return max(1, (SHARD_BUDGET - SHARD_FIXED) // SECONDS_A_MUTATION)
+    """How many *average* mutations one shard can measure inside :data:`SHARD_BUDGET`.
+
+    Only ever the answer when the selection map has not been measured — see
+    :func:`seconds_for`. Kept as a function rather than inlined because the count is what
+    the plan says out loud on that path, and a number a reader is shown is a number
+    something should be able to assert.
+    """
+    return max(1, per_shard_seconds() // SECONDS_A_MUTATION)
+
+
+def suite_size(selection: dict[str, list[str]]) -> int:
+    """How many test modules the map ever names — the denominator a share is taken over.
+
+    Read off the map and not off `tests/` on disk, so that a share is a fraction of the
+    suite **as measured**: a module that would not load is absent from the map, and
+    counting it in the denominator would make every share smaller than the run it predicts.
+    """
+    return len({module for modules in selection.values() for module in modules})
+
+
+def seconds_for(selection: dict[str, list[str]], mutation: Mutation) -> float:
+    """What one mutation is predicted to cost a shard, in seconds.
+
+    **The whole of #915 is that this is not a constant.** A mutation costs one run of the
+    modules :func:`select_for` picks for it, and that selection spans two orders of
+    magnitude in the same diff: on #914, `charter/cli.py::_plane_refusal` selects 6 of 450
+    modules and `charter/config.py::derive` selects 323 — `config` being the module every
+    other module imports. Sizing a plan by ``count × SECONDS_A_MUTATION`` deals those two as
+    equals, gives 22 mutations one shard, and spends the runner's hour reaching five of
+    them.
+
+    Two terms, because the cost has two halves: a fixed one that a count could already see
+    (:data:`SECONDS_A_MUTATION_FIXED`) and a measured one that only the map can
+    (:data:`SECONDS_A_SUITE_RUN` times the share of the suite this mutation selects).
+
+    **An unmeasured map falls back toward MORE, never less**, which is :func:`select_for`'s
+    own rule applied to the clock rather than to the tests:
+
+    * no map at all — nothing has been measured, so the honest answer is the average this
+      tool used before there was anything better, and the plan says which it used;
+    * a map that covers nothing for this mutation — :func:`decide` reads that silence as
+      "go straight to the full suite", so the prediction is a whole-suite run and not a
+      cheap one.
+
+    A share cannot exceed 1: every module in a map entry is counted in :func:`suite_size`.
+    """
+    suite = suite_size(selection)
+    if not suite:
+        return float(SECONDS_A_MUTATION)
+    modules = select_for(selection, mutation)
+    share = len(modules) / suite if modules else 1.0
+    return SECONDS_A_MUTATION_FIXED + SECONDS_A_SUITE_RUN * share
+
+
+def costs_for(selection: dict[str, list[str]], plan: list[Mutation]) -> list[float]:
+    """:func:`seconds_for` over a whole plan, in plan order.
+
+    Order is load-bearing: :func:`shards_for` deals these with the same :func:`shard_of`
+    the shards deal mutations with, so entry *i* here has to be the cost of mutation *i*
+    there or the sizing is about a different plan than the one that runs.
+    """
+    return [seconds_for(selection, mutation) for mutation in plan]
 
 
 def budget_for(sharded: bool, override: float | None = None) -> float:
@@ -3147,17 +3260,54 @@ def budget_for(sharded: bool, override: float | None = None) -> float:
     return float(SHARD_REPORT_AT) if sharded else 0.0
 
 
-def shards_for(mutations: int) -> int:
-    """How many jobs *mutations* of them need, so that none of them runs out of time.
+def heaviest_hand(costs: list[float], count: int) -> float:
+    """What the most expensive of *count* shards is predicted to carry, in seconds.
+
+    **Through :func:`shard_of` and not through arithmetic beside it**, which is the whole
+    reason this is a function. The plan is dealt round-robin, so a candidate shard count's
+    real worst hand depends on where the expensive mutations land in that deal — and a
+    sizing rule that re-derived the deal here would be a second copy of it, free to drift
+    from the one the shards use. #670's defect is a measurement written down twice; this
+    would be a *rule* written down twice, on the one number that says whether the plan fits.
+    """
+    return max(sum(shard_of(costs, index, count)) for index in range(1, count + 1))
+
+
+def shards_for(costs: list[float]) -> int:
+    """The fewest shards whose heaviest hand fits inside one shard's budget.
+
+    *costs* is :func:`costs_for` over the plan — seconds, in plan order — and the unit is
+    the point. This function used to take a **count** and divide it by :func:`per_shard`,
+    which is #915: cost is not a function of how many mutations there are, and on #914 a
+    22-mutation diff whose eight `charter/config.py` mutations each select 323 of 450 test
+    modules was sized at one shard because 22 < 28. The shard spent the runner's hour
+    reaching five of them, and `charter/instance.py` — where that branch's refusal lives —
+    was never measured at all.
+
+    Sized against the heaviest **hand** rather than against the total, because the two are
+    not the same question. A plan may total two shards' worth of seconds and still hold one
+    file whose mutations all land on one shard; dividing the total would call that a fit.
+    Asking the deal directly cannot be wrong about it.
 
     At least one, always: a branch with nothing to sweep still gets a job, because "the
     sweep ran and found nothing to do" and "the sweep did not run" are the two answers
     #617 is about and they must not arrive as the same silence.
+
+    **And never more than :data:`MAX_SHARDS`, which is the trade this function does not get
+    to make.** Past the ceiling the plan is still dealt whole and every mutation still goes
+    to a shard — the shards simply carry more than the budget, stop at
+    :data:`SHARD_REPORT_AT`, and report what they measured. Nothing is dropped to make a
+    plan fit: a dropped mutation would make the verdict's own name — `no survivors` — a
+    claim about a sweep that never ran. :func:`over_budget` is where that gets said out
+    loud, before a runner is spent rather than after.
     """
-    return max(1, min(MAX_SHARDS, -(-mutations // per_shard())))
+    for count in range(1, MAX_SHARDS + 1):
+        if heaviest_hand(costs, count) <= per_shard_seconds():
+            return count
+    return MAX_SHARDS
 
 
-def over_budget(mutations: int) -> str:
+def over_budget(costs: list[float]) -> str:
     """Why this diff will be slow, said out loud, or ``""`` when it will not be.
 
     :data:`MAX_SHARDS` is a ceiling on machines and never on questions, so a diff past it
@@ -3174,16 +3324,23 @@ def over_budget(mutations: int) -> str:
     published as `success`. A shard now stops at its own budget and reports what it
     measured, so the honest warning is that the ANSWER will be short — which is a thing
     a reader can act on, where "there may be no answer" was only a thing to dread.
+
+    **What it says the ceiling IS changed with #915.** It used to be a count — 224
+    mutations, eight shards of twenty-eight — and a count is exactly the thing that could
+    not see #914 coming: 22 mutations, comfortably inside 224, and five of them measured.
+    The ceiling is now the eight heaviest hands this plan would produce, in minutes, which
+    is the number that actually decides whether the answer arrives.
     """
-    ceiling = MAX_SHARDS * per_shard()
-    if mutations <= ceiling:
+    heaviest = heaviest_hand(costs, MAX_SHARDS)
+    if heaviest <= per_shard_seconds():
         return ""
-    return (f"{mutations} mutations is past the {ceiling} that {MAX_SHARDS} shards can "
-            f"measure inside {SHARD_BUDGET // 60} minutes each. Nothing here is dropped "
-            f"and every one of them is dealt to a shard — but a shard stops at its "
-            f"budget and reports what it measured, so this branch gets a PARTIAL answer "
-            f"with the unmeasured mutations named. Split the branch, or read the count "
-            f"as a floor.")
+    return (f"{len(costs)} mutations is {round(sum(costs) / 60)} minutes of predicted test "
+            f"time, and the heaviest of {MAX_SHARDS} shards would carry "
+            f"{round(heaviest)} s against the {per_shard_seconds()} s a shard is sized "
+            f"for. Nothing here is dropped and every one of them is dealt to a shard — but "
+            f"a shard stops at its budget and reports what it measured, so this branch gets "
+            f"a PARTIAL answer with the unmeasured mutations named. Split the branch, or "
+            f"read the count as a floor.")
 
 
 def shard_of(plan: list[Mutation], index: int, count: int) -> list[Mutation]:
@@ -4131,24 +4288,52 @@ def _plan_step(args, root: Path, ref: str, base: str, scope: dict[str, set[int]]
                log) -> int:
     """Size the sweep, and optionally leave the selection map where the shards will find it.
 
-    This is the job that decides how many jobs the gate needs, and it is cheap on purpose:
-    the mutation count is an `ast` pass over the diff, so the decision costs a second and
-    is made from the real number rather than from a guess about how big branches get. The
-    guess is exactly what ran out — the job was sized against Phase 2's 30–52 mutations
-    and met 78.
+    This is the job that decides how many jobs the gate needs. The plan itself is an `ast`
+    pass over the diff, so the *list* costs a second and is made from the real number
+    rather than from a guess about how big branches get — the guess is exactly what ran out,
+    the job having been sized against Phase 2's 30–52 mutations and met 78.
+
+    **What that list costs is a second question, and #915 is the job answering the first
+    one and calling it the second.** The map that says what a mutation costs is measured
+    right here, by `--warm-map`, for the shards to restore — so the sizing is done with the
+    measurement already in hand and already paid for, and the only change is the order:
+    warm first, then size against what the warming measured.
+
+    Without `--warm-map` there is no map and nothing better than the average, so this falls
+    back to the count and says which of the two it used. That path is a person at a terminal
+    asking how big a branch is; `sweep.yml`'s plan job always warms.
     """
     plan, _ = plan_for(root, ref, scope, dirty)
-    shards = shards_for(len(plan))
-    log(f"  {len(plan)} mutations → {shards} shard(s) of at most {per_shard()} each")
+    selection = _warm_map(args, root, ref, dirty, workdir, cache_dir, log)
+    costs = costs_for(selection, plan)
+    shards = shards_for(costs)
+    if selection:
+        log(f"  {len(plan)} mutations → {shards} shard(s); "
+            f"{round(sum(costs) / 60)} min of predicted test time over "
+            f"{suite_size(selection)} test modules, "
+            f"{round(heaviest_hand(costs, shards))} s on the heaviest shard "
+            f"(a shard is sized for {per_shard_seconds()} s)")
+    else:
+        log(f"  {len(plan)} mutations → {shards} shard(s) of at most {per_shard()} each "
+            f"— no selection map here, so sized by count and not by cost (#915)")
     # Named, so a foreign path is visible on the one job that runs before anything is
     # spent (#776). A branch charged for another branch's file used to be invisible until
     # a survivor arrived in it, and by then the reader is being asked to judge a line
     # they have never seen. Capped, because `--all` puts the whole tree through here.
+    #
+    # With a map in hand each one carries what it is predicted to cost, because "which file
+    # is making this sweep slow" is the question #914 could not answer from anything the
+    # plan printed. Alphabetical still, and not sorted by cost: this list exists so a
+    # foreign path is *findable*, and a reader looking for one wants it where it belongs.
+    per_file: dict[str, float] = {}
+    for mutation, cost in zip(plan, costs):
+        per_file[mutation.path] = per_file.get(mutation.path, 0.0) + cost
     for rel in sorted(scope)[:20]:
-        log(f"    charged: {rel}")
+        spent = f" — {round(per_file[rel] / 60)} min predicted" if rel in per_file else ""
+        log(f"    charged: {rel}{spent}")
     if len(scope) > 20:
         log(f"    charged: … and {len(scope) - 20} more file(s)")
-    loud = over_budget(len(plan))
+    loud = over_budget(costs)
     if loud:
         # An annotation and not a log line. A cap nobody can see is the failure the spec
         # names about silent truncation, and a warning in a fold nobody opens is a cap
@@ -4163,17 +4348,30 @@ def _plan_step(args, root: Path, ref: str, base: str, scope: dict[str, set[int]]
     # mutations were read against.
     _write_output(args.github_output, mutations=str(len(plan)), shards=str(shards),
                   matrix=json.dumps(list(range(1, shards + 1))), base=base)
-    if args.warm_map:
-        # From a sandbox, for the reason `main` builds it from one: the map is measured on
-        # a clean checkout of the ref so that a mutation is the only thing that ever
-        # differs from what was traced. The cache is keyed on the tree's own hash, so the
-        # shards find this one only if they are asking about the very same tree.
-        log("  warming the selection map for the shards…")
-        box = Sandbox(root, run_dir(workdir) / "map", ref, dirty)
-        load_map(box.path, tuple(args.paths or DEFAULT_PATHS), cache_dir, args.jobs,
-                 args.refresh_map, log)
-        shutil.rmtree(run_dir(workdir), ignore_errors=True)
     return 0
+
+
+def _warm_map(args, root: Path, ref: str, dirty: dict[str, bytes], workdir: Path,
+              cache_dir: Path, log) -> dict[str, list[str]]:
+    """The map the shards will restore, measured here — and now sized against here too.
+
+    Returned rather than only left on disk, which is the whole of #915's plumbing: the plan
+    job pays for this measurement so the shards do not have to, and then used to throw the
+    only copy of it away and size the fan-out off a count. ``{}`` when `--warm-map` was not
+    asked for, and :func:`seconds_for` reads that as "nothing measured, use the average".
+    """
+    if not args.warm_map:
+        return {}
+    # From a sandbox, for the reason `main` builds it from one: the map is measured on
+    # a clean checkout of the ref so that a mutation is the only thing that ever
+    # differs from what was traced. The cache is keyed on the tree's own hash, so the
+    # shards find this one only if they are asking about the very same tree.
+    log("  warming the selection map for the shards…")
+    box = Sandbox(root, run_dir(workdir) / "map", ref, dirty)
+    selection = load_map(box.path, tuple(args.paths or DEFAULT_PATHS), cache_dir,
+                         args.jobs, args.refresh_map, log)
+    shutil.rmtree(run_dir(workdir), ignore_errors=True)
+    return selection
 
 
 def _merge_step(args) -> int:


### PR DESCRIPTION
`tools/sweep.py --plan` divided the mutation count by a per-shard count. Cost is not a
function of count — it is a function of the selection map, which `--warm-map` measures in
that very job and which `plan` then threw away.

## The measurement, on #914's charged set

Reconstructed with `--ref 40ace71 --base 9d18d55`, which reproduces the issue's plan
exactly — same five files, same 22 mutations.

**Before** (`origin/main`):

```
  22 mutations → 1 shard(s) of at most 28 each
    charged: charter/cli.py
    charged: charter/config.py
    charged: charter/doctor.py
    charged: charter/frame/state.py
    charged: charter/instance.py
```

**After** (this branch, same tree, same warmed map):

```
  22 mutations → 8 shard(s); 174 min of predicted test time over 450 test modules,
                 1707 s on the heaviest shard (a shard is sized for 1680 s)
    charged: charter/cli.py — 1 min predicted
    charged: charter/config.py — 95 min predicted
    charged: charter/doctor.py — 5 min predicted
    charged: charter/frame/state.py — 4 min predicted
    charged: charter/instance.py — 69 min predicted
::warning title=The deletion sweep is over its budget::22 mutations is 174 minutes of
predicted test time, and the heaviest of 8 shards would carry 1707 s against the 1680 s a
shard is sized for. Nothing here is dropped …
```

The map, traced on this repository, is why:

| mutated symbol | test modules selected, of 450 |
| --- | --- |
| `charter/instance.py::load` | 337 |
| `charter/config.py::derive` | 323 |
| `charter/frame/state.py` (module scope) | 105 |
| `charter/doctor.py::check_control_plane_config` | 25 |
| `charter/cli.py::_plane_refusal` | 6 |

Fifty-four times apart in the tests they select, dealt as equals, and 22 < 28.

## How a shard is sized now

```
seconds_for(m) = SECONDS_A_MUTATION_FIXED + SECONDS_A_SUITE_RUN × (modules selected / 450)
```

`shards_for(costs)` then asks for **the fewest shards whose heaviest hand fits**
`SHARD_BUDGET - SHARD_FIXED`, and it asks through `shard_of` — the same round-robin the
shards deal with — rather than through a second copy of the dealing rule. Dividing the
total would call a plan a fit when one shard is carrying both expensive mutations.

Both constants are **solved from the two runs that ran out of time**, whose maps are known
and very different:

```
#626:  53×F + 53×(13/450)×S   = 2880 s        (charter/gitconfig.py, 13 of 450)
#914:   5×F + (6+4×323)/450×S = 3000 s        (cli.py ×1, config.py ×4)
        →  F ≈ 25 s,  S ≈ 996 s
```

960 rather than 996 because it is corroborated independently: the unmutated baseline is
240 s alone on the runner, a shard runs `--jobs 4`, and `unittest` is single-threaded — four
concurrent whole-suite runs queue on a four-vCPU runner rather than overlapping. And
`SUBSET_TIMEOUT` is 900, which is the same number from the other side: a subset that is the
whole suite is the run that reaches it, and on #914 every `charter/config.py` mutation did.

The model reproduces #626 at 2794 s against 2880 measured, and #914 at 2894 s against
~3000 — i.e. it predicts, from the map alone, that one shard reaches about five of those 22.
Both are asserted.

**The model does not predict the full-suite run `decide` makes when a subset does not kill,
nor a survivor's confirmation.** Those depend on the answer and not on the diff. They are
what the twenty minutes between `SHARD_BUDGET` (40) and `SHARD_REPORT_AT` (50) are for, and
that gap is untouched — asserted, so a later edit that spends it is red here.

## When cost wants more than eight shards

**#914 lands on this**: eight shards are sized for 1680 s each and its heaviest hand is
1707. Something has to give. What gives is the **budget**, never the plan.

Every mutation is still dealt. The shards carry more than they were sized for, stop at
`SHARD_REPORT_AT`, and report what they measured, so `no verdict: N out of time` stays
reachable and honest — which it must, because the verdict is the check's name. Capping the
plan to make it fit would make `no survivors` a claim about a sweep that never ran; that is
strictly worse than the bug. Raising `MAX_SHARDS` was not taken either: it is a limit on how
much of the runner pool one branch may hold, it is not a correctness knob, and no finite
value of it closes the case anyway.

What changes is *when you find out*. The warning fires on the plan job, before a runner is
spent on measuring, and names predicted minutes rather than a mutation count — the count
being exactly what could not see #914 coming, 22 being comfortably inside the old ceiling
of 224.

## The `workflow_dispatch` shard override, deliberately not taken

The issue names it as a third option. It is a safety valve for when prediction is wrong, not
a fix: a manual override does not help the branch that silently got no verdict, because
nobody knew to override. It would also install a second sizing authority, free to disagree
with the measured one — #670's shape, on the number that decides whether the answer arrives.
The annotation is the automatic version of the same warning, and it arrives before the hour
is spent rather than after.

## What stays exactly as it was

- **The count path is bit-identical.** With no map every mutation is priced at
  `SECONDS_A_MUTATION`, eight hands of 28 × 60 s are exactly the 1680 s a shard is sized
  for, and the 224/225 warning boundary this suite already pinned survives the change of
  unit untouched. `--plan` on its own still costs one `ast` pass; `sweep.yml` always warms.
- **The dealing.** `shard_of` still depends on nothing but the diff. A deal that consulted
  the map would be a slice each shard derived from its own measurement, and two shards
  disagreeing by one module would sweep one slice twice and another never while the merge
  step reported a complete sweep.
- **`SHARD_BUDGET`, `SHARD_REPORT_AT`, `timeout-minutes: 60`, `MAX_SHARDS`.** No constant
  that was a deadline moved.

One behaviour does change as a consequence of the ordering: `plan` now warms the map before
it sizes, so a trace that refuses (`the selection map is empty — refusing to sweep blind`)
leaves no `shards` output and `collect` says `no verdict: the sweep never sized itself`
rather than `no verdict: N of N shards did not report`. The shards never ran in that case
either way, so the new sentence is the true one.

## Verification

`python3 -m unittest discover -s tests -q` — read the trailer, and it is `OK`.
`tests/test_sweep.py` alone is 461 tests. The before/after above is a real `--plan` run
against a real traced map (450 modules), not a fixture.

Closes #915.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018hUBNraNfixfMMK5Jc6CNy
