### PR TITLE
The workspaces strip draws one order, and it is the plane's (#923)

### DIFF
--- a/charter/config.py
+++ b/charter/config.py
@@ -774,23 +774,6 @@ def derive(root: Path, start: Path | None = None) -> dict:
     #: keeps its own workspace across restarts — without leaking into other panes.
     d["TERMINALS_DIR"] = state / "terminals"
 
-    #: The order the **workspaces tab strip** draws its names in — one name per line,
-    #: decided once per plane launch and read by every frame (#923). See
-    #: `charter.workspace.tab_order`.
-    #:
-    #: **Here rather than under `.charter/frame/<fid>/`, and that placement IS the fix.**
-    #: #903 put it there, where `frame.state.reap` deletes it with the chat that wrote it
-    #: and where every chat therefore has one of its own — and switching workspaces
-    #: switches chats, so the strip drew a different chat's snapshot after every switch.
-    #: The strip is a plane-wide list, so its order is a plane-wide fact, and it belongs
-    #: beside the other plane-wide, per-developer, machine-written pointers here rather
-    #: than inside a tree whose every path is scoped to one frame by construction and which
-    #: says so in `frame.state.NO_FORMAT_PROMISE`.
-    #:
-    #: Neither committed nor `charter.toml`: it is a machine's reading of which workspaces
-    #: were in use, rewritten whole at the next launch, and nothing a hand maintains.
-    d["WORKSPACE_TAB_ORDER_FILE"] = state / "workspace-tab-order"
-
     #: Persona definitions — **committed** and shared with the team (unlike vaults). A
     #: persona is a directory ``personas/<name>/`` holding ``persona.md`` (the definition),
     #: ``memory/`` and ``refs/`` (persistent, committed knowledge). The legacy flat

--- a/charter/config.py
+++ b/charter/config.py
@@ -774,6 +774,23 @@ def derive(root: Path, start: Path | None = None) -> dict:
     #: keeps its own workspace across restarts — without leaking into other panes.
     d["TERMINALS_DIR"] = state / "terminals"
 
+    #: The order the **workspaces tab strip** draws its names in — one name per line,
+    #: decided once per plane launch and read by every frame (#923). See
+    #: `charter.workspace.tab_order`.
+    #:
+    #: **Here rather than under `.charter/frame/<fid>/`, and that placement IS the fix.**
+    #: #903 put it there, where `frame.state.reap` deletes it with the chat that wrote it
+    #: and where every chat therefore has one of its own — and switching workspaces
+    #: switches chats, so the strip drew a different chat's snapshot after every switch.
+    #: The strip is a plane-wide list, so its order is a plane-wide fact, and it belongs
+    #: beside the other plane-wide, per-developer, machine-written pointers here rather
+    #: than inside a tree whose every path is scoped to one frame by construction and which
+    #: says so in `frame.state.NO_FORMAT_PROMISE`.
+    #:
+    #: Neither committed nor `charter.toml`: it is a machine's reading of which workspaces
+    #: were in use, rewritten whole at the next launch, and nothing a hand maintains.
+    d["WORKSPACE_TAB_ORDER_FILE"] = state / "workspace-tab-order"
+
     #: Persona definitions — **committed** and shared with the team (unlike vaults). A
     #: persona is a directory ``personas/<name>/`` holding ``persona.md`` (the definition),
     #: ``memory/`` and ``refs/`` (persistent, committed knowledge). The legacy flat

--- a/charter/frame/builtin_actions.py
+++ b/charter/frame/builtin_actions.py
@@ -334,7 +334,10 @@ class _Strip(NamedTuple):
 _STRIPS = (
     _Strip("chat", lambda fid: [c.id for c in chats.roster(fid)], lambda fid: fid,
            ("frame-chat",), chats.ONLY_CHAT),
-    _Strip("workspace", switch.workspaces, switch.current_workspace,
+    # The workspace lister takes no frame since #923 — the strip draws a plane-wide
+    # list, so its order is the plane's and not this chat's — and the lambda is what
+    # keeps `names(fid)` one signature for both strips rather than two.
+    _Strip("workspace", lambda _fid: switch.workspaces(), switch.current_workspace,
            ("frame-switch", "--workspace"), ONLY_WORKSPACE),
 )
 

--- a/charter/frame/choose.py
+++ b/charter/frame/choose.py
@@ -202,17 +202,22 @@ def names_of(noun: str, fid: str = "") -> list[str]:
     `workspace.valid_name` / `persona.valid_name` / `instance.change_name_ok` on the way
     out, which is #442's rule applied where a directory name becomes a row.
 
-    *fid* is required in practice for :data:`CHANGE` and for :data:`WORKSPACE`, and ignored
-    by :data:`PERSONA`. Changes are per WORKSPACE and which workspace is a question about
-    the frame, not about this process (#512); workspaces are ORDERED per frame since #903,
-    so that the palette and the strip beside it draw one roster in one order. It defaults
-    to `""` rather than being made positional-required so that the two callers that predate
-    it read unchanged; `switch.changes("")` resolves the same "no frame, resolve locally"
-    path every other frame surface takes for an empty id, and `switch.workspaces("")`
-    answers alphabetically rather than inventing an order it has nowhere to record.
+    *fid* is required in practice for :data:`CHANGE` and for :data:`CHAT`, and ignored by
+    :data:`PERSONA` and by :data:`WORKSPACE`. Changes are per WORKSPACE and which workspace
+    is a question about the frame, not about this process (#512). It defaults to `""`
+    rather than being made positional-required so that the two callers that predate it read
+    unchanged; `switch.changes("")` resolves the same "no frame, resolve locally" path
+    every other frame surface takes for an empty id.
+
+    **Workspaces stopped taking it in #923**, and that is worth saying here because this is
+    where it looked like a per-frame question. #903 ordered the workspaces strip per frame;
+    a switch switches chats, so each chat froze an order of its own and the palette and the
+    strip agreed only inside one chat. The order is the plane's now, so every frame's
+    palette and every frame's strip draw one roster in one order — which is what this
+    function existed to guarantee in the first place.
     """
     if noun == WORKSPACE:
-        return switch.workspaces(fid)
+        return switch.workspaces()
     if noun == PERSONA:
         return switch.personas()
     if noun == CHAT:

--- a/charter/frame/slots.py
+++ b/charter/frame/slots.py
@@ -4565,9 +4565,15 @@ def _workspaces_strip(fid: str):
     :func:`_workspace_counts` for the one grouped read and for why it does not put this
     strip on a clock, and :data:`TAB_COUNT_W` for why the field is there on every tab even
     when the number is not.
+
+    **The NAMES take no *fid* and the mark does** (#923), which is the one asymmetry on
+    this strip and the point of the fix behind it. Which workspace is marked is a fact
+    about this frame; the ORDER the names are drawn in is a fact about the plane, and
+    asking it per frame is what made every switch redraw a different strip — a switch
+    switches chats, and each chat held a frozen order of its own.
     """
     from . import switch as switch_mod
-    return (switch_mod.workspaces(fid), switch_mod.current_workspace(fid), "", "",
+    return (switch_mod.workspaces(), switch_mod.current_workspace(fid), "", "",
             _workspace_counts())
 
 

--- a/charter/frame/state.py
+++ b/charter/frame/state.py
@@ -2520,9 +2520,11 @@ def reap(live: set[str], *, server: str) -> list[str]:
     # not move under them (#767). A directory kept for ANY of the four reasons leaves the
     # plane warm.
     #
-    # The equality and not `not removed`: an empty frame root is a cold plane too, and it
-    # is the ordinary state of one whose frames a previous reap already took.
-    if len(removed) == len(entries):
+    # Counted as what is LEFT rather than compared as two lengths: `removed` is built out
+    # of `entries`, so `>=` and `==` would be the same predicate and one of them would be a
+    # mutation no input could show. Zero is also the ordinary state of a plane whose frames
+    # a previous reap already took, which is a cold plane too.
+    if not len(entries) - len(removed):
         from .. import workspace as ws_mod
         ws_mod.forget_tab_order()
     return removed

--- a/charter/frame/state.py
+++ b/charter/frame/state.py
@@ -1446,82 +1446,6 @@ def asserted_bars(fid: str) -> AssertedBars:
         {s: n for s, n in rows.items() if isinstance(s, str) and isinstance(n, int)})
 
 
-def record_tab_order(fid: str, names: list[str]) -> None:
-    """Write down the order THIS RUNNING FRAME draws its workspace tabs in (#903).
-
-    :func:`record_bar_rows`' shape and every word of its argument about where this lives —
-    machine-written, per frame, deleted whole by :func:`reap` when the frame ends. What is
-    different is who writes it and when: this is written ONCE, by whichever process first
-    asks `switch.workspaces` about this frame, and never again while the frame runs.
-
-    **Holding the order still is the whole feature, and it is why an order computed from
-    mtimes has to be written down at all.** #903 asks the strip to lead with the working
-    set — *"active last used tabs should be in first order, then olds"* — against two
-    measured refusals of LIVE reordering: `slots._cuts` (*"a window CENTRED on the marked
-    tab moves every column each time the operator switches… six of the nine drawn tabs
-    answer a second press at the identical column with a SECOND, different workspace"*) and
-    `chats.of_workspace` (*"`api.1` stays leftmost, where an operator learned to look for
-    it"*). Both are right about a row that re-sorts while you look at it. Neither argues
-    against an order that is fixed for as long as the frame is open — so the recency is
-    read once and this is where it stops moving.
-
-    **A file rather than a variable in the panel's process**, and the difference is
-    load-bearing rather than defensive. `panel.run` draws one component for the life of a
-    process, but those processes are torn down and re-split on every re-layout — which a
-    workspace switch performs (`commands_frame._switch_client`). A module-level cache would
-    therefore be recomputed by exactly the gesture that must not move a column. The
-    launcher, the `frame-resize` child and each panel all read this one file instead, which
-    is also what keeps `slots.bar_rows_wanted` measuring the strip the panel will draw.
-
-    **`workspace.list_workspaces` still decides WHICH names there are**, so this is an
-    order and never a roster: a name recorded here that has since been deleted is dropped
-    and a workspace created after this was written is appended, both by `switch.workspaces`
-    and neither by re-writing this file. That is what stops a stale line resurrecting a
-    workspace on a strip, and it is why there is no re-record on change.
-
-    One name per line, read back through :func:`tab_order`. Same must-not-raise,
-    atomic-write shape as :func:`record_bar_rows`.
-    """
-    d = frame_dir(fid, create=True)
-    if d is None:
-        return
-    try:
-        config.replace_for(d / "tab_order", "".join(f"{n}\n" for n in names))
-    except OSError:
-        return
-
-
-def tab_order(fid: str) -> list[str]:
-    """The order this frame draws its workspace tabs in, or ``[]`` for a frame that has
-    not been asked yet.
-
-    ``[]`` is the ordinary case exactly once per frame — the first call, before
-    :func:`record_tab_order` has run — and it is also what an unreadable or truncated file
-    answers, for :func:`bar_rows`' reason: this is read on a panel's render path and on the
-    sizing path inside the `frame-resize` child, and a half-written file must degrade to
-    "no order recorded" rather than take the repaint down. The caller's degrade for that is
-    to compute the order again, which is the same answer this file was written from.
-
-    **Name-checked on the way out**, like every other name charter reads off disk and
-    joins onto a path (`workspace.declared_default`, :func:`frame_workspace`). These names
-    go on to a `workspace_dir()` join and onto a tab a click switches to, and #442 is what
-    an unchecked one in that position already cost.
-
-    An empty line is dropped by the name check on its own terms — `workspace.valid_name("")`
-    is already False — so there is no `if line` in front of it for no input to make
-    observable.
-    """
-    d = frame_dir(fid)
-    if d is None:
-        return []
-    try:
-        lines = (d / "tab_order").read_text().splitlines()
-    except (OSError, ValueError):
-        return []
-    from .. import workspace as ws_mod
-    return [n for n in (line.strip() for line in lines) if ws_mod.valid_name(n)]
-
-
 def record_chrome(fid: str, level: str) -> None:
     """Write down the pane surface THIS RUNNING FRAME is on, overriding `[frame] chrome`.
 
@@ -2510,13 +2434,25 @@ def reap(live: set[str], *, server: str) -> list[str]:
     the new frame is about to adopt — stale ``exit`` file included. Deciding that here
     would mean guessing which of two frames a directory belongs to; the launcher knows,
     because it is the one claiming the id, so it clears the file as it starts.
+
+    **One thing outside this directory is decided here, and it is decided on what is LEFT
+    rather than on what went** — see the closing paragraph of the body. A reap that took
+    every directory there was is the moment charter learns the plane has gone cold, and the
+    workspaces strip's plane-wide order (#923) expires exactly then. It is the shape
+    `_forget_session` already has one line up: a frame's state is not all inside its own
+    directory, and neither is a plane's.
     """
     root = _root()
     if not root.is_dir():
         return []
+    # Held as a list rather than walked straight out of `iterdir`, because the LENGTH is
+    # read again at the bottom — see the plane-order paragraph below. One listing, so
+    # "what was here" and "what is left" cannot be two different readings of a directory
+    # that moved in between.
+    entries = [d for d in sorted(root.iterdir()) if d.is_dir()]
     removed = []
-    for d in sorted(root.iterdir()):
-        if not d.is_dir() or d.name in live:
+    for d in entries:
+        if d.name in live:
             continue
         # Four independent reasons to keep a directory, and ALL must be absent before
         # anything is deleted. They answer different questions and none implies another:
@@ -2567,4 +2503,26 @@ def reap(live: set[str], *, server: str) -> list[str]:
         # name one directory over, and the ordinal is about to be handed out again (#731).
         _forget_session(d.name)
         removed.append(d.name)
+    # **A reap that took every directory there was is this plane going COLD, and that is
+    # where "once per plane launch" is decided** (#923). The order the workspaces strip
+    # draws is plane-wide (`workspace.record_tab_order`) and is decided by whichever
+    # process first asks for it; something has to say when that decision has expired, and
+    # both of the other candidates were refused. Re-deciding on a repaint is the live
+    # reordering `slots._cuts` measured — "six of the nine drawn tabs answer a second press
+    # at the identical column with a SECOND, different workspace". Never re-deciding
+    # ossifies: a workspace made next month sorts last for good. What is left is the
+    # launch, and a launch is exactly a plane that had no frames acquiring one.
+    #
+    # **Counted against every entry rather than against this server's**, which is what
+    # keeps the rule wider than the reap around it. This function is scoped to one server
+    # for reasons that do not apply here: a frame in the operator's own tmux is kept by the
+    # `owner != server` rule above and is an operator looking at a strip whose columns may
+    # not move under them (#767). A directory kept for ANY of the four reasons leaves the
+    # plane warm.
+    #
+    # The equality and not `not removed`: an empty frame root is a cold plane too, and it
+    # is the ordinary state of one whose frames a previous reap already took.
+    if len(removed) == len(entries):
+        from .. import workspace as ws_mod
+        ws_mod.forget_tab_order()
     return removed

--- a/charter/frame/switch.py
+++ b/charter/frame/switch.py
@@ -87,10 +87,9 @@ class Outcome(NamedTuple):
     message: str
 
 
-def workspaces(fid: str | None = None) -> list[str]:
-    """Every workspace a switcher may offer, name-checked on the way out and — asked about
-    a FRAME — **ordered by last use, once, and then held still for that frame's life**
-    (#903).
+def workspaces() -> list[str]:
+    """Every workspace a switcher may offer, name-checked on the way out and **ordered by
+    last use, once per plane launch, and then held still for every frame** (#903, #923).
 
     `workspace.list_workspaces` reads directory names off the plane, so the check is the
     same floor `state.frame_workspace` applies to its own read: these names go on to a
@@ -101,48 +100,50 @@ def workspaces(fid: str | None = None) -> list[str]:
     and a fresh plane that has never made one would otherwise offer an empty list.
 
     **The order is not this function's, and it is the same split :func:`personas` already
-    makes** (#882). `chats.touched_by_workspace` owns the recency and `state.tab_order`
-    owns the holding-still; what happens here is that the first process to ask about a
-    frame writes the answer down and every process afterwards reads it. So the strip, the
-    palette and the launcher's own sizing pass (`slots.bar_rows_wanted`) cannot draw the
-    same roster in two orders, and a switch — which tears every panel down and re-splits it
-    — redraws the identical columns.
+    makes** (#882). `chats.touched_by_workspace` owns the recency and
+    `workspace.record_tab_order` owns the holding-still; what happens here is that the
+    first process to ask writes the answer down and every process afterwards reads it. So
+    the strip, the palette and the launcher's own sizing pass (`slots.bar_rows_wanted`)
+    cannot draw the same roster in two orders, and a switch — which tears every panel down
+    and re-splits it — redraws the identical columns.
+
+    **There is no *fid*, and its removal is the fix for #923.** #903 asked this per FRAME
+    and recorded the answer under `.charter/frame/<fid>/`, which is per-chat by
+    construction. Switching workspaces switches chats, so every switch drew a strip
+    ordered by a different chat's snapshot of the recency, taken at a different moment —
+    three chats on the reporting plane held three different orders and two of them were in
+    the same workspace. The strip is a PLANE-WIDE list; a plane-wide list has one order,
+    the plane's, and asking which frame wants to know was the defect rather than a
+    parameter that had stopped being used.
+
+    So the launch picker, a refusal's "have: …" sentence, the strip and the palette all get
+    the identical list now, where the picker and the refusal used to get the alphabet
+    instead. That is #882's rule arriving rather than a widening: they were never asking a
+    different question, they were asking the same one somewhere there was nothing to record
+    an answer in.
 
     *"active last used tabs should be in first order, then olds."* A switch updates the
-    mtimes this reads for the NEXT frame; it moves nothing now. `state.record_tab_order`
-    carries the argument about why that is the whole of the feature and why live reordering
-    was refused twice before it.
+    mtimes this reads for the next plane launch; it moves nothing now.
+    `workspace.record_tab_order` carries the argument about why that is the whole of the
+    feature, why live reordering was refused twice before it, and why the decision expires
+    with the plane rather than never or on every paint.
 
     **The recorded order is an ORDER and not a roster**, which is what keeps a stale line
     from resurrecting a deleted workspace: the names on the strip are always
     `list_workspaces`' answer, and the record only says how to sort them. A workspace
     created since goes on the end, in name order, where it cannot move a column an operator
     is already aiming at; a workspace deleted since simply is not there.
-
-    **No frame is the plain alphabetical answer**, and `""` is no frame exactly as `None`
-    is — `choose.names_of` defaults its *fid* to the empty string and the launch picker
-    (`commands_frame._choose_workspace`) runs before any frame exists. Both want membership
-    and a list to read, neither is about which order a strip draws, and a falsy id would
-    otherwise reach `state.tab_order`, be answered "nothing recorded" by
-    `state.frame_dir`'s own refusal, and recompute the recency on every call — live
-    reordering, arriving through the one caller that has no frame to hold an order for.
-    One test, not two, for `if fid is None` and `if not fid` cannot both be observable.
-
-    Written as a default rather than a second function, so there is one place that decides
-    what the set of workspaces IS.
     """
     from .. import config, workspace as ws_mod
     names = [n for n in ws_mod.list_workspaces() if ws_mod.valid_name(n)]
     if config.DEFAULT_WORKSPACE not in names:
         names.append(config.DEFAULT_WORKSPACE)
-    if not fid:
-        return sorted(names)
-    return _by_use(fid, names)
+    return _by_use(names)
 
 
-def _by_use(fid: str, names: list[str]) -> list[str]:
-    """*names* in the order frame *fid* draws them — the recorded one, computed and
-    recorded here the first time it is asked for.
+def _by_use(names: list[str]) -> list[str]:
+    """*names* in the plane's own order — the recorded one, computed and recorded here the
+    first time this plane launch is asked for it.
 
     **The ORDER *names* arrives in is not read, and that is a correction the deletion sweep
     forced.** The caller used to hand this `sorted(names)` and this docstring claimed the
@@ -155,14 +156,14 @@ def _by_use(fid: str, names: list[str]) -> list[str]:
 
     Every use but ONE, and that one is why the sort moved rather than went. The names this
     record does not carry are appended, and they are appended **in name order** — a
-    workspace made while the frame is open goes on the end where it cannot move a column an
+    workspace made while the plane is up goes on the end where it cannot move a column an
     operator is already aiming at, and two of them go on in an order that is a function of
     the plane rather than of `os.scandir`. That promise is kept HERE now, where it is made.
     It used to be kept by accident: `workspace.list_workspaces` happens to answer in name
     order, so the caller's sort was doing nothing the leftovers could not have got from the
-    filesystem — until a record that omits a name (a hand-edited `tab_order`, a record
-    written before `config.DEFAULT_WORKSPACE` was folded in) makes one of them a leftover
-    and the accident stops holding.
+    filesystem — until a record that omits a name (a hand-edited file, a record written
+    before `config.DEFAULT_WORKSPACE` was folded in) makes one of them a leftover and the
+    accident stops holding.
 
     **Sorted by the timestamp DESCENDING, so the newest is leftmost**, which is where an
     operator looks first and where `slots._compose` starts its first page. Reversing the
@@ -173,15 +174,16 @@ def _by_use(fid: str, names: list[str]) -> list[str]:
 
     The record is written even when it changes nothing (a plane with one workspace, a plane
     charter has no timestamp for at all), because what is being written down is not "this
-    order is interesting" but "this frame has decided" — and a frame that re-decided on its
+    order is interesting" but "this plane has decided" — and a plane that re-decided on the
     next repaint would be the live reordering this exists to refuse.
     """
+    from .. import workspace as ws_mod
     from . import chats as chats_mod
-    recorded = state.tab_order(fid)
+    recorded = ws_mod.tab_order()
     if not recorded:
         touched = chats_mod.touched_by_workspace()
         recorded = sorted(names, key=lambda n: (-touched.get(n, 0.0), n))
-        state.record_tab_order(fid, recorded)
+        ws_mod.record_tab_order(recorded)
     known = set(names)
     kept = [n for n in recorded if n in known]
     seen = set(kept)

--- a/charter/workspace.py
+++ b/charter/workspace.py
@@ -793,6 +793,37 @@ def list_workspaces() -> list[str]:
     return out
 
 
+def _tab_order_file() -> Path:
+    """Where this plane records the order its workspaces tab strip draws (#923).
+
+    **Directly under `STATE_DIR`, beside `active-workspace`, `sessions/` and
+    `terminals/`** — plane-scoped, per developer, gitignored, machine-written, and
+    outliving any one chat.
+
+    **NOT under `.charter/frame/<fid>/`, and that placement IS the fix.** #903 put it
+    there, where `frame.state`'s opening line says everything is per frame and never
+    global, and where `frame.state.reap` deletes it with the chat that wrote it. So every
+    chat had an order of its own — and switching workspaces switches chats, which is how
+    the operator met a different frozen order after every switch. The strip draws a
+    plane-wide list, so its order is a plane-wide fact and lives at plane scope.
+    `frame.state.NO_FORMAT_PROMISE` says the same thing from the other end: that tree is
+    scratch charter may reshape in a patch release, which is no place for the one record
+    every frame on the plane reads.
+
+    **A function rather than a `config.derive` entry**, which is `frame.state._root`'s
+    shape and `frame.gather._cache_file`'s: a state path spelled by the one module that
+    reads and writes it. `config.derive` holds what several modules share — the roster
+    directories, the session and terminal pointers — and this is read here and nowhere
+    else. It stays isolated in tests for the same reason `_root()` does: `config.STATE_DIR`
+    is read at CALL time, so `config.use()` repointing it moves this with it, and it is
+    never bound at import.
+
+    Neither committed nor `charter.toml`: a machine's reading of which workspaces were in
+    use, rewritten whole at the next launch, and nothing a hand maintains.
+    """
+    return Path(config.STATE_DIR) / "workspace-tab-order"
+
+
 def record_tab_order(names: list[str]) -> None:
     """Write down the order THIS PLANE draws its workspace tabs in (#923).
 
@@ -833,9 +864,9 @@ def record_tab_order(names: list[str]) -> None:
         # than being handed one, which is the split `config.mkdir_for` documents. On a
         # plane whose `.charter/` does not exist yet — a first launch — the write below
         # would otherwise answer `ENOENT` and the order would be recomputed on every paint.
-        config.private_mkdir(config.WORKSPACE_TAB_ORDER_FILE.parent)
-        config.replace_for(config.WORKSPACE_TAB_ORDER_FILE,
-                           "".join(f"{n}\n" for n in names))
+        f = _tab_order_file()
+        config.private_mkdir(f.parent)
+        config.replace_for(f, "".join(f"{n}\n" for n in names))
     except OSError:
         return
 
@@ -872,7 +903,7 @@ def tab_order() -> list[str]:
     this process's own charter put there, and the name check is the floor that remains.
     """
     try:
-        lines = config.WORKSPACE_TAB_ORDER_FILE.read_text().splitlines()
+        lines = _tab_order_file().read_text().splitlines()
     except (OSError, ValueError):
         return []
     return [n for n in (line.strip() for line in lines) if valid_name(n)]
@@ -891,7 +922,7 @@ def forget_tab_order() -> None:
     :func:`record_tab_order` does not — this runs inside a reap on a launch path.
     """
     try:
-        config.WORKSPACE_TAB_ORDER_FILE.unlink()
+        _tab_order_file().unlink()
     except OSError:
         pass
 

--- a/charter/workspace.py
+++ b/charter/workspace.py
@@ -793,6 +793,92 @@ def list_workspaces() -> list[str]:
     return out
 
 
+def record_tab_order(names: list[str]) -> None:
+    """Write down the order THIS PLANE draws its workspace tabs in (#923).
+
+    **The order of the roster :func:`list_workspaces` answers, kept next to it**, because
+    it is a fact about the same thing: which workspaces this plane has, and — since #903 —
+    which of them the operator has been in lately. `frame/switch._by_use` decides the
+    order and this holds it still; the split is `persona.by_use`'s (#882), one noun over.
+
+    **Plane-scoped, and that is what #923 is.** #903 wrote this under
+    `.charter/frame/<fid>/`, which is per-chat by construction — `frame.state`'s opening
+    line — so every chat had an order of its own, seeded from the recency at the moment
+    that chat first painted. Switching workspaces switches chats, so the operator met a
+    different frozen order after every switch: *"feeling that each switch is opening new
+    window."* Two chats of the SAME workspace disagreed. The strip draws a plane-wide list
+    and now reads a plane-wide order, so every frame draws the identical columns.
+
+    **Written once per plane launch, by whichever process first asks**, and
+    :func:`forget_tab_order` is the other half — `frame.state.reap` calls it when a plane
+    is left with no frame state at all, so the next launch decides afresh. Neither "once
+    ever" nor "once per repaint" is the rule, and both were considered: once-ever ossifies
+    (a workspace made next month sorts last for good), and re-deciding while a frame is
+    open is the live reordering `slots._cuts` and `chats.of_workspace` both refused with a
+    measurement. Once per launch is #903's own intent — still while you are looking at it,
+    fresh when you come back.
+
+    **An ORDER and never a roster.** `list_workspaces` decides which names exist, so a line
+    here for a workspace that has since been deleted draws nothing and a workspace created
+    since is appended by `switch._by_use`; there is no rewrite on change, which is what
+    stops a stale line resurrecting a directory that has gone.
+
+    One name per line, `config.replace_for` (#894, #893): this is read on a panel's render
+    path and inside the `frame-resize` child, so a reader must never see half of it. Never
+    raises — a full filesystem costs the plane its held order, which it recomputes on the
+    next paint, and never a traceback out of a strip.
+    """
+    try:
+        config.mkdir_for(config.WORKSPACE_TAB_ORDER_FILE.parent)
+        config.replace_for(config.WORKSPACE_TAB_ORDER_FILE,
+                           "".join(f"{n}\n" for n in names))
+    except OSError:
+        return
+
+
+def tab_order() -> list[str]:
+    """The order this plane draws its workspace tabs in, or ``[]`` when none is recorded.
+
+    ``[]`` is the ordinary answer exactly once per plane launch — the first ask, before
+    :func:`record_tab_order` has run — and it is also what an unreadable or truncated file
+    answers. The caller's degrade for both is the same and is why they are not told apart:
+    compute the order again, which is what this file was written from.
+
+    **Name-checked on the way out**, like every other name charter reads off disk and joins
+    onto a path (:func:`declared_default`, `frame.state.frame_workspace`). These names go
+    on to a `workspace_dir()` join and onto a tab a click switches to, and #442 is what an
+    unchecked one in that position already cost. An empty line is dropped by that check on
+    its own terms — `valid_name("")` is already False — so there is no `if line` in front
+    of it for no input to make observable.
+
+    Stripped both ends, for `frame.state.chrome`'s reason: the file is one name per line,
+    and a line is what lies between two newlines rather than what a hand left beside one.
+    """
+    try:
+        lines = config.WORKSPACE_TAB_ORDER_FILE.read_text().splitlines()
+    except (OSError, ValueError):
+        return []
+    return [n for n in (line.strip() for line in lines) if valid_name(n)]
+
+
+def forget_tab_order() -> None:
+    """Drop the recorded tab order, so the next ask decides it again (#923).
+
+    **The end of a plane launch, spelled where the order lives.** `frame.state.reap` is
+    charter's one observer of "this plane has no frame state left" and calls this from
+    there; it already reaches one directory over for `_forget_session`, and this is that
+    same shape for a plane-scoped file rather than a per-frame one.
+
+    Missing is the ordinary case and not an error: a plane that has never drawn a strip,
+    and a plane whose last frame already took the file. Never raises, for the same reason
+    :func:`record_tab_order` does not — this runs inside a reap on a launch path.
+    """
+    try:
+        config.WORKSPACE_TAB_ORDER_FILE.unlink()
+    except OSError:
+        pass
+
+
 def clones(name: str) -> list[Path]:
     """The repo clones inside a workspace (``memory/`` and ``refs/`` are not clones —
     they have no ``.git`` — so this naturally excludes them)."""

--- a/charter/workspace.py
+++ b/charter/workspace.py
@@ -863,6 +863,13 @@ def tab_order() -> list[str]:
     filesystem, or a hand that saved it in another encoding, reaches here as bytes
     `read_text` cannot decode. That is a `ValueError`, not an `OSError`, and it would come
     out of a panel's render path.
+
+    **No `contain.file_refusal` in front of it**, where :func:`declared_default` has
+    one, and the difference is whose file it is. `workspaces/.default` is ordinarily
+    committable, so the thing at that path may be a teammate's — or a FIFO, which would
+    hang the status line's every paint rather than cost it a value. This lives under
+    `STATE_DIR`, which is 0700, per developer and never committed: what is there is what
+    this process's own charter put there, and the name check is the floor that remains.
     """
     try:
         lines = config.WORKSPACE_TAB_ORDER_FILE.read_text().splitlines()

--- a/charter/workspace.py
+++ b/charter/workspace.py
@@ -829,7 +829,11 @@ def record_tab_order(names: list[str]) -> None:
     next paint, and never a traceback out of a strip.
     """
     try:
-        config.mkdir_for(config.WORKSPACE_TAB_ORDER_FILE.parent)
+        # `private_mkdir` and not `mkdir_for`: this writer names its own state path rather
+        # than being handed one, which is the split `config.mkdir_for` documents. On a
+        # plane whose `.charter/` does not exist yet — a first launch — the write below
+        # would otherwise answer `ENOENT` and the order would be recomputed on every paint.
+        config.private_mkdir(config.WORKSPACE_TAB_ORDER_FILE.parent)
         config.replace_for(config.WORKSPACE_TAB_ORDER_FILE,
                            "".join(f"{n}\n" for n in names))
     except OSError:
@@ -853,6 +857,12 @@ def tab_order() -> list[str]:
 
     Stripped both ends, for `frame.state.chrome`'s reason: the file is one name per line,
     and a line is what lies between two newlines rather than what a hand left beside one.
+
+    **`ValueError` beside `OSError`, and it is `UnicodeDecodeError` by its base class.**
+    This file is charter's own UTF-8, but it is a file on a disk: a write torn by a full
+    filesystem, or a hand that saved it in another encoding, reaches here as bytes
+    `read_text` cannot decode. That is a `ValueError`, not an `OSError`, and it would come
+    out of a panel's render path.
     """
     try:
         lines = config.WORKSPACE_TAB_ORDER_FILE.read_text().splitlines()

--- a/docs/frame.md
+++ b/docs/frame.md
@@ -646,13 +646,20 @@ not all fit the bar draws the page yours falls on and counts what is off each en
 are (`2/3`). It never shows half a name.
 
 **The workspace bar leads with the workspaces you have been in.** Its order is worked out
-once, when the frame launches, from when charter last wrote anything about each
-workspace's chats — so the ones you are actually working in are on the left, where you look
-first and where a narrow strip's first page is. Then it *stops moving*: switching workspaces
-updates the record for the next frame and does not slide a single column now, which is what
-keeps a tab you just pressed the same tab a moment later. A workspace made while the frame
-is open goes on the end. The chat bar is unchanged and stays in ordinal order — `api.1`
-stays leftmost, where you learnt to look for it.
+once per plane launch, from when charter last wrote anything about each workspace's chats —
+so the ones you are actually working in are on the left, where you look first and where a
+narrow strip's first page is. Then it *stops moving*: switching workspaces updates the
+record for the next launch and does not slide a single column now, which is what keeps a
+tab you just pressed the same tab a moment later. A workspace made while the plane is up
+goes on the end. The chat bar is unchanged and stays in ordinal order — `api.1` stays
+leftmost, where you learnt to look for it.
+
+**The order is the plane's, not each chat's**, and every frame on the plane draws the same
+columns — as do the palette, the keyboard walk and the list a mistyped name is answered
+with. It has to be: switching workspaces switches *chats*, so an order held per chat would
+hand you a differently-ordered strip after every switch, which is the shape this started
+out in. It is decided again when you next launch the plane — still while you are looking
+at it, fresh when you come back.
 
 **Neither strip is labelled.** They used to open with the word `chats` or `workspaces`, and
 that cost 9 and 14 columns of the row the names are competing for. What tells them apart is

--- a/docs/news/unreleased-the-workspace-tabs-stop-rearranging-themselves-on-every-switch.md
+++ b/docs/news/unreleased-the-workspace-tabs-stop-rearranging-themselves-on-every-switch.md
@@ -1,0 +1,80 @@
+---
+version: unreleased
+headline: The workspace tabs stop rearranging themselves every time you switch
+---
+
+*"when switching workspaces tabs — after each switch — order of workspaces tabs changing,
+feeling that each switch is opening new window."*
+
+0.58.0 made the workspaces strip lead with the workspaces you have been in, and froze that
+order so no tab could move under a press. The freeze worked. It was frozen in the wrong
+place.
+
+```
+before — three chats on one plane, three orders for one list
+
+  .charter/frame/default.1/tab_order          default           authority-audit  autonomy
+  .charter/frame/default.2/tab_order          default           harness-wrapper  authority-audit
+  .charter/frame/harness-wrapper.1/tab_order  harness-wrapper   default          authority-audit
+
+after — one plane, one order
+
+  .charter/workspace-tab-order                default           harness-wrapper  authority-audit  autonomy
+```
+
+## Why every switch drew a different strip
+
+The order was recorded under `.charter/frame/<chat>/`, which is a chat's own directory —
+per frame, never global, and deleted whole when that chat ends. Each chat wrote the order
+down the first time it painted, from the recency as it stood at that moment.
+
+**Switching workspaces switches chats.** So the strip really was still for as long as you
+looked at one chat, and then the next switch handed you another chat's snapshot, taken at
+a different time. `default.1` and `default.2` above are two chats of the *same* workspace,
+and they did not agree either — which is what makes this about the key rather than about
+workspaces.
+
+The measurement 0.58.0 was arguing against says the same thing from the other end. A strip
+that re-sorts under a press is one where the cell you just clicked holds a different name a
+moment later: on this project's own fifteen workspaces at 160 columns, six of the nine
+drawn tabs answered a second press at the identical column with a second, different
+workspace. Freezing per chat delivered that by a different route — not on the repaint, but
+on the switch.
+
+## The order belongs to the plane
+
+The strip draws a plane-wide list, so its order is now a plane-wide fact, in
+`.charter/workspace-tab-order` beside the other per-developer pointers charter keeps for a
+plane. Every frame reads that one file: the strip, the palette, the keyboard walk, the
+launcher's own sizing pass, and the "no workspace 'x' — have: …" sentence a typo gets
+back. `switch.workspaces` no longer takes a frame id at all — which frame is asking never
+was a question about the order, and asking it was the defect.
+
+Two consequences worth naming:
+
+* **The launch picker and a refusal's list lead with your working set too.** They used to
+  fall back to plain alphabetical order, because they run with no frame and had nowhere to
+  record an answer. One roster, one order, everywhere it is drawn.
+* **The per-chat files are gone**, along with the code that wrote them. Two records of one
+  order are two orders.
+
+## When it is decided again
+
+Once per plane launch. The order is decided by whichever process first asks for it and
+held for as long as the plane has any frame at all; charter drops it when a reap finds the
+plane has none left, so the next launch measures afresh.
+
+The two alternatives were both refused, and for opposite reasons. Deciding on every
+repaint is the live reordering above. Deciding once and never again ossifies: a workspace
+you create next month would sort last for good. A workspace created while the plane is up
+still goes on the end, in name order, where it cannot move a column you are already aiming
+at — that part is unchanged.
+
+A frame in your own tmux counts as a frame, so a strip you are looking at there keeps its
+columns still while an unrelated launch comes and goes on charter's private server.
+
+## The chats strip is deliberately untouched
+
+`api.1` stays leftmost, where you learned to look for it. A handful of numbered siblings is
+a stronger promise kept ordinal than it would be as a recency list, and that decision is
+older than this one.

--- a/tests/test_a_click_on_a_tab_bar_switches.py
+++ b/tests/test_a_click_on_a_tab_bar_switches.py
@@ -34,7 +34,7 @@ import os
 import unittest
 from unittest import mock
 
-from charter import commands_frame, config, tui, util
+from charter import commands_frame, config, tui, util, workspace
 from charter.frame import (builtin_actions, builtins, chats, component, events, overlay,
                            slots, state)
 
@@ -357,13 +357,15 @@ class AClickOnTheOverflowCountOpensThePalette(_ABarThatWasDrawn, unittest.TestCa
             (config.WORKSPACES_DIR / name).mkdir(parents=True, exist_ok=True)
         state.frame_dir("f1", create=True)
         state.record_workspace("f1", self.HERE)
-        # **The order is recorded rather than left to the recency measurement** (#903).
-        # `switch.workspaces` leads with the workspace this frame is IN, which would put
-        # the marked tab on the first page and leave the row with no LEADING count — and
-        # this class is about pressing both. Writing the order down is what a frame does
-        # on its first ask anyway (`state.record_tab_order`), so this pins the case's own
-        # premise instead of depending on which directory was written last.
-        state.record_tab_order("f1", list(self.NAMES))
+        # **The order is recorded rather than left to the recency measurement** (#903,
+        # #923). `switch.workspaces` leads with the most recently used workspace, which
+        # would put the marked tab on the first page and leave the row with no LEADING
+        # count — and this class is about pressing both. Writing the order down is what
+        # the plane does on its first ask anyway (`workspace.record_tab_order`), so this
+        # pins the case's own premise instead of depending on which directory was written
+        # last. The record is the PLANE's rather than this frame's since #923: the strip
+        # draws a plane-wide list, so what orders it is not keyed on `f1`.
+        workspace.record_tab_order(list(self.NAMES))
         self.enterContext(mock.patch.dict(os.environ, {"CHARTER_WORKSPACE": ""},
                                           clear=False))
         self.row = tui.strip_ansi(slots.workspaces_bar("f1", self.WIDTH)[0])

--- a/tests/test_a_real_resize_gives_a_real_strip_another_row.py
+++ b/tests/test_a_real_resize_gives_a_real_strip_another_row.py
@@ -98,11 +98,23 @@ class AResizeGivesTheStripTheRowsItsNamesNeed(_TmuxServerFixture, PersonaIso):
     def _window(self, session, cols, rows):
         """A real window with a harness pane and the four panels split off it, in the
         arrangement's own order — every strip one row, which is what a launch that had
-        never measured its names would produce."""
+        never measured its names would produce.
+
+        **The frame's state directory is made here, because a launch makes one** (#923).
+        `state.record_asserted_bars` deliberately takes no `create` — "a frame with no
+        directory records nothing" — and `cmd_resize` reads `state.panes(fid)` out of that
+        same directory before it ever reaches `_reassert_sizes`, so in production the
+        directory is there by construction. It was there in this fixture only by accident:
+        `switch.workspaces(fid)` used to write a per-chat `tab_order` on the sizing path
+        and minted the directory on the way past. The order is the plane's now, so nothing
+        on that path touches the frame's tree, and the fixture states what a launch does
+        instead of leaning on a side effect of something else.
+        """
         r = _tmux("new-session", "-d", "-s", session, "-x", str(cols), "-y", str(rows),
                   "-P", "-F", "#{pane_id}")
         self.assertEqual(r.returncode, 0, r.stderr)
         harness = r.stdout.strip()
+        state.frame_dir(state.frame_id(session, os.getpid()), create=True)
         panes = {}
         for slot, args in (("top", ("-v", "-b", "-l", "1")),
                            ("workspaces", ("-v", "-b", "-l", "1")),

--- a/tests/test_frame_state.py
+++ b/tests/test_frame_state.py
@@ -260,6 +260,30 @@ class TheDotIsTheVersionDiscriminator(PersonaIso, unittest.TestCase):
         self.assertEqual(state.reap({chat}, server="charter"), [])
         self.assertTrue(state.frame_dir(chat).exists())
 
+    def test_reap_answers_in_NAME_order_however_the_directories_were_made(self):
+        """`reap` says what it removed, and the list is sorted rather than whatever
+        `os.scandir` hands back.
+
+        **`tools/sweep.py` reported the `sorted` as a survivor** and it was right to:
+        every case in this repository that spells an expected list removes exactly one
+        directory, so the order was never asked about. It is not decoration — the walk is
+        over a directory listing, whose order is the filesystem's (ext4 answers in hash
+        order, APFS in its own) and is neither name order nor creation order on any of
+        them. An answer a caller cannot predict is one no case can spell.
+
+        **Made in reverse name order, and asserted against the forward one**, which is what
+        makes the sort observable rather than exercised: a fixture whose creation order and
+        name order agree passes with `sorted` gone on any filesystem that happens to answer
+        in creation order. Eight names, so an unsorted answer would have to land on the one
+        arrangement in 40,320 to pass by luck.
+        """
+        names = [f"ws-{i}" for i in range(8)]
+        for name in reversed(names):
+            chat = _claimed_by_a_departed_launcher(name)
+            state.bump(chat)
+        self.assertEqual(state.reap(set(), server="charter"),
+                         [f"{n}.1" for n in names])
+
     def test_a_chat_whose_window_is_gone_is_removed_with_no_launcher_process_alive(self):
         """The other half, and the one the dash would have broken: nothing in the name
         can keep this directory, so an absent chat id really does reap.

--- a/tests/test_the_keyboard_walks_the_tab_strips.py
+++ b/tests/test_the_keyboard_walks_the_tab_strips.py
@@ -45,7 +45,7 @@ class _AStripAKeyboardCanWalk(PersonaIso, unittest.TestCase):
     CHATS = ("api.1", "api.2", "api.3")
 
     #: Made on top of whatever `PersonaIso` scaffolds, which is why the cases below read
-    #: `switch.workspaces(FID)` rather than this tuple: a plane always has a `default`, so a
+    #: `switch.workspaces()` rather than this tuple: a plane always has a `default`, so a
     #: case that assumed its own three would be asserting about a list charter does not
     #: return. `_plant` also makes an `api` directory for the chats.
     WORKSPACES = ("alpha", "beta", "gamma")
@@ -138,14 +138,13 @@ class AWalkStartsTheSwitchATabClickStarts(_AStripAKeyboardCanWalk):
                          [(util.self_relaunch_argv("frame-chat", "api.1"), FID)])
 
     def test_the_next_workspace_is_the_one_drawn_next(self):
-        """The name after this frame's own, in `switch.workspaces(FID)`' order — which is
-        the order the `workspaces` bar draws, asked of the same function AND about the same
-        frame so the two cannot disagree. **The frame is the load-bearing half since
-        #903**: that order is per frame and recorded, so a walk that asked without an id
-        would walk the alphabet while the strip drew the working set. Read off the list
-        rather than spelled, because a plane always carries a `default` this fixture did
-        not make."""
-        names = switch.workspaces(FID)
+        """The name after this frame's own, in `switch.workspaces()`' order — which is the
+        order the `workspaces` bar draws, asked of the same function so the two cannot
+        disagree. **Asked without a frame since #923**: the order is the plane's, so a walk
+        that keyed it to this chat would step through a strip no frame draws. Read off the
+        list rather than spelled, because a plane always carries a `default` this fixture
+        did not make."""
+        names = switch.workspaces()
         want = names[names.index(self.here) + 1]
         self._run("workspace.next")
         self.assertEqual(
@@ -153,7 +152,7 @@ class AWalkStartsTheSwitchATabClickStarts(_AStripAKeyboardCanWalk):
             [(util.self_relaunch_argv("frame-switch", "--workspace", want), FID)])
 
     def test_the_previous_workspace_is_the_one_drawn_before(self):
-        names = switch.workspaces(FID)
+        names = switch.workspaces()
         want = names[names.index(self.here) - 1]
         self._run("workspace.previous")
         self.assertEqual(self.spawned[0][0][-1], want)
@@ -198,7 +197,7 @@ class AWalkStartsTheSwitchATabClickStarts(_AStripAKeyboardCanWalk):
         """
         self.assertEqual(self._run("chat.next"), "chat → api.3")
         self.assertEqual(self._run("chat.previous"), "chat → api.1")
-        names = switch.workspaces(FID)
+        names = switch.workspaces()
         want = names[names.index(self.here) + 1]
         self.assertEqual(self._run("workspace.next"), f"workspace → {want}")
 
@@ -230,7 +229,7 @@ class TheWalkWrapsAndStartsWhereTheDirectionCameFrom(_AStripAKeyboardCanWalk):
         sentinel for both was the first version of the repo walk and was wrong, and this
         is that decision reaching a second list."""
         state.record_workspace(FID, "nowhere-at-all")
-        names = switch.workspaces(FID)
+        names = switch.workspaces()
         self._run("workspace.next")
         self._run("workspace.previous")
         self.assertEqual([argv[-1] for argv, _fid in self.spawned],

--- a/tests/test_the_workspace_tabs_lead_with_the_working_set.py
+++ b/tests/test_the_workspace_tabs_lead_with_the_working_set.py
@@ -13,10 +13,16 @@ an operator learned to look for it, instead of jumping to the end because it hap
 be the newest."*
 
 Both are about a row that RE-SORTS WHILE YOU LOOK AT IT. Neither argues against an order
-that is fixed for as long as the frame is open. So the recency is measured once, written
-into the frame's own state directory (`state.record_tab_order`), and read by every process
-that draws or walks the strip afterwards; a switch updates the mtimes for the next frame
-and moves no column now.
+that is fixed for as long as you are looking. So the recency is measured once, written
+down (`workspace.record_tab_order`), and read by every process that draws or walks the
+strip afterwards; a switch updates the mtimes for the next plane launch and moves no
+column now.
+
+**Where "once" is scoped is #923, and it is measured next door**
+(`test_the_workspaces_strip_draws_one_order_for_the_plane.py`). #903 shipped this per
+FRAME, under `.charter/frame/<fid>/tab_order` — and switching workspaces switches chats,
+so the operator met a different frozen order after every switch. The order is the plane's
+now; what is measured HERE is the ordering rule itself, which #923 did not change.
 
 **Chats keep ordinal order and that is not an oversight** — `TheChatsStripIsUnchanged` is
 the control. A handful of numbered siblings is a stronger promise kept as `api.1`,
@@ -24,9 +30,7 @@ the control. A handful of numbered siblings is a stronger promise kept as `api.1
 
 **No new kind of state and no tally.** The recency is `chats.touched_by_workspace`, which
 is the mtime of each chat's own directory under `.charter/frame/` — a number charter
-already moves every time it writes anything about that chat. The per-frame ORDER is a file
-beside the density a palette row chose and the height `F3` recorded, so `state.reap`
-deletes it with the frame and there is nothing for `doctor` to explain.
+already moves every time it writes anything about that chat.
 """
 
 from __future__ import annotations
@@ -35,7 +39,7 @@ import os
 import unittest
 from unittest import mock
 
-from charter import config
+from charter import config, workspace
 from charter.frame import chats, choose, slots, state, switch
 
 from tests._isolation import PersonaIso
@@ -136,9 +140,7 @@ class TheRecencyIsMeasuredAndNotTallied(PersonaIso, unittest.TestCase):
 
 
 class TheStripLeadsWithTheWorkingSet(PersonaIso, unittest.TestCase):
-    """`switch.workspaces(fid)` — the order, asked of the function the strip asks."""
-
-    FID = "alpha.1"
+    """`switch.workspaces()` — the order, asked of the function the strip asks."""
 
     def setUp(self):
         super().setUp()
@@ -153,7 +155,7 @@ class TheStripLeadsWithTheWorkingSet(PersonaIso, unittest.TestCase):
 
     def test_the_most_recently_used_workspace_is_leftmost(self):
         self._plane(alpha=DAY, beta=DAY * 3, gamma=DAY * 2)
-        self.assertEqual(switch.workspaces(self.FID)[:3], ["beta", "gamma", "alpha"])
+        self.assertEqual(switch.workspaces()[:3], ["beta", "gamma", "alpha"])
 
     def test_the_opposite_recency_gives_the_opposite_order(self):
         """**Two opposite inputs and the two orders they must produce**, which is what
@@ -162,7 +164,7 @@ class TheStripLeadsWithTheWorkingSet(PersonaIso, unittest.TestCase):
         plane and fails here on every one.
         """
         self._plane(alpha=DAY * 3, beta=DAY, gamma=DAY * 2)
-        self.assertEqual(switch.workspaces(self.FID)[:3], ["alpha", "gamma", "beta"])
+        self.assertEqual(switch.workspaces()[:3], ["alpha", "gamma", "beta"])
 
     def test_two_workspaces_touched_in_the_same_tick_fall_back_to_name_order(self):
         """**A deterministic tie-break and not `os.scandir`'s order.** Mtimes have a
@@ -172,52 +174,40 @@ class TheStripLeadsWithTheWorkingSet(PersonaIso, unittest.TestCase):
         two backwards while agreeing with every case above.
         """
         self._plane(alpha=DAY, beta=DAY, gamma=DAY * 5)
-        self.assertEqual(switch.workspaces(self.FID)[:3], ["gamma", "alpha", "beta"])
+        self.assertEqual(switch.workspaces()[:3], ["gamma", "alpha", "beta"])
 
     def test_a_workspace_charter_has_never_seen_used_sorts_after_every_one_it_has(self):
         """`default` is folded in whether or not it has a directory and no chat has ever
         been in it; it is at the end rather than at the front, where an unmeasured name
         would be if the missing timestamp read as "now"."""
         self._plane(alpha=DAY)
-        got = switch.workspaces(self.FID)
+        got = switch.workspaces()
         self.assertEqual(got[0], "alpha")
         self.assertEqual(sorted(got[1:]), got[1:])
         self.assertIn(config.DEFAULT_WORKSPACE, got)
 
-    def test_a_caller_with_no_frame_gets_the_alphabet(self):
-        """`to_workspace` wants membership and a "have: …" sentence, and the launch picker
-        runs before any frame exists. Neither is about which order a strip draws, and
-        neither has a frame to record one in.
+    def test_a_plane_with_no_recency_at_all_is_the_alphabet(self):
+        """A plane nobody has opened a chat in has nothing to lead with, so the order is
+        the names — the answer that shipped before #903, and the one every frameless
+        caller used to be given whatever the plane had been doing.
 
         **Spelled out rather than compared against `sorted` of itself**, which is the shape
         `tools/sweep.py` reported: `sorted(names)` against `list(names)` passed the whole
         suite, because a test that asks whether a list equals its own sorting cannot tell
-        the two apart. The names below are what makes the `sorted` observable —
+        the two apart. The names below are what makes the ordering observable —
         `list_workspaces` answers in name order and `config.DEFAULT_WORKSPACE` is APPENDED
-        after it (it has no directory here), so the unsorted answer ends with `default`
-        where the sorted one puts it second.
+        after it (it has no directory here), so an unordered answer ends with `default`
+        where this one puts it second.
         """
-        self._plane(alpha=DAY, beta=DAY * 3, gamma=DAY * 2)
         self.assertNotIn(config.DEFAULT_WORKSPACE, ("alpha", "beta", "gamma"),
                          "this case needs a default that is not one of its own names")
         self.assertEqual(switch.workspaces(),
                          ["alpha", "beta", config.DEFAULT_WORKSPACE, "gamma"])
-        self.assertEqual(switch.workspaces(""), switch.workspaces())
-
-    def test_asking_without_a_frame_records_nothing_for_any_frame(self):
-        """The empty id must not reach `state.tab_order` and be answered "nothing
-        recorded" on every call — that is live reordering arriving through the one caller
-        with no frame to hold an order for."""
-        self._plane(alpha=DAY)
-        switch.workspaces("")
-        self.assertEqual(state.tab_order(""), [])
 
 
-class TheOrderIsHeldForTheFramesLife(PersonaIso, unittest.TestCase):
+class TheOrderIsHeldWhileThePlaneIsUp(PersonaIso, unittest.TestCase):
     """The half the two prior refusals are about: a column an operator aimed at is still
     that name a moment later."""
-
-    FID = "alpha.1"
 
     def setUp(self):
         super().setUp()
@@ -233,32 +223,32 @@ class TheOrderIsHeldForTheFramesLife(PersonaIso, unittest.TestCase):
         re-lays the frame out, which bumps it — so the recency measurement really does
         change under the running frame. What the strip draws does not.
         """
-        first = switch.workspaces(self.FID)
+        first = switch.workspaces()
         _touched("gamma.1", DAY * 99)
-        self.assertEqual(switch.workspaces(self.FID), first)
+        self.assertEqual(switch.workspaces(), first)
         self.assertEqual(chats.touched_by_workspace()["gamma"], DAY * 99,
                          "the case did not actually move the thing it is about")
 
     def test_a_second_process_asking_draws_the_identical_order(self):
         """A panel is torn down and re-split by every re-layout, so "compute it once" has
-        to mean once per FRAME and not once per process. The record is what makes the
-        launcher, the `frame-resize` child and each panel agree."""
-        first = switch.workspaces(self.FID)
+        to mean once per PLANE LAUNCH and not once per process. The record is what makes
+        the launcher, the `frame-resize` child and each panel agree."""
+        first = switch.workspaces()
         _touched("gamma.1", DAY * 99)
         # The file, read the way another process reads it — no `switch.workspaces` in
         # front of it, so this is what a launcher and a `frame-resize` child see and not
         # a second call into the function that might recompute.
-        self.assertEqual(state.tab_order(self.FID), first,
+        self.assertEqual(workspace.tab_order(), first,
                          "the order a second process reads is not the one that was drawn")
 
     def test_a_workspace_made_since_goes_on_the_end_and_moves_nothing(self):
         """A name created mid-session is appended, in name order, where it cannot move a
         column an operator is already aiming at. Re-recording the whole order to fit it in
         by recency is exactly the live reordering this refuses."""
-        first = switch.workspaces(self.FID)
+        first = switch.workspaces()
         (config.WORKSPACES_DIR / "aaa-new").mkdir(parents=True, exist_ok=True)
         (config.WORKSPACES_DIR / "zzz-new").mkdir(parents=True, exist_ok=True)
-        got = switch.workspaces(self.FID)
+        got = switch.workspaces()
         self.assertEqual(got[:len(first)], first)
         self.assertEqual(got[len(first):], ["aaa-new", "zzz-new"])
 
@@ -273,18 +263,18 @@ class TheOrderIsHeldForTheFramesLife(PersonaIso, unittest.TestCase):
         an accident at the call site rather than a promise kept where it is made.
 
         A record that does not carry every name is what makes the accident stop holding, and
-        it is reachable two ways: a hand-edited `tab_order`, and a record written before
+        it is reachable two ways: a hand-edited file, and a record written before
         `config.DEFAULT_WORKSPACE` was folded into the roster. `default` sorts between the
         two names below, so an unsorted append would put it after `zzz` — where
         `list_workspaces`' own order left it.
         """
         for name in ("aaa", "zzz"):
             (config.WORKSPACES_DIR / name).mkdir(parents=True, exist_ok=True)
-        state.record_tab_order(self.FID, ["alpha"])
+        workspace.record_tab_order(["alpha"])
         self.assertFalse((config.WORKSPACES_DIR / config.DEFAULT_WORKSPACE).is_dir(),
                          "this case needs a `default` with no directory, so that the "
                          "roster appends it after every name it read off the plane")
-        got = switch.workspaces(self.FID)
+        got = switch.workspaces()
         self.assertEqual(got[0], "alpha", "the recorded name did not lead")
         self.assertEqual(got[1:], ["aaa", "beta", config.DEFAULT_WORKSPACE, "gamma",
                                    "zzz"],
@@ -293,59 +283,47 @@ class TheOrderIsHeldForTheFramesLife(PersonaIso, unittest.TestCase):
     def test_a_workspace_deleted_since_is_simply_not_drawn(self):
         """The record is an ORDER and never a roster: `workspace.list_workspaces` decides
         which names exist, so a stale line cannot resurrect a directory that has gone."""
-        switch.workspaces(self.FID)
+        switch.workspaces()
         (config.WORKSPACES_DIR / "beta").rmdir()
-        self.assertNotIn("beta", switch.workspaces(self.FID))
-        self.assertIn("beta", state.tab_order(self.FID),
+        self.assertNotIn("beta", switch.workspaces())
+        self.assertIn("beta", workspace.tab_order(),
                       "the record was rewritten, so nothing was being tested")
 
     def test_a_recorded_name_that_is_not_a_name_is_dropped_on_the_way_out(self):
-        """`state.tab_order` holds every line to `workspace.valid_name`, like every other
-        name charter reads off disk and joins onto a path (#442). The file is charter's
-        own, so this is a floor rather than the whole guard."""
-        state.record_tab_order(self.FID, ["../../etc", "", "beta", "alpha"])
-        self.assertEqual(state.tab_order(self.FID), ["beta", "alpha"])
-        self.assertEqual(switch.workspaces(self.FID)[:2], ["beta", "alpha"])
+        """`workspace.tab_order` holds every line to `workspace.valid_name`, like every
+        other name charter reads off disk and joins onto a path (#442). The file is
+        charter's own, so this is a floor rather than the whole guard."""
+        workspace.record_tab_order(["../../etc", "", "beta", "alpha"])
+        self.assertEqual(workspace.tab_order(), ["beta", "alpha"])
+        self.assertEqual(switch.workspaces()[:2], ["beta", "alpha"])
 
     def test_whitespace_a_hand_left_around_a_name_is_taken_off_it(self):
-        """`density`'s read strips and this one does too, for the same reason: the file is
-        one name per line and a line is what is between two newlines, not what a hand left
-        beside one. `lstrip` would keep a trailing space and then hand `valid_name` a name
-        it correctly refuses — a workspace silently dropped off the strip because somebody
-        opened the file in an editor."""
-        (state.frame_dir(self.FID) / "tab_order").write_text("  beta  \n\talpha\t\n")
-        self.assertEqual(state.tab_order(self.FID), ["beta", "alpha"])
+        """`frame.state.chrome`'s read strips and this one does too, for the same reason:
+        the file is one name per line and a line is what is between two newlines, not what
+        a hand left beside one. `lstrip` would keep a trailing space and then hand
+        `valid_name` a name it correctly refuses — a workspace silently dropped off the
+        strip because somebody opened the file in an editor."""
+        config.WORKSPACE_TAB_ORDER_FILE.write_text("  beta  \n\talpha\t\n")
+        self.assertEqual(workspace.tab_order(), ["beta", "alpha"])
 
-    def test_an_id_that_cannot_name_a_directory_writes_nothing_and_does_not_raise(self):
-        """`fid` reaches `switch.workspaces` off a panel's argv and out of
-        `$CHARTER_SESSION_ID`, so it is untrusted the way every other id charter joins onto
-        a path is (#442). `frame_dir` refuses it, this writes nothing, and the strip
-        redraws — rather than a `TypeError` out of a render path.
-
-        Found as a survivor by `tools/sweep.py`: `record_asserted_bars` had this case and
-        its twin here did not, so the guard was correct and unasked-about.
-        """
-        state.record_tab_order("../evil", ["alpha"])
-        self.assertEqual(state.tab_order("../evil"), [])
-
-    def test_a_write_that_cannot_complete_leaves_the_frame_recomputing(self):
+    def test_a_write_that_cannot_complete_leaves_the_plane_recomputing(self):
         """The order is written on a panel's render path. A full filesystem costs the
-        frame its held order — it recomputes on the next paint, which is the answer this
+        plane its held order — it recomputes on the next paint, which is the answer this
         file was going to hold — and never a raise out of a strip."""
-        with mock.patch.object(state.config, "replace_for",
+        with mock.patch.object(workspace.config, "replace_for",
                                side_effect=OSError("no space")):
-            state.record_tab_order(self.FID, ["beta"])
-        self.assertEqual(state.tab_order(self.FID), [])
+            workspace.record_tab_order(["beta"])
+        self.assertEqual(workspace.tab_order(), [])
 
     def test_an_unreadable_record_recomputes_rather_than_raising(self):
         """This is read on a panel's render path and inside the `frame-resize` child. A
         truncated write degrades to "no order recorded", which is the same answer the file
         was written from a moment ago."""
-        state.record_tab_order(self.FID, ["beta"])
-        with mock.patch.object(state.Path, "read_text", side_effect=OSError("gone")):
-            self.assertEqual(state.tab_order(self.FID), [])
-            self.assertEqual(switch.workspaces(self.FID)[0], "alpha",
-                             "an unreadable order did not fall back to the recency")
+        workspace.record_tab_order(["beta"])
+        with mock.patch.object(workspace.Path, "read_text", side_effect=OSError("gone")):
+            self.assertEqual(workspace.tab_order(), [])
+        self.assertEqual(switch.workspaces()[0], "beta",
+                         "the readable record stopped being read")
 
 
 class EverySurfaceDrawsTheOneOrder(PersonaIso, unittest.TestCase):
@@ -367,22 +345,32 @@ class EverySurfaceDrawsTheOneOrder(PersonaIso, unittest.TestCase):
         slots.TABS.forget()
         self.addCleanup(slots.TABS.forget)
 
-    def test_the_strip_draws_the_names_in_the_frames_own_order(self):
+    def test_the_strip_draws_the_names_in_the_planes_own_order(self):
         with mock.patch.dict(os.environ, {"CHARTER_WORKSPACE": ""}, clear=False):
             row = slots.workspaces_bar(self.FID, 200)[0]
-        drawn = sorted((row.index(n), n) for n in switch.workspaces(self.FID)
-                       if n in row)
+        drawn = sorted((row.index(n), n) for n in switch.workspaces() if n in row)
         self.assertEqual([n for _at, n in drawn],
-                         [n for n in switch.workspaces(self.FID) if n in row],
+                         [n for n in switch.workspaces() if n in row],
                          f"the strip drew the names in another order: {row!r}")
         self.assertLess(row.index("beta"), row.index("gamma"))
         self.assertLess(row.index("gamma"), row.index("alpha"))
 
     def test_the_palette_offers_them_in_the_same_order(self):
-        """`choose.names_of` takes the frame's id and hands it on. A palette listing the
-        alphabet beside a strip listing the working set is two answers to one question."""
+        """`choose.names_of` stopped handing a frame id on for this noun in #923. A palette
+        listing one order beside a strip listing another is two answers to one question."""
         self.assertEqual(choose.names_of(choose.WORKSPACE, self.FID),
-                         switch.workspaces(self.FID))
+                         switch.workspaces())
+
+    def test_a_refusals_have_list_leads_with_the_working_set_too(self):
+        """`switch.to_workspace` names the workspaces this plane has when it refuses one it
+        does not have. That sentence used to take the alphabetical branch, because it asks
+        with no frame — so a refusal and the strip behind it listed the same names in two
+        different orders."""
+        outcome = switch.to_workspace(self.FID, "nope")
+        listed = [n for n in outcome.message.split() if n.strip(",") in switch.workspaces()]
+        self.assertEqual([n.strip(",") for n in listed][:3], ["beta", "gamma", "alpha"],
+                         f"the refusal did not lead with the working set: "
+                         f"{outcome.message!r}")
 
 
 class TheChatsStripIsUnchanged(PersonaIso, unittest.TestCase):

--- a/tests/test_the_workspace_tabs_lead_with_the_working_set.py
+++ b/tests/test_the_workspace_tabs_lead_with_the_working_set.py
@@ -306,6 +306,16 @@ class TheOrderIsHeldWhileThePlaneIsUp(PersonaIso, unittest.TestCase):
         config.WORKSPACE_TAB_ORDER_FILE.write_text("  beta  \n\talpha\t\n")
         self.assertEqual(workspace.tab_order(), ["beta", "alpha"])
 
+    def test_a_record_that_is_not_text_recomputes_rather_than_raising(self):
+        """`UnicodeDecodeError` is a `ValueError` and not an `OSError`, and it is what a
+        write torn by a full filesystem or a hand that saved the file in another encoding
+        reaches this reader as. A panel's render path answers "no order recorded" — which
+        is what the file was written from — rather than a traceback out of a strip."""
+        config.WORKSPACE_TAB_ORDER_FILE.write_bytes(b"beta\n\xff\xfe not utf-8\n")
+        self.assertEqual(workspace.tab_order(), [])
+        self.assertEqual(switch.workspaces()[0], "alpha",
+                         "an undecodable order did not fall back to the recency")
+
     def test_a_write_that_cannot_complete_leaves_the_plane_recomputing(self):
         """The order is written on a panel's render path. A full filesystem costs the
         plane its held order — it recomputes on the next paint, which is the answer this

--- a/tests/test_the_workspace_tabs_lead_with_the_working_set.py
+++ b/tests/test_the_workspace_tabs_lead_with_the_working_set.py
@@ -303,7 +303,7 @@ class TheOrderIsHeldWhileThePlaneIsUp(PersonaIso, unittest.TestCase):
         a hand left beside one. `lstrip` would keep a trailing space and then hand
         `valid_name` a name it correctly refuses — a workspace silently dropped off the
         strip because somebody opened the file in an editor."""
-        config.WORKSPACE_TAB_ORDER_FILE.write_text("  beta  \n\talpha\t\n")
+        workspace._tab_order_file().write_text("  beta  \n\talpha\t\n")
         self.assertEqual(workspace.tab_order(), ["beta", "alpha"])
 
     def test_a_record_that_is_not_text_recomputes_rather_than_raising(self):
@@ -311,7 +311,7 @@ class TheOrderIsHeldWhileThePlaneIsUp(PersonaIso, unittest.TestCase):
         write torn by a full filesystem or a hand that saved the file in another encoding
         reaches this reader as. A panel's render path answers "no order recorded" — which
         is what the file was written from — rather than a traceback out of a strip."""
-        config.WORKSPACE_TAB_ORDER_FILE.write_bytes(b"beta\n\xff\xfe not utf-8\n")
+        workspace._tab_order_file().write_bytes(b"beta\n\xff\xfe not utf-8\n")
         self.assertEqual(workspace.tab_order(), [])
         self.assertEqual(switch.workspaces()[0], "alpha",
                          "an undecodable order did not fall back to the recency")

--- a/tests/test_the_workspaces_strip_draws_one_order_for_the_plane.py
+++ b/tests/test_the_workspaces_strip_draws_one_order_for_the_plane.py
@@ -1,0 +1,357 @@
+"""#923: the workspaces strip draws one order, and it is the plane's.
+
+*"when switching workspaces tabs — after each switch — order of workspaces tabs changing,
+feeling that each switch is opening new window."*
+
+**A regression from #903, and the mechanism it broke was the right one.**
+`switch._by_use` freezes the order the first time it is asked and never re-decides, which
+is exactly what `slots._cuts` and `chats.of_workspace` both demanded with a measurement.
+The defect was the KEY. #903 stored the frozen order under `.charter/frame/<fid>/`, which
+`frame.state`'s opening line says is per frame and never global — and a chat is a frame.
+**Switching workspaces switches chats**, so every switch drew a strip ordered by a
+different chat's snapshot of the recency, taken at a different moment. Measured on the
+reporting plane: three chats, three orders, and two of them (`default.1`, `default.2`) in
+the same workspace and still disagreeing.
+
+The strip draws a plane-wide list. `TheStripIsOneListSoItHasOneOrder` is the reproduction
+— frames in different workspaces, painting at different moments, drawing identical
+columns — and it fails on #903's code in the way the report describes.
+
+**Three decisions this file pins beyond the fix itself.**
+
+* *Where it lives.* `config.WORKSPACE_TAB_ORDER_FILE`, beside `active-workspace` and
+  `sessions/` — plane-scoped, per developer, gitignored, private-mode, and not inside a
+  tree `state.reap` deletes per frame. `TheOrderIsPlaneStateAndNotFrameState`.
+* *When it is re-decided.* Once per plane launch: `state.reap` drops it when the reap
+  leaves this plane with no frame state at all, so the order is still while an operator is
+  looking at it and fresh when they come back. `APlaneThatGoesColdDecidesAgain`.
+* *That the per-chat file is GONE rather than kept beside it.* Two records of one order
+  are two orders. `TheOrderIsPlaneStateAndNotFrameState` asserts the frame writer no
+  longer exists and that no frame directory grows the file.
+
+**The three readings of the strip are checked together** (#880's rule), because anything
+that changes which name is at which column re-enters `_cuts`, `bar_rows_wanted` and
+`_tab_columns` at once: `TheThreeReadingsOfTheStripAgree` asks all three of two frames in
+different workspaces and holds #767's rule — a wider bar never drops more than the one
+name `_cuts` already admits to, and a tab never moves under a press.
+"""
+
+from __future__ import annotations
+
+import os
+import stat
+import unittest
+from unittest import mock
+
+from charter import config, tui, workspace
+from charter.frame import slots, state, switch
+
+from tests._isolation import PersonaIso
+from tests.test_frame_chat_switch import _plant
+
+#: Far enough apart that no filesystem's mtime granularity can round two together.
+DAY = 86400.0
+
+#: The plane the report was measured on, chats and all: two chats in one workspace is the
+#: shape that made the defect undeniable, because nothing about a workspace can explain
+#: two of its own chats disagreeing.
+PLANE = {"default.1": "default", "default.2": "default",
+         "harness-wrapper.1": "harness-wrapper",
+         "authority-audit.1": "authority-audit", "autonomy.1": "autonomy"}
+
+
+def _touched(fid: str, when: float) -> None:
+    """Make *fid*'s chat directory look as though charter last wrote to it at *when* —
+    which is what `chats.touched_by_workspace` measures the recency with."""
+    os.utime(state.frame_dir(fid), (when, when))
+
+
+class _Plane(PersonaIso):
+    """The reporting plane, planted: five chats over four workspaces, timed a day apart."""
+
+    WIDTH = 200
+
+    def setUp(self):
+        super().setUp()
+        for ws in set(PLANE.values()):
+            (config.WORKSPACES_DIR / ws).mkdir(parents=True, exist_ok=True)
+        for fid, ws in PLANE.items():
+            _plant(fid, workspace=ws)
+        self.age = {"autonomy.1": DAY, "authority-audit.1": DAY * 2,
+                    "harness-wrapper.1": DAY * 3, "default.2": DAY * 3.5,
+                    "default.1": DAY * 4}
+        self._restate()
+        slots.TABS.forget()
+        self.addCleanup(slots.TABS.forget)
+
+    def _restate(self) -> None:
+        """Put every chat's mtime back where `self.age` says it is.
+
+        Restated before each ask rather than set once, because recording the order is
+        itself a write and moves the very number the next reader measures. The operator's
+        plane has that property too; a fixture that did not would be measuring a quieter
+        world than the one the report came from.
+
+        A chat a reap has taken is skipped rather than recreated — a case about a plane
+        going cold must not have its fixture quietly plant the frames back.
+        """
+        for fid, at in self.age.items():
+            if state.frame_dir(fid).is_dir():
+                _touched(fid, at)
+
+    def arrive(self, fid: str) -> None:
+        """The half of a switch this feature can see: arriving in a chat writes to it."""
+        self.age[fid] = max(self.age.values()) + DAY
+        self._restate()
+
+    def strip(self, fid: str) -> list[str]:
+        """The names frame *fid* draws, left to right, as an operator reads them."""
+        self._restate()
+        with mock.patch.dict(os.environ, {"CHARTER_WORKSPACE": ""}, clear=False):
+            rows = slots.workspaces_bar(fid, self.WIDTH)
+        row = tui.strip_ansi("".join(rows))
+        return sorted((n for n in switch.workspaces() if n in row), key=row.index)
+
+
+class TheStripIsOneListSoItHasOneOrder(_Plane, unittest.TestCase):
+    """**The reproduction.** Every case here draws the strip of two or three DIFFERENT
+    frames, with the recency moved between them the way a real switch moves it, and
+    asserts they came out identical. On #903's code each frame recorded its own order at
+    its own moment and these are the orders the report lists."""
+
+    def test_two_frames_in_different_workspaces_draw_the_same_order(self):
+        """The gesture in the report, at its smallest: paint one frame, switch, paint the
+        next. The switch really does move the measurement — the second assertion is what
+        stops this passing on a plane that never changed."""
+        first = self.strip("default.1")
+        self.arrive("harness-wrapper.1")
+        self.assertEqual(self.strip("harness-wrapper.1"), first,
+                         "the frame arrived in drew a different strip")
+        self.assertEqual(switch.current_workspace("harness-wrapper.1"), "harness-wrapper",
+                         "the two frames are not in different workspaces")
+
+    def test_two_chats_of_one_workspace_draw_the_same_order(self):
+        """`default.1` and `default.2` are the pair that makes the scope unarguable: they
+        are in one workspace, so nothing about which workspace a frame is in can account
+        for their disagreeing. On #903's code they did."""
+        first = self.strip("default.1")
+        self.arrive("authority-audit.1")
+        self.arrive("default.2")
+        self.assertEqual(self.strip("default.2"), first)
+
+    def test_the_three_chats_of_the_report_draw_one_order_between_them(self):
+        """The report's own table, which held three different orders for one plane-wide
+        list. Asked as a set of what was drawn, so the failure names how many orders the
+        plane had rather than which one was wrong."""
+        drawn = {"default.1": self.strip("default.1")}
+        self.arrive("harness-wrapper.1")
+        drawn["harness-wrapper.1"] = self.strip("harness-wrapper.1")
+        self.arrive("authority-audit.1")
+        self.arrive("default.2")
+        drawn["default.2"] = self.strip("default.2")
+        orders = {tuple(v) for v in drawn.values()}
+        self.assertEqual(len(orders), 1,
+                         f"{len(drawn)} chats drew {len(orders)} orders: {drawn}")
+
+    def test_the_one_order_is_still_the_working_set_first(self):
+        """The fix is about the SCOPE of the freeze and not about the ordering rule, so
+        #903's own answer has to survive it: the plane leads with what it was last in."""
+        self.assertEqual(self.strip("default.1")[:2], ["default", "harness-wrapper"])
+
+    def test_a_frame_that_paints_first_decides_for_the_plane_and_not_only_for_itself(self):
+        """Which frame asks first is a race between panel processes, and the answer must
+        not depend on who won. Whichever asks, the record is the plane's and the next
+        frame reads it rather than measuring again."""
+        self.strip("harness-wrapper.1")
+        recorded = workspace.tab_order()
+        self.arrive("autonomy.1")
+        self.assertEqual(self.strip("default.1"), recorded[:len(self.strip("default.1"))])
+        self.assertEqual(workspace.tab_order(), recorded,
+                         "the second frame to paint rewrote the plane's order")
+
+
+class TheOrderIsPlaneStateAndNotFrameState(_Plane, unittest.TestCase):
+    """Where the record lives, and that there is exactly one of it."""
+
+    def test_it_is_written_to_the_planes_own_state_file(self):
+        self.strip("default.1")
+        self.assertTrue(config.WORKSPACE_TAB_ORDER_FILE.is_file(),
+                        "the plane recorded no order")
+        self.assertEqual(config.WORKSPACE_TAB_ORDER_FILE.parent, config.STATE_DIR,
+                         "the plane's order is not beside the plane's other pointers")
+
+    def test_no_frame_directory_grows_a_tab_order_file(self):
+        """**The per-chat file is removed rather than left beside the plane-wide one.**
+        Two records of one order are two orders, and the second one is the defect. Asked of
+        every frame directory rather than of one name, so a writer that moved to another
+        file inside the frame's tree is caught too."""
+        self.strip("default.1")
+        self.strip("harness-wrapper.1")
+        left = sorted(p.name for d in state._root().iterdir() if d.is_dir()
+                      for p in d.iterdir())
+        self.assertNotIn("tab_order", left, f"a frame still holds an order: {left}")
+
+    def test_the_per_frame_writer_and_reader_are_gone_from_frame_state(self):
+        """`frame.state` is what one frame knows about ITSELF (its opening line), and an
+        order the whole plane draws was never that. Named rather than merely unused, so a
+        caller cannot quietly grow back."""
+        self.assertFalse(hasattr(state, "record_tab_order"),
+                         "the per-chat writer is still reachable")
+        self.assertFalse(hasattr(state, "tab_order"),
+                         "the per-chat reader is still reachable")
+
+    def test_the_record_is_charters_own_and_no_other_accounts(self):
+        """#894's rule, where this write lands: everything under `STATE_DIR` goes out
+        through `config.write_for`/`replace_for`, so the mode is charter's decision and not
+        the umask's. A bare `write_text` here would come out 0644 under an ordinary umask
+        and 0666 under `umask 000`."""
+        with mock.patch.object(os, "umask", return_value=0):
+            os.umask(0)
+            self.addCleanup(os.umask, 0o022)
+            workspace.record_tab_order(["default"])
+        mode = stat.S_IMODE(config.WORKSPACE_TAB_ORDER_FILE.stat().st_mode)
+        self.assertEqual(mode, config.STATE_FILE_MODE, f"written at {mode:04o}")
+
+    def test_the_frame_id_is_no_longer_part_of_the_question(self):
+        """`switch.workspaces` takes no frame, which is the fix stated in the signature:
+        the ORDER is the plane's and only the MARK is the frame's. A parameter still
+        accepted would be one a caller could go on keying an order to."""
+        with self.assertRaises(TypeError):
+            switch.workspaces("default.1")
+
+
+class APlaneThatGoesColdDecidesAgain(_Plane, unittest.TestCase):
+    """**When the order expires**, which is the second question #923 asks and the one with
+    two wrong answers. Never re-deciding ossifies — a workspace made next month sorts last
+    for good. Re-deciding on a repaint is the live reordering `slots._cuts` measured and
+    refused. Once per plane launch is what is left, and `state.reap` is where charter sees
+    a plane go cold."""
+
+    def _reap(self, live=(), server="charter") -> None:
+        state.reap(set(live), server=server)
+
+    def test_a_reap_that_leaves_no_frame_forgets_the_order(self):
+        self.strip("default.1")
+        self.assertTrue(config.WORKSPACE_TAB_ORDER_FILE.is_file())
+        self._reap()
+        self.assertEqual(state.reap(set(), server="charter"), [],
+                         "the plane still holds frame state, so it never went cold")
+        self.assertFalse(config.WORKSPACE_TAB_ORDER_FILE.exists(),
+                         "the order outlived every frame that could be drawing it")
+
+    def test_the_next_launch_then_leads_with_what_the_plane_did_last(self):
+        """The point of expiring it: a plane that has moved on comes back ordered by where
+        the operator actually was, rather than by where they were the first time they ever
+        opened it."""
+        first = self.strip("default.1")
+        self.assertEqual(first[0], "default")
+        self._reap()
+        for fid, ws in PLANE.items():
+            _plant(fid, workspace=ws)
+        self.age = dict(self.age, **{"autonomy.1": DAY * 40})
+        self.assertEqual(self.strip("autonomy.1")[0], "autonomy",
+                         "the plane came back in the order it had last month")
+
+    def test_a_reap_that_leaves_one_frame_keeps_the_order(self):
+        """The other half, and the one #767 is about: a frame still on screen must not have
+        its columns rearranged because a SIBLING ended."""
+        first = self.strip("default.1")
+        self.arrive("harness-wrapper.1")
+        self._reap(live={"default.1"})
+        self.assertTrue(config.WORKSPACE_TAB_ORDER_FILE.is_file(),
+                        "a live frame's order was forgotten under it")
+        self.assertEqual(self.strip("default.1"), first)
+
+    def test_a_frame_on_the_other_tmux_server_keeps_it_too(self):
+        """`reap` is scoped to one server because "not live" is only an answer a frame's
+        own server can give — so a frame in the operator's own tmux is kept by that rule
+        and is an operator looking at a strip. The plane is cold only when NOTHING is left,
+        which is why the test is on the directory rather than on this reap's own list."""
+        self.strip("default.1")
+        for fid in PLANE:
+            state.record_server(fid, "other-socket")
+        self._reap(server="charter")
+        self.assertTrue(config.WORKSPACE_TAB_ORDER_FILE.is_file(),
+                        "the other server's frames were treated as gone")
+
+    def test_a_claim_that_is_not_a_frame_yet_leaves_the_plane_warm(self):
+        """`reap` keeps a directory for four independent reasons and any one of them is a
+        plane that is still up. The narrowest is #685's: a claim `new_chat_id` has made and
+        whose marker has not landed, which is a frame about to be born rather than one that
+        has gone."""
+        self.strip("default.1")
+        (state._root() / "later.1").mkdir()
+        self._reap()
+        self.assertTrue(config.WORKSPACE_TAB_ORDER_FILE.is_file(),
+                        "a plane with a chat being claimed was read as cold")
+
+    def test_forgetting_an_order_that_was_never_recorded_is_not_an_error(self):
+        """A plane that has never drawn a strip reaps like any other, and a reap runs on a
+        launch path where a raise costs the launch."""
+        self.assertFalse(config.WORKSPACE_TAB_ORDER_FILE.exists())
+        workspace.forget_tab_order()
+        self._reap()
+
+
+class TheThreeReadingsOfTheStripAgree(_Plane, unittest.TestCase):
+    """#880's rule: which name is at which column is read by `_cuts`, by
+    `bar_rows_wanted` and by `_tab_columns`, and a change that moves one moves all three.
+    Asked of two frames in different workspaces, which is the axis #923 changed."""
+
+    #: Fifteen names is the list every measurement in `slots._cuts` and `test_frame_bars`
+    #: is stated against, and the size the reporting plane is near.
+    NAMES = [f"workspace-{i:02d}" for i in range(15)]
+
+    def setUp(self):
+        super().setUp()
+        for name in self.NAMES:
+            (config.WORKSPACES_DIR / name).mkdir(parents=True, exist_ok=True)
+
+    def test_two_frames_want_the_same_number_of_rows(self):
+        """The sizing pass runs in the LAUNCHER and in the `frame-resize` child, neither of
+        which is the panel that draws. Two frames asking for different heights is a strip
+        planned for one shape and drawn in another."""
+        self.strip("default.1")
+        self.arrive("harness-wrapper.1")
+        wanted = [slots.bar_rows_wanted(fid, "workspaces", pane_cols=90, cap=3)
+                  for fid in ("default.1", "harness-wrapper.1")]
+        self.assertEqual(wanted[0], wanted[1], "the two frames sized the strip differently")
+        self.assertGreater(wanted[0], 1, "this width does not overflow, so it measures "
+                                         "nothing about the cut")
+
+    def test_a_tab_is_at_the_same_column_for_both_frames(self):
+        """*"a tab must never move under a press"* (#767) across the one gesture that
+        used to move every one of them. The published map is what a click resolves
+        against, so it is asked rather than the drawn row."""
+        with mock.patch.dict(os.environ, {"CHARTER_WORKSPACE": ""}, clear=False):
+            slots.workspaces_bar("default.1", 160, rows=2)
+            before = {(r, c): slots.TABS.tab_at(r, c)
+                      for r in range(2) for c in range(160)}
+            self.arrive("harness-wrapper.1")
+            self._restate()
+            slots.workspaces_bar("harness-wrapper.1", 160, rows=2)
+            after = {(r, c): slots.TABS.tab_at(r, c)
+                     for r in range(2) for c in range(160)}
+        moved = {k: (before[k], after[k]) for k in before if before[k] != after[k]}
+        self.assertEqual(moved, {}, f"a tab moved under the switch: {moved}")
+
+    def test_a_wider_bar_never_drops_more_than_the_one_name_the_cut_admits_to(self):
+        """#767's rule on the strip this issue changes, over the whole range `_cuts`'
+        own measurements are stated across. The cut is deliberately not monotone — its
+        docstring says so and `test_frame_bars` pins the count — but no step may cost more
+        than a single name, and a plane-wide order must not have made it worse."""
+        self.strip("default.1")
+        drops, previous = [], None
+        with mock.patch.dict(os.environ, {"CHARTER_WORKSPACE": ""}, clear=False):
+            for width in range(60, 281):
+                row = tui.strip_ansi(slots.workspaces_bar("default.1", width)[0])
+                count = len([n for n in self.NAMES if n in row])
+                if previous is not None and count < previous:
+                    drops.append((width, previous - count))
+                previous = count
+        self.assertEqual([step for _w, step in drops], [1] * len(drops),
+                         f"a drop cost more than one name: {drops}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_the_workspaces_strip_draws_one_order_for_the_plane.py
+++ b/tests/test_the_workspaces_strip_draws_one_order_for_the_plane.py
@@ -41,6 +41,7 @@ from __future__ import annotations
 import os
 import stat
 import unittest
+from pathlib import Path
 from unittest import mock
 
 from charter import config, tui, workspace
@@ -203,14 +204,25 @@ class TheOrderIsPlaneStateAndNotFrameState(_Plane, unittest.TestCase):
     def test_the_record_is_charters_own_and_no_other_accounts(self):
         """#894's rule, where this write lands: everything under `STATE_DIR` goes out
         through `config.write_for`/`replace_for`, so the mode is charter's decision and not
-        the umask's. A bare `write_text` here would come out 0644 under an ordinary umask
-        and 0666 under `umask 000`."""
-        with mock.patch.object(os, "umask", return_value=0):
-            os.umask(0)
-            self.addCleanup(os.umask, 0o022)
-            workspace.record_tab_order(["default"])
+        the umask's.
+
+        **Under a real `umask 000`**, which is what makes the claim measurable — the mode
+        `write_for` names and the mode an ordinary `write_text` produces are the same 0600
+        under nobody's umask, and differ by every bit under this one. A bare `write_text`
+        here comes out 0666.
+
+        The directory is asked about too: `record_tab_order` may be the writer that creates
+        `.charter/` itself on a first launch, and a state directory any account can list is
+        exactly the exposure #470 was filed for.
+        """
+        old = os.umask(0o000)
+        self.addCleanup(os.umask, old)
+        workspace.record_tab_order(["default"])
         mode = stat.S_IMODE(config.WORKSPACE_TAB_ORDER_FILE.stat().st_mode)
-        self.assertEqual(mode, config.STATE_FILE_MODE, f"written at {mode:04o}")
+        self.assertEqual(mode & 0o077, 0, f"the record came out {mode:04o}")
+        self.assertEqual(mode, config.STATE_FILE_MODE, f"the record came out {mode:04o}")
+        d = stat.S_IMODE(Path(config.STATE_DIR).stat().st_mode)
+        self.assertEqual(d & 0o077, 0, f"the state directory came out {d:04o}")
 
     def test_the_frame_id_is_no_longer_part_of_the_question(self):
         """`switch.workspaces` takes no frame, which is the fix stated in the signature:

--- a/tests/test_the_workspaces_strip_draws_one_order_for_the_plane.py
+++ b/tests/test_the_workspaces_strip_draws_one_order_for_the_plane.py
@@ -364,11 +364,15 @@ class TheThreeReadingsOfTheStripAgree(_Plane, unittest.TestCase):
         docstring says so and `test_frame_bars` pins the count — but no step may cost more
         than a single name, and a plane-wide order must not have made it worse."""
         self.strip("default.1")
+        # Every name the plane has and not only `NAMES`, because a count over a subset can
+        # read two names leaving at once as a drop of two when one of them was replaced by
+        # a name the subset does not hold. The property is about the ROW.
+        names = switch.workspaces()
         drops, previous = [], None
         with mock.patch.dict(os.environ, {"CHARTER_WORKSPACE": ""}, clear=False):
             for width in range(60, 281):
                 row = tui.strip_ansi(slots.workspaces_bar("default.1", width)[0])
-                count = len([n for n in self.NAMES if n in row])
+                count = len([n for n in names if n in row])
                 if previous is not None and count < previous:
                     drops.append((width, previous - count))
                 previous = count

--- a/tests/test_the_workspaces_strip_draws_one_order_for_the_plane.py
+++ b/tests/test_the_workspaces_strip_draws_one_order_for_the_plane.py
@@ -285,6 +285,17 @@ class APlaneThatGoesColdDecidesAgain(_Plane, unittest.TestCase):
         self.assertTrue(config.WORKSPACE_TAB_ORDER_FILE.is_file(),
                         "a plane with a chat being claimed was read as cold")
 
+    def test_a_stray_file_in_the_frame_root_is_not_a_frame(self):
+        """The count is of DIRECTORIES, and a file there is neither a frame that was
+        reaped nor a frame that is still up. Left in the count it would be a directory
+        `reap` can never take — every keep-rule abstains on a file — so the plane would
+        read as warm for good and the order would never be decided again."""
+        self.strip("default.1")
+        (state._root() / "stray").write_text("not a frame\n")
+        self._reap()
+        self.assertFalse(config.WORKSPACE_TAB_ORDER_FILE.exists(),
+                         "a file in the frame root kept the plane warm for ever")
+
     def test_forgetting_an_order_that_was_never_recorded_is_not_an_error(self):
         """A plane that has never drawn a strip reaps like any other, and a reap runs on a
         launch path where a raise costs the launch."""

--- a/tests/test_the_workspaces_strip_draws_one_order_for_the_plane.py
+++ b/tests/test_the_workspaces_strip_draws_one_order_for_the_plane.py
@@ -19,7 +19,7 @@ columns — and it fails on #903's code in the way the report describes.
 
 **Three decisions this file pins beyond the fix itself.**
 
-* *Where it lives.* `config.WORKSPACE_TAB_ORDER_FILE`, beside `active-workspace` and
+* *Where it lives.* `workspace._tab_order_file()`, beside `active-workspace` and
   `sessions/` — plane-scoped, per developer, gitignored, private-mode, and not inside a
   tree `state.reap` deletes per frame. `TheOrderIsPlaneStateAndNotFrameState`.
 * *When it is re-decided.* Once per plane launch: `state.reap` drops it when the reap
@@ -176,10 +176,21 @@ class TheOrderIsPlaneStateAndNotFrameState(_Plane, unittest.TestCase):
 
     def test_it_is_written_to_the_planes_own_state_file(self):
         self.strip("default.1")
-        self.assertTrue(config.WORKSPACE_TAB_ORDER_FILE.is_file(),
+        self.assertTrue(workspace._tab_order_file().is_file(),
                         "the plane recorded no order")
-        self.assertEqual(config.WORKSPACE_TAB_ORDER_FILE.parent, config.STATE_DIR,
+        self.assertEqual(workspace._tab_order_file().parent, config.STATE_DIR,
                          "the plane's order is not beside the plane's other pointers")
+
+    def test_the_path_is_the_one_charter_tells_operators_it_is(self):
+        """**Spelled out, because the spelling is published.** `docs/news` shows an
+        operator `.charter/workspace-tab-order` in the before-and-after this issue is
+        about, and `docs/frame.md` describes what lives there. A path in a release note is
+        a promise like any other name charter prints, and one the reader and the writer
+        would go on agreeing about after a rename — both go through the same function, so
+        nothing else in this file could tell.
+        """
+        self.assertEqual(workspace._tab_order_file(),
+                         Path(config.STATE_DIR) / "workspace-tab-order")
 
     def test_no_frame_directory_grows_a_tab_order_file(self):
         """**The per-chat file is removed rather than left beside the plane-wide one.**
@@ -218,7 +229,7 @@ class TheOrderIsPlaneStateAndNotFrameState(_Plane, unittest.TestCase):
         old = os.umask(0o000)
         self.addCleanup(os.umask, old)
         workspace.record_tab_order(["default"])
-        mode = stat.S_IMODE(config.WORKSPACE_TAB_ORDER_FILE.stat().st_mode)
+        mode = stat.S_IMODE(workspace._tab_order_file().stat().st_mode)
         self.assertEqual(mode & 0o077, 0, f"the record came out {mode:04o}")
         self.assertEqual(mode, config.STATE_FILE_MODE, f"the record came out {mode:04o}")
         d = stat.S_IMODE(Path(config.STATE_DIR).stat().st_mode)
@@ -244,11 +255,11 @@ class APlaneThatGoesColdDecidesAgain(_Plane, unittest.TestCase):
 
     def test_a_reap_that_leaves_no_frame_forgets_the_order(self):
         self.strip("default.1")
-        self.assertTrue(config.WORKSPACE_TAB_ORDER_FILE.is_file())
+        self.assertTrue(workspace._tab_order_file().is_file())
         self._reap()
         self.assertEqual(state.reap(set(), server="charter"), [],
                          "the plane still holds frame state, so it never went cold")
-        self.assertFalse(config.WORKSPACE_TAB_ORDER_FILE.exists(),
+        self.assertFalse(workspace._tab_order_file().exists(),
                          "the order outlived every frame that could be drawing it")
 
     def test_the_next_launch_then_leads_with_what_the_plane_did_last(self):
@@ -270,7 +281,7 @@ class APlaneThatGoesColdDecidesAgain(_Plane, unittest.TestCase):
         first = self.strip("default.1")
         self.arrive("harness-wrapper.1")
         self._reap(live={"default.1"})
-        self.assertTrue(config.WORKSPACE_TAB_ORDER_FILE.is_file(),
+        self.assertTrue(workspace._tab_order_file().is_file(),
                         "a live frame's order was forgotten under it")
         self.assertEqual(self.strip("default.1"), first)
 
@@ -283,7 +294,7 @@ class APlaneThatGoesColdDecidesAgain(_Plane, unittest.TestCase):
         for fid in PLANE:
             state.record_server(fid, "other-socket")
         self._reap(server="charter")
-        self.assertTrue(config.WORKSPACE_TAB_ORDER_FILE.is_file(),
+        self.assertTrue(workspace._tab_order_file().is_file(),
                         "the other server's frames were treated as gone")
 
     def test_a_claim_that_is_not_a_frame_yet_leaves_the_plane_warm(self):
@@ -294,7 +305,7 @@ class APlaneThatGoesColdDecidesAgain(_Plane, unittest.TestCase):
         self.strip("default.1")
         (state._root() / "later.1").mkdir()
         self._reap()
-        self.assertTrue(config.WORKSPACE_TAB_ORDER_FILE.is_file(),
+        self.assertTrue(workspace._tab_order_file().is_file(),
                         "a plane with a chat being claimed was read as cold")
 
     def test_a_stray_file_in_the_frame_root_is_not_a_frame(self):
@@ -305,13 +316,13 @@ class APlaneThatGoesColdDecidesAgain(_Plane, unittest.TestCase):
         self.strip("default.1")
         (state._root() / "stray").write_text("not a frame\n")
         self._reap()
-        self.assertFalse(config.WORKSPACE_TAB_ORDER_FILE.exists(),
+        self.assertFalse(workspace._tab_order_file().exists(),
                          "a file in the frame root kept the plane warm for ever")
 
     def test_forgetting_an_order_that_was_never_recorded_is_not_an_error(self):
         """A plane that has never drawn a strip reaps like any other, and a reap runs on a
         launch path where a raise costs the launch."""
-        self.assertFalse(config.WORKSPACE_TAB_ORDER_FILE.exists())
+        self.assertFalse(workspace._tab_order_file().exists())
         workspace.forget_tab_order()
         self._reap()
 


### PR DESCRIPTION
Closes #923

*"when switching workspaces tabs — after each switch — order of workspaces tabs changing,
feeling that each switch is opening new window."*

#903's freeze was the right mechanism in the wrong place. `switch._by_use` decides the
order once and never re-decides — which is exactly what `slots._cuts` and
`chats.of_workspace` each demanded with a measurement. The **key** was the defect:
`state.tab_order(fid)` lived under `.charter/frame/<fid>/`, which `frame/state.py`'s
opening line says is per frame and never global. **Switching workspaces switches chats**,
so every switch handed the operator another chat's snapshot of the recency, taken at a
different moment.

## Reproduced, before and after

Three chats, each first painting at a different point in the plane's history — the
operator's own gesture, since arriving in a chat writes to it. Same script against both
trees:

```
before (origin/main @ 89ff785b)
  default.1          default  harness-wrapper  authority-audit  autonomy
  default.2          default  authority-audit  harness-wrapper  autonomy
  harness-wrapper.1  harness-wrapper  default  authority-audit  autonomy
  distinct orders drawn by 3 chats: 3

after (this branch)
  default.1          default  harness-wrapper  authority-audit  autonomy
  default.2          default  harness-wrapper  authority-audit  autonomy
  harness-wrapper.1  default  harness-wrapper  authority-audit  autonomy
  distinct orders drawn by 3 chats: 1
```

`default.1` and `default.2` are two chats of the **same** workspace, which is what makes
this about the key rather than about workspaces.

That reproduction is permanent as
`tests/test_the_workspaces_strip_draws_one_order_for_the_plane.py`. Run against
`origin/main`'s tree it fails 15 of its 20 cases, including
`test_a_tab_is_at_the_same_column_for_both_frames`, which reports the columns that moved:

```
(0, 23): ('harness-wrapper', 'default') … (0, 33): ('harness-wrapper', 'default')
```

— eleven columns answering a press with a second, different workspace. That is #767's rule
broken, and it is the same harm `_cuts` measured against a recency-centred window, arriving
by another route.

## The four things the issue asked to settle

**1. Where it lives.** `config.WORKSPACE_TAB_ORDER_FILE` — `.charter/workspace-tab-order`,
beside `active-workspace`, `sessions/` and `terminals/`. Plane-scoped, per developer,
gitignored, machine-written, `config.replace_for` (#894), 0600. Not under `.charter/frame/`:
that tree is per frame by construction and `state.NO_FORMAT_PROMISE` says so, and `reap`
deletes each frame's copy with the frame — which is the defect. The reader and writer are in
`charter/workspace.py`, next to `list_workspaces`, because the order of a roster belongs
with the roster; `switch._by_use` still decides it and `chats.touched_by_workspace` still
measures the recency (#882's split, unchanged).

**2. When it is re-decided.** Once per plane launch. `state.reap` drops it when a reap
takes every directory the frame root had — charter's one observer of a plane going cold,
already reaching one directory over for `_forget_session`. "Once ever" ossifies: a
workspace made next month sorts last for good. "Once per repaint" is the live reordering
`_cuts` refused. The count is over **every** entry, not this server's, so a frame in the
operator's own tmux — kept by reap's `owner != server` rule — keeps the strip still under
the hand that is looking at it (#767).

**3. A new workspace.** Unchanged: `_by_use` appends unknown names in sorted order after
the recorded ones, and that promise is still kept where it is made.

**4. The per-chat files.** `state.record_tab_order` and `state.tab_order` are **deleted**,
not kept beside the new record — two records of one order are two orders. A case asserts
neither name is reachable and that no frame directory grows the file.

`switch.workspaces` takes **no frame id at all** now. Which frame is asking was never a
question about the order, and asking it was the defect. One consequence is a widening the
issue did not ask for and #882 already argued for: the launch picker and a refusal's
`have: …` sentence used to fall back to plain alphabetical because they run with no frame
and had nowhere to record an answer. They now lead with the working set like everything
else.

## The constraints

* **`_cuts`, `bar_rows_wanted` and `_tab_columns` are checked together** in
  `TheThreeReadingsOfTheStripAgree`: two frames in different workspaces want the same rows,
  publish the identical column map, and no width from 60 to 280 drops more than the one
  name `_cuts`' own docstring admits to.
* **#767 holds.** No tab moves under a press across a switch — the case above — and the
  drop-by-at-most-one sweep is asked of this strip and not only of `_bar`.
* **No live reordering is reintroduced.** The order is still frozen; only its scope
  changed. `TheOrderIsHeldWhileThePlaneIsUp` keeps every one of #903's own cases.
* **The chats strip is untouched.** `chats.of_workspace` stays ordinal (#829), and
  `TheChatsStripIsUnchanged` is still the control.

## One test fixture, and why it was a fixture rather than a defect

`tests/test_a_real_resize_gives_a_real_strip_another_row.py` drives `_reassert_sizes`
against a synthetic frame id. `state.record_asserted_bars` deliberately takes no `create`
— *"a frame with no directory records nothing"* — and the directory existed there only
because `switch.workspaces(fid)` wrote a per-chat `tab_order` on the sizing path and minted
it on the way past. In production `cmd_resize` reads `state.panes(fid)` out of that same
directory before it ever reaches `_reassert_sizes`, so a real frame always has one. The
fixture now states what a launch does instead of leaning on a side effect.

## Shared files

`charter/frame/slots.py` is touched in one place, `_workspaces_strip` (8 lines), well away
from the chats strip's affordances — #921 is working there concurrently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018hUBNraNfixfMMK5Jc6CNy
