### PR TITLE
The frame says how to close a chat, and not only how to make one (#921)

### DIFF
--- a/charter/commands_frame.py
+++ b/charter/commands_frame.py
@@ -8184,6 +8184,34 @@ def _close_open_overlays(socket: str, *, harness: str) -> None:
         tmuxctl.run("closing the palette already open", argv)
 
 
+def _palette_catalogue(fid: str, reg, *, snapshot) -> tuple:
+    """Every row `F2` opens on, in the order it draws them.
+
+    **A function rather than an expression inside :func:`_draw_palette`, because the
+    catalogue is DATA and #921's rule is stated over it.** *Every row that makes a kind of
+    thing has a counterpart row that unmakes that same kind, in the same surface* — and
+    the report that produced the rule is an operator who read a strip drawing `+` and no
+    `−` and concluded, correctly from what was on screen, that closing a chat was
+    impossible. `tests/test_the_palette_advertises_unmaking_what_it_makes.py` asks that
+    question of what this returns, so the invariant is asked of the rows the palette is
+    actually built from rather than of a second list a test composed to look like them.
+
+    **`leave.open_rows` LAST, and that ordering is the guard** §4i's "warns and proceeds"
+    needs: the cursor starts on the first row that can run, so a destructive row at the
+    top of the list would be one `F2 Enter` from stopping the plane. Every harmless row
+    charter has keeps the top — `chat: new` (`builtin_actions._register_new_chat`)
+    included, which is why it is registered among the actions and not appended here.
+
+    Nothing is resolved here that the caller did not already resolve: *reg* is the
+    registry `_draw_palette` built against the moment the palette opened, and *snapshot* is
+    the gather it read once. A second `builtin_actions.build` inside this would be a second
+    reading of a plane that moves, which is the staleness `_draw_palette` records.
+    """
+    return (choose.open_rows(fid)
+            + palette.rows(reg.offers(fid=fid, snapshot=snapshot))
+            + leave.open_rows(fid))
+
+
 def _draw_palette(args) -> int:
     """Be the palette: draw the rows, take a choice, act on it, hand the pane back.
 
@@ -8233,13 +8261,7 @@ def _draw_palette(args) -> int:
     opened: list[choose.Roster] = []
     try:
         surface = palette.Palette(
-            # `leave.open_rows` LAST, and that ordering is the guard §4i's "warns and
-            # proceeds" needs: the cursor starts on the first row that can run, so a
-            # destructive row at the top of the list would be one `F2 Enter` from stopping
-            # the plane. Every harmless row charter has keeps the top.
-            catalogue=(choose.open_rows(fid)
-                       + palette.rows(reg.offers(fid=fid, snapshot=snapshot))
-                       + leave.open_rows(fid)),
+            catalogue=_palette_catalogue(fid, reg, snapshot=snapshot),
             query_only=lambda: _name_rows(fid, opened),
             mouse=True)
         def _then(row):

--- a/charter/commands_frame.py
+++ b/charter/commands_frame.py
@@ -8255,6 +8255,13 @@ def _draw_palette(args) -> int:
     fid = os.environ.get("CHARTER_SESSION_ID", "")
     socket = state.frame_server(fid) or SOCKET
     harness = state.harness_pane(fid) or ""
+    # **This process's own rectangle, read ONCE and used twice** — by :func:`_picker`, to
+    # unzoom a confirmation into the drawer it is (#921), and by `_close_palette` in the
+    # `finally`. tmux sets `$TMUX_PANE` in every process it starts and `frame/tabmenu
+    # .handback` reads the same variable for the same pane; a second read here would be a
+    # second answer to "which pane am I", on the one path where being wrong means resizing
+    # or killing the operator's harness.
+    here = os.environ.get("TMUX_PANE", "")
     reg = builtin_actions.build(fid, current_density=_current_density(fid),
                                 current_chrome=_current_chrome(fid))
     snapshot = gather.cached(fid) or {}
@@ -8270,7 +8277,7 @@ def _draw_palette(args) -> int:
             # leaves this one standing. Explicit rather than `_picker(...) or _again(...)`
             # — both answer a `Surface`, and a surface's truthiness is not a thing this
             # file gets to assume on `own_the_tty`'s behalf.
-            nxt = _picker(row, fid, opened)
+            nxt = _picker(row, fid, opened, socket=socket, pane=here)
             if nxt is not None:
                 return nxt
             return _again(row, surface, reg, fid=fid, snapshot=snapshot)
@@ -8335,8 +8342,7 @@ def _draw_palette(args) -> int:
         if not inv.started:
             _say_on_screen(fid, inv.reason)
     finally:
-        _close_palette(socket, harness=harness,
-                       overlay_pane=os.environ.get("TMUX_PANE", ""))
+        _close_palette(socket, harness=harness, overlay_pane=here)
     return 0
 
 
@@ -8396,8 +8402,47 @@ def _start_workspace_switch(fid: str, ws: str) -> None:
         util.self_relaunch_argv("frame-switch", "--workspace", ws), fid=fid)
 
 
-def _picker(row, fid: str, opened: list) -> "palette.Palette | None":
+def _as_a_drawer(surface, *, socket: str, pane: str):
+    """Hand *surface* back, having given its pane the frame above it — #921.
+
+    **A confirmation is a drawer, and the palette is not.** `overlay.modal_argvs` ends in
+    `resize-pane -Z`, so every surface this pane holds takes the whole window; that is
+    right for the palette, which lists every action, every doorway and every name an
+    operator types towards, scrolls, and has no row cap by design. It is wrong for a
+    two-row question about one chat, which read as *"an entirely new window"* rather than
+    as something that had opened over the frame the operator was looking at.
+
+    **``None`` passes straight through, and that is what makes this one call rather than
+    an `if` at two call sites.** :func:`_picker` and `frame/tabmenu.opens` both answer
+    ``None`` for every row that opens nothing, so the surface arriving here IS the
+    condition — and a route that opened a confirmation without unzooming would be a
+    confirmation that behaved differently depending on which pointer press reached it.
+
+    A tmux round trip on a keypress the operator has just made, on the one path where a
+    scan of the frame root is already being paid for (`leave.plan`). `tmuxctl.run` is what
+    reports a server that would not answer; ``None`` from `overlay.unzoom_argv` is a pane
+    id charter could not spell, and a surface that stays zoomed is the surface this shipped
+    as — never a refusal, and never a `resize-pane` aimed at a target charter cannot parse.
+    """
+    if surface is None:
+        return None
+    argv = overlay.unzoom_argv(socket, overlay_pane=pane)
+    if argv is not None:
+        tmuxctl.run("making the confirmation a drawer", argv)
+    return surface
+
+
+def _picker(row, fid: str, opened: list, *, socket: str = "",
+            pane: str = "") -> "palette.Palette | None":
     """The surface *row* opens, or ``None`` when it opens none.
+
+    *socket* and *pane* are this process's own tmux and its own rectangle, and they are
+    read for exactly one row: a confirmation gives the window back and is drawn as a
+    drawer (:func:`_as_a_drawer`), where a picker keeps the whole pane for the same reason
+    the palette does. They default to empty so a test that only asks which surface a row
+    opens does not have to invent a tmux — `overlay.unzoom_argv` answers ``None`` for a
+    pane id it cannot spell, which is the same degrade every other builder in that module
+    makes.
 
     Handed to `palette.own_the_tty` as its *then*, so a picker is drawn in the palette's
     own pane with the tty never leaving raw mode — see that function for why a second pane
@@ -8443,8 +8488,9 @@ def _picker(row, fid: str, opened: list) -> "palette.Palette | None":
         # `cmd_quit`, which spells its own.
         p = leave.plan(live=live, focus=state.own_workspace(fid),
                        only=fid if verb == leave.CLOSE else "")
-        return palette.Palette(catalogue=leave.confirm_rows(p, verb=verb),
-                               label=verb, mouse=True)
+        return _as_a_drawer(palette.Palette(catalogue=leave.confirm_rows(p, verb=verb),
+                                            label=verb, mouse=True),
+                            socket=socket, pane=pane)
     noun = choose.noun_of(row)
     if noun is None:
         return None

--- a/charter/commands_frame.py
+++ b/charter/commands_frame.py
@@ -8191,7 +8191,7 @@ def _palette_catalogue(fid: str, reg, *, snapshot) -> tuple:
     catalogue is DATA and #921's rule is stated over it.** *Every row that makes a kind of
     thing has a counterpart row that unmakes that same kind, in the same surface* — and
     the report that produced the rule is an operator who read a strip drawing `+` and no
-    `−` and concluded, correctly from what was on screen, that closing a chat was
+    `-` and concluded, correctly from what was on screen, that closing a chat was
     impossible. `tests/test_the_palette_advertises_unmaking_what_it_makes.py` asks that
     question of what this returns, so the invariant is asked of the rows the palette is
     actually built from rather than of a second list a test composed to look like them.

--- a/charter/commands_frame.py
+++ b/charter/commands_frame.py
@@ -8412,6 +8412,17 @@ def _as_a_drawer(surface, *, socket: str, pane: str):
     two-row question about one chat, which read as *"an entirely new window"* rather than
     as something that had opened over the frame the operator was looking at.
 
+    **Both verbs, and the cost is stated rather than hidden.** `chat: close` is the
+    confirmation this was reported about and it is always two rows — the confirming row and
+    the one chat `leave.plan(only=…)` names — so it fits the drawer whole. `charter: quit`
+    lists every chat on the plane, and in five rows it draws two of them at a time under a
+    heading that says how many there are, scrolled with the same up/down as everything else
+    on this surface. §4f asks that the warning be drawn *at the moment the operator is
+    deciding*, which it is; what a full-window quit bought on top of that was seeing a long
+    blast radius without scrolling. One surface with one rule was chosen over two that read
+    differently depending on which doorway reached them, and if that trade turns out wrong
+    the place to change it is here, in one expression.
+
     **``None`` passes straight through, and that is what makes this one call rather than
     an `if` at two call sites.** :func:`_picker` and `frame/tabmenu.opens` both answer
     ``None`` for every row that opens nothing, so the surface arriving here IS the

--- a/charter/frame/builtin_actions.py
+++ b/charter/frame/builtin_actions.py
@@ -698,6 +698,59 @@ def _regather(fid: str):
     _spawn(util.self_relaunch_argv("frame-gather", "--session", fid, "--workspace", ws),
            fid=fid)
     return f"gathering {ws}…"
+
+
+def _register_new_chat(reg: actions.ActionRegistry) -> None:
+    """One row that opens another chat in this workspace — **#921's create side.**
+
+    `frame/events.py`'s rule is *"a component whose only route to a piece of state is a
+    click has no route to it on most planes. Give every pointer affordance a key as
+    well."* This is the row that was missing. `slots.ADD_CHAT` — the `+` at the end of the
+    chat strip — was the frame's ONLY route to a new chat, and `[frame] mouse` ships
+    **false**, so on charter's own default plane there was no route at all and the one
+    glyph the frame advertises about making a chat could not be pressed.
+
+    That is the create half of #921, whose report is the destroy half: *"we have plus
+    button - that adding new session tab, but no any option to delete/stop"*. A surface
+    that advertises making a thing must advertise unmaking it at the same weight and in
+    the same place, and the palette is where both sentences have to be true first, because
+    the palette is the surface that works at every width and on every plane.
+
+    **Registered beside `chat: previous transcript`, not at the top.** They are the two
+    rows about the chat you are standing in, and an operator scanning left edges finds
+    them together. The placement moves no density, chrome, strip or todo row, which is
+    `_register_density`'s standing rule: *a list whose rows move is a list nobody learns*.
+
+    **Always available, and that is not this row declining to check.**
+    `commands_frame.cmd_new_chat` has four refusals and says every one of them on the
+    frame's own attention row — it runs detached with its three streams on `/dev/null` and
+    that row is the only surface it has. A second reading of those conditions here would
+    be a second answer to a question that already has one, and it would refuse a row the
+    `+` beside it still offers. `builtins._bar_events` keeps `add` as DATA for exactly
+    that reason: two routes to one command must not degrade differently.
+    """
+    reg.register(action.Action(
+        id="chat.new", title="chat: new — another chat in this workspace",
+        run=lambda ctx: _run_new_chat(ctx.fid)))
+
+
+def _run_new_chat(fid: str):
+    """Start `charter frame-new-chat` for *fid*, detached, and say so.
+
+    `--chat` named outright, as `_run_transcript` names its own target and `_regather`
+    names its `--session`. `builtins._NEW_CHAT` carries no option because :func:`_spawn`
+    sets the child's own `$CHARTER_SESSION_ID` and `commands_frame._pressers_chat` falls
+    back to it — the two spellings resolve to the same frame through that one function, so
+    this is the palette's idiom rather than a second answer.
+
+    Detached for the module docstring's measured reason: the palette closes the instant it
+    has invoked, `kill-pane` hands SIGHUP to that pane's process group, and `cmd_new_chat`
+    is a whole `new-window` launch this process would not survive to make.
+    """
+    _spawn(util.self_relaunch_argv("frame-new-chat", "--chat", fid), fid=fid)
+    return "opening another chat…"
+
+
 def _register_transcript(reg: actions.ActionRegistry) -> None:
     """One row: open what this chat had on screen before it was last stopped — §4f.
 
@@ -796,10 +849,17 @@ def build(fid: str, *, current_density: str,
     # move. `_register_regather` keeps the bottom of charter's own list, which its own
     # docstring argues for and which this does not disturb.
     #
+    # `chat: new` sits with it for the same reason and one more: they are the two rows
+    # about the chat you are standing in, and #921's whole finding is that a surface
+    # advertising one half of a pair reads as refusing the other. It is a HARMLESS row and
+    # keeps the harmless rows' half of the list — nothing is destroyed by opening a chat,
+    # which is `builtins._bar_events`' §4i argument for the `+` said one surface over.
+    #
     # The two DESTRUCTIVE rows (`charter: quit`, `chat: close`) are deliberately not here
     # at all: they are doorways onto a confirmation, they are appended after every action by
     # `commands_frame._draw_palette`, and `frame/leave.open_rows` records why that placement
     # is a guard rather than a taste.
+    _register_new_chat(reg)
     _register_transcript(reg)
     _register_regather(reg)
     for aid in reg.providers.ids():

--- a/charter/frame/builtins.py
+++ b/charter/frame/builtins.py
@@ -533,6 +533,27 @@ def _bar_events(fid: str, command: tuple[str, ...], add: tuple[str, ...] | None 
     pointer: `charter frame-quit`, which stops every harness on the plane, and which is
     behind a palette row with a confirmation for exactly that reason.
 
+    **A press on the `-` beside it opens the question of closing this chat** (#921) — the
+    fifth gesture, and the one that makes the fourth findable. *"we have plus button - that
+    adding new session tab, but no any option to delete/stop"*: closing was possible the
+    whole time through both `F2 → chat: close` and the right press below, and the strip
+    said neither. A row drawing `+` alone says making is offered and unmaking is not, which
+    is what the operator read off it and reported.
+
+    **It does NOT close on the press, and that is the paragraph above read the other way.**
+    The `+` may act because nothing is destroyed; this may not, so it does not act — it
+    spawns the same `charter frame-palette --tab` the right press does, targeted at *fid*,
+    which is what `slots._Tabs.tab_at` answers for the tab this frame is on. The menu's
+    `chat: close` row is a doorway, `leave.confirm_rows` is what it opens, and the
+    confirming row names the chat and says it will not come back. A pointer opens the
+    question; the keyboard answers it.
+
+    **The ACTIVE chat, and closing any other stays the right press.** One glyph at the end
+    of the row is what a strip can afford; a `×` on every tab would cost a column per tab
+    and re-cut the strip, which `slots.TAB_COUNT_W` and the `TAB_SPINNER` refusal both
+    forbid for one measured reason. The chat you are standing in is what a single glyph can
+    honestly be about, and it is the commonest chat anyone closes.
+
     **`add` is `None` for the workspaces bar and that is structural rather than a branch.**
     `slots.workspaces_bar` passes no note, so no rung ever publishes an affordance column
     for it and `add_at` cannot answer true — but the argument for a workspace `+` is a
@@ -610,6 +631,24 @@ def _bar_events(fid: str, command: tuple[str, ...], add: tuple[str, ...] | None 
         if name is None:
             if add is not None and _slots.TABS.add_at(ev.row, ev.col):
                 _spawn(util.self_relaunch_argv(*add), fid=fid)
+                return False
+            if menu and _slots.TABS.close_at(ev.row, ev.col):
+                # **The `-` beside the `+`, and it opens the menu about THIS chat**
+                # (`slots.CLOSE_CHAT`, #921). Byte for byte the argv the right press above
+                # builds, with *fid* where `tab_at` would have put the tab under the
+                # pointer: a left press on `-` IS a right press on the tab you are on. So
+                # this adds a route and no authority — what it opens is a surface whose
+                # `chat: close` row is a doorway onto `leave.confirm_rows`, and the
+                # keypress that commits is the one that module mints. §4i's *a pointer
+                # opens the question; the keyboard answers it*, which is the clause the
+                # `+` above meets the other way, by destroying nothing.
+                #
+                # **Gated on `menu` rather than on a fourth parameter**, and that is
+                # `add`'s data rule kept rather than an exception to it: what this spawns
+                # IS the tab menu, so a bar with no menu has nothing for a `-` to open.
+                # The workspaces bar is handed no menu and `slots._workspaces_strip` hands
+                # it no `-` to draw, so the two facts cannot come apart.
+                _spawn(util.self_relaunch_argv(*_TAB_MENU, fid), fid=fid)
                 return False
             if _slots.TABS.more_at(ev.row, ev.col):
                 # The same argv `_strip_events` spawns for a door, for its reasons — one

--- a/charter/frame/overlay.py
+++ b/charter/frame/overlay.py
@@ -1029,6 +1029,60 @@ def modal_argvs(server: str, *, harness: str,
             tmuxctl.server_argv(server, "resize-pane", "-Z", "-t", overlay_pane)]
 
 
+#: The format that says whether the window an overlay is in is zoomed right now.
+#:
+#: Read through `if-shell -F` rather than believed, because :func:`unzoom_argv` has exactly
+#: one command to spend and tmux's `resize-pane -Z` is a **toggle** — no version has an
+#: "unzoom" flag, and `cmd-resize-pane.c` unzooms the WINDOW when the window is zoomed and
+#: zooms the target pane when it is not. So a bare toggle sent to a pane that had already
+#: been unzoomed (an operator's own prefix key on charter's shared private server, a
+#: `frame-resize` in flight) would zoom the confirmation back over the whole window, which
+#: is exactly the state it exists to leave.
+ZOOMED_FLAG = "#{window_zoomed_flag}"
+
+
+def unzoom_argv(server: str, *, overlay_pane: str) -> list[str] | None:
+    """Give *overlay_pane* its five rows back — a confirmation is a **drawer**, #921.
+
+    *"no any modal/drawer for confirmation"*, reported about a surface that has had one
+    since it was written. :func:`modal_argvs` ends in `resize-pane -Z`, so a two-row
+    confirmation about one chat took the entire window and read as an entirely new place
+    rather than as something that had opened over the frame the operator was looking at.
+
+    **Dropping the zoom does not hide it.** :func:`open_argv` splits `-v -l` at
+    :data:`_SPLIT_ROWS`, so what the pane goes back to is five rows at the bottom of the
+    window with the frame still drawn above it. Measured on tmux 3.7c, a 100x30 window with
+    the overlay split off the harness::
+
+        after resize-pane -Z    %0 h=24 active=0 zoomed=1   %1 h=30 active=1 zoomed=1
+        after the unzoom        %0 h=24 active=0 zoomed=0   %1 h=5  active=1 zoomed=0
+
+    **#739's five-row pane is not this one, and the difference is `active`.** That defect
+    was a second overlay ORPHANED by a double `F2` — blank, unfocused, holding a live
+    Python process nothing could reach, which is why it read as empty terminal above the
+    repo table. This pane is the focused one, is where the keyboard is, and is the pane
+    whose :data:`MOUSE_ON` the terminal follows. Measured on 3.7c through a real pty: with
+    the overlay unzoomed and active, the outer terminal still received
+    ``\\x1b[?1006h\\x1b[?1000h`` from this pane. The zoom was never what made the pointer
+    work — `select-pane` is, and :func:`modal_argvs` keeps it.
+
+    **The PALETTE keeps the whole window and only the confirmation gives it up.** The
+    palette lists every action, every doorway and every name an operator types towards; it
+    scrolls, has no row cap by design, and earns the rows. A confirmation is one question,
+    with the answer at the top and the consequences under it.
+
+    `if-shell -F` and not a bare toggle — see :data:`ZOOMED_FLAG`. ``None`` for a pane id
+    that is not tmux's own word for one, following every other builder here: charter would
+    rather send nothing than aim `resize-pane -Z` at a target it cannot predict the parse
+    of, and a `-t` tmux cannot resolve is a command that acts on the CURRENT pane —
+    :func:`sweep_argv` records what that costs one function up.
+    """
+    if not tmuxctl.PANE_ID_RE.fullmatch(overlay_pane):
+        return None
+    return tmuxctl.server_argv(server, "if-shell", "-F", "-t", overlay_pane, ZOOMED_FLAG,
+                               f"resize-pane -Z -t {overlay_pane}")
+
+
 def close_argvs(server: str, *, harness: str, overlay_pane: str) -> list[list[str]]:
     """Hand the pane back: focus the harness, kill the overlay, disarm the hatch.
 

--- a/charter/frame/slots.py
+++ b/charter/frame/slots.py
@@ -3425,13 +3425,14 @@ class _Tabs:
     reports and this repository deletes.
     """
 
-    __slots__ = ("_cols", "_here", "_more", "_add")
+    __slots__ = ("_cols", "_here", "_more", "_add", "_close")
 
     def __init__(self) -> None:
         self._cols: dict[tuple[int, int], str] = {}
         self._here = ""
         self._more: frozenset[tuple[int, int]] = frozenset()
         self._add: frozenset[tuple[int, int]] = frozenset()
+        self._close: frozenset[tuple[int, int]] = frozenset()
 
     def forget(self) -> None:
         """Back to a bar nobody has drawn — for a test, and only a test.
@@ -3442,7 +3443,7 @@ class _Tabs:
         """
         self.publish({}, "")
 
-    def publish(self, columns: dict, here: str, more=(), add=()) -> None:
+    def publish(self, columns: dict, here: str, more=(), add=(), close=()) -> None:
         """Record what the paint that just happened put in each cell, and where you are.
 
         *columns* maps a ``(row, column)`` of the component's OWN canvas — the rectangle
@@ -3481,6 +3482,12 @@ class _Tabs:
         *make a new one* — and a caller told "this cell is special" would have to ask a
         second question anyway to know which.
 
+        *close* is the same for :data:`CLOSE_CHAT`, the `-` drawn beside it (#921). A
+        fifth thing for the fourth's reason exactly, and the pair is why the reason is
+        worth restating: `+` and `-` sit one cell apart and mean opposite things, so a
+        caller handed "this cell is one of the affordances" would have to ask which — and
+        the one it must never guess at is the one that opens a teardown.
+
         A `frozenset` and not a range, because the two counts are two disjoint runs and
         the narrow rung's is a third — and because :meth:`more_at` asks about ONE cell,
         which is the same question `_cols` answers and should be the same kind of lookup.
@@ -3489,6 +3496,7 @@ class _Tabs:
         self._here = here
         self._more = frozenset(more)
         self._add = frozenset(add)
+        self._close = frozenset(close)
 
     def switch_to(self, row: int, col: int):
         """The tab a click at canvas cell (*row*, *col*) should switch to, or ``None``.
@@ -3590,6 +3598,32 @@ class _Tabs:
         screen together to be confused with each other.
         """
         return (row, col) in self._add
+
+    def close_at(self, row: int, col: int) -> bool:
+        """Whether cell (*row*, *col*) is the affordance that asks about CLOSING a chat.
+
+        *"we have plus button - that adding new session tab, but no any option to
+        delete/stop, no any modal/drawer for confirmation."* Closing a chat had been
+        possible the whole time — `F2 → chat: close`, or a right press on a tab — and
+        neither is written anywhere on the frame. The strip drew `+` and nothing else, so
+        the operator concluded that making was offered and unmaking was not, which is the
+        only conclusion the row supported (#921).
+
+        **A fourth question and a fourth method**, for :meth:`add_at`'s reason and one
+        sharper one. This cell is not a tab (there is nothing to switch to), not a `+N`
+        (it stands for no name at all) and above all not :meth:`add_at` — it is drawn one
+        cell away from it and means the opposite. A single "is this an affordance" answer
+        would put the decision about WHICH one at the call site, where a mistake spawns a
+        teardown surface for a press that meant *new*.
+
+        **And what it opens is a question, never an answer.** `frame/builtins._bar_events`
+        spawns the same `charter frame-palette --tab` a right press on this chat's own tab
+        spawns, so the route is new and the authority is not: the menu's `chat: close` row
+        is a doorway onto `leave.confirm_rows`, and the keypress that commits is the one
+        that module mints. §4i in one line — *a pointer opens the question; the keyboard
+        answers it*.
+        """
+        return (row, col) in self._close
 
 
 #: The one tab strip this process's bar draws into. See :class:`_Tabs` for why there is
@@ -3813,8 +3847,42 @@ def _cuts(fields: list[str], room: int, gap: int) -> list[int]:
     return cuts
 
 
+#: The one cell between the two affordances a strip draws at its end — `+` and `-`.
+#:
+#: **One blank and not a :func:`_bar_gap`, because they are a PAIR and the gap is a seam
+#: between two tabs.** Every other space on this row separates two things that are about
+#: different chats; these two are about the same strip and read as one control, which is
+#: the whole of what #921 asks the row to say — a strip drawing `+` alone says making is
+#: offered and unmaking is not. On a plane at ``rules = "visible"`` a `_bar_gap` would draw
+#: `+ | -`, putting a seam through the pair that the pair exists to deny.
+#:
+#: It also costs the names one column instead of two, and the names are the readout
+#: (:data:`ADD_CHAT`). The cell itself belongs to neither affordance — `_tab_columns`' rule
+#: for the gap between two tabs, kept here: a press on a separator has nothing to be about,
+#: and picking the nearer neighbour for it would mean a press aimed between `+` and `-`
+#: guessing which of *make* and *unmake* was meant.
+_NOTE_GAP = " "
+
+
+def _affordances(note: str, close: str) -> str:
+    """The trailing affordances composed into the one field the ladder measures.
+
+    :func:`_compose` needs this twice — once for the rung that draws every name on a
+    single row and once for the run that draws them over several — and the two must
+    compose the identical string, because :func:`_span` measures where the second
+    affordance starts by subtracting its width from this one's.
+
+    An absent field contributes nothing, separator included: a bar handed no *close* draws
+    exactly the `+` it drew before #921, at exactly the width it drew it at, which is what
+    keeps `slots.workspaces_bar` and every existing measurement of the chat strip's `+`
+    unchanged.
+    """
+    return _NOTE_GAP.join(f for f in (note, close) if f)
+
+
 def _bar(names: list[str], here: str, width: int, *,
-         note: str = "", rows: int = 1, busy=(), counts=None) -> list[str]:
+         note: str = "", close: str = "", rows: int = 1, busy=(),
+         counts=None) -> list[str]:
     """One bar: *names* with *here* marked, in *rows* x *width* cells.
 
     :func:`_compose` composes it and this is what PUBLISHES it — the one call that writes
@@ -3827,19 +3895,19 @@ def _bar(names: list[str], here: str, width: int, *,
 
     *busy* and *counts* are :func:`_compose`'s and are passed straight through — see there.
     """
-    lines, cols, more, add = _compose(names, here, width, note=note, rows=rows,
-                                      busy=busy, counts=counts)
-    TABS.publish(cols, here, more, add)
+    lines, cols, more, add, close_cells = _compose(
+        names, here, width, note=note, close=close, rows=rows, busy=busy, counts=counts)
+    TABS.publish(cols, here, more, add, close_cells)
     return lines
 
 
 def _compose(names: list[str], here: str, width: int, *,
-             note: str = "", rows: int = 1, busy=(), counts=None):
+             note: str = "", close: str = "", rows: int = 1, busy=(), counts=None):
     """The strip *names*/*here* composes to, and the cells its tabs landed in.
 
-    Answers ``(lines, columns, more, add)`` — the rows to draw, the ``(row, col)`` map
-    :meth:`_Tabs.publish` takes, and the two cell sets that are not tabs. :func:`_bar` is
-    the caller that publishes; nothing here writes anything down.
+    Answers ``(lines, columns, more, add, close)`` — the rows to draw, the ``(row, col)``
+    map :meth:`_Tabs.publish` takes, and the three cell sets that are not tabs.
+    :func:`_bar` is the caller that publishes; nothing here writes anything down.
 
     *rows* is how many rows the PANE has, which the strip grows into only as far as its
     names need (#829). One is the shipped shape and every rung below is unchanged at it.
@@ -3913,8 +3981,15 @@ def _compose(names: list[str], here: str, width: int, *,
     columns from a raw name and one separator made the row wider than the pane.
 
     *note* is an extra field drawn after the names when there is room for it whole — the
-    "add chat" affordance, and nothing else today. Dropped first, before any name, because
-    it is a reminder and the names are the readout.
+    "add chat" affordance (:data:`ADD_CHAT`). Dropped first, before any name, because it is
+    a reminder and the names are the readout.
+
+    *close* is the "close chat" affordance (:data:`CLOSE_CHAT`) drawn one cell after it,
+    and the two are one field as far as the ladder is concerned (:func:`_affordances`):
+    they are measured together, dropped together, and there is no width at which a strip
+    offers to make a chat and not to unmake one. That is #921's rule said in arithmetic
+    rather than in a comment — the report is an operator who read a row drawing `+` alone
+    and concluded, correctly from the evidence, that closing was not offered.
 
     *counts* is how many chats each name holds, or ``None`` for a strip with no count field
     at all (:func:`_chats_strip`). Where it is a map, EVERY tab reserves
@@ -3982,7 +4057,7 @@ def _compose(names: list[str], here: str, width: int, *,
     gap = _bar_gap()
     gapw = tui.width(gap)
 
-    def rung(drawn_rows=(), more=(), add=()):
+    def rung(drawn_rows=(), more=(), add=(), close_cells=()):
         """This rung's rows, and the cell map for the tabs they actually drew.
 
         **Every way out of the ladder goes through here**, which is what keeps "the map
@@ -4008,16 +4083,20 @@ def _compose(names: list[str], here: str, width: int, *,
         strip is the only thing that knows where it put them, and a second walk of the
         ladder to find them again is a second answer to what is on screen.
 
-        *add* is the same for :data:`ADD_CHAT`, on the one rung that draws it.
+        *add* is the same for :data:`ADD_CHAT`, on the one rung that draws it, and
+        *close_cells* the same for :data:`CLOSE_CHAT` beside it. Named `close_cells` rather
+        than `close` because what it holds is CELLS and the enclosing function's `close` is
+        the glyph — two names for one word on a strip whose whole subject is which cell a
+        field is in is the reading error `bottom` is spelled out to refuse, one rung down.
         """
         cols: dict = {}
         lines: list[str] = []
         for r, (before, body, drawn) in enumerate(drawn_rows):
             cols.update(_tab_columns(r, tui.width(lead + before), drawn, gapw))
             lines.append(lead + before + body)
-        return lines, cols, more, add
+        return lines, cols, more, add, close_cells
 
-    def row(body: str = "", drawn=(), before: str = "", more=(), add=()):
+    def row(body: str = "", drawn=(), before: str = "", more=(), add=(), close_cells=()):
         """A rung that draws ONE row, said the way three of the four rungs say it.
 
         :func:`rung`'s single-row case, and a wrapper rather than a shape every rung has to
@@ -4027,7 +4106,7 @@ def _compose(names: list[str], here: str, width: int, *,
         the rung that draws nothing — rung 4, and a bar with no names — which is no rows at
         all rather than one blank one.
         """
-        return rung([(before, body, drawn)] if body else [], more, add)
+        return rung([(before, body, drawn)] if body else [], more, add, close_cells)
 
     if not names:
         return row()
@@ -4092,12 +4171,24 @@ def _compose(names: list[str], here: str, width: int, *,
     painted = [chrome.block(f) if i == at else f for i, f in enumerate(marked)]
     room = width - tui.width(lead)
     joined = gap.join(marked)
-    if note and tui.width(joined) + gapw + tui.width(note) <= room:
-        # The affordance's own cells, measured off this composition — :func:`_span`'s
-        # reason, and the same walk the counts get one rung down. It is drawn only where
-        # the whole list is on the strip, which is why a `+` and a `+9` are never on one.
-        return row(gap.join(painted) + gap + note, zip(names, marked),
-                   add=_span(0, tui.width(lead + joined + gap), note))
+    # **One field, measured once**, and that is what makes `+` and `-` inseparable rather
+    # than merely adjacent: the ladder asks whether there is room for the pair, so there is
+    # no width at which the strip offers to make a chat and not to unmake one (#921).
+    buttons = _affordances(note, close)
+    if buttons and tui.width(joined) + gapw + tui.width(buttons) <= room:
+        # The affordances' own cells, measured off this composition — :func:`_span`'s
+        # reason, and the same walk the counts get one rung down. Drawn only where the
+        # whole list is on the strip, which is why a `+` and a `+9` are never on one.
+        #
+        # **Where the second one starts is a subtraction and not a second composition.**
+        # `buttons` is what was drawn; `close` is its tail; so the offset is the width of
+        # everything in front of it, which cannot disagree with the string. Computing it
+        # from `note` and :data:`_NOTE_GAP` instead would be a second answer to what
+        # :func:`_affordances` composed, and the two would part the day a field is added.
+        at = tui.width(lead + joined + gap)
+        return row(gap.join(painted) + gap + buttons, zip(names, marked),
+                   add=_span(0, at, note),
+                   close_cells=_span(0, at + tui.width(buttons) - tui.width(close), close))
     if tui.width(joined) <= room:
         return row(gap.join(painted), zip(names, marked))
     if at >= 0:
@@ -4146,7 +4237,18 @@ def _compose(names: list[str], here: str, width: int, *,
         # second ROW is on screen with the first. `note` is already `""` where a caller
         # passed none, so the conjunct testing it again was a line no input could make
         # observable and is not written.
-        tail = note if not leading and not trailing else ""
+        #
+        # **The pair rides it together** (#921). `tail_add` and `tail_close` are the two
+        # affordances as this run drew them — both, or neither — and `tail` is what
+        # :func:`_affordances` composes them into, which is the same call the single-row
+        # rung makes. Two locals rather than one, because each is also the string
+        # :func:`_span` measures its own cells from: an affordance that is not on this run
+        # is `""` there, so both spans come out empty by arithmetic rather than by a test
+        # somebody has to keep true — the discipline the paragraph below states for the
+        # counts, kept for the affordances.
+        tail_add = note if not leading and not trailing else ""
+        tail_close = close if not leading and not trailing else ""
+        tail = _affordances(tail_add, tail_close)
         # **Which row each field that is NOT a name goes on, decided ONCE and not per
         # row.** The leading count belongs beside the first tab drawn and the trailing one
         # after the last, because that is where the names they stand for actually are; on a
@@ -4184,7 +4286,10 @@ def _compose(names: list[str], here: str, width: int, *,
         # whole subject is which row a field is on is the reading error to refuse.
         bottom = len(plain) - 1
         counts = _span(0, start, leading) + _span(bottom, ends[bottom], trailing)
-        add = _span(bottom, ends[bottom], tail)
+        add = _span(bottom, ends[bottom], tail_add)
+        close_cells = _span(bottom,
+                            ends[bottom] + tui.width(tail) - tui.width(tail_close),
+                            tail_close)
         # Measured, not assumed. :func:`_cuts` puts at least one name on a page, so a name
         # wider than the whole row composes a body that overflows — and this ladder gives a
         # rung up rather than drawing part of anything. Measured on the PLAIN rows for the
@@ -4193,7 +4298,7 @@ def _compose(names: list[str], here: str, width: int, *,
         # is measured, not just the first: a run whose second page overflows is a strip
         # drawing part of a name on a row nothing else would have looked at.
         if all(tui.width(before + body) <= room for before, body in plain):
-            return rung(painted_rows, more=counts, add=add)
+            return rung(painted_rows, more=counts, add=add, close_cells=close_cells)
     counted = f"{at + 1}/{len(names)}" if at >= 0 else str(len(names))
     if tui.width(counted) <= room:
         # **The narrow rung is a count too, and it is the one where this matters most.**
@@ -4235,6 +4340,42 @@ def _compose(names: list[str], here: str, width: int, *,
 #: confused: :func:`_bar` draws this only on the rung where every name fits, and draws a
 #: count only on the rung where they do not.
 ADD_CHAT = "+"
+
+#: The chat bar's close-chat affordance (#921) — the `-` beside the `+`, and one cell of it.
+#:
+#: *"we have plus button - that adding new session tab, but no any option to delete/stop,
+#: no any modal/drawer for confirmation."*
+#:
+#: **Closing a chat was already possible and the strip did not say so.** `F2 → chat: close`
+#: and a right press on a tab both reach it; neither is written anywhere on the frame, which
+#: advertises exactly two things — `F2 palette` on the attention row and this row's `+`. So
+#: an operator read a strip offering to MAKE a chat and nothing else, and concluded the
+#: system would not let them close one. **That conclusion was correct given the evidence**,
+#: and it is a worse failure than an unadvertised create: a create nobody finds costs a
+#: feature, a destroy nobody finds costs trust in the tool.
+#:
+#: **It does not close on the press, and that is the whole of §4i.** `frame/builtins
+#: ._bar_events` spawns `charter frame-palette --tab <this chat>` — byte for byte what a
+#: right press on this chat's own tab already spawns — so what a press opens is the menu
+#: whose `chat: close` row is a doorway onto `leave.confirm_rows`. A pointer opens the
+#: question; the keyboard answers it. Compare the `+` beside it, which acts on the press
+#: because nothing is destroyed by another chat.
+#:
+#: **The active chat, and closing any other stays a right press.** This is one glyph at the
+#: end of the row, not a `×` per tab: a per-tab affordance would cost a column on every tab
+#: and re-cut the strip, which is exactly the shape :data:`TAB_COUNT_W` reserves against and
+#: :data:`TAB_SPINNER` was refused in. The chat you are in is the one a single glyph can
+#: honestly be about, and it is also the commonest chat anyone closes.
+#:
+#: **ASCII — `-`, U+002D — and NOT `−`, U+2212**, though `tui.width` measures both as one
+#: cell and U+2212 is East-Asian *Neutral*. :data:`_BAR_RULE` states the rule as the ROW's
+#: rather than as any one constant's: a click here is resolved by COLUMN, and the glyph to
+#: put on this row is *the one whose width no terminal disagrees about*. A mathematical
+#: minus is a codepoint a terminal font may not carry, and a fallback into a CJK face draws
+#: two cells whatever the table says. What that buys is a prettier dash; what it risks is
+#: the one failure class this project refuses — *fires wrongly* rather than *never fires*.
+#: `+` and `-` are also the pair every operator already reads as make-and-unmake.
+CLOSE_CHAT = "-"
 
 
 #: The largest chat count a workspace tab draws as a number. Above it the field says
@@ -4340,8 +4481,14 @@ def working_chats() -> frozenset:
 
 
 def _chats_strip(fid: str):
-    """What the chat strip is a strip OF — its names, the one you are typing in, its note,
-    and no count field.
+    """What the chat strip is a strip OF — its names, the one you are typing in, both of
+    its affordances, and no count field.
+
+    **Both affordances or neither** (#921). :data:`ADD_CHAT` and :data:`CLOSE_CHAT` are
+    handed over as one pair because :func:`_compose` measures them as one field, so there
+    is no width and no rung at which this strip offers to make a chat and not to unmake
+    one. The report this answers is an operator reading a row that drew `+` alone and
+    concluding — correctly, from what was on it — that closing a chat was not on offer.
 
     **``None`` for the counts and not an empty map**, which are different instructions to
     :func:`_compose`: ``None`` reserves nothing, ``{}`` reserves :data:`TAB_COUNT_W` on
@@ -4359,7 +4506,7 @@ def _chats_strip(fid: str):
     spending nine columns of a row whose names are competing for them.
     """
     from . import chats as chats_mod
-    return [c.id for c in chats_mod.roster(fid)], fid, ADD_CHAT, None
+    return [c.id for c in chats_mod.roster(fid)], fid, ADD_CHAT, CLOSE_CHAT, None
 
 
 def _workspace_counts() -> dict:
@@ -4407,13 +4554,20 @@ def _workspaces_strip(fid: str):
     open something that takes a name, which is `charter workspace create` and is not a
     thing a one-row strip can be.
 
+    **And no `-` either, which is the same decision and not a second one** (#921). The rule
+    that strip earns its `-` from is *a surface that advertises making a thing must
+    advertise unmaking it*; a strip that advertises neither owes neither. There is no route
+    to removing a workspace anywhere in the frame today — `workspace: close` is specified
+    and unimplemented — and a `-` beside no `+` would be the create side's failure with the
+    signs exchanged. It is filed on its own; chats prove the pattern first.
+
     **The counts are this strip's and the chat strip has none** (#880) — see
     :func:`_workspace_counts` for the one grouped read and for why it does not put this
     strip on a clock, and :data:`TAB_COUNT_W` for why the field is there on every tab even
     when the number is not.
     """
     from . import switch as switch_mod
-    return (switch_mod.workspaces(fid), switch_mod.current_workspace(fid), "",
+    return (switch_mod.workspaces(fid), switch_mod.current_workspace(fid), "", "",
             _workspace_counts())
 
 
@@ -4495,12 +4649,13 @@ def bar_rows_wanted(fid: str, slot: str, *, pane_cols: int, cap: int) -> int:
     entry = BARS.get(slot)
     if entry is None:
         return 1
-    names, here, note, counts = entry(fid)
+    names, here, note, close, counts = entry(fid)
     width = pane_cols - 2 * pad_for(slot, pane_cols)
     filled = 1
     for rows in range(1, cap + 1):
-        lines, _cols, _more, _add = _compose(names, here, width,
-                                             note=note, rows=rows, counts=counts)
+        lines, _cols, _more, _add, _close = _compose(names, here, width, note=note,
+                                                     close=close, rows=rows,
+                                                     counts=counts)
         if len(lines) == rows:
             filled = rows
     return filled
@@ -4525,9 +4680,9 @@ def chats_bar(fid: str, width: int, rows: int = 1) -> list[str]:
     dispatches and this chat's notice dwell, and neither is "a sibling chat's harness
     started working".
     """
-    names, here, note, counts = _chats_strip(fid)
-    return _bar(names, here, width, note=note, rows=rows, busy=working_chats(),
-                counts=counts)
+    names, here, note, close, counts = _chats_strip(fid)
+    return _bar(names, here, width, note=note, close=close, rows=rows,
+                busy=working_chats(), counts=counts)
 
 
 def workspaces_bar(fid: str, width: int, rows: int = 1) -> list[str]:
@@ -4536,8 +4691,8 @@ def workspaces_bar(fid: str, width: int, rows: int = 1) -> list[str]:
     :func:`chats_bar`'s rules and its ladder, one noun over — see :func:`_workspaces_strip`
     for what it draws and why it draws no `+`.
     """
-    names, here, note, counts = _workspaces_strip(fid)
-    return _bar(names, here, width, note=note, rows=rows, counts=counts)
+    names, here, note, close, counts = _workspaces_strip(fid)
+    return _bar(names, here, width, note=note, close=close, rows=rows, counts=counts)
 
 
 #: Which slots draw something that CHANGES ON ITS OWN, with no version bump and no

--- a/charter/frame/tabmenu.py
+++ b/charter/frame/tabmenu.py
@@ -399,9 +399,17 @@ def draw(args) -> int:
             # the same round trip `commands_frame._picker` makes for the identical
             # doorway, and it is what makes the warning describe the plane as it is under
             # the keypress rather than as it was when the pointer landed.
-            return opens(row, target,
-                         live=commands_frame._plane_live(
-                             commands_frame._plane_servers())[0])
+            #
+            # **The confirmation is a drawer here too, and through the same call** (#921).
+            # `commands_frame._as_a_drawer` passes `None` straight back, so the transcript
+            # row is untouched and the close doorway gives the window up — two routes to
+            # `leave.confirm_rows` that must not look different, which is the whole reason
+            # `opens` builds the identical surface `_picker` does.
+            return commands_frame._as_a_drawer(
+                opens(row, target,
+                      live=commands_frame._plane_live(
+                          commands_frame._plane_servers())[0]),
+                socket=socket, pane=overlay_pane)
 
         # `act` takes the cancel too (`own_the_tty` answers `None` for Escape, for the
         # hatch, and for a pane whose writer is gone), so there is no branch here that a

--- a/docs/frame.md
+++ b/docs/frame.md
@@ -257,6 +257,13 @@ first. Close is a doorway, not a button: pressing it draws the same warning `F2 
 close` draws, naming the chat and what stopping it costs, and the keypress on *that* is what
 stops the harness. Escape leaves, `F12` always leaves, and nothing is stopped by a pointer.
 
+**A confirmation is a drawer; the palette is the whole window.** The palette and the pickers
+zoom over the frame because they are lists that scroll and have no length limit. A
+confirmation is one question with its answer at the top, so it gives the window back and
+draws in the five rows at the bottom of it, with the frame you were looking at still above.
+It is still the pane the keyboard and the pointer are in — the zoom was never what made
+those work.
+
 Right-click on the tab you *are* on works too — closing the chat you are in is the ordinary
 case of closing one. Right-click on the left inset, on the `+`, on a `+N` count or on empty
 space does nothing at all, and the `workspaces` bar has no menu: a workspace has neither a
@@ -737,11 +744,29 @@ that thinks for longer than that with no tool call blinks off and comes back on 
 one. There is no third answer available from a hook channel that reports prompts and tool
 calls: charter can be late to stop claiming, or early, and it is set to be early.
 
-**The chat bar ends in a `+`, and pressing it opens another chat.** Same workspace, same
-harness you are already in, its id allocated for you — which is why it takes nothing and
-asks nothing. It runs `charter frame-new-chat`, which is `charter <harness>` in this
-workspace with one difference: it builds the frame without becoming your terminal, because
-the process behind a click is not one.
+**The chat bar ends in a `+` and a `-`, and one of them is a button and one is a door.**
+Pressing the `+` opens another chat: same workspace, same harness you are already in, its
+id allocated for you — which is why it takes nothing and asks nothing. It runs `charter
+frame-new-chat`, which is `charter <harness>` in this workspace with one difference: it
+builds the frame without becoming your terminal, because the process behind a click is not
+one.
+
+**Pressing the `-` closes nothing.** It opens the menu about the chat you are in — the same
+one a right-click on that tab opens — whose `chat: close` row draws the warning naming the
+chat and what stopping it costs, and the keypress on *that* is what stops it. A pointer
+opens the question; the keyboard answers it, which is why making a chat may happen on a
+press and unmaking one may not.
+
+It is one glyph at the end of the row rather than a `×` on every tab, because a per-tab
+affordance would cost a column on every tab and move every one of them the moment a chat
+opened or closed — and the cell you were about to press would hold another chat's name.
+Closing a chat you are *not* in is the right-click on its own tab.
+
+The `-` is there because the frame was not saying it existed. Closing a chat has always
+been possible by `F2 → chat: close` and by right-click, and a strip that drew `+` and
+nothing else read as a tool that would let you make chats and not get rid of them. An
+unadvertised way to create something costs you a feature; an unadvertised way to destroy
+something costs you the belief that it is there.
 
 It stops, and says why on the attention row, in four cases: your frame is a window in a
 tmux you already had (charter makes no chats for you there — `charter <harness>` in the
@@ -749,9 +774,11 @@ workspace still does); charter cannot prove the workspace's tmux session is this
 rather than another project's; this chat records no harness charter can launch and your
 plane declares no `[harness] default`; or charter cannot enter the workspace's directory.
 
-**The workspace bar has no `+`, deliberately.** A new chat is nothing but a press. A new
+**The workspace bar has neither, deliberately.** A new chat is nothing but a press. A new
 workspace is a directory and a *name*, which is `charter workspace create` — and a picker
-that creates on a typo leaves litter.
+that creates on a typo leaves litter. And a strip that offers no way to make a thing owes
+no way to unmake one: there is no route to removing a workspace anywhere in the frame yet,
+so a `-` there would be the same gap with the sign reversed.
 
 **Each workspace tab says how many chats it holds** — `some-workspace 5`. A workspace with
 none draws a blank, so every count you see means something, and past nine the field says
@@ -1068,6 +1095,13 @@ cannot be resumed still comes back: its directory, its workspace and its persona
 only the conversation is gone. A chat whose *workspace* has been deleted comes back too, into
 a remade and empty one, and says the workspace was missing; charter never quietly re-homes a
 chat, and a workspace it re-makes is the chat's own.
+
+**`F2 → chat: new`** opens another chat in this workspace — the `+` on the chat strip, as a
+row you can reach with the keyboard. That matters more than it sounds: `[frame] mouse` is
+**off** by default, so on a plane that has not turned the pointer on the `+` cannot be
+pressed at all, and until this row existed the frame had no way to make a chat from inside
+itself. Every pointer affordance charter draws has a key as well, and this was the one that
+did not.
 
 **`F2 → chat: previous transcript`** opens what a chat had on screen before it was last
 stopped, in a pager, in a window of its own. tmux history dies with its session and
@@ -2437,6 +2471,7 @@ charter · 16 to choose from
   * chrome: off
     chrome: dark
     chrome: light
+    chat: new — another chat in this workspace
     chat: previous transcript          no previous transcript for this chat — one …
     refresh — gather this workspace's repos, todos and changes again
     charter: quit — stop every harness on this plane

--- a/docs/news/unreleased-the-frame-says-how-to-close-a-chat-and-not-only-how-to-make-one.md
+++ b/docs/news/unreleased-the-frame-says-how-to-close-a-chat-and-not-only-how-to-make-one.md
@@ -1,0 +1,89 @@
+---
+version: unreleased
+headline: The frame says how to close a chat, and not only how to make one
+---
+
+*"now for example no way to reactivelly close harness session, we have plus button - that
+adding new session tab, but no any option to delete/stop, no any modal/drawer for
+confirmation."*
+
+Closing a chat has been possible the whole time. `F2 → chat: close` does it, and so does a
+right-click on a tab, and both draw a confirmation naming the chat and what stopping it
+costs. The operator could not find either, and concluded from what was on screen that the
+system would not let them do it.
+
+**That conclusion was correct given the evidence.** The frame advertises exactly two
+things: `F2 palette` on the attention row, and `+` on the chat strip. Not `F3`, not `F12`,
+not the right-click menu, not the border drag, not that a tab is clickable at all — and
+nothing anywhere about closing. A strip that draws `+` and nothing else says *making is
+offered, unmaking is not*.
+
+## The rule this establishes
+
+**A surface that advertises creating a thing must advertise unmaking it, at the same weight
+and in the same place.**
+
+An unadvertised create costs an operator a feature they did not know about. An unadvertised
+destroy makes them conclude the system will not let them do it, which is strictly worse: the
+first is a gap, the second reads as a limitation of the tool.
+
+## Three things changed
+
+**`chat: new` is a palette row.** This was charter's own rule broken by charter:
+*"a component whose only route to a piece of state is a click has no route to it on most
+planes — give every pointer affordance a key as well"*. `[frame] mouse` ships **off**, and
+the palette had no new-chat row, so on a default plane an operator could not make a chat
+from the frame at all and the one glyph the frame advertises could not be pressed. It runs
+the same `charter frame-new-chat` the `+` does.
+
+**The chat strip draws a `-` beside its `+`.** It closes nothing on the press — it opens the
+menu about the chat you are in, the same one a right-click on that tab opens, whose `chat:
+close` row draws the warning and hands the decision to a keypress. A pointer opens the
+question; the keyboard answers it. Its value is not that it is faster; it is that a strip
+drawing `+` and `-` **says closing exists**, which is the whole failure.
+
+```
+   api.1  *api.2  + -
+```
+
+One glyph at the end of the row, not a `×` on every tab: a per-tab affordance would cost a
+column on every tab and re-cut the strip, so the cell you were about to press would hold
+another chat's name a moment later. Measured at every width from 0 to 220 and at one, two
+and three rows — the tab column map is byte-identical with the `-` and without it.
+
+It is an ASCII `-`, not `−` (U+2212). Both measure one cell and U+2212 is East-Asian
+Neutral; a click on this row is resolved by column, and the glyph to draw is the one whose
+width no terminal disagrees about. A mathematical minus is a codepoint a terminal font may
+not carry, and a fallback into a wide face moves every field after it.
+
+**The confirmation is a drawer.** It used to take the whole window — the overlay pane is
+zoomed, so a two-row question about one chat arrived full-screen and read as somewhere else
+entirely. It now gives the window back and draws in the five rows at the bottom, with the
+frame you were looking at still above it. The palette and the pickers keep the whole pane:
+they are lists that scroll and have no length limit, and they earn it.
+
+The pane is still the active one, which is the only thing the zoom was ever load-bearing
+for. Measured on tmux 3.7c through a real pty: unzoomed and focused, it is `h=5 active=1`
+and the outer terminal still receives that pane's own mouse request.
+
+## The rule is a test
+
+`tests/test_the_palette_advertises_unmaking_what_it_makes.py` asks it of the palette's own
+catalogue — the rows are data, and with the pointer off by default the palette is not merely
+the primary surface, it is the only one. Every kind of thing the catalogue offers to make is
+a kind it offers to unmake, stated as an equality so it fires in both directions.
+
+Against the previous release it fails on the destroy side standing alone, which is exactly
+how this shipped:
+
+```
+AssertionError: Items in the second set but not the first:
+'chat' : the palette makes [] and unmakes ['chat'] — every kind of thing a surface offers
+to make must be a kind it offers to unmake, at the same weight and in the same place
+```
+
+The day someone adds a create with no destroy, it fails the other way.
+
+`workspace: close` is the next one this rule points at: it is specified, referenced, and
+unimplemented, and there is no way to remove a workspace from the frame at all. It is filed
+on its own — chats prove the pattern first.

--- a/tests/test_a_confirmation_is_a_drawer_not_a_window.py
+++ b/tests/test_a_confirmation_is_a_drawer_not_a_window.py
@@ -281,49 +281,108 @@ class ARealTmuxUnzoomsTheDrawer(unittest.TestCase):
         self.assertEqual(self._panes()[self.overlay],
                          (str(overlay._SPLIT_ROWS), "1", "0"))
 
-    def test_the_unzoomed_drawer_still_owns_the_terminals_mouse_mode(self):
-        """**The half of #739 that mattered and the half that does not.** The zoom was
-        never what made the pointer work — `select-pane` is, because the outer terminal's
-        mouse mode follows the ACTIVE pane (§4i) — and `modal_argvs` keeps it. Measured
-        through a real client on a real pty: with the overlay unzoomed and active, the
-        bytes `overlay.MOUSE_ON` writes reach the terminal outside tmux.
+    #: What `TERM` the measuring client attaches under. A tmux client refuses to start on
+    #: a terminal it cannot look up — `open terminal failed` — and a CI runner's `TERM` is
+    #: often `dumb` or absent, which is what turned this measurement into an empty read on
+    #: the first CI run. The operator's own comes first where it is usable;
+    #: `tests/test_a_real_click_on_a_real_tab_bar_switches` keeps the identical ladder for
+    #: the identical reason.
+    TERMS = tuple(dict.fromkeys(
+        ([os.environ["TERM"]] if os.environ.get("TERM", "dumb") != "dumb" else [])
+        + ["xterm-256color", "screen", "vt100"]))
+
+    def _attached(self):
+        """A real client on a real pty, and the master end to read it from.
+
+        ``None`` when no `TERM` this machine has lets a client start at all — which is not
+        a failure of the property below, it is the absence of anything to measure it with.
         """
-        master, slave = os.openpty()
-        fcntl.ioctl(slave, termios.TIOCSWINSZ,
-                    struct.pack("HHHH", self.ROWS, self.COLS, 0, 0))
-        client = subprocess.Popen(["tmux", "-L", SOCKET_NAME, "attach", "-t", "t"],
-                                  stdin=slave, stdout=slave, stderr=slave,
-                                  start_new_session=True)
-        def _stop():
+        for term in self.TERMS:
+            master, slave = os.openpty()
+            fcntl.ioctl(slave, termios.TIOCSWINSZ,
+                        struct.pack("HHHH", self.ROWS, self.COLS, 0, 0))
+            client = subprocess.Popen(
+                ["tmux", "-L", SOCKET_NAME, "attach", "-t", "t"],
+                stdin=slave, stdout=slave, stderr=slave, start_new_session=True,
+                env=dict(os.environ, TERM=term))
+            os.close(slave)
+            deadline = time.monotonic() + 10
+            while time.monotonic() < deadline:
+                if self._tmux("list-clients", "-t", "t").stdout.strip():
+                    def _stop():
+                        client.terminate()
+                        client.wait(timeout=10)
+                    self.addCleanup(_stop)
+                    self.addCleanup(os.close, master)
+                    os.set_blocking(master, False)
+                    return master
+                time.sleep(0.05)
             client.terminate()
             client.wait(timeout=10)
-        self.addCleanup(_stop)
-        os.close(slave)
-        self.addCleanup(os.close, master)
-        os.set_blocking(master, False)
+            os.close(master)
+        return None
 
-        def drain(seconds: float = 0.8) -> bytes:
-            out, end = b"", time.monotonic() + seconds
-            while time.monotonic() < end:
-                try:
-                    out += os.read(master, 65536)
-                except BlockingIOError:
-                    time.sleep(0.02)
-                except OSError:
-                    break
-            return out
+    @staticmethod
+    def _drain(master: int, seconds: float = 0.8) -> bytes:
+        out, end = b"", time.monotonic() + seconds
+        while time.monotonic() < end:
+            try:
+                out += os.read(master, 65536)
+            except BlockingIOError:
+                time.sleep(0.02)
+            except OSError:
+                break
+        return out
 
-        drain(1.0)
-        for cmd in overlay.modal_argvs(SOCKET_NAME, harness=self.harness,
-                                       overlay_pane=self.overlay):
-            self._run(cmd)
-        self._run(overlay.unzoom_argv(SOCKET_NAME, overlay_pane=self.overlay))
-        drain()
+    def _ask_for_mouse(self, master: int) -> bytes:
+        """Make the overlay pane withdraw and re-request mouse reporting, and answer with
+        whatever the client's terminal received.
+
+        The withdrawal first because a mode tmux is already in produces no new bytes: what
+        travels to the outer terminal is the CHANGE, so a measurement that only ever asked
+        would be reading the transition it happened to catch.
+        """
         tty = self._tmux("display-message", "-p", "-t", self.overlay,
                          "#{pane_tty}").stdout.strip()
         with open(tty, "wb", buffering=0) as f:
+            f.write(overlay.MOUSE_OFF.encode())
+            self._drain(master, 0.4)
             f.write(overlay.MOUSE_ON.encode())
-        saw = drain()
+        return self._drain(master)
+
+    def test_the_unzoomed_drawer_still_owns_the_terminals_mouse_mode(self):
+        """**The half of #739 that mattered and the half that does not.**
+
+        The zoom was never what made the pointer work — `select-pane` is, because the outer
+        terminal's mouse mode follows the ACTIVE pane (§4i) — and `modal_argvs` keeps it.
+        Measured through a real client on a real pty rather than argued.
+
+        **With its own positive control**, which is this repo's rule for a measurement that
+        depends on the machine (`test_the_hotkey_injection_this_guards_against_is_live_on
+        _this_tmux`): the ZOOMED overlay is the state charter ships, so if its request does
+        not reach the client either, this environment cannot show the property at all and
+        there is nothing here for the unzoom to break. That case skips and says so, rather
+        than reporting a defect in charter for a `TERM` a runner did not have.
+        """
+        master = self._attached()
+        if master is None:
+            self.skipTest("no client would attach on any of "
+                          f"{self.TERMS!r} — nothing to measure the request against")
+        self._drain(master, 1.0)
+        for cmd in overlay.modal_argvs(SOCKET_NAME, harness=self.harness,
+                                       overlay_pane=self.overlay):
+            self._run(cmd)
+        control = self._ask_for_mouse(master)
+        if b"1006h" not in control or b"1000h" not in control:
+            self.skipTest(
+                "this tmux/terminal does not propagate a pane's mouse request to the "
+                f"client even ZOOMED ({control!r}), so the unzoom cannot be measured "
+                "against it")
+
+        self._run(overlay.unzoom_argv(SOCKET_NAME, overlay_pane=self.overlay))
+        self.assertEqual(self._panes()[self.overlay],
+                         (str(overlay._SPLIT_ROWS), "1", "0"))
+        saw = self._ask_for_mouse(master)
         self.assertIn(b"1006h", saw, "the drawer's SGR request never left tmux")
         self.assertIn(b"1000h", saw, "the drawer's mouse request never left tmux")
 

--- a/tests/test_a_confirmation_is_a_drawer_not_a_window.py
+++ b/tests/test_a_confirmation_is_a_drawer_not_a_window.py
@@ -1,0 +1,332 @@
+"""**A confirmation gives the window back; the palette keeps it — #921.**
+
+*"no any modal/drawer for confirmation"*, reported about a surface that has had one since
+it was written. `overlay.modal_argvs` ends in `resize-pane -Z`, so every surface the
+overlay pane holds takes the entire window — and a two-row question about one chat arriving
+full-screen does not read as something that opened over the frame you were looking at. It
+reads as somewhere else.
+
+**Dropping the zoom does not hide it.** `overlay.open_argv` splits `-v -l 5`, so the pane
+goes back to five rows at the bottom of the window with the frame drawn above it, still the
+ACTIVE pane and still the one whose mouse request the terminal follows.
+
+**#739's five-row pane is not this one, and the difference is `active`.** That defect was a
+second overlay ORPHANED by a double `F2` — blank, unfocused, holding a live Python process
+nothing could reach. This pane is the focused one. :class:`ARealTmuxUnzoomsTheDrawer`
+measures both halves on a real server rather than arguing them: the pane keeps its five
+rows and its focus, and the outer terminal still receives this pane's own
+``\\x1b[?1006h\\x1b[?1000h``.
+
+**Only the confirmation.** The palette lists every action, every doorway and every name an
+operator types towards; it scrolls, has no row cap by design, and earns the rows. So does a
+picker, which is a list of names of unbounded length. What gives the window up is the one
+surface that is a single question with the answer at the top.
+
+**And both routes to it, through one call.** `F2 → chat: close` and a right press on a tab
+open the same `leave.confirm_rows` over the same plan; a route that unzoomed and a route
+that did not would be two confirmations wearing one name.
+"""
+
+from __future__ import annotations
+
+import fcntl
+import os
+import shutil
+import struct
+import subprocess
+import termios
+import time
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
+
+from charter import commands_frame
+from charter.frame import choose, leave, overlay, palette, state, tabmenu, tmuxctl
+
+from tests import _tmuxreap
+from tests._isolation import PersonaIso
+
+_HAS_TMUX = shutil.which("tmux") is not None
+
+#: The socket this module's real server runs on. `_tmuxreap.name` and never a spelling of
+#: its own: a socket the reaper does not recognise is a socket that leaks for the life of
+#: the machine, and that module records 497 of them in two days.
+SOCKET_NAME = _tmuxreap.name("i921-drawer")
+
+
+class TheUnzoomIsOneGuardedCommand(unittest.TestCase):
+    """`overlay.unzoom_argv` — what it sends, and what it refuses to send."""
+
+    def test_it_asks_before_it_toggles(self):
+        """**`resize-pane -Z` is a TOGGLE and there is no unzoom flag in any tmux.** A
+        bare toggle aimed at a pane that had already been unzoomed — an operator's own
+        prefix key on charter's shared private server — would zoom the confirmation back
+        over the whole window, which is the state this exists to leave."""
+        argv = overlay.unzoom_argv("charter", overlay_pane="%7")
+        self.assertIsNotNone(argv)
+        self.assertIn("if-shell", argv)
+        self.assertIn("-F", argv)
+        self.assertIn(overlay.ZOOMED_FLAG, argv)
+        self.assertEqual(argv[-1], "resize-pane -Z -t %7")
+
+    def test_it_names_the_pane_on_both_halves(self):
+        """The condition is read `-t` the pane and the command targets it too. A
+        `resize-pane -Z` with no `-t` acts on the CURRENT pane, which `overlay.sweep_argv`
+        records the cost of: on this server that is the operator's harness."""
+        argv = overlay.unzoom_argv("charter", overlay_pane="%12")
+        self.assertEqual(argv.count("%12"), 1, argv)
+        self.assertIn("%12", argv[-1])
+
+    def test_a_pane_it_cannot_spell_gets_no_command_at_all(self):
+        """Every builder in `frame/overlay.py` degrades this way, and this one has the
+        sharpest reason to: a `-t` tmux cannot resolve is a command that resizes something
+        else."""
+        for bad in ("", "0", "%", "pane", "%1;kill-server", "%1 %2", None):
+            self.assertIsNone(overlay.unzoom_argv("charter", overlay_pane=bad or ""),
+                              repr(bad))
+
+    def test_the_palette_still_takes_the_whole_window(self):
+        """The control, and the half of #921 that is deliberately NOT changed. If the zoom
+        left `modal_argvs`, every surface would be a drawer and the palette would lose the
+        rows it scrolls."""
+        cmds = overlay.modal_argvs("charter", harness="%0", overlay_pane="%7")
+        self.assertEqual(cmds[-1][-3:], ["-Z", "-t", "%7"])
+
+
+class _AFrameWithChatsToClose(PersonaIso):
+    """One frame on an isolated plane, with the tmux round trips observable."""
+
+    FID = "alpha.1"
+    SERVER = "charter-i921"
+
+    def setUp(self) -> None:
+        super().setUp()
+        for fid, ws in ((self.FID, "alpha"), ("alpha.2", "alpha")):
+            state.frame_dir(fid, create=True)
+            state.record_server(fid, self.SERVER)
+            state.record_workspace(fid, ws)
+            state.record_harness_pane(fid, "%1")
+            state.record_identity(fid, {"CHARTER_HARNESS": "claude-code",
+                                        "CHARTER_WORKSPACE": "", "CHARTER_PERSONA": ""})
+        self.live = ({self.FID, "alpha.2"},
+                     {self.SERVER: {self.FID: "@0", "alpha.2": "@1"}},
+                     set())
+        self.ran = []
+        self.enterContext(mock.patch.object(
+            commands_frame, "_plane_live", return_value=self.live))
+        self.enterContext(mock.patch.object(
+            commands_frame, "_plane_servers", return_value=(self.SERVER,)))
+        self.enterContext(mock.patch.object(
+            tmuxctl, "run",
+            side_effect=lambda _what, argv, **kw: self.ran.append(argv)
+            or SimpleNamespace(stdout="", stderr="", returncode=0)))
+
+    def _resizes(self):
+        """Every `resize-pane -Z` this test asked tmux for, whichever command carries it."""
+        return [a for a in self.ran if any("resize-pane -Z" in w or w == "-Z" for w in a)]
+
+
+class TheConfirmationGivesTheWindowBack(_AFrameWithChatsToClose, unittest.TestCase):
+    """`commands_frame._picker` — the `F2` route."""
+
+    def _open(self, row):
+        return commands_frame._picker(row, self.FID, [], socket=self.SERVER, pane="%7")
+
+    def test_the_close_doorway_unzooms_the_pane_it_is_drawn_in(self):
+        surface = self._open(leave.open_rows(self.FID)[1])
+        self.assertIsNotNone(surface, "the close doorway opened nothing")
+        self.assertEqual(self._resizes(),
+                         [overlay.unzoom_argv(self.SERVER, overlay_pane="%7")])
+
+    def test_the_quit_doorway_does_too(self):
+        """**One surface, one rule.** Quit and close are the same `leave.confirm_rows`
+        over a wider plan, and a confirmation that behaved differently depending on which
+        doorway reached it would be two surfaces wearing one name."""
+        self._open(leave.open_rows(self.FID)[0])
+        self.assertEqual(len(self._resizes()), 1, self.ran)
+
+    def test_a_name_picker_keeps_the_whole_pane(self):
+        """A picker is a list of names of unbounded length — forty workspaces on this
+        project's own plane — and it scrolls. Five rows would be three names at a time."""
+        row = choose.open_rows(self.FID)[0]
+        self.assertIsNotNone(self._open(row), "the picker doorway opened nothing")
+        self.assertEqual(self._resizes(), [], self.ran)
+
+    def test_a_row_that_opens_nothing_sends_no_command(self):
+        """`_as_a_drawer` takes the ``None`` too, which is what makes it one call rather
+        than an `if` at two call sites — and what stops an ordinary action row paying a
+        tmux round trip on its way past."""
+        self.assertIsNone(self._open(
+            palette.overlay.Row(id="frame.detach", title="detach — leave it running")))
+        self.assertEqual(self.ran, [])
+
+    def test_a_pane_charter_cannot_name_leaves_the_surface_zoomed(self):
+        """Never a refusal: a hand-typed `charter frame-palette --pane` has no
+        `$TMUX_PANE`, and what it gets is the surface this shipped as rather than a
+        `resize-pane` aimed at whatever pane tmux thinks is current."""
+        surface = commands_frame._picker(leave.open_rows(self.FID)[1], self.FID, [],
+                                         socket=self.SERVER, pane="")
+        self.assertIsNotNone(surface)
+        self.assertEqual(self.ran, [])
+
+
+class TheTabMenuRouteIsTheSameDrawer(_AFrameWithChatsToClose, unittest.TestCase):
+    """`frame/tabmenu.py` — the right-press route, and now the `-` on the strip.
+
+    Two routes to `leave.confirm_rows` that must not look different, which is the same
+    reason `tabmenu.confirm_rows` builds `leave`'s own rows rather than enumerating its
+    own.
+    """
+
+    def _drive(self, pick):
+        chosen = []
+
+        def _own(surface, *, then=None, **kw):
+            row = next(r for r in surface.rows if pick(r))
+            nxt = then(row) if then is not None else None
+            chosen.append(nxt)
+            return None
+
+        with mock.patch.dict(os.environ, {"CHARTER_SESSION_ID": self.FID,
+                                          "TMUX_PANE": "%7"}), \
+                mock.patch.object(palette, "own_the_tty", side_effect=_own), \
+                mock.patch.object(commands_frame, "_close_palette"), \
+                mock.patch.object(commands_frame, "_say_on_screen"):
+            tabmenu.draw(SimpleNamespace(tab="alpha.2"))
+        return chosen[0]
+
+    def test_the_menus_close_doorway_unzooms(self):
+        nxt = self._drive(lambda r: r.id == tabmenu.CLOSE_ID)
+        self.assertIsNotNone(nxt, "the doorway opened nothing")
+        self.assertEqual(self._resizes(),
+                         [overlay.unzoom_argv(self.SERVER, overlay_pane="%7")])
+
+    def test_the_transcript_row_does_not(self):
+        """`_as_a_drawer`'s ``None`` passthrough, at the one call site where a row that
+        opens nothing is the ordinary case."""
+        self.assertIsNone(self._drive(lambda r: r.id == tabmenu.TRANSCRIPT_ID))
+        self.assertEqual(self._resizes(), [], self.ran)
+
+
+@unittest.skipUnless(_HAS_TMUX, "no tmux on this machine")
+class ARealTmuxUnzoomsTheDrawer(unittest.TestCase):
+    """**The two facts #739's counter-evidence turns on, measured on a real server.**
+
+    A five-row overlay pane was a defect once, and this is what says it is not one here:
+    that pane was orphaned and unfocused, and this one is neither. What is asserted is what
+    the operator would see — five rows, the frame above them — and what the pointer needs:
+    the pane is still `active`, so its own mouse request is still the one tmux propagates.
+    """
+
+    ROWS, COLS = 30, 100
+
+    def setUp(self) -> None:
+        self.addCleanup(self._teardown)
+        self._tmux("new-session", "-d", "-s", "t",
+                   "-x", str(self.COLS), "-y", str(self.ROWS), "sleep 600")
+        self.harness = self._tmux("list-panes", "-t", "t",
+                                  "-F", "#{pane_id}").stdout.strip()
+        self.overlay = self._tmux(
+            "split-window", "-t", self.harness, "-v", "-l", str(overlay._SPLIT_ROWS),
+            "-P", "-F", "#{pane_id}", "--", "sleep", "600").stdout.strip()
+
+    def _tmux(self, *args) -> subprocess.CompletedProcess:
+        return subprocess.run(["tmux", "-L", SOCKET_NAME, *args],
+                              capture_output=True, text=True, timeout=30)
+
+    def _teardown(self) -> None:
+        """`kill-server` on this socket by NAME, then the socket file — never a sweep over
+        anything matching a pattern. `tests/_tmuxreap` records why the file has to go too:
+        `kill-server` leaves it behind, one per run."""
+        self._tmux("kill-server")
+        (Path("/tmp") / f"tmux-{os.getuid()}" / SOCKET_NAME).unlink(missing_ok=True)
+
+    def _panes(self) -> dict:
+        out = self._tmux("list-panes", "-t", "t", "-F",
+                         "#{pane_id} #{pane_height} #{pane_active} "
+                         "#{window_zoomed_flag}").stdout
+        return {f[0]: tuple(f[1:]) for f in (line.split() for line in out.splitlines())}
+
+    def _run(self, argv) -> None:
+        self.assertIsNotNone(argv)
+        subprocess.run(argv, capture_output=True, text=True, timeout=30, check=True)
+
+    def test_the_pane_keeps_its_five_rows_and_its_focus(self):
+        for cmd in overlay.modal_argvs(SOCKET_NAME, harness=self.harness,
+                                       overlay_pane=self.overlay):
+            self._run(cmd)
+        zoomed = self._panes()
+        self.assertEqual(zoomed[self.overlay], (str(self.ROWS), "1", "1"),
+                         "the palette is not zoomed over the window")
+
+        self._run(overlay.unzoom_argv(SOCKET_NAME, overlay_pane=self.overlay))
+        drawer = self._panes()
+        self.assertEqual(drawer[self.overlay],
+                         (str(overlay._SPLIT_ROWS), "1", "0"),
+                         "the confirmation did not become a five-row drawer")
+        height, active, _zoom = drawer[self.harness]
+        self.assertEqual(active, "0", "the drawer gave the keyboard back to the harness")
+        self.assertGreater(int(height), 1,
+                           "#739's pane: the frame above the drawer is not drawn")
+
+    def test_it_is_idempotent_because_the_toggle_is_guarded(self):
+        """`resize-pane -Z` is a toggle, so an unguarded second send would zoom the
+        confirmation back over the window — the exact state it exists to leave."""
+        for cmd in overlay.modal_argvs(SOCKET_NAME, harness=self.harness,
+                                       overlay_pane=self.overlay):
+            self._run(cmd)
+        for _ in range(3):
+            self._run(overlay.unzoom_argv(SOCKET_NAME, overlay_pane=self.overlay))
+        self.assertEqual(self._panes()[self.overlay],
+                         (str(overlay._SPLIT_ROWS), "1", "0"))
+
+    def test_the_unzoomed_drawer_still_owns_the_terminals_mouse_mode(self):
+        """**The half of #739 that mattered and the half that does not.** The zoom was
+        never what made the pointer work — `select-pane` is, because the outer terminal's
+        mouse mode follows the ACTIVE pane (§4i) — and `modal_argvs` keeps it. Measured
+        through a real client on a real pty: with the overlay unzoomed and active, the
+        bytes `overlay.MOUSE_ON` writes reach the terminal outside tmux.
+        """
+        master, slave = os.openpty()
+        fcntl.ioctl(slave, termios.TIOCSWINSZ,
+                    struct.pack("HHHH", self.ROWS, self.COLS, 0, 0))
+        client = subprocess.Popen(["tmux", "-L", SOCKET_NAME, "attach", "-t", "t"],
+                                  stdin=slave, stdout=slave, stderr=slave,
+                                  start_new_session=True)
+        def _stop():
+            client.terminate()
+            client.wait(timeout=10)
+        self.addCleanup(_stop)
+        os.close(slave)
+        self.addCleanup(os.close, master)
+        os.set_blocking(master, False)
+
+        def drain(seconds: float = 0.8) -> bytes:
+            out, end = b"", time.monotonic() + seconds
+            while time.monotonic() < end:
+                try:
+                    out += os.read(master, 65536)
+                except BlockingIOError:
+                    time.sleep(0.02)
+                except OSError:
+                    break
+            return out
+
+        drain(1.0)
+        for cmd in overlay.modal_argvs(SOCKET_NAME, harness=self.harness,
+                                       overlay_pane=self.overlay):
+            self._run(cmd)
+        self._run(overlay.unzoom_argv(SOCKET_NAME, overlay_pane=self.overlay))
+        drain()
+        tty = self._tmux("display-message", "-p", "-t", self.overlay,
+                         "#{pane_tty}").stdout.strip()
+        with open(tty, "wb", buffering=0) as f:
+            f.write(overlay.MOUSE_ON.encode())
+        saw = drain()
+        self.assertIn(b"1006h", saw, "the drawer's SGR request never left tmux")
+        self.assertIn(b"1000h", saw, "the drawer's mouse request never left tmux")
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()

--- a/tests/test_a_key_cycles_the_tab_strips_height.py
+++ b/tests/test_a_key_cycles_the_tab_strips_height.py
@@ -468,7 +468,7 @@ class TheStripStillMeasuresItsOwnNames(unittest.TestCase):
     the ceiling moved and the measurement did not."""
 
     def test_the_cap_is_still_the_callers_and_still_bounds_the_answer(self):
-        strip = lambda fid: (list(NAMES), "harness-wrapper", "", None)  # noqa: E731
+        strip = lambda fid: (list(NAMES), "harness-wrapper", "", "", None)  # noqa: E731
         with mock.patch.dict(slots.BARS, {"probe": strip}):
             answers = [slots.bar_rows_wanted("f-1", "probe", pane_cols=120, cap=c)
                        for c in (1, 2, 3)]

--- a/tests/test_a_real_click_on_a_real_tab_bar_switches.py
+++ b/tests/test_a_real_click_on_a_real_tab_bar_switches.py
@@ -1107,18 +1107,35 @@ class ARealPressOnThePlusReachesTheCommandBehindIt(_ARealFrameWithBars,
                          "this frame already carries a notice, so the cases below could "
                          "pass on something the fixture said")
 
-    def _plus(self) -> int:
-        """The column the `+` is drawn in, read off the PANE.
+    #: What the chat strip ends in: the two affordances and the one cell between them
+    #: (`slots._affordances`). Composed from the constants rather than typed out, so a case
+    #: built on it agrees with whatever glyphs they take — `test_frame_bars` makes the same
+    #: call for the same reason.
+    TAIL = f"{slots.ADD_CHAT} {slots.CLOSE_CHAT}"
+
+    def _tail_at(self) -> int:
+        """The column the affordance PAIR starts in, read off the PANE.
 
         Not `self._column_of`, because that helper asserts the field is unique on the row
-        and a single `+` is a character an overflow count also starts with. The affordance
-        is the LAST field on the row by construction, so the last `+` is it — and the row
-        it is read off is the one tmux painted, which is what the operator's eye lands on.
+        and a single `+` is a character an overflow count also starts with. The pair is the
+        LAST thing on the row by construction (`slots._compose` draws it only where every
+        name fits, and a strip carrying it carries no `+N`), so the row's own end is where
+        it is — and the row it is read off is the one tmux painted, which is what the
+        operator's eye lands on.
         """
         row = self._bar_row(self.bar).rstrip()
-        self.assertTrue(row.endswith(slots.ADD_CHAT),
-                        f"the row does not end in the affordance: {row!r}")
-        return len(row) - 1
+        self.assertTrue(row.endswith(self.TAIL),
+                        f"the row does not end in the affordances: {row!r}")
+        return len(row) - len(self.TAIL)
+
+    def _plus(self) -> int:
+        """The column the `+` is drawn in."""
+        return self._tail_at()
+
+    def _minus(self) -> int:
+        """The column the `-` is drawn in — #921, and the reason `_plus` is no longer the
+        last cell of the row."""
+        return self._tail_at() + len(self.TAIL) - 1
 
     def test_a_press_on_the_plus_reaches_the_command_behind_it(self):
         """The whole chain, end to end, with the answer coming back on the frame's own
@@ -1154,6 +1171,40 @@ class ARealPressOnThePlusReachesTheCommandBehindIt(_ARealFrameWithBars,
             before, "a refused press still added a window")
         self.assertEqual(chats.of_workspace(self.WS), [self.here],
                          "a refused press still made a chat directory")
+
+    def test_the_strip_really_draws_both_affordances(self):
+        """**What #921 is about, on a real pane.** The strip advertising `+` and nothing
+        else is what made an operator conclude closing a chat was impossible; this is the
+        row tmux painted, read back off it, saying both halves."""
+        row = self._bar_row(self.bar).rstrip()
+        self.assertTrue(row.endswith(self.TAIL), repr(row))
+        self.assertEqual(self._minus(), self._plus() + 2, repr(row))
+
+    def test_a_press_on_the_minus_stops_nothing_and_makes_nothing(self):
+        """**§4i end to end for the one gesture that could destroy something.** What the
+        `-` starts is `charter frame-palette --tab <this chat>` — a SURFACE — so after a
+        press the chat is still on the plane, its window is still on the server, and the
+        frame's own attention row has nothing to say. The keypress that would stop it is
+        two surfaces away and no pointer can reach it."""
+        before = self._tmux("list-windows", "-t", self.WS, "-F", "#{window_id}").stdout
+        self._click(self.bar, col=self._minus())
+        time.sleep(2.0)
+        self.assertEqual(chats.of_workspace(self.WS), [self.here],
+                         "a press on the `-` closed a chat")
+        self.assertEqual(
+            self._tmux("list-windows", "-t", self.WS, "-F", "#{window_id}").stdout,
+            before, "a press on the `-` made or removed a window")
+        self.assertEqual(state.notice(self.here), "",
+                         "a press on the `-` reached a command that reports")
+
+    def test_the_cell_between_the_two_affordances_reaches_nothing(self):
+        """The separator belongs to neither, and here the two neighbours mean opposite
+        things — so picking the nearer one would guess between *make* and *unmake*."""
+        self._click(self.bar, col=self._plus() + 1)
+        time.sleep(2.0)
+        self.assertEqual(state.notice(self.here), "",
+                         "the cell between `+` and `-` reached a command")
+        self.assertEqual(chats.of_workspace(self.WS), [self.here])
 
     def test_the_cell_beside_the_plus_reaches_nothing(self):
         """The control every affordance case needs: a row that answers EVERY click is as

--- a/tests/test_a_tab_strip_grows_a_row_when_its_tabs_overflow.py
+++ b/tests/test_a_tab_strip_grows_a_row_when_its_tabs_overflow.py
@@ -84,7 +84,7 @@ def _placed(*, style=None, **sizes):
     return instance.frame_of({"frame": {"component": tables}})
 
 
-def _strip(names=NAMES, here=HERE, note="", counts=None):
+def _strip(names=NAMES, here=HERE, note="", counts=None, close=""):
     """A `slots.BARS` entry that answers *names* without touching a plane.
 
     The seam the sizer reads through, used as one. `TheRealStripsGoThroughTheSameSeam`
@@ -96,8 +96,14 @@ def _strip(names=NAMES, here=HERE, note="", counts=None):
     is `slots.TAB_COUNT_W` per tab and has its own cases; every number in this module is
     about how many rows a list of names needs, and folding a fixed six cells per name into
     them would measure the field as much as the ladder.
+
+    *close* defaults to `""` for the same reason *note* does: this fixture is the ladder's
+    arithmetic, and the chat strip's `-` (#921) rides the same field the `+` does
+    (`slots._affordances`) — it has its own cases in
+    `tests/test_the_chat_strip_says_closing_a_chat_is_possible.py`, where the property is
+    that the pair is measured together rather than that a width is a particular number.
     """
-    return lambda fid: (list(names), here, note, counts)
+    return lambda fid: (list(names), here, note, close, counts)
 
 
 class TheStripAsksForTheRowsItsNamesNeed(unittest.TestCase):

--- a/tests/test_frame_bars.py
+++ b/tests/test_frame_bars.py
@@ -1207,7 +1207,13 @@ class TheChatBarReadsThePlane(PersonaIso, unittest.TestCase):
         _plant("api.1", workspace="api")
         row = _plain(slots.chats_bar("api.1", 200)[0])
         self.assertIn("api.1", row)
-        self.assertTrue(row.rstrip().endswith(slots.ADD_CHAT), repr(row))
+        self.assertIn(slots.ADD_CHAT, row)
+        # And how to get RID of one, which is the same sentence with the sign flipped —
+        # #921 is the operator who read a row offering only the first and concluded the
+        # second was not possible. `tests/test_the_chat_strip_says_closing_a_chat_is
+        # _possible.py` owns the pair; this says the one-chat row carries it too.
+        self.assertTrue(
+            row.rstrip().endswith(f"{slots.ADD_CHAT} {slots.CLOSE_CHAT}"), repr(row))
 
     def test_the_bar_lists_both_chats_when_there_are_two_and_still_offers_a_third(self):
         """The other half: "present with two" — and the `+` stays.
@@ -1223,7 +1229,8 @@ class TheChatBarReadsThePlane(PersonaIso, unittest.TestCase):
         row = _plain(slots.chats_bar("api.2", 200)[0])
         self.assertIn("api.1", row)
         self.assertIn("*api.2", row)
-        self.assertTrue(row.rstrip().endswith(slots.ADD_CHAT), repr(row))
+        self.assertTrue(
+            row.rstrip().endswith(f"{slots.ADD_CHAT} {slots.CLOSE_CHAT}"), repr(row))
 
     def test_the_workspace_bar_offers_no_such_thing(self):
         """**A chat is a press; a workspace is a name.** A new chat has nothing for an
@@ -1241,8 +1248,13 @@ class TheChatBarReadsThePlane(PersonaIso, unittest.TestCase):
                 row = _plain(rows[0]) if rows else ""
                 self.assertFalse(row.rstrip().endswith(slots.ADD_CHAT),
                                  f"{width}: the workspace bar drew a `+`: {row!r}")
+                self.assertNotIn(slots.CLOSE_CHAT, row,
+                                 f"{width}: the workspace bar drew a `-`: {row!r}")
                 self.assertEqual([c for c in range(width) if slots.TABS.add_at(0, c)], [],
                                  f"{width}: the workspace bar published an affordance")
+                self.assertEqual([c for c in range(width)
+                                  if slots.TABS.close_at(0, c)], [],
+                                 f"{width}: the workspace bar published a close cell")
 
     def test_only_this_workspaces_chats_are_on_the_bar(self):
         _plant("api.1", workspace="api")

--- a/tests/test_the_chat_strip_says_closing_a_chat_is_possible.py
+++ b/tests/test_the_chat_strip_says_closing_a_chat_is_possible.py
@@ -1,0 +1,285 @@
+"""**The chat strip draws a `-` beside its `+`, and the `-` opens a question — #921.**
+
+*"now for example no way to reactivelly close harness session, we have plus button - that
+adding new session tab, but no any option to delete/stop, no any modal/drawer for
+confirmation."*
+
+It was possible the whole time: `F2 → chat: close`, or a right press on a tab. Neither is
+written anywhere on the frame, which advertises exactly two things — `F2 palette` on the
+attention row and `+` on this strip. So the operator read a row that offers to MAKE a chat
+and nothing else, and concluded the system would not let them close one. **That conclusion
+was correct given the evidence on screen.**
+
+Three properties carry this file, because each is a rule the decision states and a first
+implementation loses:
+
+* **It does not close on the press.** `slots.ADD_CHAT` may act on a press because nothing
+  is destroyed; this may not, so it does not act. What it spawns is byte for byte the
+  `charter frame-palette --tab` a RIGHT press on this chat's own tab already spawns, whose
+  `chat: close` row is a doorway onto `leave.confirm_rows`. §4i in one line — a pointer
+  opens the question; the keyboard answers it — and the strongest form of "adds a route and
+  no authority" available: the two gestures build the identical argv.
+* **Both affordances or neither, at every width.** `slots._compose` measures `+` and `-` as
+  one field (`slots._affordances`), so there is no width and no rung at which the strip
+  offers to make a chat and not to unmake one. A `-` that dropped first would be #921
+  arriving again at a narrower pane.
+* **It re-cuts nothing.** A `×` per tab would cost a column on every tab and move every
+  cut, which `slots.TAB_COUNT_W` reserves against and `slots.TAB_SPINNER` was refused for.
+  One glyph at the END of the row cannot, and this measures that it does not rather than
+  arguing it — at every width from 0 to 220 and at one, two and three rows.
+
+The column half of the strip generally is `tests/test_frame_bars.py`; the real-tmux half of
+a press is `tests/test_a_real_click_on_a_real_tab_bar_switches.py`. What this file adds is
+the fourth affordance and the fifth gesture.
+"""
+
+from __future__ import annotations
+
+import os
+import unicodedata
+import unittest
+from unittest import mock
+
+from charter import config, tui, util
+from charter.frame import slots, state
+
+from tests.test_a_click_on_a_tab_bar_switches import _ABarThatWasDrawn, _press
+from tests.test_frame_chat_switch import _plant
+
+#: The argv a `-` press must produce — `frame/builtins._TAB_MENU` with the ACTIVE chat
+#: appended. Spelled from the constant rather than from a literal, because the property is
+#: that the two routes to the tab menu agree, not that either says a particular string.
+_MENU = ("frame-palette", "--tab")
+
+
+class TheStripDrawsBothAffordances(_ABarThatWasDrawn, unittest.TestCase):
+    """What the row says about itself — the whole of what #921 reported."""
+
+    def setUp(self):
+        super().setUp()
+        self.enterContext(mock.patch.dict(os.environ, {"CHARTER_WORKSPACE": "api"},
+                                          clear=False))
+        for chat in ("api.1", "api.2"):
+            _plant(chat, workspace="api")
+        self.row = tui.strip_ansi(slots.chats_bar("api.1", self.WIDTH)[0])
+
+    def test_the_row_ends_in_a_plus_and_a_minus(self):
+        """The sentence the strip now says: making is offered, and so is unmaking."""
+        self.assertTrue(
+            self.row.rstrip().endswith(slots.ADD_CHAT + " " + slots.CLOSE_CHAT),
+            f"the strip does not offer to close a chat: {self.row!r}")
+
+    def test_each_glyph_owns_exactly_its_own_cell(self):
+        """`add_at` and `close_at` are two questions with two answers, one cell each, and
+        the cell between them is neither's — `slots._tab_columns`' rule for the gap between
+        two tabs, kept where a wrong answer would open a teardown for a press that meant
+        *new*."""
+        plus = self._column_of(self.row, slots.ADD_CHAT)
+        minus = self._column_of(self.row, slots.CLOSE_CHAT)
+        cells = range(self.WIDTH)
+        self.assertEqual([c for c in cells if slots.TABS.add_at(0, c)], [plus])
+        self.assertEqual([c for c in cells if slots.TABS.close_at(0, c)], [minus])
+        self.assertEqual(minus, plus + 2, f"the pair is not adjacent: {self.row!r}")
+        self.assertFalse(slots.TABS.add_at(0, plus + 1))
+        self.assertFalse(slots.TABS.close_at(0, plus + 1))
+
+    def test_the_minus_is_not_a_tab_and_not_a_count(self):
+        """Four questions, four methods. A cell that is one of them answers no to the other
+        three, which is what stops a press on `-` switching to a chat or opening a picker
+        over the chats it could not draw."""
+        minus = self._column_of(self.row, slots.CLOSE_CHAT)
+        self.assertIsNone(slots.TABS.switch_to(0, minus))
+        self.assertIsNone(slots.TABS.tab_at(0, minus))
+        self.assertFalse(slots.TABS.more_at(0, minus))
+        self.assertFalse(slots.TABS.add_at(0, minus))
+
+    def test_the_glyph_is_ascii_and_one_cell(self):
+        """**`slots._BAR_RULE`'s rule is the ROW's, not any one constant's**: a click here
+        is resolved by COLUMN, so the glyph to put on it is the one whose width no terminal
+        disagrees about.
+
+        `−` U+2212 measures one cell by `tui.width` and is East-Asian *Neutral*, and it is
+        still not what ships: it is a codepoint a terminal font may not carry, and a
+        fallback into a CJK face draws two cells whatever the table says. What that buys is
+        a prettier dash; what it risks is *fires wrongly* rather than *never fires*.
+        """
+        self.assertEqual(slots.CLOSE_CHAT, "-")
+        self.assertTrue(slots.CLOSE_CHAT.isascii(), repr(slots.CLOSE_CHAT))
+        self.assertEqual(tui.width(slots.CLOSE_CHAT), 1)
+        self.assertEqual(unicodedata.east_asian_width(slots.CLOSE_CHAT), "Na")
+
+    def test_the_workspace_strip_offers_neither(self):
+        """**The same decision as its missing `+`, not a second one.** The rule a strip
+        earns a `-` from is *a surface that advertises making a thing must advertise
+        unmaking it*; a strip that advertises neither owes neither, and there is no route
+        to removing a workspace anywhere in the frame — `workspace: close` is specified,
+        unimplemented, and filed on its own."""
+        for name in ("alpha", "beta"):
+            (config.WORKSPACES_DIR / name).mkdir(parents=True, exist_ok=True)
+        state.frame_dir("f1", create=True)
+        state.record_workspace("f1", "alpha")
+        with mock.patch.dict(os.environ, {"CHARTER_WORKSPACE": ""}):
+            row = tui.strip_ansi(slots.workspaces_bar("f1", self.WIDTH)[0])
+        self.assertNotIn(slots.CLOSE_CHAT, row)
+        self.assertEqual([c for c in range(self.WIDTH) if slots.TABS.close_at(0, c)], [])
+
+
+class BothAffordancesOrNeither(unittest.TestCase):
+    """**They are one field as far as the ladder is concerned.**
+
+    A `-` measured on its own would be dropped at a width where the `+` still fit, and the
+    strip would go back to saying exactly what #921 reported it saying — on a narrower pane
+    rather than on every pane, which is worse, because nobody would think to look.
+    """
+
+    NAMES = [f"api.{i}" for i in range(1, 8)]
+
+    def _cells(self, width: int, rows: int):
+        _lines, _cols, _more, add, close = slots._compose(
+            self.NAMES, "api.3", width, note=slots.ADD_CHAT, close=slots.CLOSE_CHAT,
+            rows=rows)
+        return list(add), list(close)
+
+    def test_no_width_draws_one_without_the_other(self):
+        for width in range(0, 220):
+            for rows in (1, 2, 3):
+                add, close = self._cells(width, rows)
+                self.assertEqual(bool(add), bool(close),
+                                 f"width {width}, {rows} row(s): + {add} / - {close}")
+
+    def test_and_some_width_draws_them(self):
+        """The case above passes on a strip that draws neither anywhere, so this is what
+        says the sweep measured something."""
+        self.assertTrue(any(self._cells(w, 1)[1] for w in range(0, 220)))
+
+    def test_the_pair_never_shares_a_row_with_an_overflow_count(self):
+        """`_Tabs.add_at`'s structural promise, restated for its neighbour: a strip
+        carrying the affordances carries no `+N` on any row, so the two fields that begin
+        with a `+` are never on screen together to be confused with each other."""
+        for width in range(0, 220):
+            for rows in (1, 2, 3):
+                _l, _c, more, add, close = slots._compose(
+                    self.NAMES, "api.3", width, note=slots.ADD_CHAT,
+                    close=slots.CLOSE_CHAT, rows=rows)
+                if add or close:
+                    self.assertEqual(list(more), [],
+                                     f"width {width}, {rows} row(s) drew both")
+
+
+class TheMinusReCutsNothing(unittest.TestCase):
+    """**The width question the decision turns on, measured rather than argued.**
+
+    Anything that changes a tab's field width moves every cut, and the cell the operator
+    was about to press holds another chat's name a moment later — #767's double press, and
+    the reason `slots.TAB_COUNT_W` is reserved unconditionally and `slots.TAB_SPINNER` took
+    the mark's cell instead of buying one. A `-` at the END of the row changes no field, so
+    the map of which cell holds which tab must be byte-identical with it and without it.
+    """
+
+    NAMES = [f"api.{i}" for i in range(1, 8)]
+
+    def test_every_tab_lands_where_it_landed_before(self):
+        for width in range(0, 220):
+            for rows in (1, 2, 3):
+                without = slots._compose(self.NAMES, "api.3", width,
+                                         note=slots.ADD_CHAT, close="", rows=rows)[1]
+                with_it = slots._compose(self.NAMES, "api.3", width,
+                                         note=slots.ADD_CHAT,
+                                         close=slots.CLOSE_CHAT, rows=rows)[1]
+                self.assertEqual(without, with_it,
+                                 f"the `-` re-cut the strip at width {width}, "
+                                 f"{rows} row(s)")
+
+
+class APressOnTheMinusOpensTheQuestion(_ABarThatWasDrawn, unittest.TestCase):
+    """**The gesture, and everything it deliberately is not.**"""
+
+    def setUp(self):
+        super().setUp()
+        self.enterContext(mock.patch.dict(os.environ, {"CHARTER_WORKSPACE": "api"},
+                                          clear=False))
+        for chat in ("api.1", "api.2"):
+            _plant(chat, workspace="api")
+        self.row = tui.strip_ansi(slots.chats_bar("api.1", self.WIDTH)[0])
+        self.on_event = self._handler("chats", "api.1")
+        self.minus = self._column_of(self.row, slots.CLOSE_CHAT)
+
+    def test_it_opens_the_tab_menu_about_the_chat_you_are_in(self):
+        """The whole of §4i's *a pointer opens the question*: what this starts is a
+        SURFACE about one chat, not a teardown."""
+        self.on_event(_press(self.minus))
+        self.assertEqual(
+            self.spawned,
+            [(util.self_relaunch_argv(*_MENU, "api.1"), "api.1")])
+
+    def test_it_is_the_same_argv_a_right_press_on_that_tab_builds(self):
+        """**Adds a route and no authority**, in the strongest form available: the two
+        gestures are one command. A `-` that spelled its own would be a second answer to
+        "how does a pointer ask about closing a chat", and the two would part."""
+        self.on_event(_press(self._column_of(self.row, "*api.1"), name="right"))
+        self.on_event(_press(self.minus))
+        by_right, by_minus = self.spawned
+        self.assertEqual(by_minus, by_right)
+
+    def test_it_closes_nothing_on_the_press(self):
+        """`frame-close` and `frame-quit` are the two commands that stop something, and
+        neither may be reached by a pointer event — §4i, and `builtins._bar_events`'
+        argument for why the `+` beside it may act and this may not."""
+        self.on_event(_press(self.minus))
+        for argv, _fid in self.spawned:
+            for word in ("frame-close", "frame-quit"):
+                self.assertNotIn(word, argv, f"a press stopped something: {argv!r}")
+
+    def test_the_press_acts_and_the_release_does_not(self):
+        """A release may arrive with no matching press — a drag that began on a pane
+        border — and this module keeps no press state, so the press is the half that is
+        never delivered unpaired."""
+        self.on_event(_press(self.minus, pressed=False))
+        self.assertEqual(self.spawned, [], "an unpaired release opened a surface")
+        self.on_event(_press(self.minus))
+        self.assertEqual(len(self.spawned), 1)
+
+    def test_the_middle_button_opens_nothing(self):
+        self.on_event(_press(self.minus, name="middle"))
+        self.assertEqual(self.spawned, [])
+
+    def test_the_cell_between_the_two_glyphs_does_nothing(self):
+        """A press aimed between `+` and `-` has no field to be about, and guessing the
+        nearer one would be guessing between *make* and *unmake*."""
+        self.on_event(_press(self.minus - 1))
+        self.assertEqual(self.spawned, [], f"the separator acted: {self.row!r}")
+
+    def test_the_plus_beside_it_still_makes_a_chat(self):
+        """The control: two answers now live one cell apart in one handler, so a case
+        asserting only the new one would pass with the old one deleted."""
+        self.on_event(_press(self._column_of(self.row, slots.ADD_CHAT)))
+        self.assertEqual(self.spawned,
+                         [(util.self_relaunch_argv("frame-new-chat"), "api.1")])
+
+    def test_the_handler_is_falsy_when_it_opened_the_surface(self):
+        """Truthy means *repaint me*, and the pane the menu carves comes off the harness —
+        nothing in THIS rectangle changed."""
+        self.assertFalse(self.on_event(_press(self.minus)))
+        self.assertEqual(len(self.spawned), 1, "the case measured nothing")
+
+    def test_the_workspace_bars_handler_will_not_open_one_either(self):
+        """**The property the drawn row cannot reach, and why the handler is handed the
+        answer as DATA.** `slots._workspaces_strip` publishes no close cell, so a handler
+        that opened a menu on `close_at` regardless would pass every case above and would
+        start opening chat menus off the workspace bar the day that renderer grew an
+        affordance of its own. This publishes the map by hand and asks the handler."""
+        state.frame_dir("f1", create=True)
+        slots.TABS.publish({}, "", close=[(0, 7)])
+        self.spawned.clear()
+        self._handler("workspaces", "f1")(_press(7))
+        self.assertEqual(self.spawned, [],
+                         "the workspace bar's handler opens a chat menu — it is only the "
+                         "renderer that is stopping it")
+        slots.TABS.publish({}, "", close=[(0, 7)])
+        self._handler("chats", "f1")(_press(7))
+        self.assertEqual([argv[-2] for argv, _fid in self.spawned], ["--tab"],
+                         "the case measured nothing on the chats bar either")
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()

--- a/tests/test_the_chat_strip_says_closing_a_chat_is_possible.py
+++ b/tests/test_the_chat_strip_says_closing_a_chat_is_possible.py
@@ -294,6 +294,28 @@ class APressOnTheMinusOpensTheQuestion(_ABarThatWasDrawn, unittest.TestCase):
         self.assertFalse(self.on_event(_press(self.minus)))
         self.assertEqual(len(self.spawned), 1, "the case measured nothing")
 
+    def test_the_close_answer_is_final_for_the_cell_it_is_about(self):
+        """**One press, one surface, even for a cell that claims to be two things.**
+
+        `_Tabs`' structural promise is that a strip carrying the affordances carries no
+        `+N`, so the two sets are disjoint on any row the renderer draws — which means the
+        handler's `return` after the spawn cannot be reddened by anything the RENDERER
+        produces. That is exactly the shape the deletion sweep reports as a survivor, and
+        the honest answer is not to argue equivalence but to ask the handler the question
+        the renderer cannot: a map that claims one cell for both, published by hand the way
+        `slots.TABS` exists to let a test publish one.
+
+        Without the `return`, a press here opens the tab menu AND the palette — two panes
+        carved off one harness for one press, which is the double-open `#739` is about.
+        """
+        state.frame_dir("f1", create=True)
+        slots.TABS.publish({}, "", more=[(0, 7)], close=[(0, 7)])
+        self.spawned.clear()
+        self._handler("chats", "api.1")(_press(7))
+        self.assertEqual([argv[-2:] for argv, _fid in self.spawned],
+                         [["--tab", "api.1"]],
+                         f"one press opened more than the menu: {self.spawned!r}")
+
     def test_the_workspace_bars_handler_will_not_open_one_either(self):
         """**The property the drawn row cannot reach, and why the handler is handed the
         answer as DATA.** `slots._workspaces_strip` publishes no close cell, so a handler

--- a/tests/test_the_chat_strip_says_closing_a_chat_is_possible.py
+++ b/tests/test_the_chat_strip_says_closing_a_chat_is_possible.py
@@ -124,6 +124,38 @@ class TheStripDrawsBothAffordances(_ABarThatWasDrawn, unittest.TestCase):
         self.assertEqual([c for c in range(self.WIDTH) if slots.TABS.close_at(0, c)], [])
 
 
+class TheFieldTheTwoGlyphsShare(unittest.TestCase):
+    """`slots._affordances` — the one string both rungs compose, asked directly.
+
+    It is measured twice inside `slots._compose` (once for the rung that draws every name
+    on a row, once for the run that draws them over several) and the second glyph's cells
+    are found by subtracting its width from this string's. So what it composes for an
+    ABSENT field is load-bearing arithmetic rather than tidiness: a separator emitted for a
+    field that is not there is a column spent on nothing, on a row whose names are
+    competing for every one of them, and on the workspaces strip it would be a trailing
+    blank the bar did not draw before.
+    """
+
+    def test_neither_field_composes_to_nothing_at_all(self):
+        self.assertEqual(slots._affordances("", ""), "")
+
+    def test_one_field_composes_to_itself_with_no_separator(self):
+        self.assertEqual(slots._affordances(slots.ADD_CHAT, ""), slots.ADD_CHAT)
+        self.assertEqual(slots._affordances("", slots.CLOSE_CHAT), slots.CLOSE_CHAT)
+
+    def test_both_are_one_cell_apart(self):
+        self.assertEqual(slots._affordances(slots.ADD_CHAT, slots.CLOSE_CHAT),
+                         f"{slots.ADD_CHAT} {slots.CLOSE_CHAT}")
+
+    def test_the_workspaces_strip_composes_no_trailing_field_at_all(self):
+        """The strip that is handed neither draws exactly the row it drew before #921 —
+        not that row plus a blank. `slots._workspaces_strip` is what hands over the two
+        empties, so this is the arithmetic that fact rests on."""
+        self.assertEqual(slots._affordances("", ""), "")
+        row = slots._bar(["alpha", "beta"], "alpha", 60, note="", close="")[0]
+        self.assertEqual(row, row.rstrip(), f"a trailing field was drawn: {row!r}")
+
+
 class BothAffordancesOrNeither(unittest.TestCase):
     """**They are one field as far as the ladder is concerned.**
 

--- a/tests/test_the_palette_advertises_unmaking_what_it_makes.py
+++ b/tests/test_the_palette_advertises_unmaking_what_it_makes.py
@@ -1,0 +1,216 @@
+"""**Every row that makes a kind of thing has a row that unmakes the same kind — #921.**
+
+*"now for example no way to reactivelly close harness session, we have plus button - that
+adding new session tab, but no any option to delete/stop, no any modal/drawer for
+confirmation."*
+
+Closing a chat had been possible the whole time — `F2 → chat: close`, or right-click a tab.
+The operator could not find either and concluded, from the evidence on screen, that it was
+not possible, and **that conclusion was correct given what the frame said about itself**:
+the frame advertises exactly two things, `F2 palette` on the attention strip and `+` on the
+chats strip. An unadvertised *create* costs an operator a feature they did not know about;
+an unadvertised *destroy* makes them conclude the system will not let them do it, which is
+strictly worse and is what happened here.
+
+**The rule is asked of the CATALOGUE and not of drawn glyphs**, and that is the decision
+this file rests on rather than a convenience. The rows are data
+(`commands_frame._palette_catalogue`); `[frame] mouse` ships false, so on charter's own
+default plane the palette is not merely the primary surface, it is the only one; and it is
+the surface that works at every width, including the widths where a strip degrades to `2/3`
+and then to nothing. A rule stated over what a bar happened to draw would be a rule that
+switches itself off on the plane it matters most on.
+
+**Stated as an EQUALITY of the two sides, which is what makes it a tripwire in both
+directions.** On `main` the catalogue held `chat: close` and no `chat: new` — the create
+half was reachable only through a pointer affordance most planes never draw
+(`frame/events.py`: *"give every pointer affordance a key as well"*) — so the failure this
+file was written to show is the destroy side standing alone::
+
+    AssertionError: Items in the second set but not the first:
+    'chat' : the palette unmakes a kind of thing it does not offer to make …
+
+and the failure it exists to catch on some future day is the create side standing alone,
+which is #921's own report. One assertion covers both because it is one rule.
+
+**`charter: quit` is deliberately in neither verb set.** Quit stops every harness on the
+plane and takes nothing away that comes back differently — `leave._close_summary` is the
+one verb that says *forget* — and there is no `charter: new`, because a plane is not
+something you make from inside one. A rule that demanded a counterpart for it would be
+demanding a row that cannot exist, which is how an invariant gets suppressed rather than
+kept.
+"""
+
+from __future__ import annotations
+
+import os
+import unittest
+from unittest import mock
+
+from charter import commands_frame, util
+from charter.frame import builtin_actions, choose, leave, state
+
+from tests._isolation import PersonaIso
+from tests.test_frame_pickers import _plane_personas, _plane_workspaces
+
+#: The title verbs that MAKE a kind of thing, and the ones that UNMAKE the same kind.
+#:
+#: Closed sets, and small on purpose: what they are asserted against is charter's own
+#: catalogue, whose titles are charter's own sentences in one shape — `<noun>: <verb> —
+#: <what it does>`. A rule that tried to read intent out of open prose would be a rule that
+#: goes quiet the first time somebody writes a title slightly differently, which is the
+#: failure mode this file is guarding *against*.
+#:
+#: A verb added here is a claim that charter has started making or unmaking a new kind of
+#: thing, and the assertion below is what then asks for its counterpart.
+_MAKES = frozenset({"new", "create"})
+_UNMAKES = frozenset({"close", "delete", "remove"})
+
+
+def _noun_and_verb(row) -> tuple[str, str] | None:
+    """The `<noun>: <verb>` a catalogue row leads with, or ``None`` for a row that leads
+    with neither.
+
+    `detach — leave the harness running` and `refresh — gather this workspace's repos…`
+    are the two rows that carry no noun at all, and they are answered ``None`` here rather
+    than being special-cased at the call site: neither makes nor unmakes anything, and a
+    row with no noun cannot be asked for a counterpart of a kind it never named.
+    """
+    noun, sep, rest = row.title.partition(":")
+    words = rest.split()
+    if not sep or not words or " " in noun.strip():
+        return None
+    return noun.strip(), words[0]
+
+
+def _catalogue_rows(fid: str):
+    """The palette's own catalogue for *fid*, with the name pickers dropped.
+
+    **`choose.noun_of` is what drops them, and never a title test.** A picker row's title
+    is `<noun>: <the name this frame is on> — pick another`, so a plane holding a workspace
+    called `new` would put `workspace: new` in front of this rule — a NAME read as a verb.
+    `choose.noun_of` is the seam `commands_frame._draw_palette` itself uses to tell a
+    doorway onto a list of names from a row that does something, matched against the ids
+    that module mints rather than by splitting on a colon, so this asks the question
+    charter already answers instead of inventing a second answer that a name can fool.
+    """
+    reg = builtin_actions.build(fid, current_density="normal", current_chrome="off")
+    rows = commands_frame._palette_catalogue(fid, reg, snapshot={})
+    return [r for r in rows if choose.noun_of(r) is None]
+
+
+class _Palette(PersonaIso):
+    """One frame on an isolated plane, with the palette's catalogue reachable."""
+
+    FID = "f-pair"
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.enterContext(mock.patch.dict(
+            os.environ, {"CHARTER_SESSION_ID": self.FID}, clear=True))
+        _plane_workspaces("alpha")
+        _plane_personas("steward")
+        state.frame_dir(self.FID, create=True)
+        state.record_server(self.FID, "charter")
+        state.record_harness_pane(self.FID, "%3")
+        state.record_workspace(self.FID, "alpha")
+
+
+class ThePaletteAdvertisesUnmakingWhatItMakes(_Palette, unittest.TestCase):
+    """The rule itself, over the rows `F2` is built from."""
+
+    def test_every_kind_the_palette_makes_it_also_unmakes(self):
+        """**The whole rule, as one equality.**
+
+        Read the failure in the direction it fires. A noun on the *makes* side alone is
+        #921's report — a surface offering to create something with no visible way to
+        remove it, which an operator reads as a refusal rather than an omission. A noun on
+        the *unmakes* side alone is what `main` shipped: `chat: close` in the catalogue
+        with no `chat: new` beside it, so the only route to a new chat was a `+` that
+        `[frame] mouse = false` never draws.
+        """
+        makes, unmakes = set(), set()
+        for row in _catalogue_rows(self.FID):
+            pair = _noun_and_verb(row)
+            if pair is None:
+                continue
+            noun, verb = pair
+            if verb in _MAKES:
+                makes.add(noun)
+            if verb in _UNMAKES:
+                unmakes.add(noun)
+        self.assertEqual(
+            makes, unmakes,
+            f"the palette makes {sorted(makes)} and unmakes {sorted(unmakes)} — every "
+            "kind of thing a surface offers to make must be a kind it offers to unmake, "
+            "at the same weight and in the same place (#921)")
+
+    def test_and_chat_is_the_kind_it_is_about(self):
+        """The rule above is satisfiable by removing rows, and this is what says which
+        answer #921 asked for. `chat` is on both sides, by name."""
+        pairs = [p for p in map(_noun_and_verb, _catalogue_rows(self.FID)) if p]
+        self.assertIn(("chat", "new"), pairs, "no palette row makes a chat")
+        self.assertIn(("chat", "close"), pairs, "no palette row unmakes a chat")
+
+
+class TheNewChatRowStartsTheSameCommandThePlusDoes(_Palette, unittest.TestCase):
+    """**One command, two routes, and neither is the other's fallback.**
+
+    `builtins._NEW_CHAT` is what the chat strip's `+` spawns and this is what the palette
+    row spawns; they must be the same `charter frame-new-chat`, or a plane with a pointer
+    and a plane without would be making chats two different ways.
+    """
+
+    def _run(self):
+        reg = builtin_actions.build(self.FID, current_density="normal",
+                                    current_chrome="off")
+        with mock.patch.object(builtin_actions, "_spawn") as spawn:
+            inv = reg.invoke("chat.new", fid=self.FID, snapshot={})
+            inv.join(timeout=5)
+        return inv, spawn
+
+    def test_it_starts_frame_new_chat_for_this_frame(self):
+        inv, spawn = self._run()
+        self.assertTrue(inv.started, inv.reason)
+        argv = spawn.call_args.args[0]
+        self.assertEqual(argv, util.self_relaunch_argv("frame-new-chat",
+                                                       "--chat", self.FID))
+        self.assertEqual(spawn.call_args.kwargs, {"fid": self.FID})
+
+    def test_it_is_offered_even_where_the_command_will_refuse(self):
+        """**`cmd_new_chat` owns its four refusals and says each on the attention row.**
+
+        A second reading of them here would refuse a row the `+` beside it still offers —
+        two routes to one command degrading differently, which is exactly what
+        `builtins._bar_events` keeps `add` as data to prevent. #512's rule points the same
+        way: an option you cannot see is one you cannot ask about.
+        """
+        reg = builtin_actions.build(self.FID, current_density="normal",
+                                    current_chrome="off")
+        row = [o for o in reg.offers(fid=self.FID, snapshot={}) if o.id == "chat.new"]
+        self.assertEqual(len(row), 1, "the palette lost its new-chat row")
+        self.assertTrue(row[0].available)
+        self.assertFalse(row[0].reason)
+
+
+class TheNewChatRowKeepsTheHarmlessHalfOfTheList(_Palette, unittest.TestCase):
+    """**Placement is a guard, not a taste** (`leave.open_rows`).
+
+    The cursor starts on the first row that can run, so the destructive rows are appended
+    last and a new row must not disturb that. `chat: new` destroys nothing, so it belongs
+    with the harmless rows — and this is what says it stayed there.
+    """
+
+    def test_it_is_above_both_destructive_rows(self):
+        titles = [r.title for r in _catalogue_rows(self.FID)]
+        self.assertLess(titles.index("chat: new — another chat in this workspace"),
+                        titles.index(leave.OPEN_QUIT))
+        self.assertLess(titles.index("chat: new — another chat in this workspace"),
+                        titles.index(leave.OPEN_CLOSE))
+
+    def test_and_the_destructive_rows_are_still_the_last_two(self):
+        titles = [r.title for r in _catalogue_rows(self.FID)]
+        self.assertEqual(titles[-2:], [leave.OPEN_QUIT, leave.OPEN_CLOSE])
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
*"now for example no way to reactivelly close harness session, we have plus button - that adding new session tab, but no any option to delete/stop, no any modal/drawer for confirmation."*

Closing a chat has been possible the whole time — `F2 → chat: close`, or right-click a tab. The operator could not find either and concluded, from the evidence on screen, that it was not possible. **That conclusion was correct given what the frame says about itself:** it advertises exactly two things, `F2 palette` on the attention row and `+` on the chats strip.

**The rule this establishes.** A surface that advertises creating a thing must advertise unmaking it, at the same weight and in the same place. An unadvertised create costs a feature nobody knew about; an unadvertised destroy makes an operator conclude the system will not let them do it, which is strictly worse.

## 1. `chat: new` is a palette row

This was a live violation of charter's own rule at `frame/events.py:70-72` — *"a component whose only route to a piece of state is a click has no route to it on most planes. Give every pointer affordance a key as well."* `[frame] mouse` ships **false**, and the palette had no new-chat row, so **on a default plane an operator could not make a chat from the frame at all** and the one glyph charter advertises was unreachable.

`chat: new — another chat in this workspace` runs the same `charter frame-new-chat` the `+` does. Registered beside `chat: previous transcript`: it moves no density, chrome, strip or todo row, and it stays well above the two destructive rows `leave.open_rows` appends last. Always available, because `cmd_new_chat` owns its four refusals and says each on the frame's attention row — a second reading here would refuse a row the `+` beside it still offers.

## 2. A `-` beside the `+`

```
   api.1  *api.2  + -
```

It does not close on the press. It spawns `charter frame-palette --tab <this chat>` — **byte for byte the argv a right press on the active tab already builds** — whose `chat: close` row is a doorway onto `leave.confirm_rows`. A pointer opens the question; the keyboard answers it. A route, and no new authority.

**The glyph is ASCII `-` (U+002D), not `−` (U+2212).** Measured: `tui.width` says 1 for both, and U+2212 is East-Asian **Neutral**. It is still not what ships — `_BAR_RULE` states the rule as the row's rather than any constant's, *"the one glyph whose width no terminal disagrees about"*, and a mathematical minus is a codepoint a terminal font may not carry; a fallback into a wide face moves every field after it. `+ -` is also the pair every operator already reads as make-and-unmake.

**It re-cuts nothing, measured rather than argued.** `slots._affordances` composes the pair as one field, so the ladder measures them together — there is no width at which the strip offers to make a chat and not to unmake one. At every width from 0 to 220 and at one, two and three rows, the tab column map is byte-identical with the `-` and without it.

One glyph at the end of the row, not a `×` per tab: that would cost a column on every tab and re-cut the strip, which `slots.TAB_COUNT_W` reserves against and `TAB_SPINNER` was refused for.

## 3. The confirmation unzooms into a drawer

`overlay.modal_argvs` ends in `resize-pane -Z`, which is why a two-row question about one chat took the whole window. `overlay.unzoom_argv` gives the pane its five split rows back — guarded by `if-shell -F '#{window_zoomed_flag}'`, because `resize-pane -Z` is a **toggle** and no tmux has an unzoom flag, so a bare toggle would re-zoom a pane an operator had already unzoomed. The palette and the pickers keep the whole pane: they scroll, have no row cap by design, and earn it.

**#739's counter-evidence does not apply, and it is measured.** That five-row pane was an *orphaned, unfocused* second overlay; this one is focused. On tmux 3.7c:

```
after resize-pane -Z    %0 h=24 active=0 zoomed=1   %1 h=30 active=1 zoomed=1
after the unzoom        %0 h=24 active=0 zoomed=0   %1 h=5  active=1 zoomed=0
```

and through a real pty the outer terminal still receives that pane's own `\x1b[?1006h\x1b[?1000h`. The zoom was never what made the pointer work — `select-pane` is, and `modal_argvs` keeps it. Both are standing tests, not a note.

**One cost, stated:** `charter: quit` lists every chat on the plane, and in a five-row drawer it draws two at a time under a heading that says how many there are. One surface with one rule was chosen over two that read differently depending on which doorway reached them; `_as_a_drawer` records it in one expression if the trade turns out wrong.

## 4. The rule, as a test over the palette catalogue

`tests/test_the_palette_advertises_unmaking_what_it_makes.py`, over `commands_frame._palette_catalogue` — the rows are data, and with the pointer off by default the palette is not merely the primary surface, it is the only one. Stated as an **equality** of the two sides so it fires in both directions.

**Seen failing against `main` first** (registration hand-removed, `__pycache__` cleared on both transitions, reverted):

```
AssertionError: Items in the second set but not the first:
'chat' : the palette makes [] and unmakes ['chat'] — every kind of thing a surface offers
to make must be a kind it offers to unmake, at the same weight and in the same place (#921)
```

Name pickers are dropped through `choose.noun_of` rather than by a title test, so a workspace literally named `new` cannot be read as a verb. `charter: quit` is deliberately in neither verb set: quit is not unmaking a kind of thing, and there is no `charter: new` for it to pair with.

## Out of scope, as filed

`workspace: close` (its own issue — chats prove the pattern first), hover (#829, twice; `overlay.MOUSE_ON` deliberately omits 1002/1003), the third liveness colour, and `display-menu`/`display-popup` (`tabmenu.py:11-26`, `overlay.py:3-15`).

## Verification

`python3 -m unittest discover -s tests -q` — trailer read, not the exit code. News entry staged as `unreleased-*` with `version: unreleased` and an unquoted `headline:` (#902).

Closes #921

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018hUBNraNfixfMMK5Jc6CNy
