### PR TITLE
The quit confirmation takes the pane, because its blast radius is the plane (#927)

### DIFF
--- a/charter/commands_frame.py
+++ b/charter/commands_frame.py
@@ -8256,11 +8256,11 @@ def _draw_palette(args) -> int:
     socket = state.frame_server(fid) or SOCKET
     harness = state.harness_pane(fid) or ""
     # **This process's own rectangle, read ONCE and used twice** — by :func:`_picker`, to
-    # unzoom a confirmation into the drawer it is (#921), and by `_close_palette` in the
-    # `finally`. tmux sets `$TMUX_PANE` in every process it starts and `frame/tabmenu
-    # .handback` reads the same variable for the same pane; a second read here would be a
-    # second answer to "which pane am I", on the one path where being wrong means resizing
-    # or killing the operator's harness.
+    # unzoom a one-chat confirmation into the drawer it is (#921, #927), and by
+    # `_close_palette` in the `finally`. tmux sets `$TMUX_PANE` in every process it starts
+    # and `frame/tabmenu.handback` reads the same variable for the same pane; a second read
+    # here would be a second answer to "which pane am I", on the one path where being wrong
+    # means resizing or killing the operator's harness.
     here = os.environ.get("TMUX_PANE", "")
     reg = builtin_actions.build(fid, current_density=_current_density(fid),
                                 current_chrome=_current_chrome(fid))
@@ -8403,31 +8403,49 @@ def _start_workspace_switch(fid: str, ws: str) -> None:
 
 
 def _as_a_drawer(surface, *, socket: str, pane: str):
-    """Hand *surface* back, having given its pane the frame above it — #921.
+    """Hand *surface* back, having given its pane the frame above it when the question is
+    small enough to fit in one — #921, narrowed by #927.
 
-    **A confirmation is a drawer, and the palette is not.** `overlay.modal_argvs` ends in
-    `resize-pane -Z`, so every surface this pane holds takes the whole window; that is
-    right for the palette, which lists every action, every doorway and every name an
-    operator types towards, scrolls, and has no row cap by design. It is wrong for a
-    two-row question about one chat, which read as *"an entirely new window"* rather than
-    as something that had opened over the frame the operator was looking at.
+    **The size of the surface matches the size of the consequence.** `overlay.modal_argvs`
+    ends in `resize-pane -Z`, so every surface this pane holds takes the whole window
+    unless something here gives it back. That is right for the palette, which lists every
+    action, every doorway and every name an operator types towards, scrolls, and has no row
+    cap by design. It is wrong for a two-row question about one chat, which read as *"an
+    entirely new window"* rather than as something that had opened over the frame the
+    operator was looking at. And it is right again for `charter: quit`.
 
-    **Both verbs, and the cost is stated rather than hidden.** `chat: close` is the
-    confirmation this was reported about and it is always two rows — the confirming row and
-    the one chat `leave.plan(only=…)` names — so it fits the drawer whole. `charter: quit`
-    lists every chat on the plane, and in five rows it draws two of them at a time under a
-    heading that says how many there are, scrolled with the same up/down as everything else
-    on this surface. §4f asks that the warning be drawn *at the moment the operator is
-    deciding*, which it is; what a full-window quit bought on top of that was seeing a long
-    blast radius without scrolling. One surface with one rule was chosen over two that read
-    differently depending on which doorway reached them, and if that trade turns out wrong
-    the place to change it is here, in one expression.
+    **So `chat: close` is a drawer and `charter: quit` is not, because their blast radii
+    are not the same size.** Close is always two rows — the confirming row and the one chat
+    `leave.plan(only=…)` names — so it fits the drawer whole and the operator reads all of
+    it without moving. Quit stops EVERY harness on the plane, and its confirmation is the
+    one place an operator sees that: every chat, in every workspace, and which of them can
+    resume the conversation. In five rows that is two at a time under a heading saying how
+    many there are, scrolled — and **scrolling a destructive list is how an operator
+    answers it without reading it.** §4f asks that the warning be drawn *at the moment the
+    operator is deciding*; that it can be read whole before the keypress that commits is
+    the other half of the same requirement. #921 chose one-surface-one-rule over two that
+    read differently by doorway, stated the cost here rather than burying it, and said the
+    place to change it was this expression if the trade turned out wrong. #927 is the owner
+    changing it.
 
-    **``None`` passes straight through, and that is what makes this one call rather than
-    an `if` at two call sites.** :func:`_picker` and `frame/tabmenu.opens` both answer
-    ``None`` for every row that opens nothing, so the surface arriving here IS the
-    condition — and a route that opened a confirmation without unzooming would be a
-    confirmation that behaved differently depending on which pointer press reached it.
+    **This is `leave.open_rows`' placement guard at a second scale.** That one keeps the
+    destructive rows LAST *"because the palette's cursor starts on the first row that can
+    run, and a destructive row at the top would be one `F2 Enter` away"*. Placement and
+    presentation are one rule at two scales: charter puts distance between the operator and
+    a destructive answer in proportion to what the answer costs, and never asks them to
+    scroll past the thing they are agreeing to.
+
+    **The verb is read off the surface's own label**, which is what both call sites already
+    spell it with (`leave.QUIT`/`leave.CLOSE`) — so the condition arrives WITH the surface
+    and this stays one expression, rather than an `if` at two call sites that could come to
+    disagree. `frame/tabmenu.opens` only ever opens close, so the tab strip only ever gets
+    a drawer, and it gets one through this call rather than by a rule of its own.
+
+    **``None`` passes straight through, and that is the same economy.** :func:`_picker` and
+    `frame/tabmenu.opens` both answer ``None`` for every row that opens nothing, so the
+    surface arriving here IS the condition — and a route that opened a confirmation without
+    unzooming would be a confirmation that behaved differently depending on which pointer
+    press reached it.
 
     A tmux round trip on a keypress the operator has just made, on the one path where a
     scan of the frame root is already being paid for (`leave.plan`). `tmuxctl.run` is what
@@ -8435,8 +8453,8 @@ def _as_a_drawer(surface, *, socket: str, pane: str):
     id charter could not spell, and a surface that stays zoomed is the surface this shipped
     as — never a refusal, and never a `resize-pane` aimed at a target charter cannot parse.
     """
-    if surface is None:
-        return None
+    if surface is None or surface.label != leave.CLOSE:
+        return surface
     argv = overlay.unzoom_argv(socket, overlay_pane=pane)
     if argv is not None:
         tmuxctl.run("making the confirmation a drawer", argv)

--- a/charter/frame/overlay.py
+++ b/charter/frame/overlay.py
@@ -1042,7 +1042,8 @@ ZOOMED_FLAG = "#{window_zoomed_flag}"
 
 
 def unzoom_argv(server: str, *, overlay_pane: str) -> list[str] | None:
-    """Give *overlay_pane* its five rows back — a confirmation is a **drawer**, #921.
+    """Give *overlay_pane* its five rows back — a one-chat confirmation is a **drawer**,
+    #921.
 
     *"no any modal/drawer for confirmation"*, reported about a surface that has had one
     since it was written. :func:`modal_argvs` ends in `resize-pane -Z`, so a two-row
@@ -1066,10 +1067,14 @@ def unzoom_argv(server: str, *, overlay_pane: str) -> list[str] | None:
     ``\\x1b[?1006h\\x1b[?1000h`` from this pane. The zoom was never what made the pointer
     work — `select-pane` is, and :func:`modal_argvs` keeps it.
 
-    **The PALETTE keeps the whole window and only the confirmation gives it up.** The
-    palette lists every action, every doorway and every name an operator types towards; it
-    scrolls, has no row cap by design, and earns the rows. A confirmation is one question,
-    with the answer at the top and the consequences under it.
+    **What gets sent this at all is decided one caller up, and the rule is that the size of
+    the surface matches the size of the consequence** — `commands_frame._as_a_drawer`, and
+    #927 for why it is not every confirmation. The palette lists every action, every
+    doorway and every name an operator types towards; it scrolls, has no row cap by design,
+    and earns the rows. `chat: close` is one question about one chat, with the answer at the
+    top and the two lines of consequence under it, and it fits here whole. `charter: quit`
+    lists every chat on the plane and keeps the window, because five rows would mean
+    scrolling a destructive list — which is how an operator answers one without reading it.
 
     `if-shell -F` and not a bare toggle — see :data:`ZOOMED_FLAG`. ``None`` for a pane id
     that is not tmux's own word for one, following every other builder here: charter would

--- a/charter/frame/tabmenu.py
+++ b/charter/frame/tabmenu.py
@@ -405,6 +405,12 @@ def draw(args) -> int:
             # row is untouched and the close doorway gives the window up — two routes to
             # `leave.confirm_rows` that must not look different, which is the whole reason
             # `opens` builds the identical surface `_picker` does.
+            #
+            # Which is also why the drawer is not asked for here (#927). This menu opens
+            # `chat: close` and nothing else, so it would ALWAYS want one — and a menu that
+            # said so itself would be a second place holding the rule that decides how big
+            # a confirmation is. That rule reads the surface's own label one call down, so
+            # this route inherits the answer instead of restating it.
             return commands_frame._as_a_drawer(
                 opens(row, target,
                       live=commands_frame._plane_live(

--- a/docs/news/unreleased-the-frame-says-how-to-close-a-chat-and-not-only-how-to-make-one.md
+++ b/docs/news/unreleased-the-frame-says-how-to-close-a-chat-and-not-only-how-to-make-one.md
@@ -56,11 +56,13 @@ Neutral; a click on this row is resolved by column, and the glyph to draw is the
 width no terminal disagrees about. A mathematical minus is a codepoint a terminal font may
 not carry, and a fallback into a wide face moves every field after it.
 
-**The confirmation is a drawer.** It used to take the whole window — the overlay pane is
-zoomed, so a two-row question about one chat arrived full-screen and read as somewhere else
-entirely. It now gives the window back and draws in the five rows at the bottom, with the
-frame you were looking at still above it. The palette and the pickers keep the whole pane:
-they are lists that scroll and have no length limit, and they earn it.
+**The `chat: close` confirmation is a drawer.** It used to take the whole window — the
+overlay pane is zoomed, so a two-row question about one chat arrived full-screen and read as
+somewhere else entirely. It now gives the window back and draws in the five rows at the
+bottom, with the frame you were looking at still above it. The palette and the pickers keep
+the whole pane: they are lists that scroll and have no length limit, and they earn it. So
+does `charter: quit`, whose confirmation lists every chat on the plane — see *The quit
+confirmation takes the pane again*, in this release.
 
 The pane is still the active one, which is the only thing the zoom was ever load-bearing
 for. Measured on tmux 3.7c through a real pty: unzoomed and focused, it is `h=5 active=1`

--- a/docs/news/unreleased-the-quit-confirmation-takes-the-pane-because-its-blast-radius-is-the-plane.md
+++ b/docs/news/unreleased-the-quit-confirmation-takes-the-pane-because-its-blast-radius-is-the-plane.md
@@ -1,0 +1,54 @@
+---
+version: unreleased
+headline: The quit confirmation takes the pane again, because its blast radius is the whole plane
+---
+
+`chat: close` opens a drawer — five rows at the bottom of the window, the frame you were
+looking at still above them. That was the right change and it stays.
+
+**`charter: quit` shared that surface, and should not have.** It stops every harness on the
+plane. Its confirmation is the one place an operator sees the full blast radius: every chat,
+in every workspace, and which of them can resume the conversation. In a five-row drawer that
+is two of them at a time, under a heading saying how many there are, scrolled.
+
+So it takes the whole pane again, and close still does not.
+
+## The rule
+
+**The size of the surface matches the size of the consequence.**
+
+A confirmation about one chat is a drawer. A confirmation about every chat on the plane
+takes the pane, because the operator has to be able to read the whole list before answering
+— and **scrolling a destructive list is how you answer it without reading it.**
+
+This is charter's existing guard at a second scale. The destructive rows are already placed
+LAST in the palette's catalogue, *"because the palette's cursor starts on the first row that
+can run, and a destructive row at the top would be one `F2 Enter` away."* Placement and
+presentation are one rule: put distance between the operator and a destructive answer in
+proportion to what the answer costs, and never ask them to scroll past the thing they are
+agreeing to.
+
+## What it cost
+
+One expression. `commands_frame._as_a_drawer` reads the verb off the surface's own label,
+which both routes into it already spell — so the condition arrives with the surface, and the
+rule lives in one place rather than as an `if` at two call sites that could come to
+disagree. The tab-strip route only ever opens `chat: close`, so it only ever gets a drawer,
+and it gets one by inheriting the rule rather than by holding a copy.
+
+That the change was one expression is not luck. The agent that built the drawer chose
+one-surface-one-rule over two surfaces that read differently by doorway, wrote down that it
+was a trade rather than a fact, and said where to change it if the trade turned out wrong.
+It turned out wrong; the note was accurate, and the fix was where it said it would be.
+
+## Both directions are pinned
+
+A test that `chat: close` is a drawer, and a test that `charter: quit` is not. A suite
+asserting only one of them leaves the other free to drift into it with nothing to say so —
+which is exactly what happened here: the previous behaviour had a passing test asserting
+quit was a drawer too, and that assertion was the thing this had to change.
+
+A third pins the discriminator: a plane with one chat on it does not make quit a drawer. The
+rule is what the verb *can* reach, not what it happens to reach at this moment — an operator
+who learns that quit takes the pane has learned something true every time, and a surface
+that changed shape with the plane's size would teach them nothing they could rely on.

--- a/tests/test_a_confirmation_is_a_drawer_not_a_window.py
+++ b/tests/test_a_confirmation_is_a_drawer_not_a_window.py
@@ -1,10 +1,23 @@
-"""**A confirmation gives the window back; the palette keeps it — #921.**
+"""**A one-chat confirmation gives the window back; the palette and the whole-plane one
+keep it — #921, narrowed by #927.**
 
 *"no any modal/drawer for confirmation"*, reported about a surface that has had one since
 it was written. `overlay.modal_argvs` ends in `resize-pane -Z`, so every surface the
 overlay pane holds takes the entire window — and a two-row question about one chat arriving
 full-screen does not read as something that opened over the frame you were looking at. It
 reads as somewhere else.
+
+**The size of the surface matches the size of the consequence, and that rule has two
+directions to hold — so this module pins both.** `chat: close` is a drawer
+(:meth:`TheConfirmationGivesTheWindowBack.test_the_close_doorway_unzooms_the_pane_it_is
+_drawn_in`). `charter: quit` is not
+(:meth:`TheConfirmationGivesTheWindowBack.test_the_quit_doorway_keeps_the_whole_pane`),
+because it stops EVERY harness on the plane and its confirmation is the one place an
+operator sees that — every chat, in every workspace, and which of them can resume. In five
+rows that is two at a time, scrolled, and scrolling a destructive list is how you answer it
+without reading it. A module asserting only one direction would leave the other free to
+drift into it silently, which is the whole shape of #927: #921 pinned quit as a drawer, and
+that assertion was the thing to change.
 
 **Dropping the zoom does not hide it.** `overlay.open_argv` splits `-v -l 5`, so the pane
 goes back to five rows at the bottom of the window with the frame drawn above it, still the
@@ -17,14 +30,17 @@ measures both halves on a real server rather than arguing them: the pane keeps i
 rows and its focus, and the outer terminal still receives this pane's own
 ``\\x1b[?1006h\\x1b[?1000h``.
 
-**Only the confirmation.** The palette lists every action, every doorway and every name an
-operator types towards; it scrolls, has no row cap by design, and earns the rows. So does a
-picker, which is a list of names of unbounded length. What gives the window up is the one
-surface that is a single question with the answer at the top.
+**Only the one-chat confirmation.** The palette lists every action, every doorway and every
+name an operator types towards; it scrolls, has no row cap by design, and earns the rows.
+So does a picker, which is a list of names of unbounded length. So does quit's warning.
+What gives the window up is the one surface that is a single question about a single chat,
+with the answer at the top and two lines under it.
 
-**And both routes to it, through one call.** `F2 → chat: close` and a right press on a tab
-open the same `leave.confirm_rows` over the same plan; a route that unzoomed and a route
-that did not would be two confirmations wearing one name.
+**And both routes to THAT, through one call.** `F2 → chat: close` and a right press on a
+tab open the same `leave.confirm_rows` over the same plan; a route that unzoomed and a
+route that did not would be two confirmations wearing one name. The tab strip only ever
+opens close, so it only ever gets a drawer — and it gets one by inheriting the rule rather
+than by holding a copy of it.
 """
 
 from __future__ import annotations
@@ -134,17 +150,44 @@ class TheConfirmationGivesTheWindowBack(_AFrameWithChatsToClose, unittest.TestCa
         return commands_frame._picker(row, self.FID, [], socket=self.SERVER, pane="%7")
 
     def test_the_close_doorway_unzooms_the_pane_it_is_drawn_in(self):
+        """**Half of #927's rule, and the half #921 was reported for.** `chat: close` is
+        two rows about one chat — the confirming row and the chat `leave.plan(only=…)`
+        names — so the whole consequence is on screen in five rows, and taking the window
+        for it read as somewhere else."""
         surface = self._open(leave.open_rows(self.FID)[1])
         self.assertIsNotNone(surface, "the close doorway opened nothing")
         self.assertEqual(self._resizes(),
                          [overlay.unzoom_argv(self.SERVER, overlay_pane="%7")])
 
-    def test_the_quit_doorway_does_too(self):
-        """**One surface, one rule.** Quit and close are the same `leave.confirm_rows`
-        over a wider plan, and a confirmation that behaved differently depending on which
-        doorway reached it would be two surfaces wearing one name."""
-        self._open(leave.open_rows(self.FID)[0])
-        self.assertEqual(len(self._resizes()), 1, self.ran)
+    def test_the_quit_doorway_keeps_the_whole_pane(self):
+        """**The other half, and the one that has to be asserted separately — #927.**
+
+        The size of the surface matches the size of the consequence. `charter: quit` stops
+        every harness on the plane, and this surface is the one place an operator sees the
+        whole blast radius: every chat, in every workspace, and which of them can resume.
+        Five rows draws two of them at a time under a heading saying how many there are —
+        and scrolling a destructive list is how an operator answers it without reading it.
+
+        Pinned facing the opposite way from
+        :meth:`test_the_close_doorway_unzooms_the_pane_it_is_drawn_in` on purpose. #921
+        asserted quit was a drawer too and the assertion was what made that a decision
+        rather than an accident; with only one direction pinned, the other is free to drift
+        into it and no test says so.
+        """
+        surface = self._open(leave.open_rows(self.FID)[0])
+        self.assertIsNotNone(surface, "the quit doorway opened nothing")
+        self.assertEqual(self._resizes(), [], self.ran)
+
+    def test_the_two_doorways_are_told_apart_by_the_verb_and_not_by_the_row_count(self):
+        """**A plane with one chat on it does not make quit a drawer.** The rule is what
+        the verb CAN reach, not what it happens to reach on this plane at this moment: an
+        operator who learns that quit takes the pane has learned something that is true
+        every time, and a surface that changed shape with the plane's size would teach them
+        nothing they could rely on. `_as_a_drawer` reads the verb off the surface's label,
+        which is why."""
+        self.live[0].discard("alpha.2")
+        self.assertIsNotNone(self._open(leave.open_rows(self.FID)[0]))
+        self.assertEqual(self._resizes(), [], self.ran)
 
     def test_a_name_picker_keeps_the_whole_pane(self):
         """A picker is a list of names of unbounded length — forty workspaces on this


### PR DESCRIPTION
Closes #927

#921 unzoomed `leave.confirm_rows` into a five-row drawer. That was right for `chat: close`
— two rows about one chat — and it fixed the complaint that closing a chat felt like leaving
the screen. It was wrong for `charter: quit`, which stops **every harness on the plane**, and
whose confirmation is the one place an operator sees the whole blast radius: every chat, in
every workspace, and which of them can resume the conversation. In a five-row drawer that is
two at a time under a heading saying how many there are, scrolled.

## The rule this encodes

**The size of the surface matches the size of the consequence.** A confirmation about one
chat is a drawer. A confirmation about every chat on the plane takes the pane, because the
operator has to be able to read the whole list before answering — and scrolling a
destructive list is how you answer it without reading it.

This is `leave.open_rows`' placement guard at a second scale. That one keeps the destructive
rows LAST *"because the palette's cursor starts on the first row that can run, and a
destructive row at the top would be one `F2 Enter` away."* Placement and presentation are one
rule at two scales — put distance between the operator and a destructive answer in proportion
to what the answer costs — and `_as_a_drawer`'s docstring now says so where the change is made.

## One expression

```python
-    if surface is None:
-        return None
+    if surface is None or surface.label != leave.CLOSE:
+        return surface
```

`_as_a_drawer` reads the verb off the surface's own label, which both call sites already
spell (`leave.QUIT` / `leave.CLOSE`), so the condition arrives WITH the surface rather than
as an `if` at two call sites that could come to disagree. `frame/tabmenu.opens` only ever
opens close, so the tab strip only ever gets a drawer — by inheriting the rule rather than by
holding a copy of it.

That it was one expression is not luck. #921's agent chose one-surface-one-rule over two
surfaces that read differently by doorway, wrote it down as a **trade rather than a fact**,
and named this expression as the place to change it if the owner preferred otherwise. The
note was accurate and the fix was where it said it would be.

## Both directions are pinned

`tests/test_a_confirmation_is_a_drawer_not_a_window.py`:

| test | pins |
| --- | --- |
| `TheConfirmationGivesTheWindowBack.test_the_close_doorway_unzooms_the_pane_it_is_drawn_in` | `chat: close` **is** a drawer — one `unzoom_argv` |
| `TheConfirmationGivesTheWindowBack.test_the_quit_doorway_keeps_the_whole_pane` | `charter: quit` is **not** — no resize at all |
| `TheConfirmationGivesTheWindowBack.test_the_two_doorways_are_told_apart_by_the_verb_and_not_by_the_row_count` | a plane with one chat on it does not make quit a drawer |

A suite asserting only one direction leaves the other free to drift into it silently — which
is exactly what happened here. #921 had a passing `test_the_quit_doorway_does_too`, and that
assertion is the thing this PR had to change; that is the argument for pinning both rather
than only the new half.

The third test pins the discriminator rather than a symptom: the rule is what the verb *can*
reach, not what it happens to reach on this plane at this moment. An operator who learns that
quit takes the pane has learned something true every time; a surface that changed shape with
the plane's size would teach them nothing they could rely on.

Hand-verified that the pins bite: reverting the expression to #921's `if surface is None`
turns exactly the two quit assertions RED (`FAILED (failures=2)`), with `__pycache__` cleared
on both transitions.

## Not a reversal of #921

The drawer was right and stays. This narrows it to the doorway it was argued for. #921's
measured facts are carried unchanged: `resize-pane -Z` is a toggle with no unzoom flag in any
tmux, so the unzoom stays guarded with `if-shell -F '#{window_zoomed_flag}'`, and the zoom was
never what carried the overlay's mouse request to the terminal — `select-pane` is, measured
through a real pty. `overlay.unzoom_argv`'s docstring already said the latter correctly; what
it said wrongly was *"only the confirmation gives it up"*, and it now says which confirmation.

#921's own news entry is still `unreleased`, so its "The confirmation is a drawer" paragraph
is corrected in place — shipping both notes in 0.60.0 unedited would have had the release
contradict itself.

## Verification

```
Ran 11768 tests in 687.983s

OK (skipped=9)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018hUBNraNfixfMMK5Jc6CNy
