### PR TITLE
A closed chat stops being a tab, so closing one looks like it worked (#929)

### DIFF
--- a/charter/commands_frame.py
+++ b/charter/commands_frame.py
@@ -9371,6 +9371,7 @@ def cmd_close(args) -> int:
         # "was open" and bring back uninvited.
         state.record_closed(target)
         _forget_transcript(target)
+        _repaint_the_other_strips(target)
         util.ok(f"charter: chat {target} was already stopped — marked closed, so it will "
                 "not come back")
         return 0
@@ -9381,6 +9382,7 @@ def cmd_close(args) -> int:
     # closed it.
     state.record_closed(target)
     _forget_transcript(target)
+    _repaint_the_other_strips(target)
     stopped = _stop_chats(doomed, windows=windows)
     if not stopped:
         util.err(f"charter frame-close: tmux would not stop chat {target} — it is marked "
@@ -9388,6 +9390,42 @@ def cmd_close(args) -> int:
         return 1
     util.ok(f"charter: closed {target} — it will not be reopened")
     return 0
+
+
+def _repaint_the_other_strips(closed: str) -> None:
+    """Wake every other chat's panels, so a closed chat leaves the strips the operator is
+    about to be looking at — #929, and the half of that fix that is not on disk.
+
+    **A panel repaints on a version bump and on nothing else** (`frame/panel.py`: liveness
+    is a poll of `state.version`, `TICK` apart). Closing a chat changes what EVERY other
+    chat's strip should draw — the roster loses a tab, and the workspaces strip's count
+    beside it loses one — but it moves no version except the closed chat's own, and that
+    one's window is being killed. Measured on a real frame before this call existed: the
+    surviving chat's strip still drew the closed tab seven seconds later, and corrected only
+    when a click happened to wake that panel for an unrelated reason. The plane was right and
+    the screen was wrong, which from the operator's seat is the same report as before the
+    scan was fixed at all.
+
+    **Once the mark is written, every other strip is stale** — so this is called from every
+    path in :func:`cmd_close` that writes one, including the path that could not stop the
+    window. `state.was_closed` is what `chats._by_workspace` reads, and it is true from the
+    moment the marker lands whether or not the kill after it succeeded; a repaint that waited
+    for the kill would leave the screen disagreeing with the plane on exactly the path where
+    charter has already told the operator that something went wrong.
+
+    The closed chat itself is skipped: its window is going, and `chats.roster` folds the chat
+    ASKING back into its own strip regardless, so a repaint there has nothing to change.
+
+    `leave.plane_chats` and not `chats.of_workspace`, because the workspaces strip draws a
+    count for every workspace on the plane and not only for this chat's own — and because
+    that scan is the one that still lists a closed chat, so it needs no special case to
+    reach the siblings of a chat whose own workspace record was lost. `state.bump` swallows
+    what it cannot write and is one atomic replace on the ~30 chats `state.reap` bounds a
+    plane to, paid once on a deliberate teardown rather than on any repaint path.
+    """
+    for other in leave.plane_chats():
+        if other != closed:
+            state.bump(other)
 
 
 def _forget_transcript(fid: str) -> None:

--- a/charter/frame/chats.py
+++ b/charter/frame/chats.py
@@ -103,7 +103,13 @@ def is_chat(fid: str) -> bool:
 
 
 def of_workspace(workspace: str) -> list[str]:
-    """Every chat that says it is in *workspace*, in ordinal order.
+    """Every chat that says it is in *workspace* and is still open, in ordinal order.
+
+    **A chat the operator closed is not one of them** (#929), which is
+    :func:`_by_workspace`'s filter and argued there: `chat: close` marks the chat and
+    kills its window, so a roster that went on listing it would be offering a tab that
+    answers *no window any more* when pressed. :func:`roster` folds the chat ASKING back
+    in regardless, so this never takes the operator's own tab off their own strip.
 
     **Membership is `state.own_workspace`, which is `state.workspace_for`'s middle** — and
     the difference between those two functions is the whole of #733. `workspace_for` is
@@ -253,7 +259,8 @@ def touched_by_workspace() -> dict[str, float]:
 
 
 def _by_workspace() -> dict[str | None, list[str]]:
-    """Every chat on this plane, grouped by the workspace it says it is in.
+    """Every chat on this plane the operator has not closed, grouped by the workspace it
+    says it is in.
 
     The scan both :func:`of_workspace` and :func:`counts_by_workspace` are, written once —
     the discipline `state.own_workspace` itself is an instance of, said one level up: two
@@ -303,7 +310,28 @@ def _by_workspace() -> dict[str | None, list[str]]:
         return {}
     out: dict[str | None, list[str]] = {}
     for name in names:
-        if is_chat(name):
+        # **A chat the operator closed is not on any strip** (#929). `cmd_close` writes
+        # `state.record_closed` and then `kill-window`, so by the time anything repaints
+        # the chat has no window to switch to — but this scan reads the DIRECTORY, which
+        # `state.reap` does not collect until a later launch. So closing a chat left its
+        # tab drawn, clickable, and answering *no window any more* when pressed: the
+        # report was *"after choosing close - its not closing"*, made about a close that
+        # had in fact done every part of its job except the part that shows.
+        #
+        # **Here rather than in the strip**, because this is the one walk `of_workspace`,
+        # `counts_by_workspace` and `touched_by_workspace` all are: a filter in the
+        # renderer would leave the count beside a workspace tab promising a chat the
+        # roster no longer offers. And `leave.plane_chats` scans the frame root ITSELF
+        # rather than calling this, so a quit still enumerates every chat directory on the
+        # plane whatever it says — that function's whole reason for existing, and why the
+        # skip a quit needs stays in `leave.plan` rather than being this one moved.
+        #
+        # One `stat` per chat, on the ~30 entries `state.reap` bounds this to, beside the
+        # two file reads `state.own_workspace` already makes for each of them on the line
+        # below. The chat ASKING is folded back in by :func:`roster` whatever this
+        # answers, so the operator never watches their own tab vanish while the window
+        # they are still typing in is being torn down.
+        if is_chat(name) and not state.was_closed(name):
             out.setdefault(state.own_workspace(name), []).append(name)
     return {ws: sorted(ids, key=_order) for ws, ids in out.items()}
 

--- a/docs/frame.md
+++ b/docs/frame.md
@@ -1127,6 +1127,15 @@ back. Closing does **not** refuse while that chat's harness is working: charter'
 tracker records no chat on any of its entries, so there is no reading to refuse on, and the
 confirmation says the chat will not come back instead of pretending to check.
 
+**And the tab goes.** A closed chat leaves every chat strip on the plane and stops being
+counted beside its workspace's tab, from the moment it is marked — the other chats are woken
+so their strips redraw rather than waiting for whatever would have repainted them next. Until
+0.60.0 they did not: the close did every other part of its job, the tab stayed, and pressing
+it answered `cannot switch: chat 'x' has no window any more` for as long as that chat's state
+directory survived. The one tab that stays is the chat you are closing *from*, for as long as
+its window is still being torn down — a strip that dropped the chat you are typing in would be
+drawing a list you are not in.
+
 **What quit stops is this plane, and nothing else on the machine.** One tmux server serves
 every frame on a machine and session names carry no plane — `default` is a name every plane
 has — so quit works from *this* plane's chat directories and kills one window at a time, never

--- a/docs/news/unreleased-a-closed-chat-stops-being-a-tab.md
+++ b/docs/news/unreleased-a-closed-chat-stops-being-a-tab.md
@@ -1,0 +1,103 @@
+---
+version: unreleased
+headline: A closed chat stops being a tab, so closing one finally looks like it worked
+---
+
+*"i'm checking `-` button is not working, its opening something like F2 menu, after
+choosing close - its not closing and breaking entire flow, even hard to explain."*
+
+Three claims in one sentence, and they have three different answers. The `-` is doing
+exactly what it was built to do. The close is doing exactly what it was built to do. The
+strip is not, and it never has been.
+
+## The close ran. Every part of it.
+
+Reproduced on a real tmux frame with a real client on a real pty: the confirmation drew,
+Enter committed, `charter frame-close` wrote the closed marker, and `kill-window` took the
+chat's window off the server. Asked afterwards, charter agreed the chat was closed and its
+window was gone.
+
+**And the tab was still on the strip.**
+
+```
+before the close    api.1  *api.2   + -
+after the close     api.1  *api.2   + -
+```
+
+So the report is exact, and *"hard to explain"* is the right words for it. Nothing an
+operator can see distinguishes a close that did every part of its job from one that never
+ran.
+
+## One scan, one missing question
+
+Closing a chat writes a marker — `chat: close` is the one teardown that deliberately
+forgets, so a later `charter: quit` does not bring the chat back uninvited. That marker has
+been written since 0.50 and read in exactly one place ever: the quit's own plan.
+
+The tab strip never asked. `chats._by_workspace` walks the frame root and lists the
+directories it finds, and a closed chat's directory survives until a reap collects it at
+some later launch. So the roster went on offering the tab, the workspaces strip went on
+counting it, and the switcher went on listing it as somewhere you could go.
+
+That last one is the *"breaking entire flow"*:
+
+```
+charter: cannot switch: chat 'api.1' has no window any more
+```
+
+A tab you can see, aim at and press, which answers that every time, for as long as the
+directory lasts.
+
+The fix is one question in the scan every one of those surfaces already shares — so the
+roster, the counts and the switcher move together and none of them holds a rule of its own
+about it.
+
+## Two things still see a closed chat, deliberately
+
+**The quit's own scan**, which must enumerate every chat directory on the plane whatever it
+says. A quit that skipped one would kill a running harness and record nothing about it —
+that scan exists for exactly that, and its skip stays one layer up where it was.
+
+**Your own tab, while you are still in it.** The marker is written *before* the window is
+killed, so for as long as the teardown takes, the chat you are typing in is a chat marked
+closed. A strip that dropped it would be drawing a list the operator is not in. The roster
+folds the chat asking back in regardless, so it stays until the window it is drawn in goes.
+
+## The half that is not on disk
+
+Getting the plane right was not enough, and the measurement is worth stating because it is
+the same report a second time.
+
+A panel repaints when its own version moves and at no other time. Closing a chat changes
+what every *other* chat's strip should draw — but moves no version except the closed
+chat's, and that one's window is being killed. With the scan already fixed, the surviving
+chat's strip still drew the closed tab seven seconds later, and corrected only when a click
+happened to wake that panel for an unrelated reason.
+
+Right plane, wrong screen. From the operator's seat, indistinguishable from the bug. So a
+close now wakes every other chat on the plane — including the ones in other workspaces,
+because the workspaces strip draws a count for each of them and one of those counts just
+changed.
+
+It wakes them on every path that writes the marker, including the one where tmux would not
+stop the window. The marker is what the strip reads, and it is true from the moment it
+lands; a repaint that waited for the kill would leave the screen disagreeing with the plane
+on exactly the path where charter has already said something went wrong.
+
+## This is older than the button that found it
+
+`F2 → chat: close` had the same defect for as long as the marker has existed, and nobody
+reported it. #925 put the close affordance on the chat strip — so the operator's eye is now
+on the one surface that does not change, where the palette route left them looking at a
+harness.
+
+A defect nobody could see became one nobody could miss. **The affordance that surfaced it
+was right, and it stays as it is** — the fix belongs where the fact was always missing.
+
+## What is not changed
+
+The `-` still opens the tab menu about the chat you are in rather than closing anything,
+and the argv it builds is byte for byte what a right press on that tab builds — verified
+rather than trusted, because the docstring asserting it was the kind of claim worth
+checking. A pointer opens the question; the keyboard answers it. `chat: close` is still a
+drawer and `charter: quit` still takes the pane.

--- a/tests/test_a_closed_chat_is_not_a_tab_any_more.py
+++ b/tests/test_a_closed_chat_is_not_a_tab_any_more.py
@@ -1,0 +1,215 @@
+"""**A chat the operator closed stops being a tab — #929.**
+
+*"`-` button is not working … after choosing close - its not closing and breaking entire
+flow, even hard to explain."*
+
+Reproduced on a real tmux frame with a real client on a real pty: the close **ran**. The
+confirmation drew, Enter committed, `charter frame-close` wrote `state.record_closed` and
+`kill-window` took the chat's window off the server. Every part of the teardown worked. What
+did not happen is the only part the operator could see — **the tab was still on the strip**,
+in the workspace's other chats and in the chat's own, because `chats._by_workspace` scanned
+the frame root and never asked `state.was_closed`.
+
+So the report is exact and the words are the right ones. From the operator's seat closing a
+chat left the strip byte-for-byte as it was, which reads as *nothing happened* — and then
+the ghost tab goes on being clickable, which is the *"breaking entire flow"*: pressing it
+answers `cannot switch: chat 'alpha.1' has no window any more`, measured, and it will do that
+for as long as the directory survives `state.reap`.
+
+**This is older than the `-` that reported it.** `state.record_closed` has been written since
+#796 and `state.was_closed` has been read in exactly one place ever — `leave.plan`, so that a
+later quit does not resurrect a closed chat. The strip has never asked. #925 is what made it
+matter: it put the close affordance ON the chat strip, so the operator's eye is now on the
+one surface that does not change, where `F2 → chat: close` left them looking at a harness.
+A defect nobody could see became one nobody could miss, and the fix belongs where the fact
+was always missing rather than in the affordance that surfaced it.
+
+**The fix is in the scan and not in the strip**, which is what makes the roster, the counts
+and the switcher agree: `_by_workspace` is the one walk `of_workspace`, `counts_by_workspace`
+and `touched_by_workspace` are, so a closed chat leaves every surface at once and none of
+them holds a rule of its own about it.
+
+**Two things deliberately keep seeing a closed chat**, and both are asserted below because
+each would be a real defect if the filter reached it:
+
+* `leave.plane_chats` — the teardown's own scan, which must enumerate every chat directory
+  on the plane whatever it says, so that a quit stops a harness that is still running rather
+  than skipping it and recording nothing (that function's own docstring is the argument).
+  `leave.plan` then skips closed chats by its own rule, one layer up.
+* `chats.roster`'s fold-in of the chat ASKING. `cmd_close` writes the marker *before* it
+  kills the window, so between those two the closing chat's own panel repaints — and a strip
+  that dropped the tab you are typing in would be drawing a list the operator is not in.
+"""
+
+from __future__ import annotations
+
+import unittest
+from types import SimpleNamespace
+from unittest import mock
+
+from charter import commands_frame
+from charter.frame import chats, leave, slots, state
+
+from tests._isolation import PersonaIso
+
+SERVER = commands_frame.SOCKET
+
+
+def _plant(fid: str, *, ws: str) -> None:
+    """One chat on the plane, recorded the way a launch records it."""
+    state.frame_dir(fid, create=True)
+    state.record_workspace(fid, ws)
+    state.record_server(fid, SERVER)
+    state.record_harness_pane(fid, "%1")
+    state.record_identity(fid, {"CHARTER_HARNESS": "claude-code"})
+
+
+class AClosedChatLeavesTheStrip(PersonaIso, unittest.TestCase):
+    """What every surface built on `chats._by_workspace` says once a chat is closed."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        _plant("alpha.1", ws="alpha")
+        _plant("alpha.2", ws="alpha")
+        _plant("alpha.3", ws="alpha")
+
+    def test_the_roster_still_has_every_chat_before_one_is_closed(self):
+        """The negative control this whole class needs: the filter below removes something
+        that was there, rather than passing on a plane the fixture never planted."""
+        self.assertEqual(chats.of_workspace("alpha"),
+                         ["alpha.1", "alpha.2", "alpha.3"])
+
+    def test_a_closed_chat_is_not_in_the_workspace_roster(self):
+        state.record_closed("alpha.2")
+
+        self.assertEqual(chats.of_workspace("alpha"), ["alpha.1", "alpha.3"])
+
+    def test_a_closed_chat_is_not_a_tab_on_another_chats_strip(self):
+        """The surface the report is about, asked as the strip asks it."""
+        state.record_closed("alpha.2")
+
+        names, here, _add, _close, _counts = slots._chats_strip("alpha.1")
+
+        self.assertEqual(names, ["alpha.1", "alpha.3"])
+        self.assertEqual(here, "alpha.1")
+
+    def test_the_closed_chat_is_not_drawn_on_the_row(self):
+        """One rung down: the text a terminal receives, not the list behind it."""
+        state.record_closed("alpha.2")
+
+        row = slots._bar(*slots._chats_strip("alpha.1")[:2], 80,
+                         note=slots.ADD_CHAT, close=slots.CLOSE_CHAT)[0]
+
+        self.assertNotIn("alpha.2", row)
+        self.assertIn("alpha.1", row)
+        self.assertIn("alpha.3", row)
+
+    def test_nothing_can_be_switched_to_a_closed_chat(self):
+        """`chats.others` is what a picker offers and what "is there anything to switch
+        to" is asked as — a closed chat in it is a row that answers *no window any more*."""
+        state.record_closed("alpha.2")
+
+        self.assertEqual(chats.others("alpha.1"), ["alpha.3"])
+
+    def test_a_closed_chat_is_not_counted_on_the_workspaces_strip(self):
+        """The count beside a workspace tab is the same walk, so it moves with the roster
+        rather than going on promising a chat that is gone."""
+        state.record_closed("alpha.2")
+
+        self.assertEqual(chats.counts_by_workspace().get("alpha"), 2)
+
+    def test_the_chat_asking_is_still_its_own_tab_even_once_marked(self):
+        """`cmd_close` writes the marker BEFORE `kill-window`, so this state is real for as
+        long as the teardown takes — and a strip that dropped the tab the operator is typing
+        in would be drawing a list they are not in (`chats.roster`'s fold-in)."""
+        state.record_closed("alpha.1")
+
+        self.assertEqual([c.id for c in chats.roster("alpha.1")],
+                         ["alpha.1", "alpha.2", "alpha.3"])
+        self.assertTrue(chats.roster("alpha.1")[0].active)
+
+    def test_the_teardown_still_sees_every_chat_on_the_plane(self):
+        """`leave.plane_chats` must NOT inherit this filter: it is the scan a quit stops
+        harnesses from, and a chat it skipped would be killed and recorded nowhere. The skip
+        for a closed chat belongs to `leave.plan`, one layer up, and is still there."""
+        state.record_closed("alpha.2")
+
+        self.assertEqual(leave.plane_chats(), ["alpha.1", "alpha.2", "alpha.3"])
+        self.assertEqual([c.chat for c in leave.plan(live=None, focus="alpha").chats],
+                         ["alpha.1", "alpha.3"])
+
+
+class ClosingWakesTheStripsThatMustRedraw(PersonaIso, unittest.TestCase):
+    """**The half of the fix that is not on disk.**
+
+    A panel repaints on a version bump and on nothing else (`frame/panel.py`), and closing a
+    chat moves no version but the closed chat's own — whose window is being killed. Measured
+    on a real frame with the scan already fixed: the surviving chat's strip still drew the
+    closed tab seven seconds later and corrected only when a click woke that panel for an
+    unrelated reason. Right plane, wrong screen, and from the operator's seat that is the
+    same report.
+    """
+
+    def _close(self, target: str, *, on: str) -> int:
+        """`cmd_close` with the tmux round trips stood in for — every one of them is
+        asserted for real in `tests/test_close_is_the_one_teardown_that_forgets.py`, and
+        what this class is about is the writes charter makes either way."""
+        with mock.patch.multiple(commands_frame,
+                                 _chat_seats=mock.DEFAULT,
+                                 _capture_transcript=mock.DEFAULT,
+                                 _stop_chats=mock.DEFAULT) as m:
+            m["_chat_seats"].return_value = [(c, f"@{i}", False) for i, c in
+                                             enumerate(leave.plane_chats())]
+            m["_capture_transcript"].return_value = False
+            m["_stop_chats"].return_value = 1
+            return commands_frame.cmd_close(
+                SimpleNamespace(chat=on, chat_id=target))
+
+    def test_every_other_chat_on_the_plane_is_bumped(self):
+        """Every other chat, and not only this workspace's: the workspaces strip draws a
+        count for every workspace on the plane, and closing a chat changes one of them."""
+        for fid, ws in (("alpha.1", "alpha"), ("alpha.2", "alpha"), ("beta.1", "beta")):
+            _plant(fid, ws=ws)
+        before = {f: state.version(f) for f in ("alpha.1", "alpha.2", "beta.1")}
+
+        self.assertEqual(self._close("alpha.2", on="alpha.1"), 0)
+
+        self.assertNotEqual(state.version("alpha.1"), before["alpha.1"])
+        self.assertNotEqual(state.version("beta.1"), before["beta.1"])
+
+    def test_the_closed_chat_is_not_bumped(self):
+        """Its window is going, and `chats.roster` folds the chat asking into its own strip
+        whatever this answers — so there is nothing a repaint there could change."""
+        _plant("alpha.1", ws="alpha")
+        _plant("alpha.2", ws="alpha")
+        before = state.version("alpha.2")
+
+        self._close("alpha.2", on="alpha.1")
+
+        self.assertEqual(state.version("alpha.2"), before)
+
+    def test_a_close_that_could_not_stop_the_window_still_wakes_them(self):
+        """`state.was_closed` is true from the moment the marker lands, whether or not the
+        kill after it worked — so the strips are stale on that path too, and a repaint that
+        waited for the kill would leave the screen disagreeing with the plane on exactly the
+        path where charter has already said something went wrong."""
+        _plant("alpha.1", ws="alpha")
+        _plant("alpha.2", ws="alpha")
+        before = state.version("alpha.1")
+
+        with mock.patch.multiple(commands_frame,
+                                 _chat_seats=mock.DEFAULT,
+                                 _capture_transcript=mock.DEFAULT,
+                                 _stop_chats=mock.DEFAULT) as m:
+            m["_chat_seats"].return_value = [("alpha.1", "@0", False),
+                                             ("alpha.2", "@1", False)]
+            m["_capture_transcript"].return_value = False
+            m["_stop_chats"].return_value = 0
+            self.assertEqual(commands_frame.cmd_close(
+                SimpleNamespace(chat="alpha.1", chat_id="alpha.2")), 1)
+
+        self.assertNotEqual(state.version("alpha.1"), before)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_a_closed_chat_is_not_a_tab_any_more.py
+++ b/tests/test_a_closed_chat_is_not_a_tab_any_more.py
@@ -188,6 +188,31 @@ class ClosingWakesTheStripsThatMustRedraw(PersonaIso, unittest.TestCase):
 
         self.assertEqual(state.version("alpha.2"), before)
 
+    def test_a_chat_whose_window_had_already_gone_still_wakes_them(self):
+        """`cmd_close`'s other marking path — the chat's harness ended on its own, so there
+        is nothing left to stop and the command marks it anyway rather than refusing. The
+        mark is what the strip reads, so that path leaves every other strip exactly as stale
+        as the ordinary one and has to wake them too."""
+        _plant("alpha.1", ws="alpha")
+        _plant("alpha.2", ws="alpha")
+        before = state.version("alpha.1")
+
+        with mock.patch.multiple(commands_frame,
+                                 _chat_seats=mock.DEFAULT,
+                                 _capture_transcript=mock.DEFAULT,
+                                 _stop_chats=mock.DEFAULT) as m:
+            # `alpha.2` is absent from the listing, so `leave.stopping` answers nothing and
+            # `cmd_close` takes the "was already stopped" branch.
+            m["_chat_seats"].return_value = [("alpha.1", "@0", False)]
+            m["_capture_transcript"].return_value = False
+            m["_stop_chats"].return_value = 0
+            self.assertEqual(commands_frame.cmd_close(
+                SimpleNamespace(chat="alpha.1", chat_id="alpha.2")), 0)
+
+        self.assertTrue(state.was_closed("alpha.2"), "this case took the wrong branch")
+        m["_stop_chats"].assert_not_called()
+        self.assertNotEqual(state.version("alpha.1"), before)
+
     def test_a_close_that_could_not_stop_the_window_still_wakes_them(self):
         """`state.was_closed` is true from the moment the marker lands, whether or not the
         kill after it worked — so the strips are stale on that path too, and a repaint that

--- a/tests/test_a_real_click_on_a_real_tab_bar_switches.py
+++ b/tests/test_a_real_click_on_a_real_tab_bar_switches.py
@@ -1180,6 +1180,21 @@ class ARealPressOnThePlusReachesTheCommandBehindIt(_ARealFrameWithBars,
         self.assertTrue(row.endswith(self.TAIL), repr(row))
         self.assertEqual(self._minus(), self._plus() + 2, repr(row))
 
+    def test_a_press_on_the_minus_opens_the_surface_it_promises(self):
+        """**The positive half, without which the negative below measures nothing** (#929).
+
+        Every other assertion about the `-` says what it did NOT do, and a `-` wired to
+        nothing at all passes all of them. This is the one that says the press ARRIVED: a
+        real pane, carved off the harness by a real detached `charter frame-palette --tab`,
+        which is the same observable `tests/test_a_real_click_opens_the_real_palette.py`
+        uses for the doorway on the attention row.
+        """
+        before = set(self._panes(self.WS))
+        self._click(self.bar, col=self._minus())
+        self.assertTrue(_await(lambda: set(self._panes(self.WS)) - before, timeout=15.0),
+                        "a press on the `-` opened no pane, so every case in this class "
+                        "that asserts the `-` destroyed nothing is measuring an empty room")
+
     def test_a_press_on_the_minus_stops_nothing_and_makes_nothing(self):
         """**§4i end to end for the one gesture that could destroy something.** What the
         `-` starts is `charter frame-palette --tab <this chat>` — a SURFACE — so after a


### PR DESCRIPTION
Closes #929.

> *"i'm checking `-` button is not working, its opening something like F2 menu, after choosing close - its not closing and breaking entire flow, even hard to explain"*

Three claims, three different answers. Reproduced on a real tmux frame with a real client on
a real pty before anything was theorised — `docs/assets/capture-frame.sh`'s pattern, with the
`TERM` ladder from `tests/test_a_real_click_on_a_real_tab_bar_switches.py`.

## The reproduction, and the two fixture artefacts it caught first

The first run showed the confirmation drawing **`no chats are open on this plane — nothing to
quit`**, with Enter doing nothing — which looks exactly like the report. It was my fixture:
it never stamped `@charter_chat` on its windows, so `_chat_seats` saw no live chat and
`leave.stopping` dropped everything. The `F2` control then would not open at all, because
`$CHARTER_PY` was unset in the server environment and the hotkey bind expands it.

Both were fixed and carried as controls. With a healthy fixture the `-` route and the
`F2 → chat: close` route behave **identically** — same drawer, same confirming row, same
kill. So the `-`-vs-`F2` difference is not the defect, and the `focus=""` that
`tabmenu.confirm_rows` passes where `_picker` passes a workspace is genuinely unobservable:
`leave.plan` never filters on it.

## What the defect actually is

The close **ran**. Measured, in order: confirmation drawn, Enter committed,
`state.record_closed` written, `kill-window` executed, `was_closed` → `True`, window gone.

And the strip did not move:

```
SETTLED   windows: @1 alpha.2
          was_closed(alpha.1): True
          strip:  '   alpha.1  *alpha.2  + -'      <-- the closed chat, still a tab
```

`chats._by_workspace` — the one walk `of_workspace`, `counts_by_workspace` and
`touched_by_workspace` all are — scans the frame root and has never asked `state.was_closed`.
That marker has been written since #796 and read in exactly one place ever: `leave.plan`.

The ghost tab stays pressable, which is claim 3:

```
notice(alpha.2): "charter: cannot switch: chat 'alpha.1' has no window any more"
```

**This is older than the affordance that reported it.** `F2 → chat: close` had it too. #925
put the close on the chat strip, so the operator's eye is now on the one surface that does
not change. The `-` is correct and is unchanged.

## The half that is not on disk

With the scan fixed, the surviving strip **still drew the closed tab seven seconds later** —
a panel repaints on a `state.version` bump and on nothing else, and a close moves no version
but the closed chat's own, whose window is being killed. It corrected only when a click woke
that panel for an unrelated reason. Right plane, wrong screen, same report.

So `cmd_close` wakes every other chat on the plane — every workspace, because the workspaces
strip draws a count for each — on every path that writes the marker, including the one where
tmux would not stop the window.

## Claim 1, verified rather than trusted

`frame/builtins._bar_events` passes `fid` where the right-press passes `tab_at(...)`. The
docstring asserts they are the same for the active tab; `chats.roster` marks
`active = (n == fid)`, so they are. Nothing to change.

## What I deliberately did not change

- **The `-` stays.** It is not the defect, and reverting it would leave the real bug in place
  for `F2 → chat: close`.
- **`tabmenu.confirm_rows`' `focus=""`** — checked and genuinely unobservable.
- **#928's rule** — close is a drawer, quit takes the pane; both still pinned.
- **`leave.plane_chats`** — must keep seeing closed chats, and a test now says so.

## Verification

```
Ran 11814 tests in 564.442s
OK (skipped=9)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018hUBNraNfixfMMK5Jc6CNy
