### PR TITLE
charter save tells a clean tree from one it could not read, and refuses the second (#917)

### DIFF
--- a/charter/commands.py
+++ b/charter/commands.py
@@ -7,8 +7,8 @@ import json
 import re
 from pathlib import Path
 
-from . import (config, contain, docsrc, doctor, instance, inventory, render, tui, util,
-               workspace, worktree)
+from . import (config, contain, docsrc, doctor, gitstate, instance, inventory, render,
+               tui, util, workspace, worktree)
 # One committer for the control plane, in charter/planegit.py. Re-exported rather
 # than moved-and-updated so every existing caller and test keeps working — the point
 # of the extraction is that there is ONE implementation, not that callers churn.
@@ -765,7 +765,18 @@ def cmd_sync(args) -> int:
 
 def _sync_one(d: Path, ws: str) -> None:
     label = f"{ws}/{d.name}"
-    if _git(["status", "--porcelain"], cwd=d).stdout.strip():
+    dirt = gitstate.read(d)
+    if not dirt.known:
+        # #917, with the polarity that makes it worse than the usual reading. Everywhere
+        # else an unread `git status` costs a warning nobody sees; here the empty answer is
+        # what AUTHORISES the `git merge --ff-only` below. Skipping is what charter does
+        # for a tree it has been told holds work, and a tree it could not read has at least
+        # as strong a claim on being left alone.
+        util.warn(f"{label}: skipping — {dirt.why()}")
+        for line in dirt.remedy():
+            util.info(f"  {line}")
+        return
+    if dirt.rows:
         util.warn(f"{label}: uncommitted changes — skipping (your work is left untouched).")
         # …and this is the one case where "your work" may be nobody's work. A submodule
         # left behind the commit the branch records IS an unstaged change to the gitlink,
@@ -900,7 +911,11 @@ def _clone_note(d: Path) -> str:
     It costs a `git submodule status` only for a clone that has a `.gitmodules` at all
     (see `submodule_drift`), so the common row is still the two calls it always was."""
     branch = _git(["rev-parse", "--abbrev-ref", "HEAD"], cwd=d).stdout.strip()
-    dirty = "dirty" if _git(["status", "--porcelain"], cwd=d).stdout.strip() else "clean"
+    # A display site, kept honest for one line's worth of change. This row already has a
+    # written record of printing `clean` over a tree that was not (the submodule case
+    # above); a `git status` that failed printed the same word for a tree nobody read.
+    state = gitstate.read(d)
+    dirty = "unknown" if not state.known else "dirty" if state.rows else "clean"
     note = f"{branch} · {dirty}"
     absent, moved = submodule_drift(d)
     if absent:

--- a/charter/commands_persona.py
+++ b/charter/commands_persona.py
@@ -17,7 +17,8 @@ import json
 import os
 import sys
 
-from . import commands_secrets, config, contain, mcpseen, persona, root, trace, tui, util
+from . import (commands_secrets, config, contain, gitstate, mcpseen, persona, root, trace,
+               tui, util)
 from .secrets import base, registry
 
 #: The scaffold a new persona starts from.
@@ -1075,21 +1076,30 @@ def cmd_persona_forget(args) -> int:
 _MEM_PATH = __import__("re").compile(r"personas/[^/]+/(?:memory|refs)/")
 
 
-def _pending_memory(root) -> list[str]:
-    """Repo-relative persona memory/refs paths with uncommitted changes."""
-    import subprocess
-    r = subprocess.run(["git", "-C", str(root), "status", "--porcelain", "--", "personas"],
-                       stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, text=True, timeout=10)
+def _pending_memory(root) -> tuple[list[str], gitstate.TreeState]:
+    """Repo-relative persona memory/refs paths with uncommitted changes, **and the state
+    they were read from**.
+
+    Two values because one could not hold the answer (#917). The list is empty when there
+    is nothing to sync AND when charter could not ask — the call used to send git's stderr
+    to ``DEVNULL`` and never look at its exit status, so an unreadable plane produced a
+    green ``✓ No uncommitted persona memory/refs — nothing to sync.`` over memory nobody
+    had looked at. Durable knowledge that an agent has been told is shared, and is not.
+
+    Its twin is `hooks._uncommitted_memory_nudge`, which asks the same question at session
+    start and used to fall silent on the same failure. Both halves of "is memory unsynced"
+    answered "no" for the same reason at the same time, which is precisely how a defect of
+    this shape survives being noticed.
+    """
+    st = gitstate.read(root, "personas", timeout=10)
     out = []
-    for line in r.stdout.splitlines():
-        if not line.strip():
-            continue
+    for line in st.rows:
         path = line[3:].strip()
         if " -> " in path:  # rename → take the destination
             path = path.split(" -> ", 1)[1]
         if _MEM_PATH.search("/" + path):
             out.append(path)
-    return out
+    return out, st
 
 
 def cmd_persona_memory_sync(args) -> int:
@@ -1107,7 +1117,20 @@ def cmd_persona_memory_sync(args) -> int:
     from .hooks import _secret_kind
 
     root = config.ROOT
-    changed = _pending_memory(root)
+    changed, state = _pending_memory(root)
+    if not state.known and not state.no_repo:
+        # A tick is a claim, and this one is about durable knowledge being safe. #917 is
+        # what a false one costs; `doctor`'s `_NOT_CHECKED_HINT` states the same rule for
+        # the same reason — "not checked" is the absence of information, not evidence of
+        # health, and a green glyph over it is read as the latter.
+        #
+        # `no_repo` is exempt: a plane `charter init` created and nobody ran `git init` in
+        # has nowhere to sync TO, which is a definite answer rather than an unread one, and
+        # `commit_push` already names that case in its own words.
+        util.err(f"Refusing to sync — {state.why()}")
+        for line in state.remedy():
+            util.info(f"  {line}")
+        return 1
     if not changed:
         util.ok("No uncommitted persona memory/refs — nothing to sync.")
         return 0

--- a/charter/commands_workspace.py
+++ b/charter/commands_workspace.py
@@ -16,7 +16,8 @@ import sys
 import time
 from types import SimpleNamespace
 
-from . import change, config, contain, gitpolicy, planegit, tui, util, workspace, worktree
+from . import (change, config, contain, gitpolicy, gitstate, planegit, tui, util,
+               workspace, worktree)
 from .commands import (_cred_flag, _git, _origin_https, cmd_clone, commit_memory_reactive,
                        commit_push)
 
@@ -448,7 +449,16 @@ def _work_at_risk(name: str) -> list[str]:
     """
     out = []
     for d in workspace.clones(name):
-        if _git(["status", "--porcelain"], cwd=d).stdout.strip():
+        # #917, and the sharpest instance of it in this package: what this list is empty of
+        # is what `cmd_workspace_remove` hands to `shutil.rmtree`. Reading a `git status`
+        # that FAILED as "no uncommitted changes" makes a clone charter could not look at
+        # indistinguishable from one it looked at and found empty — and then deletes it.
+        # An unreadable clone is at risk by definition: charter cannot say what is in it.
+        dirt = gitstate.read(d)
+        if not dirt.known:
+            out.append(f"{d.name}: could not be read — {dirt.said}")
+            continue
+        if dirt.rows:
             out.append(f"{d.name}: uncommitted changes")
             continue
         up = _git(["rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"], cwd=d)
@@ -493,7 +503,14 @@ def _worktrees_at_risk(name: str) -> list[str]:
     for repo in repos:
         for wt in sorted(worktree.dirs_for(name, repo)):
             label = f"{repo}/{wt.name}"
-            if worktree.is_dirty(wt):
+            dirt = worktree.dirt(wt)
+            if not dirt.known:
+                # The same rmtree gate, the worktree half. Said in the shape the
+                # `unique_commits` line below has always used — this function already knew
+                # how to report "could not be checked" for one of its two questions.
+                out.append(f"{label}: could not be checked for uncommitted changes")
+                continue
+            if dirt.rows:
                 out.append(f"{label}: uncommitted changes")
                 continue
             alone = worktree.unique_commits(wt)
@@ -531,10 +548,21 @@ def _git_user() -> str:
 def _restore_blockers(name: str) -> list[str]:
     """Repos whose current branch wouldn't restore for another engineer — uncommitted
     work, unpushed commits, or a branch not on the remote at all. The 'enforce push'
-    guard: a manifest branch is only meaningful if it's actually on the remote."""
+    guard: a manifest branch is only meaningful if it's actually on the remote.
+
+    A clone charter could not read blocks too (#917). This list empty is what lets
+    `cmd_workspace_snapshot` write a manifest that claims to capture reality; a `git
+    status` that failed contributes the same emptiness as one that found nothing, and the
+    manifest then asserts a state nobody measured — to another engineer, on another
+    machine, who has no way to know it was never checked.
+    """
     out = []
     for d in workspace.clones(name):
-        if _git(["status", "--porcelain"], cwd=d).stdout.strip():
+        dirt = gitstate.read(d)
+        if not dirt.known:
+            out.append(f"{d.name}: could not be read — {dirt.said}")
+            continue
+        if dirt.rows:
             out.append(f"{d.name}: uncommitted changes")
             continue
         up = _git(["rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"], cwd=d)
@@ -815,7 +843,15 @@ def cmd_workspace_autosave(args) -> int:
         rel = _ws_meta_paths(name)
         if not rel:
             return 0
-        if not _git(["status", "--porcelain", "--", *rel], cwd=config.ROOT).stdout.strip():
+        # #917: `.stdout.strip()` alone made "nothing pending" and "charter could not ask"
+        # the same answer, on the path most likely to meet a real lock — this fires at the
+        # end of every turn, in the plane root, alongside `_commit_dispatch` and
+        # `commit_memory_reactive`, which is the exact contention `hooks._commit_dispatch`
+        # takes its own flock to avoid. An unknown state falls THROUGH to `commit_push`
+        # rather than returning here, because `commit_push` is now the thing that says why
+        # out loud; returning silently is how a memo stops being saved and nobody learns.
+        pending = gitstate.read(config.ROOT, *rel)
+        if pending.known and not pending.rows:
             return 0  # nothing pending
         marker = config.STATE_DIR / "ws-autosave" / name
         config.private_mkdir(marker.parent)

--- a/charter/commands_worktree.py
+++ b/charter/commands_worktree.py
@@ -107,7 +107,15 @@ def cmd_worktree_add(args) -> int:
     if detached:
         util.warn(f"{args.repo} is on a DETACHED HEAD ({base}) — the piece branches off "
                   "that commit, not a branch.")
-    if worktree.is_dirty(clone):
+    dirt = worktree.dirt(clone)
+    if not dirt.known:
+        # An advisory line, so this stays a warning rather than becoming a refusal — but it
+        # says WHICH of the two it is. Silence here reads as "nothing to carry", which is
+        # the reading #917 is about.
+        util.warn(f"{args.repo}: {dirt.why()}")
+        for line in dirt.remedy():
+            util.info(f"  {line}")
+    elif dirt.rows:
         util.warn(f"{args.repo} has uncommitted changes — they stay in the clone and are "
                   "NOT carried into the worktree.")
 
@@ -269,7 +277,13 @@ def cmd_worktree_list(args) -> int:
                 # still lists the record, but there's no path left to run `status` on.
                 state = "missing"
             else:
-                state = "dirty" if worktree.is_dirty(Path(r["path"])) else "clean"
+                # A DISPLAY site, and it still gets the third word. `missing` above covers
+                # the one failure anybody had measured (#597); every other way `git status`
+                # can fail printed `clean` in a column an operator reads before deciding
+                # whether a piece is safe to drop.
+                dirt = worktree.dirt(Path(r["path"]))
+                state = ("unknown" if not dirt.known else
+                         "dirty" if dirt.rows else "clean")
             branch = r["branch"] or f"detached {r['path']}"
             who = pieces.claimant(claims.get((clone.name, r["piece"])))
             said = pieces.outcome(declared.get((clone.name, r["piece"])))
@@ -372,7 +386,19 @@ def cmd_worktree_remove(args) -> int:
     force = getattr(args, "force", False)
     if stale is None and not force:
         # Parallel agents are how work gets orphaned — refuse anything that would lose it.
-        if worktree.is_dirty(path):
+        dirt = worktree.dirt(path)
+        if not dirt.known:
+            # On the same terms as the `unique_commits` refusal ten lines below, which has
+            # said this since #104: a tree charter could not read is not a tree charter has
+            # cleared for deletion. Before #917 this branch did not exist and an unreadable
+            # worktree fell straight through to `git worktree remove`.
+            util.err(f"could not determine whether '{args.piece}' holds uncommitted "
+                     f"changes — refusing to remove. {dirt.why()}")
+            for line in dirt.remedy():
+                util.info(f"  {line}")
+            util.info("Check the worktree by hand, or discard with --force.")
+            return 1
+        if dirt.rows:
             util.err(f"'{args.piece}' has uncommitted changes — refusing to remove.")
             util.info("Commit them, or discard with --force.")
             return 1

--- a/charter/doctor.py
+++ b/charter/doctor.py
@@ -15,7 +15,7 @@ import sys
 from dataclasses import dataclass
 from pathlib import Path
 
-from . import contain, inventory, tui, util
+from . import contain, gitstate, inventory, tui, util
 from .forge.gitlab import GitLabForge
 
 OK, WARN, FAIL = "ok", "warn", "fail"
@@ -592,7 +592,19 @@ def check_plane_root() -> Result:
         # written to disk and never committed — so every plane a few days old carries
         # untracked files under `personas/*/memory/`. Counting those would put this row
         # permanently in the yellow, which costs the two findings that do matter.
+        #
+        # Read for its EXIT STATUS as well as its output (#917). This was the one rc-blind
+        # line in a function that checks every other git call it makes — `--show-toplevel`,
+        # `symbolic-ref`, both `rev-list`s and `@{upstream}` all branch on `returncode` —
+        # and an empty answer from a `git status` that failed produced `✓ plane root  clean
+        # on main`. The surrounding `try` already turned a TIMEOUT into an honest "not
+        # checked"; a non-zero exit deserves the same sentence, and `_NOT_CHECKED_HINT`
+        # exists to say why a tick over an unrun check is the wrong glyph.
         status = _git_in(root, "status", "--porcelain", "--untracked-files=no")
+        if status.returncode != 0:
+            return Result(name, WARN,
+                          detail=f"not checked (git status exited {status.returncode})",
+                          hint=_NOT_CHECKED_HINT)
         dirty = [ln for ln in status.stdout.splitlines() if ln.strip()]
         # How far the root has drifted behind its upstream. Read from the ALREADY-FETCHED
         # remote ref — never a live query, because this runs from the SessionStart hook and
@@ -678,6 +690,60 @@ def check_plane_root() -> Result:
              "<repo>; the plane root is one working tree every session shares.",
     )
 
+
+def check_index_lock() -> Result:
+    """A ``.git/index.lock`` left in the plane's own repository — noticed *before* a save
+    runs into it.
+
+    #917 is what happens when nothing does. The operator's lock had been there for
+    twenty-three hours, through however many sessions, and the first thing to look at it
+    was the `charter save` it broke — which then reported the tree clean and said nothing
+    about the file. A preflight row is where a fact like that belongs: it costs one `stat`
+    on a path charter can work out without a subprocess (`gitstate.git_dir_of` asks the
+    filesystem first), and it turns a silent trap into a line an operator reads at the top
+    of the session.
+
+    **A lock is not a fault, so a lock is not automatically a warning.** git takes one for
+    every write to the index; catching a legitimate `git commit` mid-flight and painting
+    the preflight yellow for it would be a false alarm on healthy behaviour, and a
+    permanently-yellow row is one people stop reading (`check_memory_indexes` records the
+    same concern for the same reason). A fresh lock is reported on an OK row — stated, on
+    the `↳` continuation `Result.render` gives a detail, because a green row keeps nothing
+    back.
+
+    **Zero bytes and hours old is different, and it is a WARN.** git creates the lock,
+    writes the new index into it, and renames it over the old one, so a lock that never
+    grew is one whose writer died before writing anything — a crash, not contention, and
+    something only a person can clear. WARN and not FAIL: `cmd_doctor` exits non-zero on
+    FAIL, and a stale lock is "the next save will refuse", not "you cannot work".
+
+    charter names it and stops there. The `rm` is the operator's, after the `ps` — see
+    `gitstate` for why that division is not a formality.
+    """
+    from . import config as _config
+
+    name = "index lock"
+    if not _config.HAS_CONTROL_PLANE:
+        return Result(name, OK, detail="no control plane found")
+    root = Path(_config.ROOT)
+    try:
+        lock = gitstate.for_repo(root, timeout=CHECK_TIMEOUT)
+    except (util.ProcTimeout, OSError) as e:
+        return Result(name, WARN, detail=f"not checked ({e})", hint=_NOT_CHECKED_HINT)
+    if lock is None:
+        return Result(name, OK, detail="none held on the plane's index")
+    if not lock.crashed:
+        return Result(name, OK, detail=f"held now — {lock.size} byte(s), "
+                                       f"{gitstate.age_phrase(lock.age)} old; a git is "
+                                       f"probably writing")
+    return Result(
+        name, WARN,
+        detail=f"{lock.path} — {lock.size} byte(s), {gitstate.age_phrase(lock.age)} old",
+        hint="A git process crashed here and left the index locked; every `charter save` "
+             "and `git add` in this plane will refuse until it is gone. Check nothing "
+             "holds it (ps -eo pid,lstart,command | grep '[g]it'), then remove it "
+             f"yourself: rm -f {lock.path}  — charter never removes a lock.",
+    )
 
 
 def session_root() -> Path:
@@ -3131,7 +3197,8 @@ def _checks():
         results.append(check_forge_cli(forge))
         results.append(check_forge_auth(forge))
     results += [check_ssh(), check_control_plane_config(), check_control_plane_schema(),
-                check_plane_root(), check_session_root(), check_session_layer(),
+                check_plane_root(), check_index_lock(),
+                check_session_root(), check_session_layer(),
                 check_harness(), check_frame(), check_guard_wired(), check_guard_seen(), check_nested_plane(),
                 check_workspace_clones(), check_workspace_harness(), check_changes(),
                 check_inventory(), check_vaults(),
@@ -3172,7 +3239,8 @@ def _checks():
 _FIXED_CHECK_NAMES = (
     "python3", "git", "git identity",
     # ← the forge cli/auth pair is spliced in here, see `check_names`
-    "git auth", "charter.toml", "schema", "plane root", "session root", "session layer",
+    "git auth", "charter.toml", "schema", "plane root", "index lock",
+    "session root", "session layer",
     "harness", "frame",
     "plane-root guard", "guard seen", "nested plane", "workspace clones",
     "workspace layer", "changes",

--- a/charter/gitstate.py
+++ b/charter/gitstate.py
@@ -173,9 +173,21 @@ def git_dir_of(root: Path | str, timeout: float | None = None) -> Path | None:
     day. Guessing ``.git`` there would look at a file belonging to a different index and
     report the wrong tree healthy.
 
+    Asked of the FILESYSTEM first, via `util.git_dir`, which already knows both spellings
+    and costs no process: a clone's ``.git`` is a directory, a linked worktree's is a file
+    holding ``gitdir: <path>``. `doctor` runs this on every SessionStart preflight, where a
+    subprocess it does not need is a subprocess against the hook's whole budget.
+
+    git is asked only when the filesystem cannot answer — a plane that is a SUBDIRECTORY of
+    some larger repository has no ``.git`` of its own and a real git directory above it,
+    and that is a layout `check_plane_root` explicitly supports.
+
     ``rev-parse --git-dir`` answers relative to the cwd when the cwd is inside the working
     tree, so the result is resolved against *root* before it is returned.
     """
+    quick = util.git_dir(Path(root))
+    if quick is not None:
+        return quick.resolve()
     try:
         r = util.run(["git", "-C", str(root), "rev-parse", "--git-dir"],
                      check=False, timeout=timeout)
@@ -234,6 +246,18 @@ class TreeState(NamedTuple):
     #: the failure path, so a healthy `git status` still costs one process.
     lock: IndexLock | None
 
+    #: There is no git repository here at all — a **definite** answer, not an unreadable
+    #: one, and the two must not be run together.
+    #:
+    #: `charter init` in a fresh directory does not run `git init`, and that is the
+    #: README's own 60-second path: a plane with no repository is a supported resting
+    #: state, not a fault. Callers for which that state means "nothing to commit" — the two
+    #: memory paths — check this and stay quiet, rather than telling every such plane at
+    #: every session start that charter cannot read it. Callers guarding a deletion do
+    #: **not** consult it: a directory git will not stand in is one charter cannot clear
+    #: for removal, whatever the reason.
+    no_repo: bool = False
+
     @property
     def known(self) -> bool:
         return self.said is None
@@ -256,8 +280,7 @@ class TreeState(NamedTuple):
         return ([extra] if extra else []) + (self.lock.remedy() if self.lock else [])
 
 
-def read(where: Path | str, *pathspec: str, flags: tuple[str, ...] = (),
-         timeout: float | None = None) -> TreeState:
+def read(where: Path | str, *pathspec: str, timeout: float | None = None) -> TreeState:
     """``git status --porcelain`` on *where*, as a :class:`TreeState`.
 
     One choke point on purpose. The survey behind #917 found eleven independent readings of
@@ -266,8 +289,13 @@ def read(where: Path | str, *pathspec: str, flags: tuple[str, ...] = (),
     `rmtree` a clone. A fix that leaves the next caller free to write ``if
     _git(["status"…]).stdout.strip():`` has not fixed the class, so the shape a caller
     reaches for is the one that cannot express the bug.
+
+    No flag pass-through, deliberately: every caller here wants the same question, and
+    `doctor.check_plane_root` — the one site that asks it with ``--untracked-files=no`` —
+    keeps its own `_git_in` call, because every other git question in that function is
+    asked and rc-checked the same way and a lone import would make it the odd one out.
     """
-    argv = ["git", "-C", str(where), "status", "--porcelain", *flags]
+    argv = ["git", "-C", str(where), "status", "--porcelain"]
     if pathspec:
         argv += ["--", *pathspec]
     try:
@@ -278,7 +306,8 @@ def read(where: Path | str, *pathspec: str, flags: tuple[str, ...] = (),
         # be reported.
         return TreeState(Path(where), (), f"{type(e).__name__}: {e}", None)
     if r.returncode != 0:
+        git_dir = git_dir_of(where, timeout=timeout)
         return TreeState(Path(where), (), said(r) or f"git status exited {r.returncode}",
-                         for_repo(where, timeout=timeout))
+                         None if git_dir is None else find(git_dir), git_dir is None)
     return TreeState(Path(where), tuple(ln for ln in r.stdout.splitlines() if ln.strip()),
                      None, None)

--- a/charter/gitstate.py
+++ b/charter/gitstate.py
@@ -155,13 +155,24 @@ def find(git_dir: Path | str) -> IndexLock | None:
     ``None`` also when the directory cannot be stat-ed at all: this module answers "is
     there a lock", and turning an unreadable git directory into a lock-shaped answer would
     be the same conflation one layer down.
+
+    The path is **resolved**, because the whole point of printing it is that the operator
+    can paste it into an `rm`, and macOS hands out temp and home paths through symlinks
+    (``/var`` → ``/private/var``) — `planegit._refuse_unreadable` passes the git dir it got
+    from `rev-parse` without normalising it first.
+
+    The age is **not** clamped here. A future mtime — a clock that went backwards, a bad
+    archive — makes this negative, and `age_phrase` clamps on the way out, which is the one
+    place it can be observed. A second clamp read as belt and braces and was really a line
+    nothing could tell apart from its own absence; the deletion sweep found it, and this
+    repository treats that as dead code rather than as an equivalent mutant.
     """
     p = Path(git_dir) / LOCK_NAME
     try:
         st = p.stat()
     except OSError:
         return None
-    return IndexLock(p.resolve(), st.st_size, max(0.0, time.time() - st.st_mtime))
+    return IndexLock(p.resolve(), st.st_size, time.time() - st.st_mtime)
 
 
 def git_dir_of(root: Path | str, timeout: float | None = None) -> Path | None:
@@ -182,8 +193,14 @@ def git_dir_of(root: Path | str, timeout: float | None = None) -> Path | None:
     some larger repository has no ``.git`` of its own and a real git directory above it,
     and that is a layout `check_plane_root` explicitly supports.
 
-    ``rev-parse --git-dir`` answers relative to the cwd when the cwd is inside the working
-    tree, so the result is resolved against *root* before it is returned.
+    ``rev-parse --git-dir`` answers relative to the cwd when the cwd is at the top of the
+    working tree, so the result is joined onto *root* before it is returned. It is **not**
+    resolved on that path, and the reason is measured rather than assumed: git 2.50.1 asked
+    from a subdirectory answers with an absolute, already-physical path (a symlinked route
+    in is resolved away), and a subdirectory is the only way this branch is reached at all —
+    the filesystem above answers for every tree that has a ``.git`` of its own. A
+    normalisation with nothing left to normalise is a line nothing can tell apart from its
+    own absence, which the deletion sweep found and this repository deletes.
     """
     quick = util.git_dir(Path(root))
     if quick is not None:
@@ -196,7 +213,7 @@ def git_dir_of(root: Path | str, timeout: float | None = None) -> Path | None:
     out = r.stdout.strip()
     if r.returncode != 0 or not out:
         return None
-    return Path(root, out).resolve()
+    return Path(root, out)
 
 
 def for_repo(root: Path | str, timeout: float | None = None) -> IndexLock | None:
@@ -214,10 +231,17 @@ def said(proc) -> str:
     a broken sweep for a day. git's stderr under a held lock is four lines of which the
     first names the file, so the first line is the useful one and the rest is the advice
     charter is giving anyway.
+
+    Stripped ONCE, and bound. The first draft tested ``if line.strip()`` and then returned
+    ``line.strip()`` — two calls, of which only the second is observable: ``bool(s.strip())``
+    and ``bool(s.lstrip())`` agree for every string, so the test's half was an equivalent
+    mutant by construction. The deletion sweep reported it as a survivor and was right;
+    binding the value is what makes the question unaskable rather than merely unanswered.
     """
     for line in (getattr(proc, "stderr", "") or "").splitlines():
-        if line.strip():
-            return line.strip()
+        first = line.strip()
+        if first:
+            return first
     return ""
 
 
@@ -309,5 +333,9 @@ def read(where: Path | str, *pathspec: str, timeout: float | None = None) -> Tre
         git_dir = git_dir_of(where, timeout=timeout)
         return TreeState(Path(where), (), said(r) or f"git status exited {r.returncode}",
                          None if git_dir is None else find(git_dir), git_dir is None)
-    return TreeState(Path(where), tuple(ln for ln in r.stdout.splitlines() if ln.strip()),
+    # `splitlines()` and nothing else. A blank-line filter here was defensive against
+    # something porcelain v1 does not produce — every record is `XY <path>` and the format
+    # has no empty records — and `"a\n".splitlines()` yields no trailing empty string, so
+    # nothing could tell the filter apart from its own absence. The deletion sweep found it.
+    return TreeState(Path(where), tuple(r.stdout.splitlines()),
                      None, None)

--- a/charter/gitstate.py
+++ b/charter/gitstate.py
@@ -1,0 +1,284 @@
+"""What git says about a working tree, **and the third answer** — the one charter used to
+print as the first.
+
+A `git status` that failed writes nothing to stdout, so ``.stdout.strip()`` is empty. A
+`git add` that failed stages nothing, so the ``git diff --cached --quiet`` after it says
+there is no difference. In both spellings the value that means *charter could not tell* is
+byte-for-byte the value that means *there is nothing there* — and every caller in this
+package that read one of them read it as the second.
+
+This module is where the two stop being the same value. :func:`read` answers a question
+about a tree in three states rather than two, and :class:`IndexLock` carries the fact that
+explains the commonest cause of the third.
+
+**#917, on the operator's own plane.** `charter save` printed *"Nothing to save — the
+control-plane working tree is clean"* while `git status --porcelain` listed thirteen
+modified files. `.git/index.lock` had been sitting there for twenty-three hours — zero
+bytes, no process holding it, left by a git that crashed the day before. With the file
+removed, the identical command on the identical tree committed twenty files.
+
+Measured against git 2.50.1, in a repository holding one modified tracked file and one
+untracked file, with a zero-byte ``.git/index.lock`` planted in it::
+
+    git status --porcelain     → rc 0, both files listed  (reading the tree needs no lock)
+    git add -A                 → rc 128, "Unable to create '…/index.lock': File exists."
+    git diff --cached --quiet  → rc 0                     (nothing staged, so no diff)
+
+That asymmetry is the whole defect. The lock is invisible to the question `commit_push`
+asks *last* and fatal to the one it asks *first*, so a failed stage arrives at the check
+below it as an empty index — indistinguishable from a tree with nothing in it. **"Clean"
+and "charter could not tell" were the same value**, and the one charter printed is the one
+whose next act is the operator deciding to stop worrying about the work.
+
+This is the family this repository has been finding all week, and the two before it were
+fixed the same way — by giving the failure a category of its own rather than a shared
+default: `tools.sweep.NoSandbox` (#905/#909) says *the machine*, not *the branch*, and
+`config.PLANE_REFUSAL` (#913/#914) says *refused*, not *carry on with defaults*. This
+module is that category for "charter asked git and git could not say".
+
+**charter reports a lock. It never clears one.**
+
+A lock held by a live git is real, and nothing inside one command can reliably tell a held
+lock from an abandoned one: the holder may be a `git commit` with an editor still open, a
+`git gc` a second from finishing, or another machine's view of the same network mount.
+Removing it would corrupt an index that was about to be written, and a program that clears
+locks teaches its operator that locks do not mean anything. So charter states the three
+facts the person deciding actually needs — the path, the size and the age — and leaves the
+`rm` to them. That is the division of labour the operator used to fix #917 by hand: `ps`,
+then the file's mtime, then the removal.
+
+The three facts are enough to tell a crash from contention because of how git takes the
+lock: it creates ``index.lock``, writes the new index *into* it, and renames it over the
+old one. A lock that never grew past zero bytes is one whose writer died before writing
+anything, and one that has not grown in hours has no writer left at all.
+"""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+from typing import NamedTuple
+
+from . import util
+
+#: The name git gives the file. Not configurable and not worth a lookup — it is
+#: ``$GIT_DIR/index.lock`` in every git there has ever been — but named once so the
+#: refusal, the doctor row and the tests cannot drift into three spellings of it.
+LOCK_NAME = "index.lock"
+
+#: How long a zero-byte lock must have sat there before charter will call it a crash
+#: rather than contention.
+#:
+#: Fifteen minutes, and the number matters less than which side of it errs. Below it
+#: charter says only that a lock is present and something may be holding it, which is
+#: true of a real one and harmless to say about a stale one. Above it charter says a git
+#: process crashed — a stronger claim, and the one that lets an operator act — so it is
+#: only made once no plausible live git is still starting up.
+#:
+#: The size does most of the work: `git commit` writes the new index into the lock before
+#: it opens an editor, so the long-lived legitimate holder is not zero bytes. This
+#: threshold is what covers the window between git creating the file and git filling it.
+STALE_AFTER = 15 * 60
+
+
+def age_phrase(seconds: float) -> str:
+    """A coarse age — ``4s``, ``12m``, ``23h``, ``3d``.
+
+    Coarse on purpose, the same way `pieces.since` is: the number is context for a human
+    deciding whether to run `rm`, never an input to a decision charter is making. There is
+    no threshold here that charter branches on except :data:`STALE_AFTER`, and that one is
+    stated where it is used.
+    """
+    secs = max(0, int(seconds))
+    if secs < 60:
+        return f"{secs}s"
+    if secs < 3600:
+        return f"{secs // 60}m"
+    if secs < 86400:
+        return f"{secs // 3600}h"
+    return f"{secs // 86400}d"
+
+
+class IndexLock(NamedTuple):
+    """A ``$GIT_DIR/index.lock`` charter found, and the three facts about it.
+
+    A record and not a verdict: :attr:`crashed` is the only judgement in it, and every
+    caller still prints the path, the size and the age beside it so the reader can
+    disagree.
+    """
+
+    #: The lock file itself, absolute, so the sentence charter prints can be pasted.
+    path: Path
+    #: Bytes. Zero means git created the file and never wrote the index into it.
+    size: int
+    #: Seconds since its mtime.
+    age: float
+
+    @property
+    def crashed(self) -> bool:
+        """Zero bytes and older than :data:`STALE_AFTER` — a crash, not contention.
+
+        The conjunction is the claim. A big lock is a git that got as far as writing an
+        index, and a young lock is a git that may still be running; neither is something
+        charter should describe as abandoned to someone who is about to delete it.
+        """
+        return self.size == 0 and self.age >= STALE_AFTER
+
+    def describe(self) -> str:
+        """One line naming the lock, its size and its age — the sentence #917 needed.
+
+        The age is here rather than in a hint because it is the fact that changes what the
+        operator does: a lock seconds old is somebody else's `git commit` and the answer is
+        to wait, and a lock hours old is a corpse and the answer is `rm`. A message that
+        said only "a lock is present" would send both of them to the same place.
+        """
+        what = ("a git process crashed here and left it behind"
+                if self.crashed else "something may still be holding it")
+        return (f"{self.path} — {self.size} byte(s), {age_phrase(self.age)} old; "
+                f"{what}.")
+
+    def remedy(self) -> list[str]:
+        """What the operator does next, in the order they should do it.
+
+        Two lines, and the `rm` is second and labelled, because the order is the safety:
+        checking for a holder first is what makes removing the file safe, and a remedy that
+        printed the removal on its own would teach the habit of skipping the check.
+        """
+        return ["who holds it:  ps -eo pid,lstart,command | grep '[g]it'",
+                f"nobody does:   rm -f {self.path}   "
+                f"(charter never removes a lock — a held one is real)"]
+
+
+def find(git_dir: Path | str) -> IndexLock | None:
+    """The index lock inside *git_dir*, or ``None`` when there is not one.
+
+    ``None`` also when the directory cannot be stat-ed at all: this module answers "is
+    there a lock", and turning an unreadable git directory into a lock-shaped answer would
+    be the same conflation one layer down.
+    """
+    p = Path(git_dir) / LOCK_NAME
+    try:
+        st = p.stat()
+    except OSError:
+        return None
+    return IndexLock(p.resolve(), st.st_size, max(0.0, time.time() - st.st_mtime))
+
+
+def git_dir_of(root: Path | str, timeout: float | None = None) -> Path | None:
+    """Where *root*'s git directory is, or ``None`` when *root* is not in a repository.
+
+    Asked of git rather than assumed to be ``root/.git``, because the two differ exactly
+    where this matters most: a **linked worktree** keeps its own index — and therefore its
+    own lock — under ``<plane>/.git/worktrees/<name>``, and charter runs from worktrees all
+    day. Guessing ``.git`` there would look at a file belonging to a different index and
+    report the wrong tree healthy.
+
+    ``rev-parse --git-dir`` answers relative to the cwd when the cwd is inside the working
+    tree, so the result is resolved against *root* before it is returned.
+    """
+    try:
+        r = util.run(["git", "-C", str(root), "rev-parse", "--git-dir"],
+                     check=False, timeout=timeout)
+    except (util.ProcTimeout, OSError):
+        return None
+    out = r.stdout.strip()
+    if r.returncode != 0 or not out:
+        return None
+    return Path(root, out).resolve()
+
+
+def for_repo(root: Path | str, timeout: float | None = None) -> IndexLock | None:
+    """The index lock on *root*'s own index — :func:`git_dir_of` then :func:`find`."""
+    git_dir = git_dir_of(root, timeout=timeout)
+    return None if git_dir is None else find(git_dir)
+
+
+def said(proc) -> str:
+    """The first line git actually wrote, or ``""``.
+
+    Kept and printed, rather than replaced with charter's own guess at what went wrong —
+    `sweep.Sandbox._must` is the same decision for the same reason (#905): "a command that
+    failed for a stated reason arrives as a command that failed" is how a full disk read as
+    a broken sweep for a day. git's stderr under a held lock is four lines of which the
+    first names the file, so the first line is the useful one and the rest is the advice
+    charter is giving anyway.
+    """
+    for line in (getattr(proc, "stderr", "") or "").splitlines():
+        if line.strip():
+            return line.strip()
+    return ""
+
+
+class TreeState(NamedTuple):
+    """What `git status` said about a tree — in three states, not two.
+
+    ``said is None`` means git answered and :attr:`rows` is the answer, empty for a clean
+    tree. ``said`` holding text means **charter does not know**: git could not be run, ran
+    out of time, or exited non-zero, and the text is what it wrote. :attr:`rows` is empty
+    on that path too, which is precisely why the two must be told apart by a field rather
+    than by whether the rows are empty.
+
+    Deliberately has no ``dirty`` property. Reading a tree's dirtiness off a state that may
+    not be known is the defect this type exists to make unwritable, and a convenience
+    attribute would put it back one dot away.
+    """
+
+    #: The tree that was asked about, for the sentence a refusal prints.
+    where: Path
+    #: Porcelain lines, blank ones dropped. Empty when the tree is clean AND when
+    #: :attr:`said` is set — check :attr:`known` first.
+    rows: tuple[str, ...]
+    #: ``None`` when git answered; what git said when it could not.
+    said: str | None
+    #: The index lock found while working out why, when there was one. Looked up only on
+    #: the failure path, so a healthy `git status` still costs one process.
+    lock: IndexLock | None
+
+    @property
+    def known(self) -> bool:
+        return self.said is None
+
+    def why(self) -> str:
+        """One line for a caller that has to explain itself, ``""`` when :attr:`known`.
+
+        Names the tree, because the commonest confusion in this package is which tree a
+        command is acting on (#806, #809), and a caller printing this may be standing in a
+        different one.
+        """
+        if self.known:
+            return ""
+        return (f"charter could not read the working tree at {self.where} — {self.said}. "
+                f"That is not the same as it being clean.")
+
+    def remedy(self) -> list[str]:
+        """Command lines the operator can act on, when charter has any to offer."""
+        extra = self.lock.describe() if self.lock else ""
+        return ([extra] if extra else []) + (self.lock.remedy() if self.lock else [])
+
+
+def read(where: Path | str, *pathspec: str, flags: tuple[str, ...] = (),
+         timeout: float | None = None) -> TreeState:
+    """``git status --porcelain`` on *where*, as a :class:`TreeState`.
+
+    One choke point on purpose. The survey behind #917 found eleven independent readings of
+    ``.stdout.strip()`` across seven modules, and they failed in pairs — both halves of "is
+    memory unsynced", both halves of the gate that decides whether `workspace remove` may
+    `rmtree` a clone. A fix that leaves the next caller free to write ``if
+    _git(["status"…]).stdout.strip():`` has not fixed the class, so the shape a caller
+    reaches for is the one that cannot express the bug.
+    """
+    argv = ["git", "-C", str(where), "status", "--porcelain", *flags]
+    if pathspec:
+        argv += ["--", *pathspec]
+    try:
+        r = util.run(argv, check=False, timeout=timeout)
+    except (util.ProcTimeout, OSError) as e:
+        # A git that could not be RUN — no binary, a cwd that has been deleted, a mount
+        # that stopped answering inside the budget. Nothing was measured, so nothing may
+        # be reported.
+        return TreeState(Path(where), (), f"{type(e).__name__}: {e}", None)
+    if r.returncode != 0:
+        return TreeState(Path(where), (), said(r) or f"git status exited {r.returncode}",
+                         for_repo(where, timeout=timeout))
+    return TreeState(Path(where), tuple(ln for ln in r.stdout.splitlines() if ln.strip()),
+                     None, None)

--- a/charter/hooks.py
+++ b/charter/hooks.py
@@ -4867,12 +4867,24 @@ def _uncommitted_memory_nudge() -> str:
         from . import instance as _instance
         if _instance.clamp_share(config.MEMORY_SHARE) == "local":
             return ""
-        import subprocess
-        r = subprocess.run(["git", "-C", str(config.ROOT), "status", "--porcelain", "--",
-                            "personas", "workspaces"],
-                           stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, text=True, timeout=3)
-        rows = [ln for ln in r.stdout.splitlines()
-                if ln.strip() and ("/memory/" in ln or "/refs/" in ln)]
+        from . import gitstate
+        state = gitstate.read(config.ROOT, "personas", "workspaces", timeout=3)
+        if not state.known and not state.no_repo:
+            # #917: silence used to be this function's answer to "nothing is uncommitted"
+            # AND to "charter could not look" — while its twin,
+            # `commands_persona._pending_memory`, printed a green tick on the same failure.
+            # Both halves of "is memory unsynced" answered no, for the same reason, at the
+            # same moment. This nudge is the only thing that tells an agent durable
+            # knowledge is unshared, so the honest line is worth more than the quiet one.
+            #
+            # `no_repo` is exempt above and is not a hedge: `charter init` in a fresh
+            # directory does not run `git init` — the README's own 60-second path — so a
+            # plane with no repository is a supported resting state, and a session-start
+            # line saying charter cannot read it would fire on every one of them forever.
+            return (f"⬤ charter could not read the control plane's working tree, so it "
+                    f"cannot say whether memory is unshared — {state.said}. That is not "
+                    f"the same as nothing being pending.")
+        rows = [ln for ln in state.rows if "/memory/" in ln or "/refs/" in ln]
         if not rows:
             return ""
         ws = sum(1 for ln in rows if "workspaces/" in ln)

--- a/charter/planegit.py
+++ b/charter/planegit.py
@@ -642,7 +642,11 @@ def _refuse_unreadable(root, git_dir, doing: str, said: str) -> int:
     util.err(f"Refusing to save — charter could not read the state of {root}, so it "
              f"cannot tell an unchanged tree from an unreadable one.")
     util.err(f"  {doing}" + (f" — {said}" if said else " without saying why"))
-    lock = gitstate.find(git_dir) if git_dir else None
+    # No `if git_dir` guard: the caller builds it from `root` unconditionally, so it is
+    # always a Path and never falsy. The guard read as caution and was a branch nothing
+    # could enter — the deletion sweep found it, and `find` already answers `None` for a
+    # directory it cannot stat.
+    lock = gitstate.find(git_dir)
     if lock:
         util.info(f"  {lock.describe()}")
         for line in lock.remedy():

--- a/charter/planegit.py
+++ b/charter/planegit.py
@@ -106,8 +106,12 @@ def commit_memory_reactive(paths: list[str], title: str) -> int:
     - ``push``   — committed locally and pushed in the BACKGROUND — so a memory reaches the
       shared repo the moment it's recorded, without blocking the turn. Best-effort.
 
-    Returns commit_push's rc (0 = committed / nothing to do / posture is local,
-    1 = a secret-shaped value was refused)."""
+    Returns commit_push's rc (0 = committed / nothing to do / posture is local, 1 = the
+    save was refused — a secret-shaped value, or a tree charter could not read (#917)).
+    Every caller ignores it: this fires reactively, from a hook, after a memory file has
+    already been written to disk, so there is nothing for it to abort. The refusal is
+    heard because `commit_push` says it out loud, not because anything here branches on
+    it."""
     from . import instance as _instance
     # Re-clamp defensively — see `instance.clamp_share`: `config.MEMORY_SHARE` is always
     # pre-clamped at import time, but this reactive path must not itself rely on that.

--- a/charter/planegit.py
+++ b/charter/planegit.py
@@ -29,7 +29,7 @@ import time
 from pathlib import Path
 from typing import NamedTuple
 
-from . import config, util
+from . import config, gitstate, util
 from . import root as _root      # `root` is a PARAMETER name throughout this module
 
 
@@ -612,6 +612,46 @@ def stages_the_whole_tree(add_cmd: list) -> bool:
     return any(f in _WHOLE_TREE_FLAGS for f in flags)
 
 
+def _refuse_unreadable(root, git_dir, doing: str, said: str) -> int:
+    """Outcome three of three: charter could not determine the tree's state, so it stops.
+
+    **The refusal is the feature.** `charter save` returning 0 is what every caller — and
+    every operator — reads as "it is saved", and #917 is entirely made of what happens
+    downstream of believing that: a `git checkout`, a worktree removal, a machine going
+    away. So this is rc 1 and a red line, on a path that used to be a tick.
+
+    Three things are said, and each earns its place:
+
+    * **what charter was doing when git stopped**, and git's own words for why. Charter's
+      guess at the reason would be a second thing to be wrong about; `sweep.Sandbox._must`
+      made the same call for the same reason (#905).
+    * **the lock, if there is one — its path, its size and its age.** The age is what
+      changes the operator's next move: seconds old is somebody else's `git commit` and the
+      answer is to wait, hours old and zero bytes is a corpse and the answer is `rm`. A
+      message that said only "a lock is present" would send both to the same place.
+    * **the `ps` before the `rm`.** charter never removes a lock — see `gitstate` — and the
+      order the remedy is printed in is what makes handing over the `rm` safe.
+
+    The word "clean" appears nowhere on this path, deliberately, and a test holds it to
+    that: the whole defect was a sentence containing it.
+    """
+    util.err(f"Refusing to save — charter could not read the state of {root}, so it "
+             f"cannot tell an unchanged tree from an unreadable one.")
+    util.err(f"  {doing}" + (f" — {said}" if said else " without saying why"))
+    lock = gitstate.find(git_dir) if git_dir else None
+    if lock:
+        util.info(f"  {lock.describe()}")
+        for line in lock.remedy():
+            util.info(f"  {line}")
+    else:
+        # No lock, so charter has nothing to name and says so rather than inventing a
+        # remedy. `git status` in that tree is where the reason is, and it is the operator's
+        # to read: this is the same shape as the "not a git repository" branch above.
+        util.info(f"  Nothing charter can name is holding this index. "
+                  f"`git -C {root} status` is where the reason will be.")
+    return 1
+
+
 def commit_push(root, add_cmd: list, message: str | None,
                 sign: bool = False, no_push: bool = False, background: bool = False) -> int:
     """Stage (``add_cmd``) → secret-scan staged memory/refs → commit → push via the
@@ -705,16 +745,41 @@ def commit_push(root, add_cmd: list, message: str | None,
     # the commit failed too, and `rev-parse --short HEAD` came back empty — printing
     # `✓ Committed : charter save: 0 file(s)` and exiting 0. The personas and memory
     # charter had just told the user to commit had no history at all.
-    if _git(["rev-parse", "--git-dir"], cwd=root).returncode != 0:
+    where = _git(["rev-parse", "--git-dir"], cwd=root)
+    if where.returncode != 0:
         util.err(f"{root} is not a git repository, so there is nothing to commit to.")
         util.info("  charter init does not create one. Run: git init && git remote add "
                   "origin <url>  — personas and memory are meant to be committed and shared.")
         return 1
+    # Kept, rather than thrown away with the return code it was asked for. It is where the
+    # index lock lives, and for a linked worktree that is `<plane>/.git/worktrees/<name>`
+    # rather than `<root>/.git` — the tree whose index this call is about.
+    git_dir = Path(root, where.stdout.strip() or ".git")
 
-    _git(add_cmd, cwd=root)
-    if _git(["diff", "--cached", "--quiet"], cwd=root).returncode == 0:
+    # #917: THE ADD'S EXIT STATUS IS THE WHOLE FIX. Under a held `.git/index.lock` this
+    # exits 128 and stages nothing, and the probe below then answers 0 — because there is
+    # no difference between HEAD and an index nothing was written to. Discarded, that made
+    # "charter could not stage anything" and "there was nothing to stage" the same value,
+    # and charter printed the second: a claim about durability that was false, to an
+    # operator whose next act is to stop worrying about the work.
+    added = _git(add_cmd, cwd=root)
+    if added.returncode != 0:
+        return _refuse_unreadable(
+            root, git_dir, f"`git {' '.join(add_cmd)}` exited {added.returncode}",
+            gitstate.said(added))
+
+    # Three outcomes, and `diff --quiet` has always answered in three: 0 for no difference,
+    # 1 for a difference, anything else for a failure. Read as `== 0` / else, the third
+    # collapsed into the second and reached `git commit` with a message about zero files
+    # (the shape the comment above records); read as `== 0` / `== 1` / else, it says which.
+    probe = _git(["diff", "--cached", "--quiet"], cwd=root)
+    if probe.returncode == 0:
         util.info("Nothing to save — the control-plane working tree is clean.")
         return 0
+    if probe.returncode != 1:
+        return _refuse_unreadable(
+            root, git_dir, f"`git diff --cached --quiet` exited {probe.returncode}",
+            gitstate.said(probe))
     staged = [ln for ln in _git(["diff", "--cached", "--name-only"], cwd=root).stdout.splitlines() if ln.strip()]
 
     # Secret guard: refuse if a staged memory/ref file looks like it holds a secret.

--- a/charter/worktree.py
+++ b/charter/worktree.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from . import config, util, workspace
+from . import config, gitstate, util, workspace
 
 #: Directory under a workspace holding every clone's worktrees (the in-plane layout).
 DIR_NAME = ".worktrees"
@@ -148,8 +148,27 @@ def head_of(clone: Path) -> tuple[str, bool]:
     return _git(clone, "rev-parse", "--short", "HEAD").stdout.strip(), True
 
 
-def is_dirty(path: Path) -> bool:
-    return bool(_git(path, "status", "--porcelain").stdout.strip())
+def dirt(path: Path) -> gitstate.TreeState:
+    """Whether *path* holds uncommitted changes — in three states, not two.
+
+    This replaced ``is_dirty(path) -> bool``, and the return type is the whole change. A
+    `git status` that failed writes nothing to stdout, ``bool("")`` is False, and so every
+    way this call can fail — a directory deleted under it, a corrupt index, a held
+    ``.git/index.lock`` — reached the two callers that gate a `shutil.rmtree` as *clean,
+    nothing to lose* (#917). A `bool` cannot carry the difference, which is why fixing the
+    call sites was not enough on its own.
+
+    Its siblings in this module have always answered this way: `unique_commits` returns
+    ``None`` when git could not answer, and `commands_worktree.cmd_worktree_remove` prints
+    "could not determine … refusing to remove" for it, four lines below where it used to
+    treat an unreadable tree as clean. `is_dirty` was the odd one out in its own module.
+
+    `tests/test_worktree.py` had already found one of these readings — a pruned worktree,
+    whose directory is gone, printed as ``clean`` — and fixed it at the one call site with
+    a `prunable` check. That check stays (it is cheaper than a subprocess and more precise
+    about the cause), but it only ever covered the one failure anybody had measured.
+    """
+    return gitstate.read(path)
 
 
 def unpushed(path: Path) -> int | None:

--- a/docs/news/unreleased-charter-save-refuses-a-tree-it-could-not-read.md
+++ b/docs/news/unreleased-charter-save-refuses-a-tree-it-could-not-read.md
@@ -1,0 +1,120 @@
+---
+version: unreleased
+headline: charter save tells a clean tree from one it could not read, and refuses the second
+---
+
+On the operator's own plane, not hypothesised:
+
+```
+$ git status --porcelain | wc -l
+      13
+$ charter save
+• Nothing to save — the control-plane working tree is clean.
+```
+
+The cause was a stale `.git/index.lock` — zero bytes, twenty-three hours old, no process
+holding it, left behind by a git that crashed the day before. The operator removed it by
+hand after checking `ps` and the file's mtime, and the identical command on the identical
+tree committed twenty files.
+
+## The lock is invisible to the question charter asked last
+
+Measured against git 2.50.1, in a repository with one modified tracked file and one
+untracked file, with a zero-byte `index.lock` planted in it:
+
+| | |
+|---|---|
+| `git status --porcelain` | rc 0, both files listed — reading the tree needs no lock |
+| `git add -A` | rc 128, `Unable to create '….git/index.lock': File exists.` |
+| `git diff --cached --quiet` | rc 0 — nothing was staged, so there is no difference |
+
+`commit_push` discarded the add's exit status. The probe below it then answered *no
+difference*, because there was none: nothing had been written to the index. **"The tree is
+clean" and "charter could not tell" were the same value**, and charter printed the first.
+
+That asymmetry is why this rendered as a confident sentence rather than as an error, and
+why it survived. It is also why this instance is worse than its siblings: every other
+version of this shape in charter degrades to *nothing to show* — a missing gauge, an empty
+row, a cache read as cold. This one degrades to a claim about durability that is false, and
+the operator's next act is to stop worrying about the work. It becomes data loss the moment
+anything afterwards assumes the save happened.
+
+## Three outcomes, and charter says which
+
+`charter save` now answers in three states instead of two. The tree is clean; the tree has
+changes; or charter could not determine the state — in which case it **refuses**, with rc 1:
+
+```
+✗ Refusing to save — charter could not read the state of /Users/…/charter, so it
+  cannot tell an unchanged tree from an unreadable one.
+✗   `git add -A` exited 128 — fatal: Unable to create '….git/index.lock': File exists.
+•   /Users/…/charter/.git/index.lock — 0 byte(s), 23h old; a git process crashed here
+    and left it behind.
+•   who holds it:  ps -eo pid,lstart,command | grep '[g]it'
+•   nobody does:   rm -f /Users/…/charter/.git/index.lock   (charter never removes a
+    lock — a held one is real)
+```
+
+The age is in there because it is the fact that changes what the operator does. A lock
+seconds old is somebody else's `git commit` and the answer is to wait; zero bytes and hours
+old is a corpse and the answer is `rm`. A message that said only "a lock is present" would
+send both of them to the same place. Zero bytes is what separates the two: git creates the
+lock, writes the new index into it, and renames it over the old one, so a lock that never
+grew is one whose writer died before it wrote anything.
+
+**charter reports a lock and never clears one.** A lock held by a live git is real, and
+nothing inside a single command can reliably tell a held lock from an abandoned one — the
+holder may be a `git commit` with an editor open, a `git gc` a second from finishing, or
+another machine's view of the same mount. Removing it would corrupt an index that was about
+to be written, and a program that clears locks teaches its operator that locks do not mean
+anything. Charter states the path, the size and the age, and leaves the `rm` to the person
+who can run `ps` first.
+
+## `doctor` notices it before a save runs into it
+
+A new `index lock` row. A lock is not a fault — git takes one for every write to the index
+— so a fresh one is stated on a green row and nothing else. Zero bytes and older than
+fifteen minutes is a WARN naming the file, its age and the two commands, because that one
+will refuse every `charter save` and every `git add` in the plane until somebody clears it.
+The operator's lock sat there for twenty-three hours, through however many sessions, and the
+first thing to look at it was the save it broke.
+
+## The same conflation, everywhere it decided something
+
+A grep for every place charter read `git status` found eleven such readings across seven
+modules, and they fail in **pairs** — which is how a defect of this shape survives being
+noticed. `charter/gitstate.py` is now the one place that asks, and it answers in three
+states rather than two. The sites that made a decision on the old two-state answer:
+
+- **`workspace remove`** — what `_work_at_risk` and `_worktrees_at_risk` come back empty of
+  is what gets handed to `shutil.rmtree`. A clone or worktree charter could not read is now
+  work at risk, which is what it always was.
+- **`workspace snapshot`** — an unreadable clone blocks. The manifest is a claim, made to
+  another engineer on another machine, that the recorded branch captures reality.
+- **`charter sync`** — the empty answer used to *authorise* the `git merge --ff-only` two
+  lines below it. An unread tree is now skipped, on the same terms as one with work in it.
+- **`worktree remove`** — refuses, in the words its `unique_commits` guard has used since
+  #104. `worktree.is_dirty` returned `bool`, which is why fixing the call sites alone could
+  not have worked; it is `worktree.dirt` now, and it answers in three.
+- **`persona memory-sync`** and the **session-start memory nudge** — both halves of "is
+  memory unsynced" answered *no* on the same failure at the same moment: one printed a green
+  tick, the other stayed silent. Both now say they could not look. A plane with no git
+  repository at all is exempt and unchanged — that is a definite answer, and `charter init`
+  in a fresh directory not running `git init` is the README's own 60-second path.
+- **`doctor`'s plane-root row** — the one rc-blind git call in a function that checks every
+  other one it makes. "not checked", never a tick.
+- **the deletion sweep** — `dirty_files` passed `check=False` to a helper that returns
+  stdout only, so an empty listing built the sandbox from committed HEAD alone and the whole
+  run reported findings against a tree the operator was not looking at. It raises
+  `NoSandbox` now, which is exactly that category and lives twenty lines above it.
+
+Two display sites got the third word for one line's worth of change each — `charter status`
+and `worktree list` print `unknown` rather than `clean` for a tree nobody could read.
+`statusline._run_state` is the one that still conflates them, and it is left alone on
+purpose: it is a glyph, it is behind a five-second cache three renderers share, and changing
+what that cache stores is a larger piece of work than this one.
+
+This is the third of these in a row, and each was fixed by giving the failure a category of
+its own rather than a shared default: `NoSandbox` (#905/#909) says *the machine*, not *the
+branch*; `config.PLANE_REFUSAL` (#913/#914) says *refused*, not *carry on with defaults*;
+and `gitstate.TreeState` says *charter could not tell*, not *there is nothing there*.

--- a/tests/test_a_table_column_is_measured_in_cells.py
+++ b/tests/test_a_table_column_is_measured_in_cells.py
@@ -42,7 +42,7 @@ from types import SimpleNamespace
 from unittest import mock
 
 from charter import (commands, commands_secrets, commands_worktree, commands_workspace,
-                     config, doctor, persona, pieces, tui, workspace)
+                     config, doctor, gitstate, persona, pieces, tui, workspace)
 from charter.secrets import registry as vault_registry
 from tests._isolation import PersonaIso
 
@@ -648,9 +648,9 @@ class WorktreeListCase(TableCase):
     """`worktree list` starts from GIT and joins the record onto what git found (ADR
     0011), so the rows are stubbed and the record is real.
 
-    `list_for` shells out to `git worktree list --porcelain` and `is_dirty` to `git
-    status` per row; what is under test is the arithmetic between them, and a real
-    worktree per fixture name would be a `git init` per case for values git never sees.
+    `list_for` shells out to `git worktree list --porcelain` and `dirt` to `git status`
+    per row; what is under test is the arithmetic between them, and a real worktree per
+    fixture name would be a `git init` per case for values git never sees.
     `tests/test_worktree.py` drives the real thing.
     """
 
@@ -672,8 +672,13 @@ class WorktreeListCase(TableCase):
         self.enterContext(mock.patch.object(
             commands_worktree.worktree, "list_for",
             side_effect=lambda clone, ws: list(self.rows)))
+        # A KNOWN clean tree, stated as one. `dirt` answers in three states now (#917), and
+        # a stub that returned an unknown state would put `unknown` in the column this case
+        # measures — which is the honest word for a tree charter could not read, and the
+        # wrong fixture for arithmetic about a tree it could.
         self.enterContext(mock.patch.object(
-            commands_worktree.worktree, "is_dirty", return_value=False))
+            commands_worktree.worktree, "dirt",
+            side_effect=lambda p: gitstate.TreeState(Path(p), (), None, None)))
         # An age, not a verdict — and a FIXED one, so `said` is the same string on every
         # row. A real `silence()` returns the age of the claim, which differs per row by
         # however long the fixture took to build and would make the tail unusable as a

--- a/tests/test_a_tree_charter_could_not_read_is_not_a_clean_one.py
+++ b/tests/test_a_tree_charter_could_not_read_is_not_a_clean_one.py
@@ -263,14 +263,39 @@ class TestAWorktreeCharterCouldNotReadIsNotRemovable(Unreadable):
         self.assertTrue(any("could not be checked for uncommitted changes" in r
                             for r in cw._worktrees_at_risk("alpha")))
 
+    def listing(self) -> str:
+        _rc, said = _said(commands_worktree.cmd_worktree_list,
+                          SimpleNamespace(workspace="alpha", repo=None))
+        return next(ln for ln in said.splitlines() if "slice" in ln)
+
     def test_the_listing_prints_unknown(self):
         _clone, wt = self.wire()
         self.break_it(wt)
-        rc, said = _said(commands_worktree.cmd_worktree_list,
-                         SimpleNamespace(workspace="alpha", repo=None))
-        line = next(ln for ln in said.splitlines() if "slice" in ln)
+        line = self.listing()
         self.assertIn("unknown", line)
         self.assertNotIn("clean", line)
+
+    def test_the_listing_still_prints_clean_for_a_healthy_piece(self):
+        """All three words, or the column says one thing. A third state that swallowed the
+        other two would be the same defect wearing the fix's clothes."""
+        self.wire()
+        self.assertIn("clean", self.listing())
+
+    def test_the_listing_still_prints_dirty_for_a_piece_holding_work(self):
+        _clone, wt = self.wire()
+        (wt / "unsaved.txt").write_text("work nobody has committed\n")
+        line = self.listing()
+        self.assertIn("dirty", line)
+        self.assertNotIn("clean", line)
+
+    def test_worktree_add_warns_about_a_clone_it_could_not_read(self):
+        """Advisory, so a warning and not a refusal — but it says WHICH of the two it is.
+        Silence here reads as "nothing to carry", which is the reading #917 is about."""
+        clone = self.broken_clone(repo="svc")
+        rc, said = _said(commands_worktree.cmd_worktree_add,
+                         SimpleNamespace(workspace="alpha", repo="svc", piece="slice",
+                                         branch=None, force=False))
+        self.assertIn("could not read", said)
 
 
 class MemoryPlane(PersonaIso):
@@ -307,6 +332,36 @@ class TestBothHalvesOfIsMemoryUnsyncedStopAnsweringNo(MemoryPlane):
             said = hooks._uncommitted_memory_nudge()
         self.assertIn("could not read", said)
         self.assertIn("bad index file", said)
+
+    def known(self, *rows: str):
+        return mock.patch.object(
+            gitstate, "read",
+            return_value=gitstate.TreeState(config.ROOT, rows, None, None))
+
+    def test_the_nudge_counts_memory_and_refs_and_nothing_else(self):
+        """The filter this line has always carried, pinned now that the line moved. A
+        persona's charter is not durable knowledge waiting to be shared — it is a file the
+        operator edits — and counting it would put a nudge on every session that touched
+        one."""
+        with mock.patch.object(config, "MEMORY_SHARE", "commit"), \
+             self.known(" M personas/qa/memory/a.md", " M personas/qa/qa.md",
+                        " M personas/qa/refs/b.md"):
+            said = hooks._uncommitted_memory_nudge()
+        self.assertIn("2 persona memory/ref file(s)", said)
+
+    def test_a_tree_dirty_in_neither_store_says_nothing(self):
+        with mock.patch.object(config, "MEMORY_SHARE", "commit"), \
+             self.known(" M personas/qa/qa.md"):
+            self.assertEqual(hooks._uncommitted_memory_nudge(), "")
+
+    def test_a_refs_file_alone_is_enough(self):
+        """`/refs/` is half of what this counts, and the half with no other witness: a
+        persona's refs are knowledge too, and a spelling that matched only `/memory/` would
+        lose them silently."""
+        with mock.patch.object(config, "MEMORY_SHARE", "commit"), \
+             self.known(" M personas/qa/refs/b.md"):
+            self.assertIn("1 persona memory/ref file(s)",
+                          hooks._uncommitted_memory_nudge())
 
 
 class TestAPlaneWithNoRepositoryIsADefiniteAnswer(MemoryPlane):

--- a/tests/test_a_tree_charter_could_not_read_is_not_a_clean_one.py
+++ b/tests/test_a_tree_charter_could_not_read_is_not_a_clean_one.py
@@ -394,6 +394,22 @@ class TestDoctorNoticesAStaleLockBeforeASaveRunsIntoIt(PersonaIso):
         r = doctor.check_index_lock()
         self.assertEqual(r.status, doctor.OK)
 
+    def test_no_plane_is_green_and_says_so(self):
+        """`check_control_plane_config` already says this loudly; a second row repeating it
+        would be noise, and a row asking git about a plane that does not exist would be a
+        subprocess spent on nothing."""
+        with mock.patch.object(config, "HAS_CONTROL_PLANE", False):
+            r = doctor.check_index_lock()
+        self.assertEqual(r.status, doctor.OK)
+        self.assertIn("no control plane", r.detail)
+
+    def test_a_git_that_will_not_answer_is_not_checked(self):
+        with mock.patch.object(doctor.gitstate, "for_repo",
+                               side_effect=OSError("no git on PATH")):
+            r = doctor.check_index_lock()
+        self.assertEqual(r.status, doctor.WARN)
+        self.assertIn("not checked", r.detail)
+
     def test_a_stale_lock_warns_and_names_it(self):
         lock = self.plant(size=0, age=23 * 3600)
         r = doctor.check_index_lock()
@@ -437,6 +453,19 @@ class TestTheSweepWillNotMeasureATreeNobodyIsLookingAt(unittest.TestCase):
         said = str(caught.exception)
         self.assertIn("could not be read", said)
         self.assertIn("not a verdict about any mutation", said)
+        self.assertIn("fatal", said)      # git's own words, kept
+
+    def test_a_git_that_failed_silently_still_raises(self):
+        """An exit status with no words is still an exit status — the phrase `_must` uses
+        for the same case, so the two readings of "the machine stopped us" read alike."""
+        import tempfile
+        from tools import sweep
+        done = subprocess.CompletedProcess(("git",), 9, "", "")
+        with tempfile.TemporaryDirectory() as d:
+            with mock.patch.object(sweep.subprocess, "run", return_value=done):
+                with self.assertRaises(sweep.NoSandbox) as caught:
+                    sweep.dirty_files(Path(d), ("charter",))
+        self.assertIn("without saying why", str(caught.exception))
 
     def test_a_clean_tree_still_returns_an_empty_dict(self):
         """The other side, and it is not decoration: a guard that raises on everything is

--- a/tests/test_a_tree_charter_could_not_read_is_not_a_clean_one.py
+++ b/tests/test_a_tree_charter_could_not_read_is_not_a_clean_one.py
@@ -1,0 +1,454 @@
+"""#917's siblings: every other place charter read an empty answer from git as a fact.
+
+`charter save` is where the conflation was observed, and it is not where it lived. A `git
+status` that failed writes nothing to stdout, so ``.stdout.strip()`` is empty — the same
+value a clean tree produces — and the survey behind #917 found eleven such readings across
+seven modules. They fail in **pairs**, which is how a defect of this shape survives being
+noticed:
+
+* `commands_persona._pending_memory` and `hooks._uncommitted_memory_nudge` are both halves
+  of "is memory unsynced". One printed a green ``✓ nothing to sync``, the other stayed
+  silent, for the same reason at the same moment.
+* `commands_workspace._work_at_risk` and `_worktrees_at_risk` are both halves of the gate
+  that decides whether `workspace remove` may hand a clone to `shutil.rmtree`.
+* `doctor.check_plane_root` and `statusline._run_state` are deliberately built to agree, so
+  they now agree on being wrong.
+
+**The failure planted here is a repository git will not stand in**, not a lock. That is
+deliberate and it is measured: under a held ``index.lock``, `git status` still answers
+correctly (see `test_save_refuses_a_tree_it_could_not_read`) — the lock breaks `git add`,
+which is why it broke `save` and nothing else. These sites break on the *other* ways git
+declines to answer, and before this they were the same value as an empty answer.
+
+What each site does about it differs, and the difference is the point rather than an
+inconsistency:
+
+======================================  ==========================================
+a gate on a deletion or a merge          refuse — an unread tree is not a cleared one
+a gate on a claim about durability       refuse, and say what charter could not read
+a preflight verdict                      "not checked", never a tick
+a column in a table                      a third word, ``unknown``
+a plane with no repository at all        unchanged — a definite answer, not an unread one
+======================================  ==========================================
+"""
+
+from __future__ import annotations
+
+import io
+import os
+import subprocess
+import time
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
+
+from charter import (commands, commands_persona, commands_worktree, config, doctor,
+                     gitstate, hooks, workspace, worktree)
+from charter import commands_workspace as cw
+from tests._isolation import PersonaIso
+
+_GIT_ENV = {"GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@e",
+            "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@e"}
+
+
+def _real_plane(case) -> Path:
+    """A plane that IS a control plane and IS a git repository, pointed at by `config`.
+
+    `PersonaIso` derives `config` from a bare tmp directory, so `HAS_CONTROL_PLANE` is
+    False there and every `doctor` row short-circuits to "no control plane found" — a green
+    row that would pass a test asserting nothing. `config.use` re-derives, and its return
+    value is restored on the way out.
+    """
+    plane = case.tmp / "plane"
+    plane.mkdir(parents=True, exist_ok=True)
+    (plane / "charter.toml").write_text("schema = 1\n")
+    subprocess.run(["git", "init", "-q", "-b", "main", str(plane)], check=True,
+                   capture_output=True, env={**os.environ, **_GIT_ENV})
+    case.addCleanup(config.restore, config.use(plane))
+    return plane
+
+
+def _said(fn, *a, **kw):
+    out, err = io.StringIO(), io.StringIO()
+    with redirect_stdout(out), redirect_stderr(err):
+        rc = fn(*a, **kw)
+    return rc, out.getvalue() + err.getvalue()
+
+
+class Unreadable(PersonaIso):
+    """A plane with one clone git refuses to answer about, and one it answers fine.
+
+    The broken clone is a directory holding an **empty ``.git`` directory**. Two properties
+    make it the right fixture and neither is incidental: `workspace.is_clone` counts it (a
+    clone's ``.git`` is a directory — that IS git's own definition), and ``git -C <it>
+    status --porcelain`` exits 128 writing nothing to stdout. Real git, real emptiness, no
+    stub anywhere in the path under test.
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+        workspace.ensure("alpha")
+        workspace.scaffold("alpha")
+
+    def git(self, cwd, *args: str):
+        return subprocess.run(["git", "-C", str(cwd), *args], check=True,
+                              capture_output=True, text=True,
+                              env={**os.environ, **_GIT_ENV})
+
+    def broken_clone(self, repo: str = "svc", ws: str = "alpha") -> Path:
+        d = workspace.workspace_dir(ws) / repo
+        (d / ".git").mkdir(parents=True, exist_ok=True)
+        return d
+
+    def healthy_clone(self, repo: str = "web", ws: str = "alpha") -> Path:
+        d = workspace.workspace_dir(ws) / repo
+        d.mkdir(parents=True, exist_ok=True)
+        subprocess.run(["git", "init", "-q", "-b", "main", str(d)], check=True,
+                       capture_output=True, env={**os.environ, **_GIT_ENV})
+        (d / "README").write_text("base\n")
+        self.git(d, "add", "-A")
+        self.git(d, "-c", "commit.gpgsign=false", "commit", "-qm", "base")
+        return d
+
+
+class TestGitStatusThatFailedIsNotAnEmptyStatus(Unreadable):
+    """The fixture itself, pinned against real git — the rest is worthless without it."""
+
+    def test_the_broken_clone_exits_non_zero_with_empty_stdout(self):
+        d = self.broken_clone()
+        r = subprocess.run(["git", "-C", str(d), "status", "--porcelain"],
+                           capture_output=True, text=True)
+        self.assertNotEqual(r.returncode, 0)
+        self.assertEqual(r.stdout.strip(), "")
+
+    def test_and_charter_can_now_tell_that_apart_from_clean(self):
+        broken, healthy = self.broken_clone(), self.healthy_clone()
+        self.assertFalse(gitstate.read(broken).known)
+        self.assertTrue(gitstate.read(healthy).known)
+        self.assertEqual(gitstate.read(healthy).rows, ())
+
+
+class TestWorkspaceRemoveWillNotDeleteWhatItCouldNotRead(Unreadable):
+    """The sharpest instance in the package: what `_work_at_risk` comes back empty of is
+    what `cmd_workspace_remove` hands to `shutil.rmtree`."""
+
+    def remove(self, force: bool = False):
+        return _said(cw.cmd_workspace_remove, SimpleNamespace(name="alpha", force=force))
+
+    def test_an_unreadable_clone_is_work_at_risk(self):
+        self.broken_clone()
+        self.assertTrue(any("could not be read" in r for r in cw._work_at_risk("alpha")))
+
+    def test_removal_refuses(self):
+        self.broken_clone()
+        rc, said = self.remove()
+        self.assertEqual(rc, 2, said)
+
+    def test_and_the_workspace_is_still_there(self):
+        self.broken_clone()
+        self.remove()
+        self.assertTrue(workspace.workspace_dir("alpha").exists())
+
+    def test_a_readable_clean_workspace_still_removes(self):
+        """The other half. A guard that refuses everything protects nothing, because the
+        first thing it teaches is `--force`."""
+        self.healthy_clone()
+        rc, said = self.remove()
+        self.assertEqual(rc, 0, said)
+        self.assertFalse(workspace.workspace_dir("alpha").exists())
+
+    def test_force_still_wins(self):
+        self.broken_clone()
+        rc, said = self.remove(force=True)
+        self.assertEqual(rc, 0, said)
+        self.assertFalse(workspace.workspace_dir("alpha").exists())
+
+
+class TestASnapshotDoesNotClaimAStateNobodyMeasured(Unreadable):
+    """`_restore_blockers` empty is what lets the manifest assert it captured reality — to
+    another engineer, on another machine, who cannot know it was never checked."""
+
+    def test_an_unreadable_clone_blocks(self):
+        self.broken_clone()
+        self.assertTrue(any("could not be read" in b
+                            for b in cw._restore_blockers("alpha")))
+
+    def test_snapshot_refuses(self):
+        self.broken_clone()
+        rc, said = _said(cw.cmd_workspace_snapshot,
+                         SimpleNamespace(name="alpha", force=False, description=None))
+        self.assertEqual(rc, 2, said)
+        self.assertIn("could not be read", said)
+
+
+class TestSyncDoesNotMergeIntoATreeItNeverRead(Unreadable):
+    """The polarity that makes this one worse than the usual reading. Everywhere else an
+    unread `git status` costs a warning nobody sees; in `_sync_one` the empty answer is
+    what AUTHORISES the `git merge --ff-only` two lines below it."""
+
+    def test_it_skips_and_says_why(self):
+        d = self.broken_clone()
+        rc, said = _said(commands._sync_one, d, "alpha")
+        self.assertIn("skipping", said)
+        self.assertIn("could not read", said)
+
+    def test_it_never_reaches_fetch_or_merge(self):
+        """Asserted on the argv rather than on the outcome: with the guard gone, `fetch`
+        runs and fails, and the test would still see a repo nothing had merged into."""
+        d = self.broken_clone()
+        real = commands._git
+        seen: list[list[str]] = []
+
+        def spy(args, cwd=None):
+            seen.append(list(args))
+            return real(args, cwd=cwd)
+
+        with mock.patch.object(commands, "_git", spy):
+            _said(commands._sync_one, d, "alpha")
+        self.assertEqual([a for a in seen if a and a[0] in ("fetch", "merge")], [])
+
+
+class TestTheStatusTableSaysUnknownRatherThanClean(Unreadable):
+    """A display site, and it still gets the third word. This row already has a written
+    record of printing `clean` over a tree that was not (uninitialised submodules, #817)."""
+
+    def test_an_unreadable_clone_is_not_clean(self):
+        note = commands._clone_note(self.broken_clone())
+        self.assertIn("unknown", note)
+        self.assertNotIn("clean", note)
+
+    def test_a_healthy_clone_still_reads_clean(self):
+        self.assertIn("clean", commands._clone_note(self.healthy_clone()))
+
+
+class TestAWorktreeCharterCouldNotReadIsNotRemovable(Unreadable):
+    """`worktree.is_dirty` returned `bool`, so the third state was unrepresentable — which
+    is why fixing the call sites alone could not have worked. Its own siblings already
+    answered in three: `unique_commits` returns ``None``, and the refusal four lines below
+    this one has said "could not determine … refusing to remove" since #104."""
+
+    def wire(self, piece: str = "slice"):
+        clone = self.healthy_clone(repo="svc")
+        wt = worktree.path_for("alpha", "svc", piece)
+        wt.parent.mkdir(parents=True, exist_ok=True)
+        self.git(clone, "worktree", "add", "-q", "-b", piece, str(wt))
+        return clone, wt
+
+    def break_it(self, wt: Path):
+        """Point the worktree's ``.git`` file at nothing. The directory still EXISTS, which
+        is what keeps this off the `prunable` path that #597 already covers — the two
+        failures are different and only one of them had ever been measured."""
+        (wt / ".git").write_text("gitdir: /nonexistent/worktrees/gone\n")
+
+    def test_dirt_says_it_could_not_look(self):
+        _clone, wt = self.wire()
+        self.break_it(wt)
+        self.assertFalse(worktree.dirt(wt).known)
+
+    def test_worktree_remove_refuses(self):
+        _clone, wt = self.wire()
+        self.break_it(wt)
+        rc, said = _said(commands_worktree.cmd_worktree_remove,
+                         SimpleNamespace(workspace="alpha", repo="svc", piece="slice",
+                                         force=False))
+        self.assertEqual(rc, 1, said)
+        self.assertIn("could not determine", said)
+
+    def test_the_workspace_gate_lists_it_too(self):
+        """The other half of the pair. `_worktrees_at_risk` feeds the same rmtree."""
+        _clone, wt = self.wire()
+        self.break_it(wt)
+        self.assertTrue(any("could not be checked for uncommitted changes" in r
+                            for r in cw._worktrees_at_risk("alpha")))
+
+    def test_the_listing_prints_unknown(self):
+        _clone, wt = self.wire()
+        self.break_it(wt)
+        rc, said = _said(commands_worktree.cmd_worktree_list,
+                         SimpleNamespace(workspace="alpha", repo=None))
+        line = next(ln for ln in said.splitlines() if "slice" in ln)
+        self.assertIn("unknown", line)
+        self.assertNotIn("clean", line)
+
+
+class MemoryPlane(PersonaIso):
+    """A plane that IS a git repository, so the memory pair has something to fail at."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        (config.ROOT / "charter.toml").write_text('schema = 1\n')
+        subprocess.run(["git", "init", "-q", "-b", "main", str(config.ROOT)], check=True,
+                       capture_output=True, env={**os.environ, **_GIT_ENV})
+
+    def unreadable(self):
+        """`git status` fails while the plane still HAS a repository — so `no_repo` is
+        False and the exemption below cannot be what makes a test pass."""
+        return mock.patch.object(
+            gitstate, "read",
+            return_value=gitstate.TreeState(config.ROOT, (), "fatal: bad index file",
+                                            None, False))
+
+
+class TestBothHalvesOfIsMemoryUnsyncedStopAnsweringNo(MemoryPlane):
+    """They failed together, so they are pinned together."""
+
+    def test_memory_sync_refuses_rather_than_ticking(self):
+        with self.unreadable():
+            rc, said = _said(commands_persona.cmd_persona_memory_sync,
+                             SimpleNamespace(no_push=True, sign=False))
+        self.assertEqual(rc, 1, said)
+        self.assertNotIn("nothing to sync", said)
+        self.assertIn("bad index file", said)
+
+    def test_the_session_start_nudge_says_it_could_not_look(self):
+        with mock.patch.object(config, "MEMORY_SHARE", "commit"), self.unreadable():
+            said = hooks._uncommitted_memory_nudge()
+        self.assertIn("could not read", said)
+        self.assertIn("bad index file", said)
+
+
+class TestAPlaneWithNoRepositoryIsADefiniteAnswer(MemoryPlane):
+    """`charter init` in a fresh directory does not run `git init` — the README's own
+    60-second path. A plane with no repository has nowhere to sync TO, which is a fact
+    rather than a failure to look, and telling every such plane at every session start that
+    charter cannot read it would be a new false alarm on a supported resting state."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        import shutil
+        shutil.rmtree(config.ROOT / ".git")
+
+    def test_the_state_says_so(self):
+        state = gitstate.read(config.ROOT, "personas")
+        self.assertFalse(state.known)
+        self.assertTrue(state.no_repo)
+
+    def test_the_nudge_stays_silent(self):
+        with mock.patch.object(config, "MEMORY_SHARE", "commit"):
+            self.assertEqual(hooks._uncommitted_memory_nudge(), "")
+
+    def test_memory_sync_does_not_refuse_over_it(self):
+        rc, said = _said(commands_persona.cmd_persona_memory_sync,
+                         SimpleNamespace(no_push=True, sign=False))
+        self.assertNotIn("could not read", said)
+
+
+class TestDoctorWillNotTickOverAStatusItCouldNotRun(PersonaIso):
+    """`check_plane_root` was the one rc-blind git call in a function that checks every
+    other one it makes — `--show-toplevel`, `symbolic-ref`, both `rev-list`s and
+    `@{upstream}` all branch on `returncode`. The surrounding `try` already turned a
+    TIMEOUT into an honest "not checked"; a non-zero exit deserves the same sentence."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        plane = _real_plane(self)
+        (plane / "README").write_text("x\n")
+        subprocess.run(["git", "-C", str(plane), "add", "-A"], check=True,
+                       capture_output=True, env={**os.environ, **_GIT_ENV})
+        subprocess.run(["git", "-C", str(plane), "-c", "commit.gpgsign=false",
+                        "commit", "-qm", "base"], check=True, capture_output=True,
+                       env={**os.environ, **_GIT_ENV})
+
+    def test_a_status_that_exits_non_zero_is_not_checked(self):
+        real = doctor._git_in
+
+        def fake(root, *args):
+            if args and args[0] == "status":
+                return subprocess.CompletedProcess(args, 128, "", "fatal: bad index file")
+            return real(root, *args)
+
+        with mock.patch.object(doctor, "_git_in", fake):
+            r = doctor.check_plane_root()
+        self.assertEqual(r.status, doctor.WARN)
+        self.assertIn("not checked", r.detail)
+
+    def test_a_status_that_answers_still_reads_clean(self):
+        r = doctor.check_plane_root()
+        self.assertEqual(r.status, doctor.OK)
+        self.assertIn("clean", r.detail)
+
+
+class TestDoctorNoticesAStaleLockBeforeASaveRunsIntoIt(PersonaIso):
+    """The row #917 asked for. The operator's lock had been there for twenty-three hours,
+    through however many sessions, and the first thing to look at it was the `charter save`
+    it broke."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        _real_plane(self)
+
+    def plant(self, *, size: int, age: float) -> Path:
+        p = config.ROOT / ".git" / gitstate.LOCK_NAME
+        p.write_bytes(b"x" * size)
+        when = time.time() - age
+        os.utime(p, (when, when))
+        self.addCleanup(p.unlink, missing_ok=True)
+        return p
+
+    def test_the_row_exists_and_is_named(self):
+        self.assertIn("index lock", doctor.check_names())
+
+    def test_no_lock_is_green(self):
+        r = doctor.check_index_lock()
+        self.assertEqual(r.status, doctor.OK)
+
+    def test_a_stale_lock_warns_and_names_it(self):
+        lock = self.plant(size=0, age=23 * 3600)
+        r = doctor.check_index_lock()
+        self.assertEqual(r.status, doctor.WARN)
+        self.assertIn(str(lock.resolve()), r.detail)
+        self.assertIn("23h", r.detail)
+        self.assertIn(f"rm -f {lock.resolve()}", r.hint)
+
+    def test_the_remedy_is_the_operators_and_charter_says_so(self):
+        lock = self.plant(size=0, age=23 * 3600)
+        r = doctor.check_index_lock()
+        self.assertIn("charter never removes a lock", r.hint)
+        doctor.check_index_lock()
+        self.assertTrue(lock.exists(), "doctor removed a lock it does not own")
+
+    def test_a_lock_a_live_git_is_holding_is_not_a_warning(self):
+        """A lock is not a fault — git takes one for every write to the index. Painting the
+        preflight yellow for a healthy `git commit` mid-flight is a false alarm on correct
+        behaviour, and a permanently-yellow row is one people stop reading."""
+        self.plant(size=4096, age=2)
+        r = doctor.check_index_lock()
+        self.assertEqual(r.status, doctor.OK)
+        self.assertIn("held now", r.detail)
+
+
+class TestTheSweepWillNotMeasureATreeNobodyIsLookingAt(unittest.TestCase):
+    """`tools.sweep.dirty_files` passed `check=False` to a helper that returns stdout only,
+    so the exit status was not merely unchecked — it was unavailable. An empty listing
+    built the sandbox from committed HEAD alone and the whole run reported findings against
+    a tree the operator was not looking at.
+
+    `NoSandbox` is that category and it is twenty lines up in the same file: a statement
+    about the machine, made before a single mutation has been measured."""
+
+    def test_a_status_that_failed_raises_nosandbox(self):
+        import tempfile
+        from tools import sweep
+        with tempfile.TemporaryDirectory() as d:
+            with self.assertRaises(sweep.NoSandbox) as caught:
+                sweep.dirty_files(Path(d), ("charter",))
+        said = str(caught.exception)
+        self.assertIn("could not be read", said)
+        self.assertIn("not a verdict about any mutation", said)
+
+    def test_a_clean_tree_still_returns_an_empty_dict(self):
+        """The other side, and it is not decoration: a guard that raises on everything is
+        indistinguishable from this one until something passes through it."""
+        import tempfile
+        from tools import sweep
+        with tempfile.TemporaryDirectory() as d:
+            root = Path(d)
+            subprocess.run(["git", "init", "-q", "-b", "main", str(root)], check=True,
+                           capture_output=True, env={**os.environ, **_GIT_ENV})
+            self.assertEqual(sweep.dirty_files(root, ("charter",)), {})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_persona_memory_sync.py
+++ b/tests/test_persona_memory_sync.py
@@ -95,10 +95,16 @@ class EveryPlaneCommitOffersTheForgeToken(PersonaIso):
     """
 
     def test_memory_sync_delegates_to_the_one_committer(self):
+        from pathlib import Path
         from unittest import mock
-        from charter import commands_persona, planegit
-        with mock.patch.object(commands_persona, "_pending_memory",
-                               return_value=["personas/p/memory/m.md"]), \
+        from charter import commands_persona, gitstate, planegit
+        # A KNOWN state carrying one pending file. `_pending_memory` returns the paths AND
+        # the state they were read from since #917, because "nothing pending" and "charter
+        # could not ask" used to produce the same empty list — and the same green tick.
+        pending = (["personas/p/memory/m.md"],
+                   gitstate.TreeState(Path("/plane"), (" M personas/p/memory/m.md",),
+                                      None, None))
+        with mock.patch.object(commands_persona, "_pending_memory", return_value=pending), \
              mock.patch.object(planegit, "commit_push", return_value=0) as cp, \
              mock.patch("charter.hooks._secret_kind", return_value=None):
             rc = commands_persona.cmd_persona_memory_sync(_Args(no_push=False))

--- a/tests/test_save_refuses_a_tree_it_could_not_read.py
+++ b/tests/test_save_refuses_a_tree_it_could_not_read.py
@@ -262,7 +262,8 @@ class TestCharterReportsALockAndLeavesIt(LockedPlane):
     def test_and_the_check_that_makes_it_safe_comes_first(self):
         """`ps` before `rm`. A remedy that printed the removal alone would teach the habit
         of skipping the one step that makes it safe."""
-        rc, said = self.save() if self.plant_lock() else (None, "")
+        self.plant_lock()
+        rc, said = self.save()
         self.assertLess(said.index("ps -eo"), said.index("rm -f"), said)
 
 

--- a/tests/test_save_refuses_a_tree_it_could_not_read.py
+++ b/tests/test_save_refuses_a_tree_it_could_not_read.py
@@ -318,6 +318,39 @@ class TestAnUnreadableIndexIsRefusedWithoutALock(LockedPlane):
         self.assertNotIn("Nothing to save", said)
         self.assertIn("bad index file", said)
 
+    def test_with_no_lock_to_name_charter_says_it_has_none(self):
+        """The other half of the refusal, and it is not filler. Charter has no remedy to
+        offer here, and inventing one — or printing the lock lines with nothing in them —
+        is how a message stops being read. It names where the reason is instead."""
+        real = planegit._git
+
+        def fake(args, cwd=None):
+            if args[:2] == ["diff", "--cached"] and "--quiet" in args:
+                return subprocess.CompletedProcess(args, 128, "", "fatal: bad index file")
+            return real(args, cwd=cwd)
+
+        with mock.patch.object(planegit, "_git", fake):
+            rc, said = self.save()
+        self.assertIn("Nothing charter can name is holding this index", said)
+        self.assertNotIn("rm -f", said)
+
+    def test_a_git_that_failed_silently_is_still_refused(self):
+        """git writing nothing to stderr is not git having no complaint. `sweep`'s
+        `_must` says "without saying why" for the same case and for the same reason: an
+        exit status with no words is still an exit status."""
+        real = planegit._git
+
+        def fake(args, cwd=None):
+            if args and args[0] == "add":
+                return subprocess.CompletedProcess(args, 9, "", "")
+            return real(args, cwd=cwd)
+
+        with mock.patch.object(planegit, "_git", fake):
+            rc, said = self.save()
+        self.assertEqual(rc, 1, said)
+        self.assertIn("without saying why", said)
+        self.assertNotIn("Nothing to save", said)
+
 
 class TestALockIsDescribedByThreeFacts(unittest.TestCase):
     """`gitstate` on its own: the record, not the command that prints it."""
@@ -333,6 +366,14 @@ class TestALockIsDescribedByThreeFacts(unittest.TestCase):
     def test_zero_bytes_and_young_is_not(self):
         lock = gitstate.IndexLock(Path("/x/index.lock"), 0, 1)
         self.assertFalse(lock.crashed)
+
+    def test_the_threshold_itself_counts_as_stale(self):
+        """`>=`, not `>`, and the boundary is asserted from both sides. The number is a
+        judgement call; which way it rounds should not also be one."""
+        self.assertTrue(
+            gitstate.IndexLock(Path("/x/index.lock"), 0, gitstate.STALE_AFTER).crashed)
+        self.assertFalse(
+            gitstate.IndexLock(Path("/x/index.lock"), 0, gitstate.STALE_AFTER - 1).crashed)
 
     def test_a_lock_with_an_index_in_it_is_not_a_crash_however_old(self):
         """git writes the new index INTO the lock before it opens an editor, so the
@@ -382,6 +423,39 @@ class TestALockedWorktreeIsItsOwnIndex(LockedPlane):
         plain.mkdir()
         self.assertIsNone(gitstate.git_dir_of(plain))
         self.assertIsNone(gitstate.for_repo(plain))
+
+    def test_a_subdirectory_of_a_repo_finds_the_repos_git_dir(self):
+        """The fallback, and it is load-bearing. `util.git_dir` reads the FILESYSTEM — no
+        subprocess, which is why `doctor` can ask this on every preflight — and a directory
+        inside a working tree has no ``.git`` of its own. `check_plane_root` supports
+        exactly that layout (a `charter.toml` in a subdirectory of some larger repo), so
+        stopping at the filesystem answer would report no git directory for a tree that has
+        one."""
+        deep = self.plane / "personas"
+        self.assertIsNone(__import__("charter").util.git_dir(deep))
+        self.assertEqual(gitstate.git_dir_of(deep), (self.plane / ".git").resolve())
+
+
+class TestAGitThatCouldNotBeRunIsNotAnAnswer(LockedPlane):
+    """`read` catches what `util.run` raises, and reports it as the third state rather
+    than letting it reach a hook. Every caller here runs from a Stop or SessionStart hook
+    at some point, and a traceback there is a broken turn."""
+
+    def test_a_timeout_is_not_a_clean_tree(self):
+        from charter import util
+        boom = util.ProcTimeout(["git", "status", "--porcelain"], 3)
+        with mock.patch.object(gitstate.util, "run", side_effect=boom):
+            state = gitstate.read(self.plane)
+        self.assertFalse(state.known)
+        self.assertEqual(state.rows, ())
+        self.assertIn("timed out after 3s", state.said)
+
+    def test_a_git_that_will_not_start_is_not_a_clean_tree(self):
+        with mock.patch.object(gitstate.util, "run",
+                               side_effect=FileNotFoundError("no git on PATH")):
+            state = gitstate.read(self.plane)
+        self.assertFalse(state.known)
+        self.assertIn("no git on PATH", state.said)
 
 
 if __name__ == "__main__":

--- a/tests/test_save_refuses_a_tree_it_could_not_read.py
+++ b/tests/test_save_refuses_a_tree_it_could_not_read.py
@@ -388,6 +388,8 @@ class TestALockIsDescribedByThreeFacts(unittest.TestCase):
         self.assertEqual(gitstate.age_phrase(60), "1m")
         self.assertEqual(gitstate.age_phrase(3600), "1h")
         self.assertEqual(gitstate.age_phrase(23 * 3600), "23h")
+        self.assertEqual(gitstate.age_phrase(86399), "23h")
+        self.assertEqual(gitstate.age_phrase(86400), "1d")
         self.assertEqual(gitstate.age_phrase(86400 * 3), "3d")
 
     def test_a_negative_age_reads_as_now(self):
@@ -434,6 +436,105 @@ class TestALockedWorktreeIsItsOwnIndex(LockedPlane):
         deep = self.plane / "personas"
         self.assertIsNone(__import__("charter").util.git_dir(deep))
         self.assertEqual(gitstate.git_dir_of(deep), (self.plane / ".git").resolve())
+
+
+class TestTheRecordIsBuiltFromWhatCanBePasted(LockedPlane):
+    """The parts of `gitstate` a reader acts on: the path in an `rm`, git's own words, and
+    the remedy list a caller prints under them."""
+
+    def test_a_lock_is_named_by_its_physical_path(self):
+        """`resolve()`, and it is not cosmetic. macOS hands out temp and home paths through
+        symlinks (``/var`` → ``/private/var``), `planegit` passes the git dir straight from
+        `rev-parse` without normalising it, and the line charter prints is one the operator
+        is invited to paste into an `rm`."""
+        link = self.tmp / "linked-git"
+        link.symlink_to(self.plane / ".git")
+        self.lock_path.write_bytes(b"")
+        self.addCleanup(self.lock_path.unlink, missing_ok=True)
+        found = gitstate.find(link)
+        self.assertIsNotNone(found)
+        self.assertEqual(found.path, self.lock_path.resolve())
+        self.assertNotIn("linked-git", str(found.path))
+
+    def test_the_git_dir_of_a_symlinked_tree_is_the_physical_one(self):
+        link = self.tmp / "linked-tree"
+        link.symlink_to(self.plane)
+        self.assertEqual(gitstate.git_dir_of(link), (self.plane / ".git").resolve())
+
+    def test_the_filesystem_answers_without_starting_a_process(self):
+        """`doctor` asks this on every SessionStart preflight, inside a hook budget that a
+        stalled 1Password once ate whole. `util.git_dir` reads the `.git` entry directly —
+        so a git that cannot even be spawned still gets an answer here."""
+        with mock.patch.object(gitstate.util, "run",
+                               side_effect=AssertionError("started a process")):
+            self.assertEqual(gitstate.git_dir_of(self.plane),
+                             (self.plane / ".git").resolve())
+
+    def test_a_git_that_will_not_run_leaves_the_git_dir_unknown(self):
+        """The fallback's own failure. Reached only when the filesystem could not answer,
+        so both halves are stubbed: no `.git` to read, and no git to ask."""
+        with mock.patch.object(gitstate.util, "git_dir", return_value=None), \
+             mock.patch.object(gitstate.util, "run",
+                               side_effect=OSError("no git on PATH")):
+            self.assertIsNone(gitstate.git_dir_of(self.plane))
+
+    def test_a_proc_with_no_stderr_at_all_says_nothing(self):
+        """`stderr` is `None` on a `CompletedProcess` captured without text, and `None` has
+        no `.splitlines()`. The fallback is what keeps a refusal from becoming a traceback
+        on the path that exists to explain one."""
+        self.assertEqual(gitstate.said(subprocess.CompletedProcess([], 1, "", None)), "")
+        self.assertEqual(gitstate.said(SimpleNamespace()), "")
+
+    def test_git_is_quoted_without_its_whitespace(self):
+        """Both ends. git's stderr under a held lock is four lines, and the message this
+        goes into is one line — a trailing newline or an indent pasted into the middle of a
+        sentence is how a quoted reason stops reading as a quote."""
+        proc = subprocess.CompletedProcess([], 1, "", "\n\n   fatal: Unable to create  \n")
+        self.assertEqual(gitstate.said(proc), "fatal: Unable to create")
+
+    def test_a_known_tree_explains_nothing(self):
+        """`why()` is a sentence for a caller that has to explain itself. A tree charter
+        read has nothing to explain, and a caller printing this unconditionally would tell
+        every healthy plane that charter could not read it."""
+        self.assertEqual(gitstate.read(self.plane).why(), "")
+        self.assertNotEqual(gitstate.read(self.tmp / "nowhere").why(), "")
+
+    def test_a_state_with_no_lock_offers_no_remedy(self):
+        self.assertEqual(gitstate.read(self.plane).remedy(), [])
+        self.assertEqual(gitstate.read(self.tmp / "nowhere").remedy(), [])
+
+    def test_a_state_with_a_lock_offers_the_description_and_both_commands(self):
+        lock = gitstate.IndexLock(self.lock_path, 0, gitstate.STALE_AFTER + 1)
+        state = gitstate.TreeState(self.plane, (), "fatal: bad index file", lock)
+        remedy = state.remedy()
+        self.assertEqual(len(remedy), 3)
+        self.assertIn("crashed", remedy[0])
+        self.assertIn("ps -eo", remedy[1])
+        self.assertIn("rm -f", remedy[2])
+
+    def test_a_pathspec_bounds_what_is_read(self):
+        """Without the `--`, `read(root, "personas")` asks about the whole tree, and every
+        caller that scopes its question — the memory pair, the workspace autosave — starts
+        answering a different one."""
+        (self.plane / "elsewhere.txt").write_text("not a persona\n")
+        self.assertTrue(gitstate.read(self.plane).rows)
+        scoped = gitstate.read(self.plane, "elsewhere.txt")
+        self.assertEqual([r[3:] for r in scoped.rows], ["elsewhere.txt"])
+        for i in range(DIRTY_FILES):
+            (self.plane / "personas" / f"p{i}.md").write_text(f"# persona {i}\n")
+        self.assertEqual(gitstate.read(self.plane, "personas").rows, ())
+
+    def test_a_tree_that_could_not_be_read_still_carries_its_lock(self):
+        """The two facts arrive together or the refusal has nothing to name. Built from a
+        repository git will not stand in — an empty `.git` — with a lock inside it, because
+        a lock alone does not stop `git status` (measured above)."""
+        broken = self.tmp / "broken"
+        (broken / ".git").mkdir(parents=True)
+        (broken / ".git" / gitstate.LOCK_NAME).write_bytes(b"")
+        state = gitstate.read(broken)
+        self.assertFalse(state.known)
+        self.assertIsNotNone(state.lock)
+        self.assertEqual(state.lock.path, (broken / ".git" / gitstate.LOCK_NAME).resolve())
 
 
 class TestAGitThatCouldNotBeRunIsNotAnAnswer(LockedPlane):

--- a/tests/test_save_refuses_a_tree_it_could_not_read.py
+++ b/tests/test_save_refuses_a_tree_it_could_not_read.py
@@ -1,0 +1,387 @@
+"""`charter save` said the tree was clean when it had not been able to read the tree.
+
+#917, on the operator's own plane and not hypothesised::
+
+    $ git status --porcelain | wc -l
+          13
+    $ charter save
+    • Nothing to save — the control-plane working tree is clean.
+
+The cause was a stale ``.git/index.lock`` — zero bytes, twenty-three hours old, no process
+holding it, left by a git that had crashed the day before. With the file removed, the
+identical command on the identical tree committed twenty files.
+
+**The mechanism, measured against git 2.50.1** and reproduced by `LockedPlane` below:
+
+===========================  ==============================================
+``git status --porcelain``   rc 0, every modified file listed
+``git add -A``               rc 128, ``Unable to create '…/index.lock'``
+``git diff --cached --quiet``rc 0 — nothing was staged, so there is no diff
+===========================  ==============================================
+
+`planegit.commit_push` discarded the add's exit status and read the diff's ``0`` as *the
+tree is clean*. The lock is invisible to the question charter asks last and fatal to the
+one it asks first, which is why the defect renders as a confident sentence rather than as
+an error.
+
+**Why this instance is worse than its siblings.** Every other version of this shape in
+charter degrades to "nothing to show" — a missing gauge, an empty row, a cache read as
+cold. This one degrades to a claim about durability that is false, and the operator's next
+act is to stop worrying about the work. It becomes data loss the moment anything
+afterwards assumes the save happened: a `git checkout`, a worktree removal, a machine
+going away.
+
+So `commit_push` now answers three questions where it used to answer two, and this module
+pins all three: the tree is clean, the tree has changes, or **charter could not tell** — in
+which case it refuses, names the lock and says how old it is.
+
+**And it never removes the lock.** `TestCharterReportsALockAndLeavesIt` is that rule. A
+lock held by a live git is real and one command cannot tell the two apart from the inside;
+the operator cleared #917's by hand after checking `ps` and the file's mtime, which is the
+right division of labour.
+"""
+
+from __future__ import annotations
+
+import io
+import os
+import subprocess
+import time
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
+
+from charter import commands, config, gitstate, planegit
+from tests._isolation import PersonaIso
+
+#: How many files the operator's tree held. Thirteen because that is the number in the
+#: issue: the reproduction is worth nothing if it is not the observed shape.
+DIRTY_FILES = 13
+
+#: The age of the lock that was actually found. Twenty-three hours, so `23h` is what the
+#: refusal has to be able to say.
+LOCK_AGE = 23 * 3600
+
+PLANE_TOML = 'schema = 1\n\n[[forge]]\nkind = "github"\n'
+
+
+def _run(fn, *a, **kw):
+    """Call *fn*, returning ``(rc, everything it said)``. `util` writes to stderr and some
+    commands print to stdout; a refusal has to be findable in either."""
+    out, err = io.StringIO(), io.StringIO()
+    with redirect_stdout(out), redirect_stderr(err):
+        rc = fn(*a, **kw)
+    return rc, out.getvalue() + err.getvalue()
+
+
+def _save_args(message=None):
+    return SimpleNamespace(message=message, sign=False, no_push=True)
+
+
+class LockedPlane(PersonaIso):
+    """A real plane repository, really dirty, with a real lock file planted in it.
+
+    Real git throughout. The defect is a disagreement between what two git subcommands do
+    with the same lock, so a fixture that faked either of them would be asserting against
+    this module's idea of git rather than against git's.
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.plane = self.tmp / "plane"
+        self.plane.mkdir(parents=True, exist_ok=True)
+        (self.plane / "charter.toml").write_text(PLANE_TOML)
+        (self.plane / "personas").mkdir()
+        for i in range(DIRTY_FILES):
+            (self.plane / "personas" / f"p{i}.md").write_text(f"# persona {i}\n")
+        self.git("init", "-q", "-b", "main", ".")
+        # Repo-scoped, never global: `tests._gitguard` already redirects the config files
+        # every child of this suite reads, and a fixture writing outside the repo under
+        # test would put that back.
+        self.git("config", "user.email", "r@e.invalid")
+        self.git("config", "user.name", "r")
+        self.git("config", "commit.gpgsign", "false")
+        self.git("add", "-A")
+        self.git("commit", "-qm", "plane")
+        self.base = self.head()
+
+        # The operator's thirteen modified files.
+        for i in range(DIRTY_FILES):
+            (self.plane / "personas" / f"p{i}.md").write_text(f"# persona {i}\nedited\n")
+
+        self.addCleanup(config.restore, config.use(self.plane))
+        self.standing_in(self.plane)
+
+    # -- the repository ---------------------------------------------------- #
+    def git(self, *argv: str) -> str:
+        p = subprocess.run(["git", "-C", str(self.plane), *argv],
+                           check=True, capture_output=True, text=True)
+        return p.stdout.strip()
+
+    def head(self) -> str:
+        return self.git("rev-parse", "HEAD")
+
+    def porcelain(self) -> list[str]:
+        return [ln for ln in self.git("status", "--porcelain").splitlines() if ln.strip()]
+
+    def staged(self) -> list[str]:
+        return [ln for ln in self.git("diff", "--cached", "--name-only").splitlines() if ln]
+
+    def standing_in(self, where: Path):
+        """chdir for the rest of the test. Registered rather than a ``finally``, and before
+        `PersonaIso`'s rmtree: a cwd left inside a deleted temp directory makes
+        `Path.cwd()` raise for every test that runs after this one."""
+        here = Path.cwd()
+        self.addCleanup(os.chdir, here)
+        os.chdir(where)
+
+    # -- the lock ---------------------------------------------------------- #
+    @property
+    def lock_path(self) -> Path:
+        return self.plane / ".git" / gitstate.LOCK_NAME
+
+    def plant_lock(self, *, size: int = 0, age: float = LOCK_AGE) -> Path:
+        """Leave an ``index.lock`` behind, exactly as a crashed git does.
+
+        **Always removed again on the way out**, whatever the test does with it. A fixture
+        that left one behind would hand the next module a repository no `git add` can
+        touch — this defect, planted in the suite that exists to catch it.
+        """
+        p = self.lock_path
+        p.write_bytes(b"x" * size)
+        when = time.time() - age
+        os.utime(p, (when, when))
+        self.addCleanup(p.unlink, missing_ok=True)
+        return p
+
+    def save(self, **kw):
+        return _run(commands.cmd_save, _save_args(**kw))
+
+
+class TestTheTreeWasReadableAndTheAnswerWasStillEmpty(LockedPlane):
+    """The asymmetry the defect is made of, pinned against real git.
+
+    Not a test of charter at all, and that is the point: if git ever stops answering
+    `status` under a held lock, or starts refusing `diff --cached`, the reproduction below
+    is no longer reproducing #917 and this fails first and says so.
+    """
+
+    def test_status_still_lists_every_file(self):
+        self.plant_lock()
+        self.assertEqual(len(self.porcelain()), DIRTY_FILES)
+
+    def test_add_cannot_stage_anything(self):
+        self.plant_lock()
+        r = subprocess.run(["git", "-C", str(self.plane), "add", "-A"],
+                           capture_output=True, text=True)
+        self.assertNotEqual(r.returncode, 0)
+        self.assertIn("index.lock", r.stderr)
+
+    def test_and_the_index_then_looks_exactly_like_a_clean_tree(self):
+        """``diff --cached --quiet`` → 0. The lie, one layer below charter."""
+        self.plant_lock()
+        r = subprocess.run(["git", "-C", str(self.plane), "diff", "--cached", "--quiet"],
+                           capture_output=True, text=True)
+        self.assertEqual(r.returncode, 0)
+
+
+class TestSaveRefusesATreeItCouldNotRead(LockedPlane):
+    """Outcome 3. The sentence in the issue must not be printable here."""
+
+    def test_it_does_not_say_the_tree_is_clean(self):
+        self.plant_lock()
+        rc, said = self.save()
+        self.assertNotIn("Nothing to save", said)
+        self.assertNotIn("clean", said)
+
+    def test_it_refuses(self):
+        """rc 1, not 0. `charter save` exiting 0 is what a caller reads as "it is saved",
+        and every harm in #917 is downstream of something believing that."""
+        self.plant_lock()
+        rc, said = self.save()
+        self.assertEqual(rc, 1, said)
+
+    def test_it_names_the_lock(self):
+        lock = self.plant_lock()
+        rc, said = self.save()
+        self.assertIn(str(lock.resolve()), said)
+
+    def test_it_says_how_old_the_lock_is(self):
+        """The age is the fact that decides what the operator does: seconds means wait,
+        hours means the writer is dead. A refusal without it sends both to the same place."""
+        self.plant_lock()
+        rc, said = self.save()
+        self.assertIn("23h", said)
+
+    def test_a_zero_byte_lock_hours_old_is_called_a_crash(self):
+        self.plant_lock(size=0, age=LOCK_AGE)
+        rc, said = self.save()
+        self.assertIn("crashed", said)
+
+    def test_a_fresh_lock_is_not_called_a_crash(self):
+        """Contention is a different sentence, because it has a different answer. A live
+        `git commit` holding the index is not something to `rm`."""
+        self.plant_lock(size=0, age=2)
+        rc, said = self.save()
+        self.assertEqual(rc, 1, said)
+        self.assertNotIn("crashed", said)
+
+    def test_it_commits_nothing(self):
+        self.plant_lock()
+        self.save()
+        self.assertEqual(self.head(), self.base)
+
+    def test_it_stages_nothing(self):
+        self.plant_lock()
+        self.save()
+        self.assertEqual(self.staged(), [])
+
+    def test_the_operators_work_is_still_there_to_save(self):
+        """The harm stated as what was actually at stake: thirteen files that charter had
+        just reported safe."""
+        self.plant_lock()
+        self.save()
+        self.assertEqual(len(self.porcelain()), DIRTY_FILES)
+
+
+class TestCharterReportsALockAndLeavesIt(LockedPlane):
+    """charter never runs the `rm`. This is a rule, not an implementation detail."""
+
+    def test_the_lock_survives_the_refusal(self):
+        lock = self.plant_lock()
+        self.save()
+        self.assertTrue(lock.exists(), "charter removed a lock it does not own")
+
+    def test_the_removal_is_offered_to_the_operator(self):
+        lock = self.plant_lock()
+        rc, said = self.save()
+        self.assertIn(f"rm -f {lock.resolve()}", said)
+
+    def test_and_the_check_that_makes_it_safe_comes_first(self):
+        """`ps` before `rm`. A remedy that printed the removal alone would teach the habit
+        of skipping the one step that makes it safe."""
+        rc, said = self.save() if self.plant_lock() else (None, "")
+        self.assertLess(said.index("ps -eo"), said.index("rm -f"), said)
+
+
+class TestTheOtherTwoOutcomesAreUnchanged(LockedPlane):
+    """A refusal that also broke saving would be a worse defect than the one it fixed."""
+
+    def test_a_clean_tree_still_says_nothing_to_save(self):
+        self.git("add", "-A")
+        self.git("commit", "-qm", "everything")
+        rc, said = self.save()
+        self.assertEqual(rc, 0, said)
+        self.assertIn("Nothing to save", said)
+
+    def test_a_dirty_tree_still_saves(self):
+        """The other half of the issue's reproduction: with no lock in the way, the
+        identical command on the identical tree commits."""
+        rc, said = self.save()
+        self.assertEqual(rc, 0, said)
+        self.assertNotEqual(self.head(), self.base)
+        self.assertIn(f"{DIRTY_FILES} file(s)", said)
+
+    def test_the_same_tree_saves_once_the_operator_clears_the_lock(self):
+        lock = self.plant_lock()
+        self.assertEqual(self.save()[0], 1)
+        lock.unlink()
+        rc, said = self.save()
+        self.assertEqual(rc, 0, said)
+        self.assertNotEqual(self.head(), self.base)
+
+
+class TestAnUnreadableIndexIsRefusedWithoutALock(LockedPlane):
+    """The category is *charter could not tell*, not *there is a lock*.
+
+    A lock is the way #917 happened; it is not the only way git answers "I could not
+    compute that". ``diff --cached --quiet`` returns 0 for no difference, 1 for a
+    difference and something else entirely when it failed, and the third of those used to
+    fall into the same branch as the second and reach `git commit` with an empty message
+    about zero files.
+    """
+
+    def test_a_diff_that_could_not_run_is_not_a_clean_tree(self):
+        real = planegit._git
+
+        def fake(args, cwd=None):
+            if args[:2] == ["diff", "--cached"] and "--quiet" in args:
+                return subprocess.CompletedProcess(args, 128, "", "fatal: bad index file")
+            return real(args, cwd=cwd)
+
+        with mock.patch.object(planegit, "_git", fake):
+            rc, said = self.save()
+        self.assertEqual(rc, 1, said)
+        self.assertNotIn("Nothing to save", said)
+        self.assertIn("bad index file", said)
+
+
+class TestALockIsDescribedByThreeFacts(unittest.TestCase):
+    """`gitstate` on its own: the record, not the command that prints it."""
+
+    def test_a_missing_lock_is_none(self):
+        self.assertIsNone(gitstate.find(Path("/nonexistent-git-dir-917")))
+
+    def test_zero_bytes_and_old_is_a_crash(self):
+        lock = gitstate.IndexLock(Path("/x/index.lock"), 0, gitstate.STALE_AFTER + 1)
+        self.assertTrue(lock.crashed)
+        self.assertIn("crashed", lock.describe())
+
+    def test_zero_bytes_and_young_is_not(self):
+        lock = gitstate.IndexLock(Path("/x/index.lock"), 0, 1)
+        self.assertFalse(lock.crashed)
+
+    def test_a_lock_with_an_index_in_it_is_not_a_crash_however_old(self):
+        """git writes the new index INTO the lock before it opens an editor, so the
+        long-lived legitimate holder is not zero bytes. Calling that one abandoned is how a
+        report gets someone to delete an index that was about to be renamed into place."""
+        lock = gitstate.IndexLock(Path("/x/index.lock"), 4096, 30 * 86400)
+        self.assertFalse(lock.crashed)
+
+    def test_the_age_is_coarse_and_true(self):
+        self.assertEqual(gitstate.age_phrase(0), "0s")
+        self.assertEqual(gitstate.age_phrase(59), "59s")
+        self.assertEqual(gitstate.age_phrase(60), "1m")
+        self.assertEqual(gitstate.age_phrase(3600), "1h")
+        self.assertEqual(gitstate.age_phrase(23 * 3600), "23h")
+        self.assertEqual(gitstate.age_phrase(86400 * 3), "3d")
+
+    def test_a_negative_age_reads_as_now(self):
+        """A clock that went backwards, or a file stamped in the future by a bad archive.
+        `-4s old` would read as a defect in charter rather than in the mtime."""
+        self.assertEqual(gitstate.age_phrase(-5), "0s")
+
+
+class TestALockedWorktreeIsItsOwnIndex(LockedPlane):
+    """A linked worktree keeps its own index under ``.git/worktrees/<name>``, so the lock
+    that stops a save there is not the plane's. Guessing ``root/.git`` would report the
+    wrong tree healthy, and charter runs from worktrees all day."""
+
+    def test_the_git_dir_is_the_worktrees_own(self):
+        wt = self.tmp / "wt"
+        self.git("worktree", "add", "-q", "-b", "side", str(wt))
+        found = gitstate.git_dir_of(wt)
+        self.assertIsNotNone(found)
+        self.assertEqual(found, (self.plane / ".git" / "worktrees" / "wt").resolve())
+
+    def test_a_lock_there_is_the_one_found(self):
+        wt = self.tmp / "wt"
+        self.git("worktree", "add", "-q", "-b", "side", str(wt))
+        lock = (self.plane / ".git" / "worktrees" / "wt" / gitstate.LOCK_NAME)
+        lock.write_bytes(b"")
+        self.addCleanup(lock.unlink, missing_ok=True)
+        found = gitstate.for_repo(wt)
+        self.assertIsNotNone(found)
+        self.assertEqual(found.path, lock.resolve())
+
+    def test_a_directory_that_is_not_a_repository_has_no_git_dir(self):
+        plain = self.tmp / "plain"
+        plain.mkdir()
+        self.assertIsNone(gitstate.git_dir_of(plain))
+        self.assertIsNone(gitstate.for_repo(plain))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_workspace_enforcement.py
+++ b/tests/test_workspace_enforcement.py
@@ -78,7 +78,8 @@ class TestAutosaveGating(unittest.TestCase):
             setattr(config, k, v)
         shutil.rmtree(self.tmp, ignore_errors=True)
 
-    def _run(self, pending: bool, live: bool = True, share: str = "push"):
+    def _run(self, pending: bool, live: bool = True, share: str = "push",
+             known: bool = True):
         config.MEMORY_SHARE = share
         # A KNOWN state, empty or not. `cmd_workspace_autosave` reads `gitstate.read` since
         # #917 — "nothing pending" and "charter could not ask" used to be the same empty
@@ -86,7 +87,8 @@ class TestAutosaveGating(unittest.TestCase):
         # turn, in the plane root, beside two other committers). An unknown state falls
         # through to `commit_push` deliberately, so it must not be what these cases stub.
         rows = ((" M workspaces/default/memory/notes.md",) if pending else ())
-        status = gitstate.TreeState(config.ROOT, rows, None, None)
+        status = gitstate.TreeState(config.ROOT, rows, None if known else "fatal: bad index",
+                                    None)
         with mock.patch.object(cw.gitstate, "read", return_value=status), \
              mock.patch.object(cw, "commit_push", return_value=0) as cp, \
              mock.patch.object(cw.subprocess, "Popen") as popen, \
@@ -99,6 +101,16 @@ class TestAutosaveGating(unittest.TestCase):
         cp, popen = self._run(pending=False)
         cp.assert_not_called()
         popen.assert_not_called()
+
+    def test_a_tree_it_could_not_read_is_not_nothing_pending(self):
+        """#917's shape on the path most likely to meet a real lock: this fires at the end
+        of every turn, in the plane root, beside `_commit_dispatch` and
+        `commit_memory_reactive` — the contention `hooks._commit_dispatch` takes its own
+        flock to avoid. An unknown state has NO rows, exactly as a clean tree has none, so
+        `not rows` alone reads it as nothing to do and the memo is never committed, silently
+        and forever. It falls through to `commit_push` instead, which says why out loud."""
+        cp, _popen = self._run(pending=False, known=False)
+        cp.assert_called_once()
 
     def test_commits_and_bg_pushes_when_pending(self):
         cp, popen = self._run(pending=True)

--- a/tests/test_workspace_enforcement.py
+++ b/tests/test_workspace_enforcement.py
@@ -7,7 +7,7 @@ import unittest
 from types import SimpleNamespace
 from unittest import mock
 
-from charter import config, hooks, workspace
+from charter import config, gitstate, hooks, workspace
 from charter import commands_workspace as cw
 from tests._isolation import PersonaIso, PlaneIso, run_hook
 
@@ -80,8 +80,14 @@ class TestAutosaveGating(unittest.TestCase):
 
     def _run(self, pending: bool, live: bool = True, share: str = "push"):
         config.MEMORY_SHARE = share
-        status = SimpleNamespace(stdout=(" M workspaces/default/memory/notes.md\n" if pending else ""))
-        with mock.patch.object(cw, "_git", return_value=status), \
+        # A KNOWN state, empty or not. `cmd_workspace_autosave` reads `gitstate.read` since
+        # #917 — "nothing pending" and "charter could not ask" used to be the same empty
+        # string, on the path most likely to meet a real lock (it fires at the end of every
+        # turn, in the plane root, beside two other committers). An unknown state falls
+        # through to `commit_push` deliberately, so it must not be what these cases stub.
+        rows = ((" M workspaces/default/memory/notes.md",) if pending else ())
+        status = gitstate.TreeState(config.ROOT, rows, None, None)
+        with mock.patch.object(cw.gitstate, "read", return_value=status), \
              mock.patch.object(cw, "commit_push", return_value=0) as cp, \
              mock.patch.object(cw.subprocess, "Popen") as popen, \
              mock.patch.object(cw.workspace, "is_live", return_value=live), \

--- a/tests/test_worktree.py
+++ b/tests/test_worktree.py
@@ -134,10 +134,24 @@ class TestGitState(WorktreeIso):
         self.assertTrue(detached)
         self.assertTrue(sha.startswith(label))
 
-    def test_is_dirty(self):
-        self.assertFalse(worktree.is_dirty(self.clone))
+    def test_dirt(self):
+        self.assertEqual(worktree.dirt(self.clone).rows, ())
         (self.clone / "README.md").write_text("changed\n")
-        self.assertTrue(worktree.is_dirty(self.clone))
+        self.assertTrue(worktree.dirt(self.clone).rows)
+
+    def test_dirt_knows_when_it_could_not_look(self):
+        """The third state, and why `is_dirty` could not survive as a `bool` (#917).
+
+        `git -C <missing> status --porcelain` exits 128 with EMPTY stdout — the same
+        emptiness a clean tree produces — and every caller that gated a removal on it read
+        that as "nothing to lose". `test_a_pruned_worktree_is_shown_as_missing_not_clean`
+        below found one instance of this and fixed it at the call site; the return type is
+        what fixes the rest."""
+        gone = self.clone.parent / "never-existed"
+        state = worktree.dirt(gone)
+        self.assertFalse(state.known)
+        self.assertEqual(state.rows, ())
+        self.assertIn(str(gone), state.why())
 
     def test_unpushed_is_none_without_upstream(self):
         """No upstream means the commits exist nowhere else — the conservative case."""
@@ -347,7 +361,7 @@ class TestList(WorktreeIso):
         `git -C <missing-path> status --porcelain` — which exits 128 with EMPTY
         stdout (the error goes to stderr) — so `bool("")` is False and the row
         printed as "clean". It must print a distinct "missing" state instead, and
-        must not silently call is_dirty() on the missing path."""
+        must not silently ask `dirt()` about the missing path."""
         p = self.add_worktree("spi-schema")
         self.assertTrue(p.exists())
         shutil.rmtree(p)  # delete the worktree dir WITHOUT `git worktree prune`

--- a/tools/sweep.py
+++ b/tools/sweep.py
@@ -2199,11 +2199,33 @@ class Sandbox:
 
 
 def dirty_files(root: Path, paths: tuple[str, ...]) -> dict[str, bytes]:
-    """Uncommitted work under the swept paths, so the tool is usable before a commit."""
+    """Uncommitted work under the swept paths, so the tool is usable before a commit.
+
+    `check=False` used to hide the exit status here, and `git` returns only stdout, so a
+    failed `git status` produced an empty listing — the same value as a clean tree. The
+    sandbox was then built from committed HEAD alone and the whole sweep measured a tree
+    the operator was not looking at, reporting survivors and killed mutants against it,
+    with nothing anywhere saying so (#917).
+
+    That is :class:`NoSandbox`'s category exactly, twenty lines up in this same file: a
+    statement about the machine, made before a single mutation has been measured. Raising
+    it here rather than inventing a second one, because a reader who has met one of these
+    has met both.
+    """
     out: dict[str, bytes] = {}
-    listing = git("status", "--porcelain", "--untracked-files=all", "--", *paths,
-                  cwd=root, check=False)
-    for line in listing.splitlines():
+    done = subprocess.run(("git", "status", "--porcelain", "--untracked-files=all", "--",
+                           *paths), cwd=str(root), check=False,
+                          stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+    if done.returncode != 0:
+        said = (done.stderr or "").strip()
+        raise NoSandbox(
+            f"the uncommitted work under {', '.join(paths)} could not be read — `git "
+            f"status` exited {done.returncode} in {root}"
+            + (f" — {said}" if said else " without saying why") + ". "
+            "That is the machine this sweep is running on, not a verdict about any "
+            "mutation: sweeping the committed tree instead would measure a tree nobody "
+            "is looking at.")
+    for line in done.stdout.splitlines():
         rel = line[3:].strip()
         if rel.endswith(".py") and (root / rel).exists():
             out[rel] = (root / rel).read_bytes()


### PR DESCRIPTION
Closes #917.

`charter save` printed *"Nothing to save — the control-plane working tree is clean"* while `git status --porcelain` listed thirteen modified files. Observed on the operator's own plane. The cause was a stale `.git/index.lock` — zero bytes, twenty-three hours old, no process holding it, left by a git that crashed the day before. With the file removed by hand, the identical command on the identical tree committed twenty files.

## The lock is invisible to the question charter asked last

Measured against git 2.50.1, in a repository holding one modified tracked file and one untracked file, with a zero-byte `index.lock` planted in it — and pinned by `TestTheTreeWasReadableAndTheAnswerWasStillEmpty`, so if git's behaviour ever changes the reproduction fails first and says so:

| | |
|---|---|
| `git status --porcelain` | rc 0, both files listed — reading the tree needs no lock |
| `git add -A` | rc 128, `Unable to create '….git/index.lock': File exists.` |
| `git diff --cached --quiet` | rc 0 — nothing was staged, so there is no difference |

`commit_push` discarded the add's exit status. The probe below it then answered *no difference*, because there was none: nothing had been written to the index. **"The tree is clean" and "charter could not tell" were the same value**, and charter printed the first — a claim about durability that is false, to an operator whose next act is to stop worrying about the work.

## Three outcomes, and charter says which

The tree is clean; the tree has changes; or charter could not determine the state — refuse, rc 1. Reproduced end to end on a throwaway plane with thirteen modified files and a zero-byte lock stamped 23 hours ago:

```
✗ Refusing to save — charter could not read the state of …/demo, so it cannot tell an
  unchanged tree from an unreadable one.
✗   `git add -A` exited 128 — fatal: Unable to create '…/demo/.git/index.lock': File exists.
•   …/demo/.git/index.lock — 0 byte(s), 23h old; a git process crashed here and left it behind.
•   who holds it:  ps -eo pid,lstart,command | grep '[g]it'
•   nobody does:   rm -f …/demo/.git/index.lock   (charter never removes a lock — a held one is real)
```

and with the lock removed, the same command committed 13 files, then said *Nothing to save* on the next run.

The age is there because it is the fact that changes what the operator does: seconds old is somebody else's `git commit` and the answer is to wait; zero bytes and hours old is a corpse and the answer is `rm`. Zero bytes is what separates them — git creates the lock, writes the new index into it, and renames it over the old one, so a lock that never grew is one whose writer died before writing anything.

**charter reports a lock and never clears one.** A lock held by a live git is real and one command cannot tell the two apart from the inside. `TestCharterReportsALockAndLeavesIt` holds that as a rule, including that the `ps` is printed before the `rm`.

## The siblings — every site that DECIDED on the old two-state answer

A grep for every place charter reads `git status` found eleven readings of `.stdout.strip()` across seven modules, failing in pairs. `charter/gitstate.py` is now the one place that asks.

| site | what the empty answer caused | now |
|---|---|---|
| `commands_workspace._work_at_risk` | `shutil.rmtree` on the workspace and its clones | an unreadable clone is work at risk |
| `commands_workspace._worktrees_at_risk` | the same rmtree, worktree half | "could not be checked" |
| `commands_workspace._restore_blockers` | a manifest asserting a state nobody measured | blocks the snapshot |
| `commands_workspace.cmd_workspace_autosave` | the turn-end memo silently never committed | falls through to `commit_push`, which says why |
| `commands._sync_one` | **authorised** `git merge --ff-only` into an unread tree | skipped, and pinned on the argv |
| `worktree.is_dirty` → `worktree.dirt` | `bool` could not carry a third state | `TreeState`; the removal gate refuses |
| `commands_persona._pending_memory` | a green `✓ nothing to sync` over memory nobody read | refuses |
| `hooks._uncommitted_memory_nudge` | silence at session start | says it could not look |
| `doctor.check_plane_root` | `✓ clean on main` | `not checked`, with the existing hint |
| `tools/sweep.dirty_files` | the sweep measured a tree nobody was looking at | raises `NoSandbox` |

A plane with **no git repository at all** is exempt from the two memory sites and unchanged — that is a definite answer, and `charter init` in a fresh directory not running `git init` is the README's own 60-second path (`TreeState.no_repo`).

Two display sites got the third word for a line each: `charter status` and `worktree list` print `unknown` rather than `clean`. **`statusline._run_state` is reported, not fixed**: it is a glyph, it is behind a five-second `repostate.json` cache three renderers share, and changing what that cache stores is a larger piece of work than this one. `commands_workspace`'s `ls-files` on rename and the two advisory `is_dirty` warnings are display-shaped and now inherit the third state through `dirt`.

## `doctor` grew a row

`index lock`. A lock is not a fault — git takes one for every write to the index — so a fresh one is a green row with a detail. Zero bytes and older than fifteen minutes is a WARN naming the file, its age and the two commands. The operator's lock sat there for twenty-three hours, through however many sessions, and the first thing to look at it was the save it broke.

## The family

Third of these in a row, each fixed by giving the failure a category of its own rather than a shared default: `sweep.NoSandbox` (#905/#909) says *the machine*, not *the branch*; `config.PLANE_REFUSAL` (#913/#914) says *refused*, not *carry on with defaults*; `gitstate.TreeState` says *charter could not tell*, not *there is nothing there*.

## The deletion sweep

80 mutations, 3 shards, **27 survivors** on the first complete run. Every one was hand-applied, watched go RED, and reverted, with `__pycache__` cleared on both transitions.

**Deleted (5)** — lines nothing could tell apart from their own absence:

- `gitstate.find` — `max(0.0, …)` on the age. `age_phrase` clamps on the way out, which is the only place a negative is observable.
- `gitstate.git_dir_of` — `.resolve()` on the git-fallback answer. Measured on git 2.50.1: asked from a subdirectory (the only way that branch is reached, since the filesystem answers for any tree with a `.git` of its own) git returns an absolute, already-physical path. The join onto `root` stays — it is load-bearing.
- `gitstate.read` — the blank-line filter. Porcelain v1 has no empty records and `"a\n".splitlines()` yields no trailing empty string.
- `gitstate.said` — the second `strip`. `bool(s.strip())` and `bool(s.lstrip())` agree for every string, so the `if` half was an equivalent mutant by construction; binding the value makes the question unaskable rather than merely unanswered.
- `planegit._refuse_unreadable` — `if git_dir else None`. The caller builds it unconditionally.

**Pinned (22)**, the sharpest being `commands_workspace.py:854`: dropping the `known` half of the autosave guard *is* #917 — an unknown state has no rows, so `not rows` reads it as nothing to do and the workspace memo is never committed, silently. The rest cover all three words in the `worktree list` column, the `worktree add` advisory, the day boundary in `age_phrase`, `resolve()` on a lock path and a symlinked tree, the filesystem fast path answering with no subprocess at all, `said` on a proc with no stderr and on git's leading blank lines, `why()` staying silent for a tree charter read, `remedy()` with and without a lock, the pathspec actually bounding the read, the lock arriving with the state that could not be read, and `hooks`' memory/refs filter — where `/refs/` had had no witness at all.

None left unkillable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018hUBNraNfixfMMK5Jc6CNy
