### PR TITLE
The tab menu opens with Enter aimed at something it can do (#931)

### DIFF
--- a/charter/frame/leave.py
+++ b/charter/frame/leave.py
@@ -450,8 +450,17 @@ def open_rows(fid: str) -> tuple:
 
     **They are the LAST rows in the catalogue**, which `commands_frame._draw_palette`
     arranges by appending them, and that placement is a guard rather than a taste: the
-    palette's cursor starts on the first row that can run, and a destructive row at the top
-    would be one `F2 Enter` away. Charter's own harmless rows keep the top of the list.
+    palette's cursor starts on the first row that can run (`palette.aim`), and a destructive
+    row at the top would be one `F2 Enter` away. Charter's own harmless rows keep the top of
+    the list.
+
+    **That premise only became true in #931**, and this guard is what it was written for.
+    Until then the cursor opened on the first row FULL STOP, refused or not — so this
+    ordering was protecting the operator from a keypress the implementation was aiming
+    somewhere else anyway, and a surface with a refused row above these two spent that
+    keypress on nothing. Nothing here moves: every row `commands_frame._catalogue` puts
+    above these can run on an ordinary plane, so `F2 Enter` reaches them no more easily than
+    it did.
 
     No plan is built here. The confirmation is where the per-chat warning is drawn (§4f:
     *at the moment the operator is deciding*), and the operator is not deciding while the
@@ -523,19 +532,26 @@ def confirm_rows(p: Plan, *, verb: str) -> tuple:
     does nothing.
 
     **The confirming row is FIRST, and an earlier draft had it last.** Under the list it is
-    about reads better and was measured to be wrong: `frame/palette.narrow` puts the cursor
-    on the first row when nothing has been typed, refused or not, so the surface opened with
+    about reads better and was measured to be wrong: `Palette._refilter` put the cursor on
+    the first row when nothing had been typed, refused or not, so the surface opened with
     `> alpha.1 · claude-code` selected and Enter bound to nothing at all. *"A palette row
     that visibly does nothing reads as broken and costs the operator a whole `F2` to find
     out"* is `builtin_actions._register_selection`'s own finding, and it applies here more
     than anywhere: the one surface where the operator has just asked a question and is
     waiting for the keypress that answers it.
 
-    So the shape is the shape of every confirmation an operator has ever used: the thing you
-    press at the top, what it will do underneath it, and the whole list on screen before the
-    first keypress that commits anything. §4f's requirement is that the warning is drawn *at
-    the moment of deciding*, and it is — the doorway's Enter draws this surface and nothing
-    else.
+    **That measurement is now fixed at its source, and the order stays anyway** (#931).
+    `palette.aim` opens the cursor on the first row that can run, so this surface would
+    answer Enter with the confirming row wherever it sat — every other row here is
+    `refused`. What kept the row at the top was never only the cursor: it is the shape of
+    every confirmation an operator has ever used — the thing you press at the top, what it
+    will do underneath it, and the whole list on screen before the first keypress that
+    commits anything. So the placement is now a reading-order decision rather than a guard,
+    which is worth saying plainly, because a reader who moved it would find the cursor
+    followed it and would learn nothing about why it reads worse.
+
+    §4f's requirement is that the warning is drawn *at the moment of deciding*, and it is —
+    the doorway's Enter draws this surface and nothing else.
 
     A plan with nothing to stop gets one refused row saying so and **no confirming row at
     all**, so there is no keypress that quietly succeeds at nothing.

--- a/charter/frame/palette.py
+++ b/charter/frame/palette.py
@@ -47,6 +47,11 @@ that does not have it.
 position the catalogue gave it — see :func:`narrow`, which states the whole ordering rule
 and why the two things it does not do (score, cap) are still not done.
 
+*Enter is aimed at a row that CAN run* (#931). :func:`aim` is one line, and it is the line
+six docstrings and `docs/frame.md` had already promised was there — see it for what the
+promise said, what the code did instead, and why the ordering guard built on top of the
+promise is unharmed by the promise coming true.
+
 **The query never reaches a parser.** It is built one keypress at a time out of
 `overlay.decode`'s printable single-character events, so no newline and no escape
 sequence can enter it; it is nevertheless contained before it is measured or drawn, for
@@ -235,15 +240,74 @@ def narrow(catalogue: Iterable[overlay.Row], query: str) -> tuple[overlay.Row, .
 
     **The "no ranking" this replaces defended itself with a property this class does not
     have.** It argued that reordering "would move the row under the cursor out from under
-    it between keystrokes" — but `Palette._refilter` sets the selection back to the top on
-    every single edit, deliberately and with its own docstring saying so. There was no row
-    under the cursor to move. The real cost of reordering is that the LIST reads
-    differently, which is why the sort is two buckets rather than a score: with nothing
-    typed, no row is an exact match for `""`, so `F2` draws exactly the list it drew
-    before this function learned to sort.
+    it between keystrokes" — but `Palette._refilter` re-aims the cursor on every single
+    edit, deliberately and with its own docstring saying so. There was no row under the
+    cursor to move. The real cost of reordering is that the LIST reads differently, which
+    is why the sort is two buckets rather than a score: with nothing typed, no row is an
+    exact match for `""`, so `F2` draws exactly the list it drew before this function
+    learned to sort.
+
+    **This decides the ORDER and :func:`aim` decides the CURSOR, and #931 is what happens
+    when one function is asked to be both.** The second bucket key here (`r.refused`) is
+    this function's whole opinion about refusals, and it applies only to rows the operator
+    typed the whole name of — a two-row menu where the first row is refused and nothing has
+    been typed sorts unchanged, correctly, and used to open with Enter bound to nothing all
+    the same.
     """
     kept = [r for r in catalogue if matches(query, r)]
     return tuple(sorted(kept, key=lambda r: (0, r.refused) if exact(query, r) else (1, 0)))
+
+
+def aim(rows: Iterable[overlay.Row]) -> int:
+    """Where the cursor opens: **the first row that can run**, and 0 when none can.
+
+    **This sentence was already charter's rule; it was simply not charter's code** (#931).
+    `leave.open_rows`, `commands_frame._catalogue`, `commands_frame._as_a_drawer`,
+    `tabmenu.catalogue`, `docs/frame.md` and a shipped release note all say *the cursor
+    starts on the first row that can run*, and each of them puts a destructive row at the
+    bottom of a list on the strength of it. What `Palette._refilter` actually did was
+    ``self._sel = 0`` — the first row, refused or not — so every one of those six was
+    reasoning from a premise the implementation did not keep.
+
+    **The report is what a two-row surface does to that gap.** `frame/tabmenu.catalogue`
+    lists the transcript row and then close; a chat that has never been quit has no capture,
+    which is the ordinary state of a chat running normally, so the menu the chat strip's `-`
+    opens arrived with the cursor on a row that cannot run. Press `-`, press Enter, and the
+    surface closes having started nothing — one keystroke from the report #929 came from,
+    reached by a different route and on the commonest state a chat is in.
+
+    **The two rules were never actually in conflict, and that is the resolution.** *Do not
+    open on a row that does nothing* and *do not open on a destructive row* look opposed on
+    a two-row menu where one row is usually refused, but the second rule is enforced by
+    ORDER — the destructive row is last — and the first is enforced HERE, by which of the
+    listed rows the cursor is put on. Making this true is what lets the ordering guard
+    finally mean what it says: every row above `chat: close` in `F2`'s catalogue can run,
+    so `F2 Enter` still cannot reach it, and it reaches it no more easily than before
+    because nothing here moves a row.
+
+    **What was rejected, because each is a worse answer to the same report:**
+
+    * *Opening with NO row selected, and saying so.* `overlay.Surface.selected` answers
+      ``None`` for one thing today — *there are no rows* — and a second meaning would be
+      indistinguishable at every call site: `tabmenu.act` and `commands_frame._draw_palette`
+      both read ``None`` as a CANCEL, so Enter on an unaimed surface would tear the pane
+      down silently and change nothing. That is the reported defect reintroduced by its own
+      fix.
+    * *Reordering the tab menu so close comes first.* `leave.open_rows`' guard, at the one
+      surface that opens under a pointer instead of a keypress.
+    * *Dropping a refused row from the list.* #512, and `narrow` says it again: an option
+      you cannot see is one you cannot ask about.
+    * *Skipping refused rows under the arrow keys too.* An operator pressing `down` is
+      aiming for themselves, and a list that will not stop on a row is a list whose reason
+      column cannot be read. Only the OPENING position is charter's to choose.
+
+    **Zero, and not −1, when nothing can run.** A surface where every row is refused is not
+    a surface whose cursor lies — `leave.confirm_rows`' nothing-left-to-stop plan is exactly
+    one such row, and it says so in its title. The cursor sits on it, Enter answers with its
+    note, and there is no second index state for the window arithmetic in
+    `overlay.Surface._window` to be handed.
+    """
+    return next((i for i, r in enumerate(rows) if not r.refused), 0)
 
 
 @dataclass
@@ -329,14 +393,21 @@ class Palette(overlay.Surface):
     def _refilter(self) -> None:
         """Recompute the visible rows, the header, and where the cursor sits.
 
-        The selection goes back to the top on every edit, deliberately: after a keystroke
-        the operator is looking at a different list, and keeping an index into the old one
+        The selection is re-aimed on every edit, deliberately: after a keystroke the
+        operator is looking at a different list, and keeping an index into the old one
         would leave the cursor on whichever row happened to land in that position.
         `_top` follows it because `Surface._window` recomputes from the selection, so
         there is no second scroll state to keep in step.
+
+        **Where it is re-aimed TO is :func:`aim`, and it was ``0`` until #931** — the
+        first row rather than the first row that can run, which is not what a single
+        docstring in this repository claimed and is what a `-` on a chat with no
+        transcript pressed Enter into. This is the one call site, so there is one answer
+        to *where does the cursor open*: the opening position and every re-aim after a
+        keystroke are the same rule rather than two that can drift.
         """
         self.rows = narrow(self._reachable(), self.query)
-        self._sel = 0
+        self._sel = aim(self.rows)
         self._top = 0
         self.said = ""
         self._headline()

--- a/charter/frame/tabmenu.py
+++ b/charter/frame/tabmenu.py
@@ -184,6 +184,15 @@ def catalogue(target: str) -> tuple[overlay.Row, ...]:
     that has never been quit has no transcript, which is the ordinary state of a chat
     running normally, and an operator cannot ask about an option they cannot see.
 
+    **And that sentence is FRONT-LOADED, which is the half #931 asked about.** The note is
+    the right-hand column and `overlay._title_width` splits the pane between the two, so on
+    a two-row menu it is truncated on any real terminal: `no previous transcript for…` at 60
+    columns, `…for this chat — one is captured when…` at 120. What survives every one of
+    those cuts is the answer to *why can this not run*, because that clause is first; the
+    clause about how a transcript comes to exist is the one that goes. A rewording that led
+    with `one is captured when a plane is quit` would read better whole and would leave an
+    operator who has just pressed `-` looking at a row with no reason on it at all.
+
     **Which is the state that broke this surface, and the fix is not here** (#931). The two
     facts above are each correct and together they made a two-row menu whose first row is
     usually refused — so `-` then Enter started nothing at all, on the commonest state a

--- a/charter/frame/tabmenu.py
+++ b/charter/frame/tabmenu.py
@@ -184,6 +184,37 @@ def catalogue(target: str) -> tuple[overlay.Row, ...]:
     that has never been quit has no transcript, which is the ordinary state of a chat
     running normally, and an operator cannot ask about an option they cannot see.
 
+    **Which is the state that broke this surface, and the fix is not here** (#931). The two
+    facts above are each correct and together they made a two-row menu whose first row is
+    usually refused — so `-` then Enter started nothing at all, on the commonest state a
+    chat is in, one keystroke from the report #929 came from. The cursor is what was wrong,
+    not the order: `palette.aim` now opens it on the first row that CAN run, which is what
+    the paragraph above always claimed happened.
+
+    **So on a chat with no capture the cursor opens on `chat: close`, and that is the
+    answer rather than a cost accepted quietly.** It is defensible on this surface and on
+    no other, for a reason this menu can state and `F2` cannot:
+
+    * the row is a **doorway** — :func:`chose` refuses it by id and :func:`opens` replaces
+      the surface with `leave.confirm_rows` — so the Enter under the cursor draws the
+      warning that names the chat, and a second, deliberate Enter on a row that says *stop
+      it and do not bring it back* is what stops anything. `leave.open_rows`' guard is about
+      the number of keypresses between an operator and an irreversible answer, and there
+      are still two, with the whole warning drawn between them;
+    * `F2` is opened without a target and carries every row charter has, so a destructive
+      row under its cursor would be a trap for an operator who came for something else.
+      This menu has no something else: it is opened AT one chat, by `slots.CLOSE_CHAT` — a
+      `-` whose own docstring says *a pointer opens the question; the keyboard answers it*
+      — or by a right press on that chat's tab, and both of its rows are about that chat;
+    * and the alternative is the defect. A cursor on the refused row spends the operator's
+      Enter on nothing, and a cursor on no row at all cannot be told from a cancel
+      (`palette.aim` lists what that costs at every call site).
+
+    Nothing is added to make the cursor somewhere harmless to sit. A third row — `chat:
+    switch to <target>`, say — would be a row that exists for the cursor rather than for
+    the operator, and this module's scope argument above is what refuses it: switching is
+    about the FRAME, and the menu's two rows are the ones a TAB has.
+
     No plan is built here and nothing is scanned. `frame/leave.open_rows` makes the same
     promise for the same reason: the operator is not deciding while a menu is merely open,
     and the warning belongs at the moment they are (§4f).

--- a/docs/frame.md
+++ b/docs/frame.md
@@ -2481,8 +2481,8 @@ chats was last in front of you.
 
 ```
 charter · 16 to choose from
->   workspace: alpha — pick another    cannot switch: a chat belongs to its workspa…
-    persona: steward — pick another
+    workspace: alpha — pick another    cannot switch: a chat belongs to its workspa…
+>   persona: steward — pick another
     detach — leave the harness running
     repo: select the next row
     repo: select the previous row
@@ -2519,11 +2519,12 @@ says what would make it available. The reason is the right-hand column. A refuse
 listed lower than a row you typed the whole name of, and never dropped.
 
 **The cursor opens on the first row that can run, and it skips a refused row to get
-there.** A refused row stays exactly where it is in the list — this moves the cursor, not
-the rows — so what you can see does not change and `Enter` is never aimed at a row that
-would answer it with nothing. `up`/`down` still stop on every row, refused or not, because
-that is how you read the reason beside one. Where nothing in a list can run, the cursor
-sits on the first row and `Enter` says why.
+there** — which is why the `>` above is on the second row and not the first. A refused row
+stays exactly where it is in the list, so this moves the cursor and not the rows: what you
+can see does not change, and `Enter` is never aimed at a row that would answer it with
+nothing. `up`/`down` still stop on every row, refused or not, because that is how you read
+the reason beside one. Where nothing in a list can run, the cursor sits on the first row
+and `Enter` says why.
 
 **Every row reserves the `*` column, whether or not it has a mark to put in it** — the
 frame's one-inset rule, applied here. Four cells stand in front of every row's text: two

--- a/docs/frame.md
+++ b/docs/frame.md
@@ -257,6 +257,11 @@ first. Close is a doorway, not a button: pressing it draws the same warning `F2 
 close` draws, naming the chat and what stopping it costs, and the keypress on *that* is what
 stops the harness. Escape leaves, `F12` always leaves, and nothing is stopped by a pointer.
 
+A chat that has never been quit has no transcript, so on most chats the first row is refused
+— it stays on the menu with its reason beside it, and the cursor opens on `chat: close`
+underneath, because that is the row `Enter` can actually answer. Two keypresses still stand
+between the menu and a stopped harness, and the warning is drawn between them.
+
 **A confirmation is a drawer; the palette is the whole window.** The palette and the pickers
 zoom over the frame because they are lists that scroll and have no length limit. A
 confirmation is one question with its answer at the top, so it gives the window back and
@@ -763,6 +768,11 @@ one a right-click on that tab opens — whose `chat: close` row draws the warnin
 chat and what stopping it costs, and the keypress on *that* is what stops it. A pointer
 opens the question; the keyboard answers it, which is why making a chat may happen on a
 press and unmaking one may not.
+
+`-` then `Enter` reaches that warning on a chat with no transcript, because the cursor opens
+on the row that can run. It did not until 0.60.0: the menu opened on the refused transcript
+row, `Enter` started nothing, and a `-` that did nothing twice reads as a `-` that does not
+work.
 
 It is one glyph at the end of the row rather than a `×` on every tab, because a per-tab
 affordance would cost a column on every tab and move every one of them the moment a chat
@@ -2507,6 +2517,13 @@ list; see *Leaving* below for what those two do.
 An option you cannot see is one you cannot ask about, so a row that is refused stays and
 says what would make it available. The reason is the right-hand column. A refused row is
 listed lower than a row you typed the whole name of, and never dropped.
+
+**The cursor opens on the first row that can run, and it skips a refused row to get
+there.** A refused row stays exactly where it is in the list — this moves the cursor, not
+the rows — so what you can see does not change and `Enter` is never aimed at a row that
+would answer it with nothing. `up`/`down` still stop on every row, refused or not, because
+that is how you read the reason beside one. Where nothing in a list can run, the cursor
+sits on the first row and `Enter` says why.
 
 **Every row reserves the `*` column, whether or not it has a mark to put in it** — the
 frame's one-inset rule, applied here. Four cells stand in front of every row's text: two

--- a/docs/news/unreleased-the-cursor-opens-on-a-row-that-can-run.md
+++ b/docs/news/unreleased-the-cursor-opens-on-a-row-that-can-run.md
@@ -1,0 +1,83 @@
+---
+version: unreleased
+headline: The tab menu opens with Enter aimed at something it can actually do
+---
+
+*"`-` … after choosing close - its not closing and breaking entire flow."*
+
+That report had two independent causes. The first was a closed chat that stayed on the
+strip, and it is fixed. **This is the second, and it is the one an operator hits first** —
+because it does not need the close to run at all.
+
+## Press `-`, press Enter, and nothing starts
+
+The tab menu has two rows. The transcript, then close.
+
+```
+chat alpha.1 · 2 to choose from
+>   chat: previous transcript — alpha.1     no previous transcript for this chat — one …
+    chat: close alpha.1 — stop it and do not bring it back
+  up/down move   enter choose   esc cancel   F12 back to the harness
+```
+
+A chat that has never been quit has no transcript to open — which is not a fault, it is
+what a chat running normally looks like. So the first row is refused, and the cursor opened
+on it. `-`, Enter, and the surface closes having started nothing; the reason goes to the
+attention row, and the chat you just asked to close is still there.
+
+An operator who does that concludes the button does not work. They would be right.
+
+## Charter had already written the rule down. Six times.
+
+Every place in charter that puts a destructive row at the bottom of a list says the same
+sentence out loud — *the cursor starts on the first row that can run* — and each of them
+banks on it. `docs/frame.md` says it to you. The 0.56.0 release note said it.
+
+The palette put the cursor on the first row, full stop. Refused or not. So six arguments
+were reasoning from a premise the code did not keep, and the first surface narrow enough to
+notice was a two-row menu whose first row is usually refused.
+
+**The cursor now opens on the first row that can run.** No row moves. A refused row is still
+listed, still where it was, still with its reason beside it — `up` and `down` still stop on
+it, which is how you read that reason. What changed is only which row `Enter` is aimed at,
+which is the one thing every one of those six docstrings thought was already true.
+
+## Two rules that looked opposed, and were not
+
+*Do not open the cursor on a row that does nothing.* *Do not open the cursor on a row that
+destroys something.* On a two-row menu where one row is usually refused, those cannot both
+be satisfied by moving rows around — and moving rows around is what charter was trying to
+do with them.
+
+They are two different mechanisms. **Order** keeps a destructive row off the top of a list;
+**the cursor** keeps `Enter` off a row that cannot answer it. Nothing here reorders anything,
+so `F2` still cannot reach `chat: close` or `charter: quit` with one `Enter`, and the tab
+menu still lists close last.
+
+Where the tab menu has no transcript to offer, the cursor does open on `chat: close` — and
+that row starts nothing. It is a doorway: `Enter` on it draws the same warning `F2 → chat:
+close` draws, and the keypress on *that* is what stops a harness. Two keypresses and a
+warning still stand between a pointer and a stopped chat, which is what the ordering guard
+was ever counting.
+
+## What was rejected
+
+**Opening with no row selected at all.** It reads honest — no cursor, no promise — and it is
+the reported bug in costume. Charter's surfaces answer "nothing is selected" and "the
+operator pressed Escape" with the same value, so `Enter` on an unaimed menu would close the
+pane and change nothing. That is precisely what was being fixed.
+
+**Putting `chat: close` first.** The guard exists for a reason, and it exists most at the one
+surface that opens under a pointer rather than under a keypress.
+
+**Dropping the refused row.** An option you cannot see is one you cannot ask about.
+
+**Adding a third, harmless row for the cursor to sit on.** A row that exists for the cursor
+rather than for the operator.
+
+## Unchanged
+
+The `-` still opens the tab menu about the chat you are in rather than closing anything, and
+what it opens is byte for byte what a right press on that tab opens. `chat: close` is still
+a drawer; `charter: quit` still takes the pane. Every refused row charter draws is still
+drawn, in the place it was drawn before.

--- a/tests/test_a_real_click_on_a_real_tab_bar_switches.py
+++ b/tests/test_a_real_click_on_a_real_tab_bar_switches.py
@@ -52,7 +52,7 @@ import unittest
 from pathlib import Path
 
 from charter import commands_frame, config
-from charter.frame import chats, layout, slots, state, tmuxctl
+from charter.frame import chats, layout, leave, overlay, slots, state, tmuxctl
 
 from tests import _tmuxreap
 from tests._isolation import PersonaIso, make_plane
@@ -1211,6 +1211,107 @@ class ARealPressOnThePlusReachesTheCommandBehindIt(_ARealFrameWithBars,
             before, "a press on the `-` made or removed a window")
         self.assertEqual(state.notice(self.here), "",
                          "a press on the `-` reached a command that reports")
+
+    def _menu_from_the_minus(self) -> str:
+        """Press the `-` and hand back the overlay pane it opened, once the menu is on it.
+
+        The two cases above, composed rather than repeated: what makes the keypress cases
+        below real is that the pane they type into is the one THAT press opened, on this
+        frame, carrying this chat's rows.
+        """
+        before = set(self._panes(self.WS))
+        self._click(self.bar, col=self._minus())
+        self.assertTrue(_await(lambda: set(self._panes(self.WS)) - before, timeout=15.0),
+                        "a press on the `-` opened no pane at all")
+        pane = (set(self._panes(self.WS)) - before).pop()
+        self.assertTrue(
+            _await(lambda: f"chat: close {self.here}" in self._shown(pane)),
+            f"the pane that opened never drew the menu: {self._shown(pane)!r}")
+        return pane
+
+    def _cursor_row(self, pane: str) -> str:
+        """The one row of *pane* the overlay put its cursor on.
+
+        `overlay._MARK` is two cells on EVERY row — `"> "` on the selected one and two
+        spaces on the rest — so the marked row is the only line of a captured pane that
+        starts with it. Read off the pane rather than off a `Palette` in this process: what
+        this file is for is the trip, and the cursor is drawn by a `charter frame-palette`
+        three processes away.
+        """
+        shown = self._shown(pane)
+        marked = [ln for ln in shown.split("\n") if ln.startswith(overlay._MARK[0])]
+        self.assertEqual(len(marked), 1,
+                         f"not exactly one cursor on the surface: {shown!r}")
+        return marked[0]
+
+    def test_a_press_on_the_minus_puts_the_cursor_on_the_row_enter_can_answer(self):
+        """**#931, on the surface that reported it and in the state it reported.**
+
+        This chat has never been quit, so it has no capture and the menu's first row is
+        refused — the ordinary state of a chat running normally rather than a fault. What
+        `origin/main` drew on this same fixture is the pane #931 captured::
+
+            chat alpha.1 · 2 to choose from
+            >   chat: previous transcript — alpha.1   no previous transcript for this…
+                chat: close alpha.1 — stop it and do not bring it back
+
+        so `-` then Enter started nothing at all, and the operator was left looking at the
+        chat they had just asked to close. `palette.aim` puts the cursor on the first row
+        that CAN run, which is the sentence six docstrings in this repository already
+        claimed was the code.
+
+        The rows do not move — #512's refused row is still listed, still above, still
+        carrying its reason, and asserted here because a cursor rule that fixed itself by
+        dropping the row would pass the first assertion alone.
+        """
+        pane = self._menu_from_the_minus()
+        shown = self._shown(pane)
+
+        self.assertIn(f"chat: close {self.here}", self._cursor_row(pane))
+        self.assertIn("chat: previous transcript", shown)
+        self.assertIn("no previous transcript for this chat", shown)
+
+    def test_and_that_enter_really_reaches_the_close_confirmation(self):
+        """**What the press BUYS**, and the assertion #929 found this whole surface had
+        never had: not that Enter avoided doing something, but the surface it reaches.
+
+        `tabmenu.opens` builds `leave.confirm_rows` and `commands_frame._as_a_drawer`
+        replaces the menu with it in the pane the operator is already looking at — so the
+        pane SURVIVES the keypress and stops being the menu. On `origin/main` that same
+        Enter landed on the refused row: `tabmenu.act` put its note on the attention row,
+        the `finally` killed the pane, and a `-` that did nothing twice reads as a `-` that
+        does not work.
+
+        **Enter is pressed once and only once.** The row now under the cursor is `leave`'s
+        own confirming row, and going through with it stops a harness.
+
+        **What the warning SAYS is asserted in the unit file and not here**, because this
+        fixture cannot honestly be asked. `leave.plan` counts what is live through
+        `commands_frame._chat_seats`, which reads the `@charter_chat` a real launch writes
+        on its window; this fixture's harness is a shell in a hand-made session, so the
+        plan is empty and `leave.confirm_rows` draws its nothing-left-to-stop row — with no
+        confirming row at all, which is that function's own promise that no keypress
+        quietly succeeds at nothing. The heading is what identifies the surface either way:
+        `leave.CLOSE` is the label `tabmenu.opens` gives it and `chat` is the label the menu
+        had.
+        """
+        pane = self._menu_from_the_minus()
+
+        os.write(self.fd, b"\r")
+
+        self.assertTrue(
+            _await(lambda: self._shown(pane).split("\n")[0].startswith(leave.CLOSE)),
+            f"Enter did not reach the close confirmation: {self._shown(pane)!r}")
+        shown = self._shown(pane)
+        self.assertIn(pane, self._panes(self.WS),
+                      "Enter closed the pane instead of drawing a surface in it")
+        self.assertNotIn("chat: previous transcript", shown,
+                         "the menu is still on screen, so this is not the confirmation")
+        self.assertEqual(chats.of_workspace(self.WS), [self.here],
+                         "the Enter that draws the confirmation also stopped something")
+        self.assertEqual(state.notice(self.here), "",
+                         "the Enter answered on the attention row, which is what a "
+                         "refused row does and a doorway does not")
 
     def test_the_cell_between_the_two_affordances_reaches_nothing(self):
         """The separator belongs to neither, and here the two neighbours mean opposite

--- a/tests/test_the_palette_aims_enter_at_a_row_that_can_run.py
+++ b/tests/test_the_palette_aims_enter_at_a_row_that_can_run.py
@@ -72,7 +72,7 @@ def _row(rid: str, *, refused: bool = False) -> overlay.Row:
 
 
 class TheCursorOpensOnTheFirstRowThatCanRun(unittest.TestCase):
-    """`palette.aim` on its own, over the four shapes a list of rows comes in."""
+    """`palette.aim` on its own, over the five shapes a list of rows comes in."""
 
     def test_a_runnable_first_row_keeps_the_cursor_where_it_always_was(self):
         """The compatibility claim this whole change rests on: `F2`'s catalogue leads with

--- a/tests/test_the_palette_aims_enter_at_a_row_that_can_run.py
+++ b/tests/test_the_palette_aims_enter_at_a_row_that_can_run.py
@@ -1,0 +1,351 @@
+"""**The cursor opens on a row that can run — #931.**
+
+Filed off a real frame while #929 was being reproduced, and filed rather than folded in
+because it needed a decision. The tab menu — what a right press on a tab opens, and what
+the chat strip's `-` opens — has two rows, transcript then close. Captured on a chat that
+has never been quit, which is the ordinary state of a chat running normally:
+
+    chat alpha.1 · 2 to choose from
+    >   chat: previous transcript — alpha.1     no previous transcript for this chat…
+        chat: close alpha.1 — stop it and do not bring it back
+
+The cursor opened on a **refused** row, so `-` then Enter started nothing at all: the
+surface closed, the note went to the attention row, and the chat was still there. That is
+one keystroke from the report #929 came from — *"after choosing close - its not closing"* —
+reached by a different route.
+
+**The rule was already written down six times; it was never the code.** `leave.open_rows`,
+`commands_frame._catalogue`, `commands_frame._as_a_drawer`, `tabmenu.catalogue`,
+`docs/frame.md` and the 0.56.0 release note all say *the cursor starts on the first row
+that can run*, and each puts a destructive row at the bottom of a list on the strength of
+it. `Palette._refilter` said ``self._sel = 0``. `palette.aim` is that sentence, and this
+file is the pin on it.
+
+**The two rules that looked opposed, and why they were not.** *Do not open on a row that
+does nothing* (`leave.confirm_rows`' own measurement) and *do not open on a destructive
+row* (`leave.open_rows`') are in direct conflict on a two-row menu where the first row is
+usually refused — but only if one mechanism has to serve both. It does not: the second is
+enforced by ORDER, which nothing here moves, and the first by which listed row the cursor
+is put on. `TheOrderingGuardIsNotWhatMoved` is the half of this file that proves the first
+change did not buy itself out of the second.
+
+**Where that leaves the tab menu, said plainly because it is the one surface it bites.**
+On a chat with no capture the only row that can run is `chat: close`, so the cursor opens
+there. It is a DOORWAY — `tabmenu.chose` refuses it by id and `tabmenu.opens` replaces the
+surface with `leave.confirm_rows` — so there are still two keypresses and a warning naming
+the chat between the pointer and a stopped harness, which is what `leave.open_rows`' guard
+is actually counting. `F2` is the surface that guard was written for, and there every row
+above close can run.
+
+**What was rejected**, each asserted below where it would show:
+
+* opening with NO row selected — `overlay.Surface.selected` answers ``None`` for *there
+  are no rows*, and `tabmenu.act` and `commands_frame._draw_palette` both read ``None`` as
+  a CANCEL, so Enter on an unaimed surface would tear the pane down silently and change
+  nothing. That is the reported defect reintroduced by its own fix;
+* reordering the menu so close comes first — `leave.open_rows`' guard, at the one surface
+  that opens under a pointer;
+* dropping the refused row — #512;
+* skipping refused rows under the arrow keys as well — a list that will not stop on a row
+  is a list whose reason column cannot be read.
+
+Every assertion here says what the surface DOES. #930's finding about this same `-` is
+that *"every assertion about the `-` said what it didn't do, so a `-` wired to nothing
+passed them all"*, and a cursor rule is even easier to test that way: `assertNotEqual(sel,
+refused_row)` passes on a palette with no rows at all.
+"""
+
+from __future__ import annotations
+
+import unittest
+from unittest import mock
+
+from charter import commands_frame
+from charter.frame import builtin_actions, leave, overlay, palette, reopen, tabmenu
+
+from tests._isolation import PersonaIso
+from tests.test_frame_chat_switch import _plant
+
+
+def _row(rid: str, *, refused: bool = False) -> overlay.Row:
+    return overlay.Row(id=rid, title=f"row {rid}", refused=refused)
+
+
+class TheCursorOpensOnTheFirstRowThatCanRun(unittest.TestCase):
+    """`palette.aim` on its own, over the four shapes a list of rows comes in."""
+
+    def test_a_runnable_first_row_keeps_the_cursor_where_it_always_was(self):
+        """The compatibility claim this whole change rests on: `F2`'s catalogue leads with
+        rows that can run, so the palette an operator knows opens on the row it always
+        opened on. A version of `aim` that preferred a refused row, or counted from the
+        end, fails here and nowhere else."""
+        self.assertEqual(palette.aim((_row("a"), _row("b", refused=True), _row("c"))), 0)
+
+    def test_a_refused_first_row_is_skipped_and_the_next_runnable_one_is_taken(self):
+        """The reported case, at its smallest. `1`, not "not 0": which row Enter is aimed
+        at is the whole defect."""
+        self.assertEqual(palette.aim((_row("a", refused=True), _row("b"))), 1)
+
+    def test_it_skips_a_RUN_of_refused_rows_rather_than_stepping_over_one(self):
+        """`leave.confirm_rows` draws one refused row per doomed chat, so "the next one"
+        and "the next runnable one" are different answers on any plane with two chats."""
+        self.assertEqual(
+            palette.aim((_row("a", refused=True), _row("b", refused=True),
+                         _row("c", refused=True), _row("d"))), 3)
+
+    def test_a_list_where_nothing_can_run_aims_at_its_first_row(self):
+        """Not −1, and not "no selection". A surface where every row is refused is not a
+        surface whose cursor lies — `leave.confirm_rows`' nothing-left-to-stop plan is
+        exactly one such row and its title says so. The cursor sits on it and Enter answers
+        with its note."""
+        self.assertEqual(palette.aim((_row("a", refused=True),
+                                      _row("b", refused=True))), 0)
+
+    def test_an_empty_list_answers_zero_so_the_window_arithmetic_is_handed_an_index(self):
+        """`overlay.Surface._window` clamps against `len(rows)` and `Surface.selected`
+        tests `self.rows` before indexing, so 0 is the value both already expect for a
+        palette that filtered everything out."""
+        self.assertEqual(palette.aim(()), 0)
+
+
+class APaletteAimsItselfOnEveryEdit(unittest.TestCase):
+    """The same rule at the surface, which is where an operator meets it."""
+
+    CATALOGUE = (_row("refused.1", refused=True), _row("runs"),
+                 _row("refused.2", refused=True))
+
+    def test_the_palette_opens_with_enter_aimed_at_the_row_that_can_run(self):
+        p = palette.Palette(catalogue=self.CATALOGUE)
+
+        self.assertEqual(p.selected.id, "runs")
+        self.assertFalse(p.selected.refused)
+
+    def test_the_row_the_cursor_is_on_is_the_one_the_pane_marks(self):
+        """One rung down: the text a terminal receives. `overlay.Surface.render` draws
+        `_MARK[0]` on `_sel` and nothing on the rest, so this is the `>` the operator sees
+        rather than the index behind it."""
+        drawn = [ln for ln in palette.Palette(catalogue=self.CATALOGUE).render(60, 8)]
+        marked = [ln for ln in drawn if overlay._MARK[0] in ln]
+
+        self.assertEqual(len(marked), 1, drawn)
+        self.assertIn("row runs", marked[0])
+
+    def test_typing_re_aims_rather_than_going_back_to_the_top(self):
+        """`_refilter` is called on every keystroke, so the rule has to hold for the list
+        the operator narrowed to as well as for the one the palette opened with. Typing
+        `refused` leaves two rows, neither runnable, and typing it away must land back on
+        the runnable one rather than on whichever index survived."""
+        p = palette.Palette(catalogue=self.CATALOGUE)
+        for ch in "refused":
+            p.handle(overlay.Event(kind=overlay.KEY, name=ch), 24)
+        self.assertEqual([r.id for r in p.rows], ["refused.1", "refused.2"])
+        self.assertEqual(p.selected.id, "refused.1",
+                         "a list where nothing can run still aims at its first row")
+
+        for _ in "refused":
+            p.handle(overlay.Event(kind=overlay.KEY, name="backspace"), 24)
+        self.assertEqual(p.selected.id, "runs")
+
+    def test_the_arrow_keys_still_stop_on_a_refused_row(self):
+        """**The rejected alternative, pinned where it would show.** Only the OPENING
+        position is charter's to choose: an operator pressing `up` is aiming for
+        themselves, and a row the cursor cannot land on is a row whose reason column cannot
+        be read on a surface that has no other way to show it."""
+        p = palette.Palette(catalogue=self.CATALOGUE)
+        p.handle(overlay.Event(kind=overlay.KEY, name="up"), 24)
+
+        self.assertEqual(p.selected.id, "refused.1")
+        self.assertTrue(p.selected.refused)
+
+    def test_enter_on_a_palette_with_rows_is_never_a_cancel(self):
+        """**The other rejected alternative.** `overlay.Surface.handle` answers
+        :data:`overlay.CHOOSE` and `run` hands back `selected`; if that were ``None`` for
+        "nothing is aimed at", `tabmenu.act` and `commands_frame._draw_palette` would both
+        take it for an Escape and close the pane having done nothing — the reported defect,
+        rebuilt out of its own fix."""
+        p = palette.Palette(catalogue=self.CATALOGUE)
+
+        self.assertEqual(p.handle(overlay.Event(kind=overlay.KEY, name="enter"), 24),
+                         overlay.CHOOSE)
+        self.assertIsNotNone(p.selected)
+
+
+class TheTabMenuAimsEnterAtSomethingItCanDo(PersonaIso, unittest.TestCase):
+    """The reported surface, built the way `tabmenu.draw` builds it."""
+
+    FID = "alpha.1"
+    TAB = "alpha.1"
+
+    def setUp(self) -> None:
+        super().setUp()
+        for chat in ("alpha.1", "alpha.2"):
+            _plant(chat, workspace="alpha")
+
+    def _menu(self) -> palette.Palette:
+        """`tabmenu.draw`'s own two lines, so what is aimed at here is what a `-` aims
+        at rather than a list this file composed to look like one."""
+        return palette.Palette(catalogue=tabmenu.catalogue(self.TAB),
+                               label=tabmenu.label(self.TAB), mouse=True)
+
+    def _capture(self) -> None:
+        path = reopen.transcript_path(self.TAB)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("what was on screen\n", encoding="utf-8")
+
+    def test_on_a_chat_never_quit_enter_is_aimed_at_the_close_doorway(self):
+        """The report, fixed. Said as *which row*, because "not the transcript row" would
+        pass on a menu that had lost the close row too."""
+        self.assertEqual(self._menu().selected.id, tabmenu.CLOSE_ID)
+
+    def test_that_enter_really_opens_the_warning_that_names_the_chat(self):
+        """**What the fix BUYS, which is the assertion #930 says this surface kept
+        missing.** Not "Enter is not refused" — the surface the keypress reaches, built by
+        `tabmenu.opens` from the row the cursor is really on, carrying `leave`'s own
+        confirming row for this one chat."""
+        chosen = self._menu().selected
+
+        nxt = tabmenu.opens(chosen, self.TAB, live=("alpha.1", "alpha.2"))
+
+        self.assertIsNotNone(nxt, "Enter on the aimed row opened no surface at all")
+        self.assertEqual(nxt.label, leave.CLOSE)
+        self.assertEqual(nxt.catalogue[0].id, leave.GO_ID.format(leave.CLOSE))
+        self.assertIn(self.TAB, nxt.catalogue[0].title)
+
+    def test_the_refused_row_is_still_listed_above_it_with_its_reason(self):
+        """#512, which this change does not get to relax: the cursor moved and the rows did
+        not. An operator who pressed `-` can still see that a transcript is a thing this
+        menu offers, and read why they are not being offered one."""
+        p = self._menu()
+
+        self.assertEqual([r.id for r in p.rows],
+                         [tabmenu.TRANSCRIPT_ID, tabmenu.CLOSE_ID])
+        self.assertTrue(p.rows[0].refused)
+        self.assertEqual(
+            p.rows[0].note,
+            "no previous transcript for this chat — one is captured when a plane is quit "
+            "(`F2 → charter: quit`) and offered on the chat that comes back")
+
+    def test_the_reason_is_on_screen_beside_the_row_and_not_only_in_the_data(self):
+        """The refusal has to be legible to somebody who has just pressed `-`, which is a
+        different question from whether the row carries a note: the row is no longer the
+        one under the cursor, so the dim right-hand column is the only place it is said."""
+        drawn = "\n".join(self._menu().render(140, 8))
+
+        self.assertIn("no previous transcript for this chat", drawn)
+        self.assertIn("chat: previous transcript", drawn)
+
+    def test_a_chat_WITH_a_transcript_still_opens_on_its_transcript_row(self):
+        """The negative control the case above needs, and the compatibility claim: nothing
+        about a chat that has a capture changes. The cursor is on the first row because the
+        first row can run, which is the same answer `_sel = 0` used to give for a different
+        reason."""
+        self._capture()
+        p = self._menu()
+
+        self.assertEqual(p.selected.id, tabmenu.TRANSCRIPT_ID)
+        self.assertFalse(p.selected.refused)
+
+    def test_and_that_enter_really_opens_that_chats_transcript(self):
+        """Same shape as the close case: what the keypress STARTS, off the row the cursor
+        is really on."""
+        self._capture()
+        spawned = []
+        with mock.patch("charter.frame.builtin_actions._spawn",
+                        side_effect=lambda argv, *, fid: spawned.append((argv, fid))):
+            self.assertTrue(tabmenu.chose(self._menu().selected, self.TAB, fid=self.FID))
+
+        self.assertEqual(len(spawned), 1, spawned)
+        self.assertIn("frame-transcript", spawned[0][0])
+        self.assertIn(self.TAB, spawned[0][0])
+
+    def test_the_aimed_row_still_starts_nothing_by_itself(self):
+        """§4i, and the reason a cursor on `chat: close` is answerable at all: the row the
+        Enter lands on is a DOORWAY. `tabmenu.chose` refuses it by id, so the keypress that
+        stops a harness is the NEXT one, on a surface that names the chat."""
+        spawned = []
+        with mock.patch("charter.frame.builtin_actions._spawn",
+                        side_effect=lambda argv, *, fid: spawned.append((argv, fid))):
+            started = tabmenu.chose(self._menu().selected, self.TAB, fid=self.FID)
+
+        self.assertFalse(started)
+        self.assertEqual(spawned, [])
+
+
+class TheOrderingGuardIsNotWhatMoved(PersonaIso, unittest.TestCase):
+    """**The half that proves the fix did not buy itself out of the other rule.**
+
+    `leave.open_rows` keeps its destructive rows last *"because the palette's cursor starts
+    on the first row that can run"* — a premise that only became true in #931. If aiming
+    the cursor had been paid for by moving a row, this class is where it would show.
+    """
+
+    FID = "alpha.1"
+
+    def setUp(self) -> None:
+        super().setUp()
+        for chat in ("alpha.1", "alpha.2"):
+            _plant(chat, workspace="alpha")
+
+    def test_the_two_rows_that_stop_something_are_still_last(self):
+        rows = leave.open_rows(self.FID)
+
+        self.assertEqual([r.id for r in rows],
+                         [leave.OPEN_ID.format(leave.QUIT),
+                          leave.OPEN_ID.format(leave.CLOSE)])
+
+    def test_F2_still_opens_on_a_row_that_stops_nothing(self):
+        """The guard's whole point, asked of the catalogue the palette is really built
+        from rather than of a list composed to look like one: `F2` `Enter` may not reach
+        `charter: quit` or `chat: close`. Aiming the cursor moves it FORWARD past refused
+        rows, and both of those live at the end, so the only way this could break is a
+        plane on which nothing else can run."""
+        reg = builtin_actions.build(self.FID, current_density="normal",
+                                    current_chrome="off")
+        p = palette.Palette(
+            catalogue=commands_frame._palette_catalogue(self.FID, reg, snapshot={}))
+
+        self.assertFalse(leave.is_row(p.selected),
+                         f"F2 Enter is aimed at {p.selected.id}, which stops something")
+        self.assertFalse(p.selected.refused)
+
+
+class AConfirmationStillAnswersItsOwnQuestion(PersonaIso, unittest.TestCase):
+    """`leave.confirm_rows`, whose row order was decided by the defect this change fixes.
+
+    Its docstring records putting the confirming row FIRST because *"the surface opened
+    with `> alpha.1 · claude-code` selected and Enter bound to nothing at all"*. That is now
+    fixed at the source, so the placement is a reading-order decision — and the surface has
+    to keep working either way, which is what these two cases are.
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+        for chat in ("alpha.1", "alpha.2"):
+            _plant(chat, workspace="alpha")
+
+    def test_enter_is_aimed_at_the_confirming_row_and_not_at_a_warning_row(self):
+        p = palette.Palette(
+            catalogue=leave.confirm_rows(
+                leave.plan(live=("alpha.1", "alpha.2"), focus="alpha"), verb=leave.QUIT),
+            label=leave.QUIT)
+
+        self.assertEqual(p.selected.id, leave.GO_ID.format(leave.QUIT))
+        self.assertTrue(all(r.refused for r in p.rows[1:]),
+                        "the per-chat rows stopped being a warning")
+
+    def test_a_plan_with_nothing_to_stop_aims_at_the_row_that_says_so(self):
+        """The one surface charter draws where NOTHING can run, and the case that pins
+        `aim`'s fallback: there is no confirming row at all, so a cursor that refused to
+        land on a refused row would have nowhere to go."""
+        p = palette.Palette(
+            catalogue=leave.confirm_rows(leave.plan(live=(), focus="alpha"),
+                                         verb=leave.QUIT),
+            label=leave.QUIT)
+
+        self.assertEqual(len(p.rows), 1)
+        self.assertEqual(p.selected.title, leave.NOTHING_OPEN)
+        self.assertTrue(p.selected.refused)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_the_palette_aims_enter_at_a_row_that_can_run.py
+++ b/tests/test_the_palette_aims_enter_at_a_row_that_can_run.py
@@ -234,6 +234,22 @@ class TheTabMenuAimsEnterAtSomethingItCanDo(PersonaIso, unittest.TestCase):
         self.assertIn("no previous transcript for this chat", drawn)
         self.assertIn("chat: previous transcript", drawn)
 
+    def test_the_reason_survives_the_width_every_real_pane_truncates_it_to(self):
+        """**#931's second question, and it is about word order rather than about the
+        note.** `overlay._title_width` splits the pane between the title and the reason, so
+        on a two-row menu the reason is cut on every terminal anyone has: at 60 columns the
+        operator gets `no previous transcript for…` and at 120 `…one is captured when…`.
+
+        What has to survive the cut is the answer to *why can this not run*, and it does
+        because that clause is first. A rewording that led with how a transcript comes to
+        exist would read better whole and would leave a `-` presser looking at a row with no
+        reason on it at all — so this asserts the visible prefix, not the note.
+        """
+        for width in (60, 72, 80, 96, 120, 200):
+            drawn = "\n".join(self._menu().render(width, 8))
+            self.assertIn("no previous transcript for", drawn,
+                          f"the reason is cut past its answer at {width} columns:\n{drawn}")
+
     def test_a_chat_WITH_a_transcript_still_opens_on_its_transcript_row(self):
         """The negative control the case above needs, and the compatibility claim: nothing
         about a chat that has a capture changes. The cursor is on the first row because the

--- a/tests/test_the_palette_lands_on_the_name_you_typed.py
+++ b/tests/test_the_palette_lands_on_the_name_you_typed.py
@@ -114,8 +114,15 @@ class TypingAWholeNameLandsOnIt(unittest.TestCase):
 
     def test_the_row_the_cursor_starts_on_is_one_that_can_run(self):
         """The second half of the report, said about the palette rather than about
-        `narrow`: a `Palette` puts its cursor at 0, so "first" and "under the cursor" are
-        the same row and the surface is where that is worth pinning."""
+        `narrow`: the surface is where "which row is first" becomes "which row Enter is
+        aimed at", so it is the place worth pinning it.
+
+        **Two rules make this the answer and #931 separated them.** `narrow` sorts an exact
+        match that can run ahead of one that cannot; `palette.aim` then puts the cursor on
+        the first row that can run at all. Here they agree. A two-row surface whose first
+        row is refused with nothing typed is where they would not, and
+        `tests/test_the_palette_aims_enter_at_a_row_that_can_run.py` is that half.
+        """
         p = palette.Palette(catalogue=_DOORWAYS + _ACTIONS,
                             query_only=lambda: _NAMES)
         for ch in "alpha":


### PR DESCRIPTION
Closes #931.

`-` then Enter started nothing, on the ordinary state of a chat running normally. That is
one keystroke from the report #929 came from, reached by a different route, and it is
still live after #930.

## Reproduced first, off `origin/main`

```
chat alpha.1 · 2 to choose from
>   chat: previous transcript — alpha.1     no previous transcript for this chat — one i…
    chat: close alpha.1 — stop it and do not bring it back

cursor on ......: tab:transcript | refused: True
Enter starts ...: nothing
Enter opens ....: nothing
```

and on a real tmux client, on #930's own harness — real server, real pty, real
`charter panel chats`, a real button-1 report at the `-`'s column, a real `\r`:

```
AssertionError: 'chat: close alpha.1' not found in
  '>   chat: previous transcript — alpha.1   no previous transcript for this chat — one…'

Enter did not reach the close confirmation: ''
```

That empty capture is the pane being killed. The surface closes and the chat is still
there, which is exactly what was reported.

After:

```
    chat: previous transcript — alpha.1     no previous transcript for this chat — one i…
>   chat: close alpha.1 — stop it and do not bring it back

cursor on ......: tab:close | refused: False
Enter opens ....: 'close' surface
```

and the real client's pane survives the Enter carrying `close · 1 to choose from`.

## How the conflict was resolved

**The rule was never in dispute — it was never the code.** `leave.open_rows`,
`commands_frame._palette_catalogue`, `commands_frame._as_a_drawer`, `tabmenu.catalogue`,
`docs/frame.md` and the 0.56.0 release note all say *the cursor starts on the first row
that can run*, and each puts a destructive row at the bottom of a list on the strength of
it. `Palette._refilter` said `self._sel = 0`. Six arguments, one false premise.

So the two rules the issue calls opposed are two different mechanisms, and only one of them
was ever asked to do both jobs:

* **order** keeps a destructive row off the top of a list — nothing here moves a row, so
  `F2 Enter` still cannot reach `chat: close` or `charter: quit`, asserted on the real
  catalogue in `TheOrderingGuardIsNotWhatMoved`;
* **the cursor** keeps Enter off a row that cannot answer it — `palette.aim`, one line, one
  call site.

On the tab menu with no capture the only runnable row is `chat: close`, so the cursor opens
there. That is answerable on this surface and on no other: the row is a **doorway** —
`tabmenu.chose` refuses it by id and `tabmenu.opens` replaces the surface with
`leave.confirm_rows` — so two keypresses and a warning naming the chat still stand between
the pointer and a stopped harness, which is the distance `leave.open_rows`' guard is
actually counting. `F2` is the surface that guard was written for, and there every row above
close can run. The argument is in `tabmenu.catalogue`.

### Rejected, each pinned where it would show

* **No row selected, and say so.** `overlay.Surface.selected` answers `None` for *there are
  no rows*; `tabmenu.act` and `commands_frame._draw_palette` both read `None` as a CANCEL.
  Enter on an unaimed surface would tear the pane down silently and change nothing — the
  reported defect rebuilt out of its own fix. Pinned by
  `test_enter_on_a_palette_with_rows_is_never_a_cancel`.
* **Reordering so close comes first.** `leave.open_rows`' guard, at the one surface that
  opens under a pointer.
* **Dropping the refused row.** #512. Pinned by
  `test_the_refused_row_is_still_listed_above_it_with_its_reason`.
* **Skipping refused rows under the arrow keys too.** A list that will not stop on a row is
  a list whose reason column cannot be read. Pinned by
  `test_the_arrow_keys_still_stop_on_a_refused_row`.
* **A third harmless row for the cursor to sit on.** A row that exists for the cursor rather
  than for the operator.

## The refusal itself

`chat: previous transcript` stays listed and stays refused — #512, and it is the right
refusal: handing `charter frame-transcript` a chat with no capture opens an empty pager for
an operator who was just told there was nothing to open. `NO_TRANSCRIPT` says why and says
how one comes to exist, and it is now read in the dim right-hand column of an unselected row
rather than under a cursor that promised Enter would do it — which is strictly more legible
to somebody who has just pressed `-`. Asserted off the rendered pane, not off the row.

## Tests

23 new cases. 12 fail on `origin/main`.

Every assertion says what the surface **does** — #930's finding about this same `-` is that
*"every assertion about the `-` said what it didn't do, so a `-` wired to nothing passed
them all"*, and a cursor rule is even easier to write that way: `assertNotEqual(sel,
refused_row)` passes on a palette with no rows at all. So the tab-menu cases assert the
surface `tabmenu.opens` really builds and the argv `tabmenu.chose` really spawns, off the
row the cursor is really on, and the real-tmux cases assert the pane that survives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018hUBNraNfixfMMK5Jc6CNy
