### PR TITLE
A charged file with no mutation is nothing to sweep, and a shard that refuses is not a shard that vanished (#920)

### DIFF
--- a/docs/news/unreleased-a-charged-file-with-no-mutation-is-nothing-to-sweep.md
+++ b/docs/news/unreleased-a-charged-file-with-no-mutation-is-nothing-to-sweep.md
@@ -1,0 +1,111 @@
+---
+version: unreleased
+headline: A charged file with no mutation is nothing to sweep, and a shard that refuses is not a shard that vanished
+---
+
+The 0.59.0 release pull request published this, with every check green:
+
+```
+deletion sweep / no verdict: 1 of 1 shard did not report
+```
+
+`no verdict` is the deletion sweep's word for **the sweep could not decide** — a red
+baseline, a shard out of its hour, a sandbox that would not build. It is the one name whose
+whole job is to say *do not read this green tick as safety*, and a release commit's only
+Python change is `__version__ = "0.59.0"`, by construction. So the loudest thing this gate
+can say was about to fire on every release forever.
+
+## What the shard actually did
+
+The plan job had already said there was nothing to do:
+
+```
+0 mutations → 1 shard(s); 0 min of predicted test time over 452 test modules,
+              0 s on the heaviest shard (a shard is sized for 1680 s)
+  charged: charter/__init__.py
+```
+
+The shard then ran anyway, and its log says why it reported nothing:
+
+```
+  preparing the reference sandbox…
+  baseline: full suite, unmutated…
+    Ran 11721 tests — tests.test_a_denial_names_its_override.TestTheTallyKeysAreUnchanged
+    .test_each_guard_still_traces_the_key_it_always_did in 541s
+  ! the tree is RED before any mutation. Every mutation below will look
+  ! pinned for a reason that has nothing to do with the guard. Fix first.
+```
+
+Nine minutes of unmutated suite for a plan of nothing, one flaky test in it, and then the
+red-baseline exit — which returned `0` **without writing its `--json`**. The upload step
+found no file, the merge step downloaded no artifact, and a shard that writes nothing is a
+shard that did not report. That is a true sentence about a runner that vanished mid-run. It
+is a false one about a shard sitting in the log stating, in two exclamation marks, exactly
+what it decided and why.
+
+That test passes on demand. Nothing was wrong with the branch, and nothing was wrong with
+the tool's judgement — only with the fact that a refusal and a death were the same value.
+
+## Two states, two names
+
+**The plan is taken before anything is spent on measuring it.** It costs one `ast` pass over
+the diff, and it now happens before a sandbox, a selection map or a baseline. A run with no
+mutation to measure has no use for a baseline: the baseline exists to tell *pinned by your
+mutation* from *already broken*, and there is no mutation. Both ways of sweeping nothing —
+no swept file changed, or the swept files that changed offer no operator anything — now
+reach the same answer, in a second, and say which of the two they are:
+
+```
+before:  sweeping 6a0aef6a3fe1 (paths: charter)
+           diff against aeb3e8394844: 1 file(s), 1 added line(s)
+           preparing the reference sandbox…
+           baseline: full suite, unmutated…                    (9 minutes)
+           ! the tree is RED before any mutation.
+         → no verdict: 1 of 1 shard did not report
+
+after:   sweeping 6a0aef6a3fe1 (paths: charter)
+           diff against aeb3e8394844: 1 file(s), 1 added line(s)
+           0 mutations across 1 file(s)
+           1 charged file(s), and no operator finds a mutation in what they add.
+         → nothing to sweep
+```
+
+**A shard that refuses writes the refusal down.** `as_refusal` writes a JSON object where
+the result file is normally a JSON array, so the two are told apart by shape rather than by
+a flag inside one of them, and the merge step counts a refusal as a *report* — it has
+answered, just not with results. On a genuinely red tree the pull request now reads:
+
+```
+deletion sweep / no verdict: 1 shard refused: the baseline is red
+```
+
+with the failing test named on the run summary, where it is a click away instead of a job
+away.
+
+## The three answers, and why the middle one matters
+
+| what happened | what the check says |
+| --- | --- |
+| nothing was charged, or nothing charged offers a mutation | `nothing to sweep` |
+| a shard ran and declined to sweep, and said why | `no verdict: N shard(s) refused: …` |
+| a shard wrote no file at all | `no verdict: N of M shard(s) did not report` |
+
+The middle row is the new one, and it is ranked with the third rather than with the first:
+a refusing shard measured nothing, so a conclusion that ignored it would have let a red tree
+fall all the way through to `nothing to sweep`. That is the benign name on the alarming
+state, and it is worse than the inversion this started from.
+
+This is the fourth fix in a row of the same shape — [#909][], [#914][], [#918][] — where a
+third state was sharing a benign default and the remedy was to give it its own name. Here it
+was sharing an *alarming* one, on the one signal that has to stay rare to be worth reading.
+
+[#909]: https://github.com/diazoxide/charter/issues/909
+[#914]: https://github.com/diazoxide/charter/issues/914
+[#918]: https://github.com/diazoxide/charter/issues/918
+
+## Nothing to adopt
+
+`tools/sweep.py` is this repository's own test harness and no part of charter's runtime.
+Nothing in a plane, a workspace or the CLI moves. What changes is that a release stops
+being told its sweep could not decide, and a release stops paying nine minutes of runner
+time to find out it had nothing to do.

--- a/tests/test_sweep.py
+++ b/tests/test_sweep.py
@@ -6659,5 +6659,271 @@ class ThePlanSizesItselfFromTheMapItWarmed(unittest.TestCase):
         self.assertEqual(got, {})
 
 
+class ASweepThatMeasuredNothingSaysWhichKindOfNothing(unittest.TestCase):
+    """#920. Three outcomes share one shape — an empty result set — and only two of them
+    had a name.
+
+    The 0.59.0 release is the measurement. `charter/__init__.py` was charged for a
+    one-line version bump, the plan held **0 mutations**, and the shard published
+    `no verdict: 1 of 1 shard did not report` on a green check. It did not fail and it did
+    not vanish: it ran a nine-minute unmutated baseline it had no mutation to interpret,
+    that baseline came back red on one flaky test, and the red-baseline exit returned 0
+    without writing its `--json`. Silence is how a dead shard reports, so the merge step
+    read a deliberate refusal as a runner that disappeared.
+
+    `no verdict` is the one name whose whole job is to say *do not read this green as
+    safety*. A release commit's only Python change is the version string, by construction,
+    so every release would have worn it — and a signal that fires when nothing is wrong is
+    a signal nobody finishes reading.
+    """
+
+    def _repo(self, added: str):
+        """A repository whose branch adds *added* to a charged file, and its base sha."""
+        tmp = Path(tempfile.mkdtemp(prefix="sweep-920-"))
+        self.addCleanup(lambda: __import__("shutil").rmtree(tmp, ignore_errors=True))
+        env = dict(os.environ, GIT_CONFIG_GLOBAL=os.devnull, GIT_CONFIG_SYSTEM=os.devnull,
+                   GIT_CONFIG_NOSYSTEM="1", GIT_TERMINAL_PROMPT="0")
+
+        def run(*a):
+            subprocess.run(("git", "-c", "core.hooksPath=", "-c", "commit.gpgsign=false")
+                           + a, cwd=tmp, check=True, env=env, timeout=60,
+                           stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+
+        run("init", "-q", "-b", "main")
+        run("config", "user.email", "sweep@example.invalid")
+        run("config", "user.name", "sweep")
+        (tmp / "charter").mkdir()
+        (tmp / "charter" / "__init__.py").write_text('__version__ = "0.58.0"\n')
+        run("add", "-A")
+        run("commit", "-qm", "one")
+        base = sweep.git("rev-parse", "HEAD", cwd=tmp).strip()
+        (tmp / "charter" / "__init__.py").write_text(added)
+        run("add", "-A")
+        run("commit", "-qm", "two")
+        return tmp, base
+
+    def _cli(self, where, *args):
+        said = io.StringIO()
+        cwd = os.getcwd()
+        os.chdir(where)
+        try:
+            with contextlib.redirect_stdout(said):
+                code = sweep.main(list(args))
+        finally:
+            os.chdir(cwd)
+        return code, said.getvalue()
+
+    # ----------------------------------------------------------------------------------
+    # The release diff itself, charged and swept.
+    # ----------------------------------------------------------------------------------
+
+    def test_the_release_diff_is_nothing_to_sweep_and_never_reaches_a_baseline(self):
+        """The 0.59.0 case, reconstructed: one charged file, one added line, no mutation.
+
+        `--no-baseline` is deliberately NOT passed, because the baseline is the defect. A
+        run that spends a full unmutated suite on a plan of nothing has bought itself
+        nothing to interpret and one more way to fail, and that way is the way this
+        release failed. The assertion is on the sentence the baseline prints, so the only
+        way to satisfy it is not to run one.
+        """
+        tmp, base = self._repo('__version__ = "0.59.0"\n')
+        out = tmp / "r.json"
+        outputs = tmp / "outputs.txt"
+        summary = tmp / "summary.md"
+        code, said = self._cli(tmp, "--gate", "--base", base, "--jobs", "1",
+                               "--shard", "1/1", "--workdir", str(tmp / "wd"),
+                               "--json", str(out), "--summary", str(summary),
+                               "--github-output", str(outputs))
+        self.assertEqual(code, 0, said)
+        self.assertIn("1 file(s), 1 added line(s)", said)
+        self.assertIn("0 mutations across 1 file(s)", said)
+        self.assertNotIn("baseline: full suite", said)
+        self.assertNotIn("preparing the reference sandbox", said)
+        # And the shard leaves an answer behind rather than an absence.
+        self.assertEqual(out.read_text(), "[]")
+        got = dict(line.split("=", 1) for line in outputs.read_text().splitlines() if line)
+        self.assertEqual(got, {"conclusion": "nothing", "headline": "nothing to sweep"})
+
+    def test_the_aggregator_on_that_release_says_nothing_to_sweep_and_not_no_verdict(self):
+        """The other end of the same run: the merge step, on the file the shard now
+        writes. Before this, the directory was empty and the pull request read
+        `no verdict: 1 of 1 shard did not report`."""
+        tmp, base = self._repo('__version__ = "0.59.0"\n')
+        shards = tmp / "shards"
+        shards.mkdir()
+        code, said = self._cli(tmp, "--gate", "--base", base, "--jobs", "1",
+                               "--shard", "1/1", "--workdir", str(tmp / "wd"),
+                               "--json", str(shards / "sweep-results-1.json"))
+        self.assertEqual(code, 0, said)
+        outputs = tmp / "outputs.txt"
+        code, said = self._cli(tmp, "--verdict", str(shards), "--shards", "1",
+                               "--ref", "HEAD", "--github-output", str(outputs))
+        self.assertEqual(code, 0, said)
+        got = dict(line.split("=", 1) for line in outputs.read_text().splitlines() if line)
+        self.assertEqual(got, {"conclusion": "nothing", "headline": "nothing to sweep"})
+        # The sentence the release actually published, and the one that must not come back.
+        self.assertNotIn("did not report", said)
+
+    def test_a_charged_file_with_no_mutation_gets_the_same_banner_as_an_unchanged_tree(self):
+        """Two ways to sweep nothing, one answer, and one page. They used to print
+        different things — a charged file with no mutation got the full report, an
+        unchanged tree got a single line — so a reader who has seen one cannot tell what
+        the other is saying."""
+        tmp, base = self._repo('__version__ = "0.59.0"\n')
+        _, charged = self._cli(tmp, "--gate", "--base", base, "--jobs", "1",
+                               "--workdir", str(tmp / "wd"))
+        _, unchanged = self._cli(tmp, "--gate", "--base", "HEAD", "--jobs", "1",
+                                 "--workdir", str(tmp / "wd"))
+        self.assertIn("1 charged file(s), and no operator finds a mutation", charged)
+        self.assertIn("nothing under the swept paths changed", unchanged)
+        for said in (charged, unchanged):
+            self.assertIn("NOTHING TO SWEEP", said)
+            self.assertIn("nothing to sweep", said)
+
+    # ----------------------------------------------------------------------------------
+    # A shard's zero, a shard's refusal and a shard's silence are three values.
+    # ----------------------------------------------------------------------------------
+
+    def test_a_zero_a_refusal_and_a_silence_are_three_different_answers(self):
+        """The question #920 asks first, answered on the aggregator's own input.
+
+        A shard that swept an empty plan writes `[]`; a shard that refused writes an
+        object; a shard that died writes nothing. All three carry no results, and the
+        whole of this issue is that the middle one used to be spelled as the last.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            (Path(tmp) / "zero.json").write_text(sweep.as_json([]))
+            nothing, _, none_refused = sweep.merge(Path(tmp), 1)
+        with tempfile.TemporaryDirectory() as tmp:
+            (Path(tmp) / "refused.json").write_text(
+                sweep.as_refusal(sweep.RED_BASELINE, "tests.test_x.T.test_y"))
+            _, refused_missing, refused = sweep.merge(Path(tmp), 1)
+        with tempfile.TemporaryDirectory() as tmp:
+            _, silent_missing, silent_refused = sweep.merge(Path(tmp), 1)
+        self.assertEqual((nothing, none_refused), ([], []))
+        # A refusal is a report: it does not count against `missing`, and it arrives.
+        self.assertEqual(refused_missing, 0)
+        self.assertEqual(refused, [sweep.Refusal(sweep.RED_BASELINE,
+                                                 "tests.test_x.T.test_y")])
+        self.assertEqual((silent_missing, silent_refused), (1, []))
+        # And the three conclusions are three sentences.
+        self.assertEqual(sweep.headline(sweep.classify([])), "nothing to sweep")
+        self.assertEqual(sweep.headline(sweep.classify([], refused)),
+                         "no verdict: 1 shard refused: the baseline is red")
+        self.assertEqual(sweep.headline(sweep.classify([]), 1, 1),
+                         "no verdict: 1 of 1 shard did not report")
+
+    def test_a_refusal_is_no_verdict_and_not_nothing_to_sweep(self):
+        """The inversion, guarded in the other direction. A refusing shard's file holds no
+        results at all, so a `gate_conclusion` that did not rank it would let a red tree
+        fall through to `nothing to sweep` — the benign name on the alarming state, which
+        is worse than the mistake this issue started from."""
+        refused = [sweep.Refusal(sweep.RED_BASELINE, "tests.test_x.T.test_y")]
+        gate = sweep.classify([], refused)
+        self.assertEqual(sweep.gate_conclusion(gate), sweep.NO_VERDICT)
+        self.assertEqual(sweep.gate_conclusion(sweep.classify([])), sweep.NOTHING)
+        # And it blocks like every other thing that could not be measured, once enforced.
+        self.assertEqual(sweep.gate_exit_code(gate, True), 3)
+        self.assertEqual(sweep.gate_exit_code(gate, False), 0)
+
+    def test_the_page_names_the_test_that_went_red_and_not_a_missing_runner(self):
+        """`detail` travels with the refusal for the reason `as_json` already carries it
+        for a mutation: which test went red is the first thing anyone asks of a run that
+        went red, and the shard's own log is on another machine."""
+        gate = sweep.classify([], [sweep.Refusal(sweep.RED_BASELINE,
+                                                 "tests.test_x.T.test_y")])
+        page = sweep.gate_summary(gate, "a" * 40, "b" * 40, None, False, 0, 1)
+        self.assertIn("Refused — a shard swept nothing", page)
+        self.assertIn("`tests.test_x.T.test_y`", page)
+        self.assertIn("This is not a shard that died", page)
+        # The alarming paragraph about a vanished runner belongs to the other state.
+        self.assertNotIn("Did not report", page)
+
+    def test_five_shards_on_one_red_tree_say_it_once(self):
+        """A check's name is read at a glance or not at all, so the reason is said per
+        distinct reason and not per shard."""
+        gate = sweep.classify([], [sweep.Refusal(sweep.RED_BASELINE, f"t{n}")
+                                   for n in range(5)])
+        self.assertEqual(sweep.headline(gate, 0, 5),
+                         "no verdict: 5 shards refused: the baseline is red")
+
+    # ----------------------------------------------------------------------------------
+    # The file the shard writes, and what a reader that cannot name it does.
+    # ----------------------------------------------------------------------------------
+
+    def test_a_refusal_and_a_result_set_are_told_apart_by_shape(self):
+        """An array is results, an object is a refusal. A reader that guessed would
+        report a refusal as a complete sweep of an empty plan."""
+        rows, why = sweep.shard_report(sweep.as_json([_result("pinned")]))
+        self.assertEqual((len(rows), why), (1, None))
+        rows, why = sweep.shard_report(sweep.as_json([]))
+        self.assertEqual((rows, why), ([], None))
+        rows, why = sweep.shard_report(sweep.as_refusal("the baseline is red", "t"))
+        self.assertEqual((rows, why), ([], sweep.Refusal("the baseline is red", "t")))
+
+    def test_an_object_this_reader_cannot_name_is_a_shard_that_did_not_report(self):
+        """#914's rule, applied to this file. A reader that cannot name the shape in front
+        of it has nothing to say about that shard, and the honest way to say nothing is to
+        count it among the ones that did not answer — never to read around the key."""
+        with self.assertRaises(KeyError):
+            sweep.shard_report('{"skipped": "why not"}')
+        with tempfile.TemporaryDirectory() as tmp:
+            (Path(tmp) / "a.json").write_text('{"skipped": "why not"}')
+            results, missing, refused = sweep.merge(Path(tmp), 1)
+        self.assertEqual((results, missing, refused), ([], 1, []))
+
+    def test_the_shard_writes_its_refusal_where_it_used_to_write_nothing(self):
+        """End to end, through the exit that produced the 0.59.0 name. The baseline is
+        forced red rather than waited for: what is under test is what the shard leaves on
+        disk when it decides not to sweep, not how long a suite takes to fail."""
+        tmp, base = self._repo(textwrap.dedent("""
+            def close(arm, pane):
+                if arm is None:
+                    return []
+                return [arm, pane]
+        """).lstrip())
+        for name, stub in (("load_map", lambda *a, **k: {}),
+                           ("Sandbox", _RedBaseline)):
+            real = getattr(sweep, name)
+            setattr(sweep, name, stub)
+            self.addCleanup(setattr, sweep, name, real)
+        shards = tmp / "shards"
+        shards.mkdir()
+        code, said = self._cli(tmp, "--gate", "--base", base, "--jobs", "1",
+                               "--shard", "1/1", "--workdir", str(tmp / "wd"),
+                               "--json", str(shards / "sweep-results-1.json"))
+        self.assertEqual(code, 0, said)
+        self.assertIn("the tree is RED before any mutation", said)
+        self.assertEqual(
+            json.loads((shards / "sweep-results-1.json").read_text()),
+            {"refused": "the baseline is red", "detail": "tests.test_x.T.test_y"})
+        outputs = tmp / "outputs.txt"
+        summary = tmp / "summary.md"
+        code, said = self._cli(tmp, "--verdict", str(shards), "--shards", "1",
+                               "--ref", "HEAD", "--summary", str(summary),
+                               "--github-output", str(outputs))
+        self.assertEqual(code, 0, said)
+        got = dict(line.split("=", 1) for line in outputs.read_text().splitlines() if line)
+        self.assertEqual(got["conclusion"], "no-verdict")
+        self.assertEqual(got["headline"],
+                         "no verdict: 1 shard refused: the baseline is red")
+        self.assertNotIn("did not report", got["headline"])
+        self.assertIn("`tests.test_x.T.test_y`", summary.read_text())
+
+
+class _RedBaseline:
+    """A sandbox whose unmutated full run fails, and which is never asked for more."""
+
+    memory_cap = 0
+    full_timeout = 0.0
+
+    def __init__(self, root, path, ref, dirty):
+        self.path = Path(path)
+        self.path.mkdir(parents=True, exist_ok=True)
+
+    def full(self):
+        return sweep.Outcome(False, 11721, "tests.test_x.T.test_y")
+
+
 if __name__ == "__main__":      # pragma: no cover
     unittest.main()

--- a/tests/test_sweep.py
+++ b/tests/test_sweep.py
@@ -2128,15 +2128,12 @@ class AMutantThatEatsTheMachineIsARedAndNotAnOutage(unittest.TestCase):
         self.addCleanup(setattr, sweep, "Sandbox", real)
         plan = [sweep.Mutation("charter/m.py", n, n, "drop-if", "q?", "if x: pass",
                                "", "f") for n in range(3)]
-        for name, stub in (("plan_for", lambda *a: (plan, {})),
-                           ("decide", lambda box, m, mods:
-                            ("pinned", sweep.Outcome(False, 1, "x"), None))):
-            was = getattr(sweep, name)
-            setattr(sweep, name, stub)
-            self.addCleanup(setattr, sweep, name, was)
+        was = sweep.decide
+        sweep.decide = lambda box, m, mods: ("pinned", sweep.Outcome(False, 1, "x"), None)
+        self.addCleanup(setattr, sweep, "decide", was)
         with contextlib.redirect_stdout(io.StringIO()):
-            sweep.sweep(self.tmp, "HEAD", {"charter/m.py": {1}}, {}, self.tmp, 2, {},
-                        0, print, 60.0, None, cap=7 * 1024 ** 2)
+            sweep.sweep(self.tmp, "HEAD", plan, {}, {}, self.tmp, 2, {},
+                        0, print, 60.0, cap=7 * 1024 ** 2)
         self.assertEqual(len(boxes), 2)
         self.assertEqual([b.memory_cap for b in boxes], [7 * 1024 ** 2] * 2)
 
@@ -4398,7 +4395,7 @@ class TheAnswerSurvivesTheTripThroughAFile(unittest.TestCase):
             for i in range(3):
                 (Path(tmp) / f"sweep-results-{i + 1}.json").write_text(
                     sweep.as_json(results[i::3]))
-            merged, missing = sweep.merge(Path(tmp), 3)
+            merged, missing, _ = sweep.merge(Path(tmp), 3)
         self.assertEqual(missing, 0)
         self.assertEqual(len(merged), len(results))
         self.assertEqual(sorted(r.mutation.path for r in merged),
@@ -4420,7 +4417,7 @@ class TheAnswerSurvivesTheTripThroughAFile(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp:
             for i, r in enumerate(pair, start=1):
                 (Path(tmp) / f"sweep-results-{i}.json").write_text(sweep.as_json([r]))
-            merged, missing = sweep.merge(Path(tmp), 2)
+            merged, missing, _ = sweep.merge(Path(tmp), 2)
         gate = sweep.classify(merged)
         self.assertEqual((missing, len(gate.masked), gate.unpinned), (0, 2, []))
         self.assertIn("### Masked cluster",
@@ -4429,7 +4426,7 @@ class TheAnswerSurvivesTheTripThroughAFile(unittest.TestCase):
     def test_a_shard_that_wrote_nothing_is_counted_as_a_shard_that_did_not_report(self):
         with tempfile.TemporaryDirectory() as tmp:
             (Path(tmp) / "sweep-results-1.json").write_text(sweep.as_json([]))
-            merged, missing = sweep.merge(Path(tmp), 3)
+            merged, missing, _ = sweep.merge(Path(tmp), 3)
         self.assertEqual((len(merged), missing), (0, 2))
 
     def test_a_result_file_that_will_not_parse_is_not_a_shard_that_answered(self):
@@ -4438,7 +4435,7 @@ class TheAnswerSurvivesTheTripThroughAFile(unittest.TestCase):
             (Path(tmp) / "a.json").write_text(sweep.as_json([]))
             (Path(tmp) / "b.json").write_text('[{"path": "charter/a.py"')
             (Path(tmp) / "c.json").write_text('[{"path": "charter/a.py"}]')
-            merged, missing = sweep.merge(Path(tmp), 3)
+            merged, missing, _ = sweep.merge(Path(tmp), 3)
         self.assertEqual((len(merged), missing), (0, 2))
 
     def test_an_empty_sweep_that_ran_is_not_a_sweep_that_did_not(self):
@@ -4453,9 +4450,9 @@ class TheAnswerSurvivesTheTripThroughAFile(unittest.TestCase):
         """
         with tempfile.TemporaryDirectory() as tmp:
             (Path(tmp) / "sweep-results-1.json").write_text(sweep.as_json([]))
-            ran, ran_missing = sweep.merge(Path(tmp), 1)
+            ran, ran_missing, _ = sweep.merge(Path(tmp), 1)
         with tempfile.TemporaryDirectory() as tmp:
-            gone, gone_missing = sweep.merge(Path(tmp), 1)
+            gone, gone_missing, _ = sweep.merge(Path(tmp), 1)
         self.assertEqual((ran, ran_missing), ([], 0))
         self.assertEqual(gone_missing, 1)
         self.assertEqual(sweep.gate_conclusion(sweep.classify(ran), ran_missing),
@@ -4464,7 +4461,7 @@ class TheAnswerSurvivesTheTripThroughAFile(unittest.TestCase):
                          sweep.NO_VERDICT)
 
     def test_a_directory_that_is_not_there_is_no_verdict_and_not_a_clean_one(self):
-        merged, missing = sweep.merge(Path("/nonexistent-sweep-shards"), 2)
+        merged, missing, _ = sweep.merge(Path("/nonexistent-sweep-shards"), 2)
         self.assertEqual((merged, missing), ([], 2))
 
     def test_a_plan_that_never_said_how_many_shards_is_not_no_shards(self):
@@ -4652,17 +4649,20 @@ class TheWorkflowAsksTheToolAndNotTheOtherWayAround(unittest.TestCase):
         must not do is arrive as something else. A slice that is silently wrong does not
         fail — it sweeps some mutations twice and others never, and the merge then reports
         a complete sweep of an incomplete plan."""
+        plan = self._five()
         seen = []
-        for name, stub in (("sweep", lambda *a, **k: (seen.append(a[-1]), ([], []))[1]),
-                           ("load_map", lambda *a, **k: {})):
-            real = getattr(sweep, name)
-            setattr(sweep, name, stub)
-            self.addCleanup(setattr, sweep, name, real)
+        real = sweep.sweep
+        sweep.sweep = lambda *a, **k: (seen.append(a[2]), ([], []))[1]
+        self.addCleanup(setattr, sweep, "sweep", real)
         code, said = self._cli("--gate", "--jobs", "1", "--base", self.base,
                                "--shard", "2/3", "--no-baseline",
                                "--workdir", str(self.workdir))
         self.assertEqual(code, 0, said)
-        self.assertEqual(seen, [(2, 3)])
+        # The SLICE and not the pair, because since #920 the string is parsed and applied
+        # before `sweep` is called at all — so what proves `"2/3"` arrived is the two
+        # mutations of five that a shard 2 of 3 is dealt, and not a tuple on its way past.
+        self.assertEqual([[m.line for m in s] for s in seen], [[2, 5]])
+        self.assertIn("5 mutations across 1 file(s); shard 2 of 3 takes 2 of them", said)
 
     def test_the_slice_a_shard_takes_is_the_slice_it_says_it_took(self):
         """The log line a cancelled run leaves behind is the only trace of what it was
@@ -4670,15 +4670,10 @@ class TheWorkflowAsksTheToolAndNotTheOtherWayAround(unittest.TestCase):
         said = io.StringIO()
         plan = [sweep.Mutation("charter/m.py", n, n, "drop-if", "q?", "if x: pass",
                                "", "close") for n in range(1, 6)]
-        real = sweep.plan_for
-        sweep.plan_for = lambda *a: (plan, {})
-        self.addCleanup(lambda: setattr(sweep, "plan_for", real))
-        with contextlib.redirect_stdout(said):
-            results, _ = sweep.sweep(self.tmp, "HEAD", {"charter/m.py": {1}}, {},
-                                     self.workdir, 1, {}, 0, print, 60.0, (2, 3))
+        mine = sweep.dealt(plan, 1, (2, 3), said.write)
         self.assertIn("5 mutations across 1 file(s); shard 2 of 3 takes 2 of them",
                       said.getvalue())
-        self.assertEqual([r.mutation.line for r in results], [2, 5])
+        self.assertEqual([m.line for m in mine], [2, 5])
 
     def test_no_shard_at_all_still_means_the_whole_plan(self):
         """Found by the sweep, on this branch, against this file: forcing `if shard is not
@@ -4688,13 +4683,8 @@ class TheWorkflowAsksTheToolAndNotTheOtherWayAround(unittest.TestCase):
         said = io.StringIO()
         plan = [sweep.Mutation("charter/m.py", n, n, "drop-if", "q?", "if x: pass",
                                "", "close") for n in range(1, 6)]
-        real = sweep.plan_for
-        sweep.plan_for = lambda *a: (plan, {})
-        self.addCleanup(lambda: setattr(sweep, "plan_for", real))
-        with contextlib.redirect_stdout(said):
-            results, _ = sweep.sweep(self.tmp, "HEAD", {"charter/m.py": {1}}, {},
-                                     self.workdir, 1, {}, 0, print, 60.0, None)
-        self.assertEqual([r.mutation.line for r in results], [1, 2, 3, 4, 5])
+        mine = sweep.dealt(plan, 1, None, lambda line: said.write(line + "\n"))
+        self.assertEqual([m.line for m in mine], [1, 2, 3, 4, 5])
         self.assertIn("5 mutations across 1 file(s)\n", said.getvalue())
         self.assertNotIn("shard", said.getvalue())
 
@@ -4714,7 +4704,7 @@ class TheWorkflowAsksTheToolAndNotTheOtherWayAround(unittest.TestCase):
                                "--json", str(self.tmp / "r.json"))
         self.assertEqual(code, 0, said)
         self.assertEqual((self.tmp / "r.json").read_text(), "[]")
-        merged, missing = sweep.merge(self.tmp, 1)
+        merged, missing, _ = sweep.merge(self.tmp, 1)
         self.assertEqual((merged, missing), ([], 0))
         self.assertEqual(self._read_outputs(),
                          {"conclusion": "nothing", "headline": "nothing to sweep"})
@@ -4742,12 +4732,12 @@ class TheWorkflowAsksTheToolAndNotTheOtherWayAround(unittest.TestCase):
 
         The clock is scripted rather than real: `now` is called once per mutation, so
         "two of five" is a boundary and not a stopwatch reading."""
-        self._five()
+        plan = self._five()
         ticks = iter([0.0, 0.0, 99.0, 99.0, 99.0])
         said = io.StringIO()
         with contextlib.redirect_stdout(said):
-            results, _ = sweep.sweep(self.tmp, "HEAD", {"charter/m.py": {1}}, {},
-                                     self.workdir, 1, {}, 0, print, 60.0, None,
+            results, _ = sweep.sweep(self.tmp, "HEAD", plan, {}, {},
+                                     self.workdir, 1, {}, 0, print, 60.0,
                                      deadline=50.0, now=lambda: next(ticks))
         self.assertEqual([r.verdict == sweep.OUT_OF_TIME for r in results],
                          [False, False, True, True, True])
@@ -4762,11 +4752,11 @@ class TheWorkflowAsksTheToolAndNotTheOtherWayAround(unittest.TestCase):
         be killed. Found by the sweep on this branch: `shift-boundary` swapped them and
         nothing went red, because the scripted clocks elsewhere step over the boundary
         rather than landing on it."""
-        self._five()
+        plan = self._five()
         ticks = iter([49.0, 50.0, 50.0, 50.0, 50.0])
         with contextlib.redirect_stdout(io.StringIO()):
-            results, _ = sweep.sweep(self.tmp, "HEAD", {"charter/m.py": {1}}, {},
-                                     self.workdir, 1, {}, 0, print, 60.0, None,
+            results, _ = sweep.sweep(self.tmp, "HEAD", plan, {}, {},
+                                     self.workdir, 1, {}, 0, print, 60.0,
                                      deadline=50.0, now=lambda: next(ticks))
         self.assertEqual([r.verdict == sweep.OUT_OF_TIME for r in results],
                          [False, True, True, True, True])
@@ -4784,8 +4774,8 @@ class TheWorkflowAsksTheToolAndNotTheOtherWayAround(unittest.TestCase):
         plan = self._five()
         calls = []
         with contextlib.redirect_stdout(io.StringIO()):
-            sweep.sweep(self.tmp, "HEAD", {"charter/m.py": {1}}, {}, self.workdir, 1, {},
-                        0, print, 60.0, None,
+            sweep.sweep(self.tmp, "HEAD", plan, {}, {}, self.workdir, 1, {},
+                        0, print, 60.0,
                         record=lambda rows: calls.append([r.verdict for r in rows]))
         self.assertEqual(len(calls), len(plan) + 2)
         self.assertEqual(calls[0], [sweep.OUT_OF_TIME] * len(plan))
@@ -4796,10 +4786,10 @@ class TheWorkflowAsksTheToolAndNotTheOtherWayAround(unittest.TestCase):
         away: an unsharded local `--gate` has no budget and must still sweep everything.
         `no_shard_at_all_still_means_the_whole_plan` is the sibling of this for slicing,
         and it exists because the sweep found the unsharded path untested."""
-        self._five()
+        plan = self._five()
         with contextlib.redirect_stdout(io.StringIO()):
-            results, _ = sweep.sweep(self.tmp, "HEAD", {"charter/m.py": {1}}, {},
-                                     self.workdir, 1, {}, 0, print, 60.0, None,
+            results, _ = sweep.sweep(self.tmp, "HEAD", plan, {}, {},
+                                     self.workdir, 1, {}, 0, print, 60.0,
                                      deadline=None, now=lambda: 10.0 ** 9)
         self.assertNotIn(sweep.OUT_OF_TIME, [r.verdict for r in results])
         self.assertEqual(len(results), 5)
@@ -4827,8 +4817,8 @@ class TheWorkflowAsksTheToolAndNotTheOtherWayAround(unittest.TestCase):
         sweep.decide = spy
         self.addCleanup(setattr, sweep, "decide", real)
         with contextlib.redirect_stdout(io.StringIO()):
-            sweep.sweep(self.tmp, "HEAD", {"charter/m.py": {1}}, {}, self.workdir, 1, {},
-                        0, print, 60.0, None, record=lambda rows:
+            sweep.sweep(self.tmp, "HEAD", plan, {}, {}, self.workdir, 1, {},
+                        0, print, 60.0, record=lambda rows:
                         out.write_text(sweep.as_json(rows)))
         self.assertEqual(len(snapshots), len(plan))
         # Before the first answer, the file already names the WHOLE plan. A file holding
@@ -4872,7 +4862,7 @@ class TheWorkflowAsksTheToolAndNotTheOtherWayAround(unittest.TestCase):
         """End to end and through the file, because that is how the answer travels: the
         shard writes JSON, another machine reads it, and the NAME is the deliverable
         (#630). What must never come back out of that trip is `no survivors`."""
-        self._five()
+        plan = self._five()
         ticks = iter([0.0, 99.0, 99.0, 99.0, 99.0])
         real = sweep.sweep
         # The budget below is real and switches the deadline on; the boundary is pinned
@@ -5955,14 +5945,14 @@ class TheMergeStepHoldsItsOwnEdges(unittest.TestCase):
         complete sweep complete."""
         for n in (1, 2, 3, 4):
             self._shard(f"s{n}.json", [_result("pinned")])
-        results, missing = sweep.merge(self.shards, 3)
+        results, missing, _ = sweep.merge(self.shards, 3)
         self.assertEqual((len(results), missing), (4, 0))
 
     def test_a_file_that_will_not_parse_is_a_shard_that_did_not_report(self):
         """There is no third reading of a truncated upload."""
         self._shard("good.json", [_result("pinned")])
         (self.shards / "torn.json").write_text("[{\"path\":", encoding="utf-8")
-        results, missing = sweep.merge(self.shards, 2)
+        results, missing, _ = sweep.merge(self.shards, 2)
         self.assertEqual((len(results), missing), (1, 1))
 
     def test_the_merge_step_says_how_many_of_how_many_answered(self):

--- a/tests/test_sweep.py
+++ b/tests/test_sweep.py
@@ -6763,6 +6763,7 @@ class ASweepThatMeasuredNothingSaysWhichKindOfNothing(unittest.TestCase):
         self.assertEqual(got, {"conclusion": "nothing", "headline": "nothing to sweep"})
         # The sentence the release actually published, and the one that must not come back.
         self.assertNotIn("did not report", said)
+        self.assertIn("0 shard(s) refused", said)
 
     def test_a_charged_file_with_no_mutation_gets_the_same_banner_as_an_unchanged_tree(self):
         """Two ways to sweep nothing, one answer, and one page. They used to print
@@ -6836,8 +6837,25 @@ class ASweepThatMeasuredNothingSaysWhichKindOfNothing(unittest.TestCase):
         self.assertIn("Refused — a shard swept nothing", page)
         self.assertIn("`tests.test_x.T.test_y`", page)
         self.assertIn("This is not a shard that died", page)
+        # And it is a row in the outcome table too, not only a section further down: the
+        # table is what a reader counts, and a bucket missing from it is a bucket they
+        # conclude was zero. A bare count and no `N of M` — see the row's own note.
+        self.assertIn("| **refused** | 1 | a shard that swept nothing", page)
         # The alarming paragraph about a vanished runner belongs to the other state.
         self.assertNotIn("Did not report", page)
+        self.assertNotIn("**did not report**", page)
+        # A gate with nothing refused carries neither, and that is what makes the row
+        # above evidence rather than decoration.
+        clean = sweep.gate_summary(sweep.classify([]), "a" * 40, "b" * 40, None, False)
+        self.assertNotIn("refused", clean)
+
+    def test_a_refusal_with_no_test_to_name_still_gets_a_row(self):
+        """`detail` defaults to empty, and a table cell that renders `None` or nothing at
+        all reads as a page that lost a column rather than as a refusal with no test to
+        name."""
+        gate = sweep.classify([], [sweep.Refusal(sweep.RED_BASELINE)])
+        page = sweep.gate_summary(gate, "a" * 40, "b" * 40, None, False, 0, 1)
+        self.assertIn("| the baseline is red | — |", page)
 
     def test_five_shards_on_one_red_tree_say_it_once(self):
         """A check's name is read at a glance or not at all, so the reason is said per
@@ -6846,6 +6864,20 @@ class ASweepThatMeasuredNothingSaysWhichKindOfNothing(unittest.TestCase):
                                    for n in range(5)])
         self.assertEqual(sweep.headline(gate, 0, 5),
                          "no verdict: 5 shards refused: the baseline is red")
+
+    def test_two_reasons_arrive_in_the_order_the_shards_did(self):
+        """A check NAME that reorders itself between two runs of one branch is a check
+        nobody can compare to yesterday's, and `sorted(set(...))` was the wrong way to get
+        that: the `set` is what makes the order a `PYTHONHASHSEED` question, and no test
+        can pin the `sorted` that hides it — `list(set(...))` agrees on most seeds. So the
+        reasons keep the order they arrived in, which is `merge`'s filename order, and this
+        case is that order said out loud rather than a sort nothing could hold."""
+        gate = sweep.classify([], [sweep.Refusal("the sandbox would not build", "b"),
+                                   sweep.Refusal("the baseline is red", "a")])
+        self.assertEqual(
+            sweep.headline(gate, 0, 2),
+            "no verdict: 2 shards refused: the sandbox would not build; "
+            "the baseline is red")
 
     # ----------------------------------------------------------------------------------
     # The file the shard writes, and what a reader that cannot name it does.
@@ -6860,6 +6892,12 @@ class ASweepThatMeasuredNothingSaysWhichKindOfNothing(unittest.TestCase):
         self.assertEqual((rows, why), ([], None))
         rows, why = sweep.shard_report(sweep.as_refusal("the baseline is red", "t"))
         self.assertEqual((rows, why), ([], sweep.Refusal("the baseline is red", "t")))
+        # `detail` is read with a fallback and `refused` is not, and the asymmetry is the
+        # point: the reason is what makes the file a refusal at all, and the evidence is
+        # something a writer may not have. A `KeyError` on the second would turn a shard
+        # that answered into one that did not report, over a missing test name.
+        rows, why = sweep.shard_report('{"refused": "the baseline is red"}')
+        self.assertEqual((rows, why), ([], sweep.Refusal("the baseline is red", "")))
 
     def test_an_object_this_reader_cannot_name_is_a_shard_that_did_not_report(self):
         """#914's rule, applied to this file. A reader that cannot name the shape in front
@@ -6909,6 +6947,9 @@ class ASweepThatMeasuredNothingSaysWhichKindOfNothing(unittest.TestCase):
                          "no verdict: 1 shard refused: the baseline is red")
         self.assertNotIn("did not report", got["headline"])
         self.assertIn("`tests.test_x.T.test_y`", summary.read_text())
+        # The log's inventory names the bucket, and names it whether or not it fired: a
+        # term that only appears when something goes wrong teaches nobody it exists.
+        self.assertIn("1 shard(s) refused", said)
 
 
 class _RedBaseline:

--- a/tools/sweep.py
+++ b/tools/sweep.py
@@ -3606,9 +3606,18 @@ def headline(gate: Gate, missing: int = 0, shards: int = 1) -> str:
     # is not a mystery (#920). Distinct reasons and not one per shard — five shards on a
     # red tree are one fact said once, and a check name that repeats it five times is a
     # check name nobody finishes reading.
+    #
+    # `dict.fromkeys` and not `sorted(set(...))`, and the hand sweep on this branch is why.
+    # A `set` of strings iterates in an order `PYTHONHASHSEED` decides, so the `sorted`
+    # around it was the only thing keeping this NAME the same between two runs of one
+    # branch — and nothing could pin it there: `list(set(...))` agrees with `sorted` on
+    # most seeds and disagrees on the rest, so a test either passes for the wrong reason or
+    # flakes. A guard no test can hold is a guard this harness cannot hold itself to, and
+    # the answer is not to need one. `dict.fromkeys` dedupes in the order the reasons
+    # arrived, and they arrive in `merge`'s filename order, which does not move.
     if gate.refused:
         unsure.append(f"{_plural(len(gate.refused), 'shard', 'shards')} refused: "
-                      + "; ".join(sorted({r.reason for r in gate.refused})))
+                      + "; ".join(dict.fromkeys(r.reason for r in gate.refused)))
     if missing:
         unsure.append(f"{missing} of {_plural(shards, 'shard', 'shards')} did not report"
                       if shards >= 1 else "the sweep never sized itself")
@@ -3785,9 +3794,14 @@ def gate_summary(gate: Gate, ref: str, base: str, elapsed: float | None,
     w("")
     w("| outcome | n | what it means |")
     w("|---|---:|---|")
+    # A bare count and not the row below's `N of M`. A denominator is what makes "did not
+    # report" mean anything — six of eight is a different page from one of eight — and it
+    # is exactly what a refusal does not need: "2 refused" is complete on its own. The
+    # denominator this row started with brought a `shards >= 1` branch with it that nothing
+    # could reach, which is what the hand sweep on this branch found.
     if gate.refused:
-        w(f"| **refused** | {f'{len(gate.refused)} of {shards}' if shards >= 1 else '?'}"
-          " | a shard that swept nothing and said why — read nothing below as a count |")
+        w(f"| **refused** | {len(gate.refused)} | a shard that swept nothing and said "
+          "why — read nothing below as a count |")
     if missing:
         w(f"| **did not report** | {f'{missing} of {shards}' if shards >= 1 else '?'} | "
           "a shard that never wrote a result — read nothing below as a count |")
@@ -4472,8 +4486,11 @@ def _say(args, gate: Gate, log, missing: int = 0, shards: int = 1) -> None:
         f"{len(gate.platform)} platform-deferred, {len(gate.unresolved)} unresolved, "
         f"{len(gate.out_of_time)} out of time, "
         f"{len(gate.unapplied)} not applied, {len(gate.withheld)} withheld, "
-        f"{gate.pinned} pinned"
-        + (f", {len(gate.refused)} shard(s) refused" if gate.refused else ""))
+        # Always, like every other bucket on this line, and not only when it is non-zero.
+        # This line is an inventory: a reader counts it once and knows what the vocabulary
+        # is. A term that appears only when it fires teaches nobody it exists, and the
+        # conditional it took to hide it was a survivor on this branch's own sweep.
+        f"{gate.pinned} pinned, {len(gate.refused)} shard(s) refused")
     log(f"gate: {headline(gate, missing, shards)}")
     if not args.enforce:
         log("gate: reporting only — nothing here blocks. Pass --enforce to make it.")
@@ -4608,7 +4625,11 @@ def _merge_step(args) -> int:
     #617 there were N step summaries and no sentence at all.
     """
     shards = expected_shards(args.shards)
-    results, missing, refused = merge(Path(args.verdict), max(shards, 1))
+    # `shards` and not `max(shards, 1)`: the floor was dead, and the sweep on this branch
+    # is what said so. `shards` is 0 exactly when the plan never sized itself, and the two
+    # lines below force `missing` to at least 1 in that case — so a floor here only ever
+    # computed the same answer twice, in the place where the answer is less legible.
+    results, missing, refused = merge(Path(args.verdict), shards)
     # `shards` stays 0 when the plan never answered, and travels that way: everything
     # downstream renders "how many did not report" differently from "how many there were
     # supposed to be is not known", and flattening the second into `1 of 1` would report

--- a/tools/sweep.py
+++ b/tools/sweep.py
@@ -2454,13 +2454,22 @@ def plan_for(root: Path, ref: str, scope: dict[str, set[int]], dirty: dict[str, 
     return plan, sources
 
 
-def sweep(root: Path, ref: str, scope: dict[str, set[int]], selection: dict[str, list[str]],
+def sweep(root: Path, ref: str, plan: list[Mutation], sources: dict[str, bytes],
+          selection: dict[str, list[str]],
           workdir: Path, jobs: int, dirty: dict[str, bytes], second_order: int = 0,
-          log=print, full_timeout: float = FULL_TIMEOUT,
-          shard: tuple[int, int] | None = None, cap: int = 0,
+          log=print, full_timeout: float = FULL_TIMEOUT, cap: int = 0,
           deadline: float | None = None, record=None, now=time.time
           ) -> tuple[list[Result], list["Pair"]]:
     """Every mutation, run; every survivor, re-run against the whole suite.
+
+    *plan* is this run's slice, already sharded, and *sources* the blobs it was read
+    from — both from :func:`plan_for`, and both **handed in rather than worked out here**
+    (#920). A run that discovers its own plan discovers it after it has paid for a
+    sandbox, a selection map and a full unmutated suite, so a plan of nothing spent nine
+    minutes on a baseline it had no mutation to interpret — and on the 0.59.0 release that
+    baseline came back red on a flake, took the shard's silent early exit, and published
+    `no verdict: 1 of 1 shard did not report` about a branch with nothing to sweep. The
+    caller asks first and spends afterwards.
 
     *deadline* is an absolute :func:`time.time`, past which no further mutation is dealt
     to a sandbox: the rest come back :data:`OUT_OF_TIME` and the run ends early with what
@@ -2478,14 +2487,6 @@ def sweep(root: Path, ref: str, scope: dict[str, set[int]], selection: dict[str,
     measures the machine it runs on. A scripted clock makes the boundary exact, which is
     what a boundary has to be to be worth asserting.
     """
-    plan, sources = plan_for(root, ref, scope, dirty)
-    whole = len(plan)
-    if shard is not None:
-        plan = shard_of(plan, *shard)
-        log(f"  {whole} mutations across {len(scope)} file(s); "
-            f"shard {shard[0]} of {shard[1]} takes {len(plan)} of them")
-    else:
-        log(f"  {whole} mutations across {len(scope)} file(s)")
     if not plan:
         return [], []
 
@@ -2887,6 +2888,52 @@ def as_json(results: list[Result]) -> str:
     } for r in results], indent=1)
 
 
+#: Why a shard swept nothing, when the answer is "the tree was already broken" (#920).
+#:
+#: Short enough to be part of a check's NAME, because that is where it ends up: the merge
+#: step renders it as `no verdict: 1 shard refused: the baseline is red`. The failing test
+#: travels beside it as :attr:`Refusal.detail` and is printed on the page, never in the
+#: name — one is a sentence a reader skims, the other is a test id.
+RED_BASELINE = "the baseline is red"
+
+
+@dataclasses.dataclass(frozen=True)
+class Refusal:
+    """A shard that ran, decided not to sweep, and said so on the way out (#920).
+
+    **The third state between a shard's results and a shard's silence.** A result file
+    holding `[]` says "I swept, and there was nothing to sweep"; no file at all says "I
+    died before I could tell you anything". Until this existed, a shard that refused —
+    the one case where it knows exactly what happened and why — produced the second of
+    those, because the red-baseline exit returned without writing anything. The 0.59.0
+    release is what that costs: a flaky test in an unmutated baseline, on a branch whose
+    plan was empty, published as `no verdict: 1 of 1 shard did not report`.
+
+    *reason* is a phrase for the check's name and *detail* is the evidence for the page —
+    the failing test, which `as_json` already carries for a mutation and for the same
+    stated reason: it is the first thing anyone asks of a run that went red.
+    """
+
+    reason: str
+    detail: str = ""
+
+
+def as_refusal(reason: str, detail: str = "") -> str:
+    """What a shard writes INSTEAD of results when it swept nothing on purpose (#920).
+
+    An object where :func:`as_json` writes an array, so the two are told apart by shape
+    rather than by a flag inside one of them — a reader that mistook one for the other
+    would report a refusal as a complete sweep of an empty plan, which is the benign
+    reading of the alarming state and the exact inversion this issue is about.
+
+    A reader too old to know the shape refuses it rather than guessing: `shard_report`
+    subscripts `refused`, so an object without it raises and `merge` counts that shard as
+    one that did not report. That is a worse answer than this one and a better answer than
+    a wrong one.
+    """
+    return json.dumps({"refused": reason, "detail": detail}, indent=1)
+
+
 # --------------------------------------------------------------------------------------
 # 8. The gate — stage C
 # --------------------------------------------------------------------------------------
@@ -2929,6 +2976,12 @@ class Gate:
       fails the gate, for the same reason `reach()` does not: a question not asked is not
       a finding about the branch. It is loud in the report so that it is not a finding
       about nothing either.
+    * ``refused`` — a whole shard that swept nothing and said why (#920). Not a bucket of
+      mutations, because a shard that refuses has none: it is the reason the numbers on
+      this page are short. **Its own bucket and not `missing`**, which is the shape of
+      every other fix in this family: `missing` is "no file arrived", and reading a
+      refusal as that sends a reader to look for a runner that vanished when the shard is
+      sitting there in the log saying what it did.
     """
 
     unpinned: list[Result] = dataclasses.field(default_factory=list)
@@ -2939,6 +2992,7 @@ class Gate:
     unapplied: list[Result] = dataclasses.field(default_factory=list)
     withheld: list[Result] = dataclasses.field(default_factory=list)
     pinned: int = 0
+    refused: list[Refusal] = dataclasses.field(default_factory=list)
 
     @property
     def actionable(self) -> list[Result]:
@@ -2966,9 +3020,15 @@ class Gate:
                 + len(self.unresolved) + len(self.unapplied))
 
 
-def classify(results: list[Result]) -> Gate:
-    """Sort a sweep into :class:`Gate`'s buckets."""
-    gate = Gate()
+def classify(results: list[Result], refused: list[Refusal] | None = None) -> Gate:
+    """Sort a sweep into :class:`Gate`'s buckets.
+
+    *refused* is the shards that swept nothing and said why (#920). It carries no results
+    by construction — a shard that refused measured none — so it travels beside them
+    rather than through them, and every reader of a :class:`Gate` gets it without a second
+    argument to thread through :func:`headline`, :func:`gate_summary` and the rest.
+    """
+    gate = Gate(refused=list(refused or ()))
     crowded: dict[tuple[str, str], int] = {}
     for r in results:
         if r.verdict == "survived":
@@ -3020,7 +3080,7 @@ def gate_exit_code(gate: Gate, enforce: bool) -> int:
         return 4
     if gate.actionable:
         return 1
-    return 3 if gate.unresolved or gate.out_of_time else 0
+    return 3 if gate.unresolved or gate.out_of_time or gate.refused else 0
 
 
 # --------------------------------------------------------------------------------------
@@ -3393,6 +3453,29 @@ def shard_of(plan: list[Mutation], index: int, count: int) -> list[Mutation]:
     return plan[index - 1::count]
 
 
+def dealt(plan: list[Mutation], files: int, shard: tuple[int, int] | None, log
+          ) -> list[Mutation]:
+    """The slice this run will measure, announced as it is taken.
+
+    Its own function and not two lines inside the caller, for #572's reason and because
+    #920 moved it: the slice is now taken *before* a sandbox, a selection map or a
+    baseline is paid for, so that a run with nothing to measure can say so without
+    spending nine minutes finding out. A rule that moved into `main` on the way would
+    have been a rule no test could reach — and the log line it prints is, on a cancelled
+    shard, the only trace of what that shard was doing.
+
+    *files* is how many the plan was read from, and it is a count rather than the scope
+    itself because that is all this sentence says about them.
+    """
+    if shard is None:
+        log(f"  {len(plan)} mutations across {files} file(s)")
+        return plan
+    mine = shard_of(plan, *shard)
+    log(f"  {len(plan)} mutations across {files} file(s); "
+        f"shard {shard[0]} of {shard[1]} takes {len(mine)} of them")
+    return mine
+
+
 # --------------------------------------------------------------------------------------
 # 8b. The conclusion — the three things a gate run can have found (#617)
 # --------------------------------------------------------------------------------------
@@ -3465,9 +3548,13 @@ def gate_conclusion(gate: Gate, missing: int = 0) -> str:
     :data:`NOTHING` is last and it is reached only from the bottom — every count zero AND
     every shard in. Anything unmeasured has already answered above it, so "nothing to
     sweep" can never be worn by a run that lost a shard, and `missing` is what keeps
-    `classify([])` from a cancelled sweep saying it.
+    `classify([])` from a cancelled sweep saying it. :attr:`Gate.refused` joins it at the
+    top for the same reason (#920): a refusing shard's file holds no results, so without
+    this clause a sweep that measured nothing because the tree was red would fall all the
+    way through to `nothing to sweep` — which is the benign name on the alarming state,
+    and worse than the alarming name on the benign one that issue starts from.
     """
-    if missing or gate.unapplied or gate.out_of_time:
+    if missing or gate.unapplied or gate.out_of_time or gate.refused:
         return NO_VERDICT
     if gate.actionable:
         return SURVIVORS
@@ -3511,6 +3598,14 @@ def headline(gate: Gate, missing: int = 0, shards: int = 1) -> str:
         return f"no survivors{aside}"
     found = _plural(len(gate.actionable), "survivor", "survivors")
     unsure = []
+    # First, because it is the one line that explains the others: a shard that refused
+    # measured nothing, so every count below it is short by a shard's worth and the reason
+    # is not a mystery (#920). Distinct reasons and not one per shard — five shards on a
+    # red tree are one fact said once, and a check name that repeats it five times is a
+    # check name nobody finishes reading.
+    if gate.refused:
+        unsure.append(f"{_plural(len(gate.refused), 'shard', 'shards')} refused: "
+                      + "; ".join(sorted({r.reason for r in gate.refused})))
     if missing:
         unsure.append(f"{missing} of {_plural(shards, 'shard', 'shards')} did not report"
                       if shards >= 1 else "the sweep never sized itself")
@@ -3687,6 +3782,9 @@ def gate_summary(gate: Gate, ref: str, base: str, elapsed: float | None,
     w("")
     w("| outcome | n | what it means |")
     w("|---|---:|---|")
+    if gate.refused:
+        w(f"| **refused** | {f'{len(gate.refused)} of {shards}' if shards >= 1 else '?'}"
+          " | a shard that swept nothing and said why — read nothing below as a count |")
     if missing:
         w(f"| **did not report** | {f'{missing} of {shards}' if shards >= 1 else '?'} | "
           "a shard that never wrote a result — read nothing below as a count |")
@@ -3727,6 +3825,21 @@ def gate_summary(gate: Gate, ref: str, base: str, elapsed: float | None,
         for r in sorted(gate.withheld, key=lambda r: (r.mutation.path, r.mutation.line)):
             m = r.mutation
             w(f"| `{m.path}:{m.line}` | `{m.operator}` | {m.withheld} |")
+        w("")
+    if gate.refused:
+        w("### Refused — a shard swept nothing, and this is what it said")
+        w("")
+        w(f"{_plural(len(gate.refused), 'shard', 'shards')} declined to sweep at all. "
+          "**This is not a shard that died.** It ran, decided, and wrote its reason down "
+          "— and that distinction is #920: a refusal left as silence arrives here as "
+          "`did not report`, which sends a reader looking for a runner that vanished "
+          "while the shard is in the log saying exactly what it did. It is still **no "
+          "verdict**, because nothing on this page was measured.")
+        w("")
+        w("| why | what went red |")
+        w("|---|---|")
+        for r in sorted(gate.refused, key=lambda r: (r.reason, r.detail)):
+            w(f"| {r.reason} | {f'`{r.detail}`' if r.detail else '—'} |")
         w("")
     if missing:
         w("### Did not report — this page is not a count")
@@ -3842,11 +3955,21 @@ def results_from_json(payload: str) -> list[Result]:
     from the operator and the shipped source rather than trusted from the file, so a shard
     that ran on a different platform than the merge cannot smuggle its own answer in.
     """
+    return results_from_rows(json.loads(payload))
+
+
+def results_from_rows(rows: list[dict]) -> list[Result]:
+    """:func:`results_from_json`, from the rows rather than from the text.
+
+    Split out so that :func:`shard_report` can decide what a shard's file *is* from one
+    parse rather than two (#920) — an array is results, an object is a refusal, and the
+    reader that tells them apart should not have to read the file twice to do it.
+    """
     def outcome(o: dict | None) -> Outcome | None:
         return None if not o else Outcome(o["green"], o["ran"], o["detail"])
 
     out: list[Result] = []
-    for row in json.loads(payload):
+    for row in rows:
         m = Mutation(path=row["path"], line=row["line"], end_line=row["end_line"],
                      operator=row["operator"], question=row["question"],
                      before=row["before"], after=row["after"], symbol=row["symbol"],
@@ -3868,8 +3991,28 @@ def results_from_json(payload: str) -> list[Result]:
     return out
 
 
-def merge(directory: Path, shards: int) -> tuple[list[Result], int]:
-    """Every shard's results, and how many shards did not report.
+def shard_report(payload: str) -> tuple[list[Result], Refusal | None]:
+    """What one shard's file says: what it measured, or why it measured nothing (#920).
+
+    **The two are told apart by the document's SHAPE**, and exactly one of them is ever
+    non-empty. :func:`as_json` writes an array — possibly empty, which is a shard saying
+    "I swept, and the plan held nothing". :func:`as_refusal` writes an object, which is a
+    shard saying "I did not sweep, and here is why". Neither of those is the third thing,
+    which is no file at all, and which only :func:`merge` can see.
+
+    An object without `refused` in it raises rather than being read around. A reader that
+    cannot name the shape in front of it has nothing to say about that shard, and the
+    honest way to say nothing is to let `merge` count it as one that did not report —
+    which is #914's rule applied to this file rather than to a plane's.
+    """
+    body = json.loads(payload)
+    if isinstance(body, dict):
+        return [], Refusal(str(body["refused"]), str(body.get("detail", "")))
+    return results_from_rows(body), None
+
+
+def merge(directory: Path, shards: int) -> tuple[list[Result], int, list[Refusal]]:
+    """Every shard's results, how many did not report, and every refusal among them.
 
     Counted, not named: the merge asks *how many of the answers arrived*, and answering
     that by parsing shard numbers out of filenames would put the workflow's shell quoting
@@ -3877,16 +4020,26 @@ def merge(directory: Path, shards: int) -> tuple[list[Result], int]:
     complete sweep of an incomplete plan. A file is one shard's answer if it parses, and
     a file that will not parse is a shard that did not report; there is no third reading
     of a truncated upload.
+
+    **A refusal is a report** (#920), and that is the whole of the change here: a shard
+    that wrote down why it swept nothing has answered, so it does not count against
+    `missing` — it arrives in the third value instead, where :func:`classify` can put it
+    on the page under its own name. Before this, its file did not exist and it was
+    counted as a shard that vanished.
     """
     results: list[Result] = []
+    refused: list[Refusal] = []
     reported = 0
     for f in sorted(Path(directory).glob("*.json")) if Path(directory).is_dir() else []:
         try:
-            results.extend(results_from_json(f.read_text(encoding="utf-8")))
+            rows, why = shard_report(f.read_text(encoding="utf-8"))
         except (OSError, ValueError, KeyError, TypeError):
             continue
+        results.extend(rows)
+        if why is not None:
+            refused.append(why)
         reported += 1
-    return results, max(0, shards - reported)
+    return results, max(0, shards - reported), refused
 
 
 def verdict_exit_code(gate: Gate, missing: int, enforce: bool) -> int:
@@ -4157,8 +4310,32 @@ def main(argv: list[str] | None = None) -> int:
     if args.plan or args.warm_map:
         return _plan_step(args, root, ref, base, scope, dirty, workdir, cache_dir,
                           log)
-    if not scope:
-        log("  nothing under the swept paths changed. Nothing to do.")
+    # **Asked before a sandbox, a selection map or a baseline is paid for (#920).** The
+    # plan is one `ast` pass over the diff, and until this moved up here the run learned
+    # it had nothing to do only after nine minutes of unmutated suite — a baseline with no
+    # mutation to interpret, whose only remaining power was to go red and take the silent
+    # exit below with it. That is the 0.59.0 release: `charter/__init__.py` charged, zero
+    # mutations, a flaky test in the baseline, and `no verdict: 1 of 1 shard did not
+    # report` on a branch where there was nothing to report about.
+    shard = parse_shard(args.shard) if args.shard else None
+    plan, sources = plan_for(root, ref, scope, dirty)
+    plan = dealt(plan, len(scope), shard, log)
+    if not plan:
+        # Two ways to arrive and one answer, said as the two (#920). "No swept file
+        # changed" and "the swept files that changed offer no operator anything" are
+        # different facts about a branch and a reader wants the one that is true — but
+        # they license exactly the same belief, which is none, and `nothing to sweep` is
+        # the sentence for that. Before this, only the first reached it.
+        log("  nothing under the swept paths changed. Nothing to do." if not scope else
+            f"  {len(scope)} charged file(s), and no operator finds a mutation in what "
+            "they add. Nothing to do.")
+        # The same banner the long path ends on, and not a shorter line because the answer
+        # arrived sooner. The two ways to sweep nothing used to print different things —
+        # a charged file with no mutation got the full report, an unchanged tree got one
+        # sentence — and a reader who has seen one of them cannot tell what the other is
+        # saying.
+        log("")
+        log(report([], root, ref, base, None, time.time() - started, []))
         # The same page and the same sentence the merge step publishes, and not a private
         # paragraph of its own (#782). This branch used to write "there was nothing to
         # sweep" here while the check on the pull request said `no survivors` — two
@@ -4217,6 +4394,14 @@ def main(argv: list[str] | None = None) -> int:
                         "## Deletion sweep — not run\n\nThe tree is **red before any "
                         "mutation**, so every mutation would have looked pinned for a "
                         f"reason that has nothing to do with any guard: {baseline.detail}\n")
+            # **Written down and not left as silence (#920).** This return used to leave
+            # no `--json` behind at all, and a shard that writes nothing is a shard that
+            # never reported — so a refusal the log states in two exclamation marks
+            # arrived at the merge step as an absence, and the pull request read
+            # `no verdict: 1 of 1 shard did not report`. That is true of a runner that
+            # vanished and it is false here: this shard ran, decided, and can say why.
+            if args.json:
+                Path(args.json).write_text(as_refusal(RED_BASELINE, baseline.detail))
             # A reporting gate blocks nothing, and that has to include this. A red baseline
             # is a real problem and the summary above says so in the loudest terms the page
             # has — but failing a pull request over it, on a job whose numbers nobody has
@@ -4225,7 +4410,6 @@ def main(argv: list[str] | None = None) -> int:
             # else, and it decides once.
             return 2 if args.enforce or not args.gate else 0
 
-    shard = parse_shard(args.shard) if args.shard else None
     budget = budget_for(shard is not None, args.budget)
     # One fact and not two. This line used to also work out how much of the budget was
     # left after the map and the baseline, and the sweep's own sweep found every piece of
@@ -4249,8 +4433,8 @@ def main(argv: list[str] | None = None) -> int:
             part.write_text(as_json(rows))
             os.replace(part, path)
 
-    results, pairs = sweep(root, ref, scope, selection, workdir, args.jobs, dirty,
-                           args.second_order, log, full_timeout, shard, cap=cap,
+    results, pairs = sweep(root, ref, plan, sources, selection, workdir, args.jobs, dirty,
+                           args.second_order, log, full_timeout, cap=cap,
                            deadline=started + budget if budget else None, record=record)
     elapsed = time.time() - started
     text = report(results, root, ref, base, baseline, elapsed, pairs)
@@ -4285,7 +4469,8 @@ def _say(args, gate: Gate, log, missing: int = 0, shards: int = 1) -> None:
         f"{len(gate.platform)} platform-deferred, {len(gate.unresolved)} unresolved, "
         f"{len(gate.out_of_time)} out of time, "
         f"{len(gate.unapplied)} not applied, {len(gate.withheld)} withheld, "
-        f"{gate.pinned} pinned")
+        f"{gate.pinned} pinned"
+        + (f", {len(gate.refused)} shard(s) refused" if gate.refused else ""))
     log(f"gate: {headline(gate, missing, shards)}")
     if not args.enforce:
         log("gate: reporting only — nothing here blocks. Pass --enforce to make it.")
@@ -4420,14 +4605,14 @@ def _merge_step(args) -> int:
     #617 there were N step summaries and no sentence at all.
     """
     shards = expected_shards(args.shards)
-    results, missing = merge(Path(args.verdict), max(shards, 1))
+    results, missing, refused = merge(Path(args.verdict), max(shards, 1))
     # `shards` stays 0 when the plan never answered, and travels that way: everything
     # downstream renders "how many did not report" differently from "how many there were
     # supposed to be is not known", and flattening the second into `1 of 1` would report
     # a sweep that was never planned as a sweep that was planned and lost one shard.
     if not shards:
         missing = max(missing, 1)
-    gate = classify(results)
+    gate = classify(results, refused)
     if args.summary:
         # "merge-base" and not "the merge-base": the header shortens a sha to twelve
         # characters, and a fallback longer than that comes out clipped mid-word.

--- a/tools/sweep.py
+++ b/tools/sweep.py
@@ -2487,9 +2487,12 @@ def sweep(root: Path, ref: str, plan: list[Mutation], sources: dict[str, bytes],
     measures the machine it runs on. A scripted clock makes the boundary exact, which is
     what a boundary has to be to be worth asserting.
     """
-    if not plan:
-        return [], []
-
+    # No `if not plan: return` here any more, and its absence is the point (#920). The
+    # caller decides that now — before a sandbox, a map or a baseline — so a guard here
+    # could never be the one that fires, and this file's own rule (see `shard_of`) is that
+    # a line the suite would not miss gets deleted rather than kept for shape. Two places
+    # holding one rule is #670 in miniature: the day they disagree, one of them is wrong
+    # and nothing can say which.
     log(f"  building {jobs} sandbox(es)…")
     boxes = [Sandbox(root, run_dir(workdir) / f"w{i}", ref, dirty) for i in range(jobs)]
     for box in boxes:


### PR DESCRIPTION
Closes #920.

## The issue's diagnosis was half right, and the other half is the defect

The issue says the gap is the middle case — a diff that charges a file but yields zero
mutations — taking the `no verdict` name. **That case already reported `nothing to sweep`**,
and does so on this tree before any change here: a shard with an empty plan writes `[]`,
`merge` counts a parsed `[]` as a report, and `classify([])` is `NOTHING`.

What the 0.59.0 run actually did is in its own logs. Shard job 101726592829:

```
sweeping 6a0aef6a3fe1 (paths: charter)
  diff against aeb3e8394844: 1 file(s), 1 added line(s)
  preparing the reference sandbox…
  selection map: cached
  baseline: full suite, unmutated…
    Ran 11721 tests — tests.test_a_denial_names_its_override
    .TestTheTallyKeysAreUnchanged.test_each_guard_still_traces_the_key_it_always_did in 541s
  ! the tree is RED before any mutation. Every mutation below will look
  ! pinned for a reason that has nothing to do with the guard. Fix first.
##[warning]No files were found with the provided path: sweep-results-1.json.
```

and collect job 101729099807:

```
Found 0 artifact(s) … Total of 0 artifact(s) downloaded
merged 0 result(s) from 0 of 1 shard(s)
gate: no verdict: 1 of 1 shard did not report
```

A plan of **zero mutations** still paid nine minutes for an unmutated baseline it had no
mutation to interpret, that baseline went red on one flaky test, and the red-baseline exit
`return`ed 0 **without writing its `--json`**. Both jobs concluded `success`.

That test passes on demand — `python3 -m unittest tests.test_a_denial_names_its_override
.TestTheTallyKeysAreUnchanged` is green — so the branch was fine, the tool's judgement was
fine, and the only thing wrong was that a shard's refusal and a shard's death were the same
value.

## Is a shard's zero the same value as a shard's silence?

**In `merge`'s input, no.** Measured on `origin/main`'s own `tools/sweep.py`, against the
0.59.0 shas:

```
$ python3 origin-main-sweep.py --verdict shards/ --shards 1 \
      --ref 0116b37b1db7 --base aeb3e8394844        # shards/ holds one file containing []
gate: nothing to sweep

$ python3 origin-main-sweep.py --verdict empty/ --shards 1 \
      --ref 0116b37b1db7 --base aeb3e8394844        # empty/ — what 0.59.0 actually had
gate: no verdict: 1 of 1 shard did not report
```

A parsed `[]` counts as reported and a missing file counts as missing, and
`test_an_empty_sweep_that_ran_is_not_a_sweep_that_did_not` has held that since #782.

**In practice, yes**, because the shard had a green exit that manufactured silence on
purpose. The conflation is real; it lives one level up from where #920 looks for it — not in
how the aggregator reads a zero, but in a shard that reports a decision by not reporting.

## What changed

**The plan is taken before anything is spent on measuring it.** `plan_for` and the shard
slice move ahead of the sandbox, the selection map and the baseline. A run with no mutation
to measure has no use for a baseline — the baseline exists to tell *pinned by your mutation*
from *already broken* — so it now answers in a second instead of finding out in nine
minutes, and says which of the two nothings it is. The slice and its log line move into
`dealt()` rather than into `main`, because a rule inside a caller is a rule no test can
reach.

**A shard that refuses writes the refusal down.** `as_refusal` writes a JSON object where
the result file is normally a JSON array; `shard_report` tells them apart by shape; `merge`
counts a refusal as a report and returns it; `Gate.refused` carries it to every reader that
already takes a `Gate`. An object whose shape this reader cannot name raises rather than
being read around, and `merge` counts that shard as one that did not report — #914's rule
applied to this file.

`Gate.refused` ranks with `missing` in `gate_conclusion`, not below it: a refusing shard
measured nothing, so without that clause a red tree would fall through to `nothing to
sweep` — the benign name on the alarming state, which is worse than the inversion this
issue starts from.

| what happened | what the check says |
| --- | --- |
| nothing charged, or nothing charged offers a mutation | `nothing to sweep` |
| a shard ran, declined to sweep, and said why | `no verdict: 1 shard refused: the baseline is red` |
| a shard wrote no file at all | `no verdict: 1 of 1 shard did not report` |

## The 0.59.0 case, before and after

Reconstructed against the real shas — `0116b37b1db7` (the release branch head) charged
against `aeb3e8394844` (its merge-base), one file, one added line, zero mutations, exactly
as the plan job reported.

**Before** — the artifact directory the merge step actually saw was empty:

```
$ python3 tools/sweep.py --verdict shards/ --shards 1 --ref 0116b37b1db7 --base aeb3e8394844
merged 0 result(s) from 0 of 1 shard(s)
gate: no verdict: 1 of 1 shard did not report
```

**After** — the shard reaches no baseline, writes `[]`, and the aggregator reads it:

```
$ python3 tools/sweep.py --gate --ref 0116b37b1db7 --base aeb3e8394844 \
      --shard 1/1 --json shards/sweep-results-1.json
sweeping 0116b37b1db7 (paths: charter)
  diff against aeb3e8394844: 1 file(s), 1 added line(s)
  0 mutations across 1 file(s); shard 1 of 1 takes 0 of them
  1 charged file(s), and no operator finds a mutation in what they add. Nothing to do.
NOTHING TO SWEEP — not one mutation was applied, so this is a record of a
                   question nobody asked rather than of an answer.
gate: nothing to sweep

$ python3 tools/sweep.py --verdict shards/ --shards 1 --ref 0116b37b1db7 --base aeb3e8394844
merged 0 result(s) from 1 of 1 shard(s)
gate: nothing to sweep
```

No sandbox, no selection map, no nine-minute baseline, and no flaky test standing between a
release and the truth about it.

## Tests

Ten new cases in `ASweepThatMeasuredNothingSaysWhichKindOfNothing`, including the release
diff run end to end through the CLI the workflow runs. That case deliberately does **not**
pass `--no-baseline` — the baseline is the defect, so it asserts on the sentence a baseline
prints, and the only way to satisfy it is not to run one.

Every guard hand-checked by mutation, `__pycache__` cleared on both transitions:

| line | mutation | result |
| --- | --- | --- |
| `tools/sweep.py:3560` | `gate_conclusion`, minus `or gate.refused` | 4 failures |
| `tools/sweep.py:4407` | the red-baseline exit, minus its `--json` write | 1 error |
| `tools/sweep.py:4042` | `merge`, minus its refusal branch | 2 failures |
| `tools/sweep.py:4326` | `if not plan:` back to `if not scope:` | 3 errors |

`sweep()`'s own `if not plan: return [], []` is **deleted** rather than kept: the caller
decides that now, so the guard could never be the one that fires, and this file's rule (see
`shard_of`) is that a line the suite would not miss goes rather than being kept for shape.

`python3 -m unittest discover -s tests -q` — `Ran 11733 tests in 663.115s`, `OK (skipped=9)`.


## The hand-run sweep, and the ten survivors it found

`DEFAULT_PATHS` charges `charter/`, so this branch's own CI sweep reports `nothing to
sweep` — honest and empty. So it was run by hand over `tools/`, on an idle box, twice.

**First run**, at `5561a40a`, `--gate --path tools --base origin/main --jobs 4`:

```
baseline          : Ran 11731 tests — OK
mutations applied : 32
pinned            : 22
SURVIVED          : 10
UNRESOLVED        : 0
wall clock        : 64.8 min
```

Every one of the ten was in code this branch added. By `file:line` against the swept tree:

| survivor | operator | classification |
| --- | --- | --- |
| `tools/sweep.py:3789` ×2 | collapse-ifexp (both ways) | dead code — deleted |
| `tools/sweep.py:3789` | shift-boundary on `shards >= 1` | dead code — deleted with it |
| `tools/sweep.py:4476` ×2 | collapse-ifexp (both ways) | dead code — deleted |
| `tools/sweep.py:4611` | unclamp `max(shards, 1)` | dead code — deleted |
| `tools/sweep.py:3611` | swap-synonym `sorted` → `list` | load-bearing and unpinnable — restructured |
| `tools/sweep.py:3788` | drop-if, the summary table row | missing test — written |
| `tools/sweep.py:3845` | collapse-ifexp, the `'—'` fallback | missing test — written |
| `tools/sweep.py:4013` | no-fallback `body.get("detail", "")` | missing test — written |

Six were code that should not have existed:

* **The refused row carried a denominator.** `N of M` is what makes *did not report* mean
  something — six of eight is a different page from one of eight — and a refusal count is
  complete on its own. Gone, and the unreachable `shards >= 1` branch with it.
* **`_say`'s line is an inventory of every bucket.** A term that appears only when it fires
  teaches nobody the term exists, so it is unconditional now like the other eight.
* **`max(shards, 1)` was dead.** `shards` is 0 exactly when the plan never sized itself, and
  the two lines below already force `missing` to at least 1.
* **`sorted({…})` was load-bearing *and* unpinnable, which is worse than either.** A `set` of
  strings iterates in a `PYTHONHASHSEED` order, so the `sorted` was the only thing keeping
  the check's NAME stable between two runs of one branch — and no test can hold it there,
  because `list(set(…))` agrees with `sorted` on most seeds and disagrees on the rest, so a
  test either passes for the wrong reason or flakes. The answer is not to need it:
  `dict.fromkeys` dedupes in the order the reasons arrived, which is `merge`'s filename
  order and does not move.

The other four were real questions with no test behind them, and now have one each.

**Second run**, at `5693bd62`, same command, after the fixes:

```
baseline          : Ran 11733 tests — OK
mutations applied : 24
pinned            : 24
SURVIVED          : 0
UNRESOLVED        : 0
wall clock        : 22.1 min

gate: no survivors
```


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018hUBNraNfixfMMK5Jc6CNy
