### PR TITLE
A close names one chat, stops that one, and hands you back a frame (#933)

### DIFF
--- a/charter/commands_frame.py
+++ b/charter/commands_frame.py
@@ -9413,6 +9413,13 @@ def cmd_close(args) -> int:
                 "not come back")
         return 0
     _warn_about(p, on=fid if fid != target else "", verb=leave.CLOSE)
+    # **Move the operator off the chat that is about to stop, while it still HAS a window**
+    # (#933, and see the function). This sits in front of the mark rather than after the
+    # kill because it is a switch and not a teardown: `cmd_chat` establishes where the
+    # asking chat is standing before it aims anything, and refuses outright when that
+    # window is gone — so the same call one line later would be a refusal, and the same
+    # call after the kill would be the refusal it was written to be.
+    _hand_the_client_a_frame(target, fid=fid)
     # The mark FIRST, for `cmd_quit`'s ordering reason turned around: this is the record,
     # and a record written after the kill it describes is one a crash in between loses.
     # Losing it here is not merely untidy — it is the chat coming back after the operator
@@ -9425,7 +9432,6 @@ def cmd_close(args) -> int:
         util.err(f"charter frame-close: tmux would not stop chat {target} — it is marked "
                  "closed and will not be reopened, but its harness may still be running")
         return 1
-    _hand_the_client_a_frame(target, fid=fid)
     util.ok(f"charter: closed {target} — it will not be reopened")
     return 0
 
@@ -9461,29 +9467,44 @@ def _hand_the_client_a_frame(closed: str, *, fid: str) -> None:
     so a switch would drag them off the chat they were reading to answer a question they did
     not ask. *fid* is the presser's chat (`_pressers_chat`) and *closed* is the target; they
     differ on exactly that path, which is the same distinction `_warn_about`'s ``on=`` makes
-    two lines up.
+    one line up.
+
+    **Before the kill, in this process, and both halves are the design rather than taste.**
+    `cmd_chat` step 0 asks tmux where the ASKING chat is standing before it aims anything,
+    and refuses when that window cannot be found — *"a switch that cannot establish where it
+    is standing must not tear anything down"*. After a `kill-window` that is exactly the
+    state, so a switch started afterwards is a switch written to refuse; and a switch started
+    DETACHED would race the kill for the same reading. Going first also means the operator
+    never sees the bare window at all: they are moved off the doomed chat while it still has
+    a frame, and its window dies behind them. This function is only ever reached from a
+    `frame-close` that is itself a detached child (`_start_leaving`) or an operator's own
+    foreground command, so the switch's ~20 round trips are nobody's paint loop —
+    `_start_chat_switch` detaches because the PALETTE cannot wait, and that is not this.
+
+    **`cmd_chat` and not a layout of its own**, which is the same front door a tab click, a
+    palette row and a typed switch all use. A second in-process layout here would be a
+    second answer to "how does a chat get its frame", and the day either moved they would
+    part. Its refusals go to `_say_on_screen` on the closing chat, which is a row about to
+    stop existing — deliberately: there is nothing an operator can do about a switch that
+    could not happen, and the close itself is still going to succeed.
 
     **The first surviving chat of the closed chat's workspace, which is the first TAB.**
-    `chats.of_workspace` is the strip's own order and already drops the chat just marked
-    closed (#930), so what the operator lands on is the leftmost tab they can see. tmux has
-    by then put them on whichever window it chose, which is not necessarily that one — a
-    second move is one `select-window`, and landing somewhere the strip explains is worth
-    it. No survivor means the session's last window has gone with the chat, so the client is
-    already detached and there is nothing to hand it: **not a refusal, and nothing is said
-    about it**, because the operator asked to close a chat and that is what happened.
-
-    `builtin_actions._spawn` and never in-process, for `_start_chat_switch`'s measured
-    reason: this process is about to have its own pane killed by `_close_palette`, and
-    `kill-pane` hands SIGHUP to the group.
+    `chats.of_workspace` is the strip's own order, and the closed chat is dropped here by
+    name rather than by its marker: the mark is written AFTER this call, so #930's scan
+    still lists it. No survivor means this was the workspace's last chat, and killing a
+    session's last window ends the session (measured, `_stop_chats`) — the client is going
+    to be handed back its terminal, which is the right outcome and not one to switch away
+    from. **Not a refusal, and nothing is said about it**, because the operator asked to
+    close a chat and that is what happened.
     """
+    from types import SimpleNamespace
     if fid != closed:
         return
     ws = state.own_workspace(closed) or ""
-    survivors = chats.of_workspace(ws) if ws else []
+    survivors = [c for c in chats.of_workspace(ws) if c != closed] if ws else []
     if not survivors:
         return
-    builtin_actions._spawn(util.self_relaunch_argv("frame-chat", survivors[0]),
-                           fid=closed)
+    cmd_chat(SimpleNamespace(chat_id=survivors[0], chat=closed))
 
 
 def _repaint_the_other_strips(closed: str) -> None:

--- a/charter/commands_frame.py
+++ b/charter/commands_frame.py
@@ -9455,12 +9455,21 @@ def _hand_the_client_a_frame(closed: str, *, fid: str) -> None:
     the one row that says *stop it and do not bring it back*, so the reading that charter
     stopped everything is the reasonable one rather than a careless one.
 
-    So the close ends by handing the client to a surviving chat **through the ordinary front
-    door** — the same `charter frame-chat <id>` a tab click, a palette row and a typed
-    switch all use (`_start_chat_switch`, `frame/builtins._CHAT_SWITCH`). A second in-process
-    layout here would be a second answer to "how does a chat get its frame", and the two
-    would drift; going through the switch also means the entered chat is gathered and its
-    strips are painted by the code that already knows how.
+    So the close hands the client to a surviving chat **through the ordinary front door** —
+    the same `charter frame-chat <id>` a tab click, a palette row and a typed switch all use
+    (`_start_chat_switch`, `frame/builtins._CHAT_SWITCH`). A second in-process layout here
+    would be a second answer to "how does a chat get its frame", and the two would drift;
+    going through the switch also means the entered chat is gathered and its strips are
+    painted by the code that already knows how.
+
+    **And it cannot cost the close, which is why the whole call is caught.** Every refusal
+    `cmd_chat` has is a `return 0` with a sentence, so nothing here is catching a refusal —
+    what it catches is the switch being a courtesy in front of a teardown. This runs BEFORE
+    `state.record_closed`, so an exception escaping it would leave the chat open, unmarked
+    and un-killed while the operator watched their confirmation disappear — which is
+    *"after choosing close it's not closing"*, the report this whole area is answering,
+    reintroduced by the fix for a different half of it. The operator asked for a close; the
+    close happens, and a frame they could not be handed costs them one `F2` at worst.
 
     **Only when the closed chat was the operator's own.** Closing a chat from another tab —
     a right press on its tab, `charter frame-close <id>` typed in a sibling — moves nobody,
@@ -9500,11 +9509,14 @@ def _hand_the_client_a_frame(closed: str, *, fid: str) -> None:
     from types import SimpleNamespace
     if fid != closed:
         return
-    ws = state.own_workspace(closed)
-    survivors = [c for c in chats.of_workspace(ws) if c != closed] if ws else []
-    if not survivors:
+    try:
+        ws = state.own_workspace(closed)
+        survivors = [c for c in chats.of_workspace(ws) if c != closed] if ws else []
+        if not survivors:
+            return
+        cmd_chat(SimpleNamespace(chat_id=survivors[0], chat=closed))
+    except Exception:  # noqa: BLE001 - a courtesy may never cost the close behind it
         return
-    cmd_chat(SimpleNamespace(chat_id=survivors[0], chat=closed))
 
 
 def _repaint_the_other_strips(closed: str) -> None:

--- a/charter/commands_frame.py
+++ b/charter/commands_frame.py
@@ -9515,16 +9515,27 @@ def _hand_the_client_a_frame(closed: str, *, fid: str) -> None:
     to be handed back its terminal, which is the right outcome and not one to switch away
     from. **Not a refusal, and nothing is said about it**, because the operator asked to
     close a chat and that is what happened.
+
+    **`next(…, "")` and no guard on the workspace, and the sweep is what asked for both.**
+    An earlier draft read `[c for c in chats.of_workspace(ws) if c != closed] if ws else []`
+    and then `if not survivors: return`, and both lines came back as survivors that MASK
+    each other. Each was idle for its own reason and the pair hid it: `state.own_workspace`
+    answers ``None`` for a chat with no record and `chats.of_workspace` answers ``[]`` for
+    ``None`` and for ``""`` alike — measured, so the `if ws` was a repair for damage that
+    cannot arrive — while `survivors[0]` on an empty list raised into the ``except`` below,
+    which turned "there is nobody to hand you" into a swallowed IndexError that looked
+    exactly like the deliberate return. One expression that cannot raise leaves one guard,
+    and dropping it now sends `cmd_chat` an empty chat id, which a test can see.
     """
     from types import SimpleNamespace
     if fid != closed:
         return
     try:
-        ws = state.own_workspace(closed)
-        survivors = [c for c in chats.of_workspace(ws) if c != closed] if ws else []
-        if not survivors:
+        survivor = next((c for c in chats.of_workspace(state.own_workspace(closed))
+                         if c != closed), "")
+        if not survivor:
             return
-        cmd_chat(SimpleNamespace(chat_id=survivors[0], chat=closed))
+        cmd_chat(SimpleNamespace(chat_id=survivor, chat=closed))
     except Exception:  # noqa: BLE001 - a courtesy may never cost the close behind it
         return
 

--- a/charter/commands_frame.py
+++ b/charter/commands_frame.py
@@ -8999,7 +8999,17 @@ def _capture_transcript(socket: str, pane_id: str, dest) -> bool:
 #: kill is aimed at — never a session name, which in another plane is another plane's
 #: session (§3.3: `default` is a name every plane has), and never the chat's own recorded
 #: pane id, which is a value from before the server may have restarted.
-_CHAT_WINDOW_FORMAT = f"#{{{_CHAT_OPTION}}}\t#{{window_id}}\t#{{window_active}}"
+#:
+#: **The fourth field is :data:`_PLANE_OPTION`, and it is the whole of #933.** The three
+#: fields above say which chats a SERVER has; one shared server carries every plane on the
+#: machine (§3.3), so without a plane the answer to "which chats does this PLANE have open"
+#: was every plane's — and chat ids collide by construction, because `default.1` is the id
+#: every plane's first chat gets (`DEFAULT_WORKSPACE_FALLBACK`). Measured on the reporting
+#: operator's own socket: three planes, each with a `default.1` on disk. A session option
+#: resolves in a `list-windows` format exactly as it does in `list-panes`' — see
+#: :data:`_PANE_SEAT_FORMAT`, which asks the same marker the same way for the same reason.
+_CHAT_WINDOW_FORMAT = (f"#{{{_CHAT_OPTION}}}\t#{{window_id}}\t#{{window_active}}"
+                       f"\t#{{{_PLANE_OPTION}}}")
 
 
 def _chat_seats(socket: str) -> list[tuple[str, str, bool]] | None:
@@ -9021,6 +9031,30 @@ def _chat_seats(socket: str) -> list[tuple[str, str, bool]] | None:
     :data:`_FRAME_ID_RE` and the window id to :data:`_WINDOW_ID_RE` on the way out — these
     values came off a tmux option and are about to be a `-t` target and a state directory's
     name, which is #475's boundary exactly.
+
+    ---
+
+    **A window whose marker names ANOTHER plane is not this plane's chat, however well its
+    id matches — #933.** This function's own docstring said "every chat *socket* reports"
+    and meant it: one tmux server carries every plane on the machine (§3.3), so a listing
+    filtered by nothing answered with all of them, and the ids collide by construction —
+    `default` is `DEFAULT_WORKSPACE_FALLBACK` and every plane's first chat is `default.1`.
+    What that cost is two things, and the second is the one worth naming twice:
+
+    * `leave.plan` marked a chat **live** because a chat of that NAME was live somewhere on
+      the machine, so a confirmation could promise to stop something whose own window was
+      already gone;
+    * :func:`_stop_chats` aims `kill-window` at ``windows[server][chat]``, one entry per id,
+      **last row wins** — so a close on this plane could kill another plane's window. That
+      is a destructive act on a target the operator never named, which is the one failure
+      class this whole area is built to refuse.
+
+    **The rule is `_plane_session`'s, not a second one**: an ABSENT marker decides nothing
+    and the row is kept, because a session an older charter created carries none and reading
+    that as "not mine" would make every pre-marker frame read as dead — a quit that recorded
+    nothing and killed nothing while saying it had done both, which is exactly the tri-state
+    above, arrived at from the other side. A marker that names a DIFFERENT plane is a veto.
+    That asymmetry is the whole of why this is a filter and not a match.
     """
     out = tmuxctl.run("listing the chats this plane has open",
                       tmuxctl.server_argv(socket, "list-windows", "-a", "-F",
@@ -9029,11 +9063,14 @@ def _chat_seats(socket: str) -> list[tuple[str, str, bool]] | None:
     if out.returncode != 0:
         return None
     seats: list[tuple[str, str, bool]] = []
+    ours = _this_plane()
     for line in out.stdout.splitlines():
         fields = line.split("\t")
-        if len(fields) != 3:
+        if len(fields) != 4:
             continue
-        chat, window, active = fields
+        chat, window, active, plane = fields
+        if plane not in ("", ours):
+            continue
         if _FRAME_ID_RE.fullmatch(chat) and _WINDOW_ID_RE.fullmatch(window):
             seats.append((chat, window, active == "1"))
     return seats
@@ -9388,8 +9425,65 @@ def cmd_close(args) -> int:
         util.err(f"charter frame-close: tmux would not stop chat {target} — it is marked "
                  "closed and will not be reopened, but its harness may still be running")
         return 1
+    _hand_the_client_a_frame(target, fid=fid)
     util.ok(f"charter: closed {target} — it will not be reopened")
     return 0
+
+
+def _hand_the_client_a_frame(closed: str, *, fid: str) -> None:
+    """Put the operator back on a chat that HAS a frame, when the close took theirs — #933.
+
+    *"after again closing it — charter seems closing fully and showing pure claude code
+    session."* Nothing closed and nothing crashed: the frame is laid out on **one** chat at
+    a time. `cmd_chat`'s step 2 is `_apply_arrangement(<chat being left>, want=[])`, so
+    every chat the operator is not on is a window holding its harness pane and nothing else
+    — measured on the reporting operator's own live server, where the chat they were not on
+    records ``panes: {}`` while its window is perfectly alive. That is the correct resting
+    state and it is invisible, because charter is what moves them between chats and
+    `cmd_chat` lays the entered one out on the way in.
+
+    **A `kill-window` moves them without going through `cmd_chat`.** tmux picks the next
+    window itself when the current one dies, and it picks a bare one — no strips, no
+    attention row, no `F2` hint, just the harness filling the screen. From the operator's
+    seat that is charter having exited, which is the report; and it is reached by pressing
+    the one row that says *stop it and do not bring it back*, so the reading that charter
+    stopped everything is the reasonable one rather than a careless one.
+
+    So the close ends by handing the client to a surviving chat **through the ordinary front
+    door** — the same `charter frame-chat <id>` a tab click, a palette row and a typed
+    switch all use (`_start_chat_switch`, `frame/builtins._CHAT_SWITCH`). A second in-process
+    layout here would be a second answer to "how does a chat get its frame", and the two
+    would drift; going through the switch also means the entered chat is gathered and its
+    strips are painted by the code that already knows how.
+
+    **Only when the closed chat was the operator's own.** Closing a chat from another tab —
+    a right press on its tab, `charter frame-close <id>` typed in a sibling — moves nobody,
+    so a switch would drag them off the chat they were reading to answer a question they did
+    not ask. *fid* is the presser's chat (`_pressers_chat`) and *closed* is the target; they
+    differ on exactly that path, which is the same distinction `_warn_about`'s ``on=`` makes
+    two lines up.
+
+    **The first surviving chat of the closed chat's workspace, which is the first TAB.**
+    `chats.of_workspace` is the strip's own order and already drops the chat just marked
+    closed (#930), so what the operator lands on is the leftmost tab they can see. tmux has
+    by then put them on whichever window it chose, which is not necessarily that one — a
+    second move is one `select-window`, and landing somewhere the strip explains is worth
+    it. No survivor means the session's last window has gone with the chat, so the client is
+    already detached and there is nothing to hand it: **not a refusal, and nothing is said
+    about it**, because the operator asked to close a chat and that is what happened.
+
+    `builtin_actions._spawn` and never in-process, for `_start_chat_switch`'s measured
+    reason: this process is about to have its own pane killed by `_close_palette`, and
+    `kill-pane` hands SIGHUP to the group.
+    """
+    if fid != closed:
+        return
+    ws = state.own_workspace(closed) or ""
+    survivors = chats.of_workspace(ws) if ws else []
+    if not survivors:
+        return
+    builtin_actions._spawn(util.self_relaunch_argv("frame-chat", survivors[0]),
+                           fid=closed)
 
 
 def _repaint_the_other_strips(closed: str) -> None:

--- a/charter/commands_frame.py
+++ b/charter/commands_frame.py
@@ -1865,6 +1865,16 @@ def _live_chats(socket: str) -> set[str] | None:
     strings, so no test can tell the guard from its own mutation. Stripping into a name
     and asking whether the NAME is empty says the same thing once, and both halves are
     then pinnable — `tests/test_frame_launcher.TheChatListIsParsedLineByLine` pins them.
+
+    **This is NOT filtered by plane, and its sibling :func:`_chat_seats` is** (#933). They
+    read one option off one server and they are used in opposite directions, which is the
+    whole of the difference. That one names the window a `kill-window` is aimed at, so
+    another plane's row in it is a destructive act on a target nobody chose. This one is a
+    KEEP list: `state.reap` deletes the state of every chat that is not in it, so an answer
+    polluted by another plane's chats over-keeps a directory and can never remove one that
+    is running — the same direction the tri-state above is chosen for, arrived at from the
+    other side. Narrowing it would make `reap` delete MORE, which is the dangerous
+    direction and needs its own argument rather than this one's.
     """
     out = tmuxctl.run("listing the chats already running",
                       tmuxctl.server_argv(socket, "list-windows", "-a", "-F",

--- a/charter/commands_frame.py
+++ b/charter/commands_frame.py
@@ -9500,7 +9500,7 @@ def _hand_the_client_a_frame(closed: str, *, fid: str) -> None:
     from types import SimpleNamespace
     if fid != closed:
         return
-    ws = state.own_workspace(closed) or ""
+    ws = state.own_workspace(closed)
     survivors = [c for c in chats.of_workspace(ws) if c != closed] if ws else []
     if not survivors:
         return

--- a/docs/frame.md
+++ b/docs/frame.md
@@ -1146,11 +1146,30 @@ directory survived. The one tab that stays is the chat you are closing *from*, f
 its window is still being torn down — a strip that dropped the chat you are typing in would be
 drawing a list you are not in.
 
+**Closing the chat you are in hands you another one first.** The frame is laid out on one
+chat at a time — switching tears the panels off the chat you leave and splits them into the
+one you enter — so every chat you are *not* on is a window holding its harness and nothing
+else. Killing the window you are looking at would drop you onto one of those, with no strips
+and no attention row, which reads as charter having exited. So a close aimed at your own chat
+switches you to the first surviving tab of its workspace before it marks or kills anything,
+through the same `charter frame-chat` a tab click uses. Closing a chat from another tab moves
+nobody. Before 0.60.0 you were left on a bare harness pane.
+
 **What quit stops is this plane, and nothing else on the machine.** One tmux server serves
 every frame on a machine and session names carry no plane — `default` is a name every plane
 has — so quit works from *this* plane's chat directories and kills one window at a time, never
 `kill-server` and never a session by name. Two planes with a workspace of the same name can
 share one tmux session, and quitting one leaves the other's chats running.
+
+That last sentence is now true of the *window listing* too, and until 0.60.0 it was not.
+Both quit and close ask the server which windows carry a chat marker, and aim their
+`kill-window` by the answer; the listing was filtered by nothing, so it answered with every
+plane's chats — and chat ids collide by construction, since `default.1` is the id every
+plane's first chat gets. One entry per id, last one wins. A close on one plane could kill
+another plane's window, and a chat could read as live because a chat of that *name* was live
+somewhere else on the machine. Charter marks every session with the plane that made it, and
+the listing now honours it: a marker naming a different plane is a veto, an absent one — a
+session an older charter created — still counts as yours.
 
 ## Exit codes
 

--- a/docs/news/unreleased-a-close-names-one-chat-and-stops-that-one.md
+++ b/docs/news/unreleased-a-close-names-one-chat-and-stops-that-one.md
@@ -1,0 +1,84 @@
+---
+version: unreleased
+headline: A close names one chat, stops that one, and hands you back a frame
+---
+
+*"the menu was about `default.1` and the confirmation is about `default.2`… showing broken
+layout… after again closing it charter seems closing fully and showing pure claude code
+session."*
+
+Third report on this surface. The first two were real and are fixed — a closed chat that
+stayed on the strip (0.59.0), and a cursor that opened on a row it could not run (0.59.0).
+This one turned out to be three separate things wearing one costume, and **the target was
+never re-resolved.**
+
+## The confirmation was not naming the wrong chat
+
+The screenshots show a menu headed `chat default.1` and, one Enter later, a confirmation
+reading `close default.2` — the chat that was active. Read straight, that is the doorway
+re-resolving its target from "the chat the menu names" to "the chat I am in", which would be
+the worst thing this surface could do.
+
+It is not what happened, and the reporting plane is what says so. With that plane's own chat
+directories and the live set its server actually reports, the plan behind a menu about
+`default.1` produces `close default.1` — the second screenshot's text is reachable from
+exactly two states, and the plane's third live chat rules one of them out. Two gestures in
+two chats, an Enter apart in the retelling.
+
+**Which is not the operator being careless — it is the surface being unreadable.** Every
+route is now driven end to end on a real tmux with two live chats and the client sitting on
+the *second* one, so "the chat the menu names" and "the chat I am in" are different strings
+in every case: a right press on the other tab, the `-` on your own, the menu's heading, the
+confirmation's row, the marker on disk, and which window dies. The previous two fixes were
+both verified on fixtures where those two chats were the same chat — the one arrangement
+that cannot tell a correct target from a re-resolved one.
+
+## What could genuinely kill the wrong window, and now cannot
+
+One tmux server carries every plane on the machine. Chat ids collide by construction:
+`default` is the fallback workspace name, so `default.1` is the id every plane's first chat
+gets. On the reporting machine, three planes each have one.
+
+The listing a close aims its `kill-window` by asked that server for every window carrying a
+chat marker — and filtered by nothing. One entry per id, last row wins. **So a close on one
+plane could kill another plane's window**, and the same listing decided whether a chat was
+live at all, so a confirmation could promise to stop something whose own window was already
+gone.
+
+Charter has marked every session with its plane since it learned that a session name is not
+a plane. This reader never asked. It does now, with the same rule the workspace switch
+already uses: a marker naming a different plane is a veto, and an **absent** marker decides
+nothing — a session an older charter created carries none, and reading that as "not mine"
+would make every pre-marker frame read as dead.
+
+## "charter seems closing fully"
+
+It was not closing fully. The frame is laid out on **one chat at a time**: switching tears
+the panels off the chat you leave and splits them into the chat you enter. So every chat you
+are not on is a window holding its harness and nothing else — the correct resting state, and
+one you never see, because charter is what moves you between chats.
+
+A `kill-window` moves you without going through that. tmux picks the next window itself, and
+it picks a bare one: no strips, no attention row, no `F2` hint, just the harness filling the
+screen. From your seat that is charter having exited — and you reached it by pressing the row
+that says *stop it and do not bring it back*, so it is a reasonable thing to conclude.
+
+**A close that takes your own chat now hands you a surviving one first**, through the same
+`charter frame-chat` a tab click uses, before the mark and before the kill. You are moved
+off the doomed chat while it still has a frame, and its window dies behind you. Closing a
+chat from another tab still moves nobody.
+
+## The drawer
+
+`chat: close` gives its pane back to the frame rather than taking the window (0.59.0), which
+is right for a two-row question about one chat. The pane it gives back is the one split off
+the harness — so on a frame with panels below the harness, the drawer sits above them and
+there is frame content drawn underneath it. That is what "broken layout" was: the frame is
+intact, the confirmation is simply not at the foot of the window. It is unchanged here and
+filed on its own.
+
+## Unchanged
+
+The `-` still opens a menu about the chat you are in and closes nothing on the press; it is
+still byte for byte what a right press on that tab opens. `chat: close` is still a drawer,
+`charter: quit` still takes the pane, and a close is still the one teardown that forgets.

--- a/tests/test_a_quit_records_the_plane_before_it_kills.py
+++ b/tests/test_a_quit_records_the_plane_before_it_kills.py
@@ -795,7 +795,7 @@ class TheWindowListingRefusesWhatItCannotRead(PersonaIso, unittest.TestCase):
             return commands_frame._chat_seats(SERVER)
 
     def test_a_well_formed_listing_is_read_whole(self):
-        seats = self._seats_from("alpha.1\t@0\t1\nalpha.2\t@3\t0\n")
+        seats = self._seats_from("alpha.1\t@0\t1\t\nalpha.2\t@3\t0\t\n")
 
         self.assertEqual(seats, [("alpha.1", "@0", True), ("alpha.2", "@3", False)])
 
@@ -803,24 +803,25 @@ class TheWindowListingRefusesWhatItCannotRead(PersonaIso, unittest.TestCase):
         # A window with no `@charter_chat` prints an empty first field, and a format that
         # ever changed shape would arrive here as a row of the wrong width. Neither is a
         # seat, and neither may be read as one by index.
-        seats = self._seats_from("alpha.1\t@0\t1\n"
+        seats = self._seats_from("alpha.1\t@0\t1\t\n"
                                  "only-two\t@1\n"
-                                 "a\tb\tc\td\n"
+                                 "a\tb\tc\n"
+                                 "a\tb\tc\td\te\n"
                                  "\n")
 
         self.assertEqual(seats, [("alpha.1", "@0", True)])
 
     def test_a_chat_id_outside_the_alphabet_is_dropped(self):
-        seats = self._seats_from("alpha.1;kill-server\t@0\t1\nalpha.2\t@1\t0\n")
+        seats = self._seats_from("alpha.1;kill-server\t@0\t1\t\nalpha.2\t@1\t0\t\n")
 
         self.assertEqual(seats, [("alpha.2", "@1", False)])
 
     def test_a_window_id_that_is_not_tmuxs_own_shape_is_dropped(self):
         # The window id is what `_stop_chats` aims `kill-window` at. Anything that is not
         # `@<digits>` is a target charter did not get from tmux.
-        seats = self._seats_from("alpha.1\t$0\t1\n"
-                                 "alpha.2\tnot-a-window\t1\n"
-                                 "alpha.3\t@7\t1\n")
+        seats = self._seats_from("alpha.1\t$0\t1\t\n"
+                                 "alpha.2\tnot-a-window\t1\t\n"
+                                 "alpha.3\t@7\t1\t\n")
 
         self.assertEqual(seats, [("alpha.3", "@7", True)])
 
@@ -828,9 +829,44 @@ class TheWindowListingRefusesWhatItCannotRead(PersonaIso, unittest.TestCase):
         # `#{window_active}` is `0` or `1`. Anything else is not a claim charter may read as
         # "this is the chat the operator was looking at" — that answer decides which tab a
         # reopen puts them back on.
-        seats = self._seats_from("alpha.1\t@0\t1\nalpha.2\t@1\t0\nalpha.3\t@2\ttrue\n")
+        seats = self._seats_from("alpha.1\t@0\t1\t\nalpha.2\t@1\t0\t\n"
+                                 "alpha.3\t@2\ttrue\t\n")
 
         self.assertEqual([c for c, _w, showing in seats if showing], ["alpha.1"])
+
+    # -- the plane marker, #933 --------------------------------------------- #
+
+    def test_a_window_marked_for_another_plane_is_not_a_seat(self):
+        """**The whole of #933 at the boundary it was lost at.**
+
+        One tmux server carries every plane on the machine (§3.3) and `default.1` is the id
+        every plane's first chat gets, so a listing filtered by nothing answered with all of
+        them. What that costs is `_stop_chats`, which aims `kill-window` at
+        ``windows[server][chat]`` — one entry per id, last row wins — so a close on this
+        plane could kill another plane's window.
+        """
+        seats = self._seats_from(f"default.1\t@0\t1\t/somewhere/else/.charter\n"
+                                 f"default.1\t@9\t1\t{commands_frame._this_plane()}\n")
+
+        self.assertEqual(seats, [("default.1", "@9", True)],
+                         "another plane's window is still in the map a kill is aimed by")
+
+    def test_an_unmarked_window_is_kept_and_decides_nothing(self):
+        """`_plane_session`'s rule, not a second one: a session an older charter created
+        carries no marker, and reading that as "not mine" would make every pre-marker frame
+        read as dead — a quit that recorded nothing and killed nothing while saying it had
+        done both."""
+        seats = self._seats_from("alpha.1\t@0\t1\t\n")
+
+        self.assertEqual(seats, [("alpha.1", "@0", True)])
+
+    def test_this_planes_own_marker_is_kept(self):
+        """The control the veto needs: a filter that dropped everything would pass the case
+        above and be the tri-state defect it exists to prevent."""
+        seats = self._seats_from(
+            f"alpha.1\t@0\t1\t{commands_frame._this_plane()}\n")
+
+        self.assertEqual(seats, [("alpha.1", "@0", True)])
 
     def test_a_server_that_would_not_answer_is_none_and_not_empty(self):
         run, _seen = _answers("", returncode=1)
@@ -841,7 +877,7 @@ class TheWindowListingRefusesWhatItCannotRead(PersonaIso, unittest.TestCase):
         # The opposite fact from the line above, and the whole reason the tri-state exists.
         self.assertEqual(self._seats_from(""), [])
 
-    def test_the_listing_is_one_call_asking_for_all_three_fields(self):
+    def test_the_listing_is_one_call_asking_for_every_field(self):
         run, seen = _answers("")
         with mock.patch.object(commands_frame.tmuxctl, "run", side_effect=run):
             commands_frame._chat_seats(SERVER)

--- a/tests/test_the_close_confirmation_names_the_chat_it_stops.py
+++ b/tests/test_the_close_confirmation_names_the_chat_it_stops.py
@@ -1,0 +1,400 @@
+"""A close confirmation names ONE chat, and the chat it names is the one that stops — #933.
+
+The report is two screenshots that contradict each other: a tab menu headed `chat
+default.1` with `chat: close default.1` under the cursor, and — the operator's account —
+one Enter later, a confirmation reading `close default.2`, the chat that was *active*.
+Read straight, that is the target being re-resolved at the doorway, from "the chat the
+menu names" to "the chat I am in", which would be the worst defect this surface can have.
+
+**It is not what happened, and the operator's own plane is what says so.** With that
+plane's frame directories and the live set its server actually reports,
+`leave.plan(only="default.1")` produces `close default.1` — never `close default.2`. The
+second screenshot's text is producible from exactly two states, `only="default.2"` and a
+plane-wide plan with `default.2` the only live chat, and the plane's third live chat rules
+the second out. So the two surfaces were two gestures in two chats, and every route below
+resolves its target correctly on a real tmux. **That is asserted here rather than argued**,
+because the previous two fixes on this surface were both verified on fixtures where the
+menu's target and the active chat were the same chat — the one case that cannot tell a
+correct target from a re-resolved one.
+
+**What the report DID find, and what this file is really for**, is three things that made
+one gesture indistinguishable from the other:
+
+* **#930's finding, one layer up.** Every assertion this surface had about its confirmation
+  said the surface *appeared* — `_shown(pane)` starting with `close` — and #932's own case
+  says why it could not say more: its fixture's plan is empty, so `leave.confirm_rows` drew
+  its nothing-left-to-stop row and passed. A confirmation about the wrong chat passed every
+  one of them. Every case here asserts the chat by NAME, on the row, and then follows it to
+  `state.was_closed` and to the window's death.
+* **The listing a kill is aimed by was not filtered by plane** — `_chat_seats`, the change
+  this file's sibling class is about, and the one thing here that really could have killed
+  the wrong window.
+* **A close took the frame with it**, which is the operator's *"charter seems closing fully
+  and showing pure claude code session"* — `_hand_the_client_a_frame`.
+
+The fixture has two chats and both are LIVE, which is what the previous ones lacked in two
+ways at once: `@charter_chat` on each window is what `commands_frame._chat_seats` reads, so
+`leave.plan` produces real rows here rather than the empty plan #932 recorded, and the
+client sits on the SECOND chat, so "the chat the menu names" and "the chat I am in" are
+different chats in every case that opens a menu about the first.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+import unittest
+from types import SimpleNamespace
+
+from charter import commands_frame, config
+from charter.frame import chats, leave, slots, state
+
+from tests._isolation import PersonaIso, make_plane
+from tests.test_a_real_click_on_a_real_tab_bar_switches import (
+    _HAS_TMUX, _ARealFrameWithBars, _await)
+
+
+class _TwoLiveChatsWithTheSecondOnScreen(_ARealFrameWithBars):
+    """`alpha.1` and `alpha.2`, both live on one server, the client on `alpha.2`.
+
+    **Both halves of "live" are here and neither was in the fixtures this replaces.**
+    `_ARealChatBarOverTwoChats` builds two chats and two windows but marks neither with
+    `@charter_chat`, so `commands_frame._chat_seats` reports nothing, `leave.plan` marks
+    every chat `live=False`, and `leave.confirm_rows` draws *no chats are open on this
+    plane* — a confirmation with no confirming row, which is the surface #932's case
+    admitted it was asserting against. Setting the option is what makes the plan real, and a
+    real plan is the only thing that can name the wrong chat.
+
+    The client is on the SECOND chat, and the chats bar is that chat's own panel, so a menu
+    opened about `alpha.1` is a menu about a chat the operator is not in — the case both
+    previous fixes were verified without.
+    """
+
+    WS = "alpha"
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.first, self.here = f"{self.WS}.1", f"{self.WS}.2"
+        self.other_harness = self._start_session(self.first, session=self.WS)
+        second = self._tmux("new-window", "-t", self.WS, "-P", "-F", "#{pane_id}",
+                            "cat", env=self.env)
+        self.assertEqual(second.returncode, 0, second.stderr)
+        self.harness = second.stdout.strip()
+        for chat, pane in ((self.first, self.other_harness),
+                           (self.here, self.harness)):
+            state.frame_dir(chat, create=True)
+            state.record_workspace(chat, self.WS)
+            state.record_server(chat, self.socket)
+            state.record_harness_pane(chat, pane)
+            state.record_identity(chat, {"CHARTER_SESSION_ID": chat,
+                                         "CHARTER_ROOT": str(self.plane),
+                                         "CHARTER_HARNESS": "claude-code"})
+            # `commands_frame._chat_option_argv`'s own write, made the way the launcher
+            # makes it: this is what `_chat_seats` reads, and without it the plan below is
+            # the empty one #932 was measured against.
+            marked = self._tmux("set-option", "-w", "-t", self._window_of(pane),
+                                commands_frame._CHAT_OPTION, chat)
+            self.assertEqual(marked.returncode, 0, marked.stderr)
+        self._source_conf(self.WS)
+        self.assertEqual(self._tmux("select-window", "-t", self.harness).returncode, 0)
+        self.bar = self._split_bar(self.harness, "chats", self.here)
+        state.record_panes(self.here, panels={"chats": self.bar})
+        self.assertEqual(self._tmux("select-pane", "-t", self.harness).returncode, 0)
+        self.fd = self._attach(self.WS)
+        self.assertTrue(
+            _await(lambda: self.first in self._bar_row(self.bar)),
+            f"the chat bar never painted both chats: {self._bar_row(self.bar)!r}")
+        self.assertIn(f"*{self.here}", self._bar_row(self.bar),
+                      "the client is not on the second chat, so every case below is the "
+                      "one-chat case the previous fixtures already covered")
+
+    #: What the chat strip ends in — `slots._affordances`, composed from the constants.
+    TAIL = f"{slots.ADD_CHAT} {slots.CLOSE_CHAT}"
+
+    def _minus(self) -> int:
+        """The column the `-` is drawn in, read off the pane tmux painted."""
+        row = self._bar_row(self.bar).rstrip()
+        self.assertTrue(row.endswith(self.TAIL),
+                        f"the row does not end in the affordances: {row!r}")
+        return len(row) - 1
+
+    def _overlay_from(self, do) -> str:
+        """Do *do*, and hand back the one pane it opened on this frame."""
+        before = set(self._panes(self.WS))
+        do()
+        self.assertTrue(_await(lambda: set(self._panes(self.WS)) - before, timeout=20.0),
+                        "the gesture opened no pane at all, so nothing below is measured")
+        return (set(self._panes(self.WS)) - before).pop()
+
+    def _menu_about(self, target: str, do) -> str:
+        """Open a menu with *do* and assert it is about *target* before anything is typed.
+
+        The menu names its chat on both rows (`tabmenu.transcript_title`,
+        `tabmenu.close_title`) and in its heading (`tabmenu.label`), so this is where a
+        target that was wrong from the start would be caught — before Enter, and separately
+        from the surface it opens.
+        """
+        pane = self._overlay_from(do)
+        self.assertTrue(
+            _await(lambda: f"chat: close {target}" in self._shown(pane), timeout=20.0),
+            f"the pane never drew a menu about {target}: {self._shown(pane)!r}")
+        return pane
+
+    def _confirmation_on(self, pane: str) -> str:
+        """Press Enter and hand back the confirmation it draws in the same pane."""
+        os.write(self.fd, b"\r")
+        self.assertTrue(
+            _await(lambda: self._shown(pane).split("\n")[0].startswith(leave.CLOSE),
+                   timeout=20.0),
+            f"Enter did not reach the close confirmation: {self._shown(pane)!r}")
+        # The drawer is `_as_a_drawer`'s `resize-pane -Z`, a round trip after the paint, so
+        # the rows can still be arriving when the heading lands.
+        self.assertTrue(
+            _await(lambda: len(self._shown(pane).strip().split("\n")) > 1, timeout=10.0),
+            f"the confirmation drew a heading and no rows: {self._shown(pane)!r}")
+        return self._shown(pane)
+
+    def _says_only(self, shown: str, target: str, other: str) -> None:
+        """The assertion #929 asked for, made about the sentence rather than the surface.
+
+        `leave._close_summary` spells the confirming row `close <chat> — stop it and forget
+        it`, so the chat is IN the row the cursor is on and a confirmation about the wrong
+        one is a string this can read. Both halves are needed: naming the right chat while
+        also listing the other is `leave.plan`'s `only=` lost, which is the plane-wide plan
+        wearing close's title.
+        """
+        self.assertIn(f"close {target} —", shown,
+                      f"the confirmation does not say it will close {target}")
+        self.assertNotIn(other, shown,
+                         f"the confirmation about {target} also names {other}")
+
+
+@unittest.skipUnless(_HAS_TMUX, "no tmux on this machine")
+class AMenuAboutAnotherTabStopsThatTabAndOnlyThatTab(
+        _TwoLiveChatsWithTheSecondOnScreen, unittest.TestCase):
+    """A right press on the tab you are NOT on — the shape of the report's first screenshot.
+
+    Every previous case on this surface opened its menu about the chat the frame was
+    already on, where a target read from the frame and a target read from the pointer are
+    the same string. This is the one that can tell them apart, and it follows the answer all
+    the way down: what the menu says, what the confirmation says, and which window dies.
+    """
+
+    def test_the_menu_the_confirmation_and_the_kill_are_one_chat(self):
+        pane = self._menu_about(
+            self.first,
+            lambda: self._click(self.bar,
+                                col=self._column_of(self.bar, f" {self.first}"),
+                                button=2))
+        self.assertIn(f"chat {self.first}", self._shown(pane).split("\n")[0],
+                      "the menu's own heading does not name the chat it is about")
+
+        shown = self._confirmation_on(pane)
+        self._says_only(shown, self.first, self.here)
+
+        os.write(self.fd, b"\r")
+        self.assertTrue(_await(lambda: state.was_closed(self.first), timeout=20.0),
+                        "the confirmation's Enter never reached `state.record_closed`")
+        self.assertTrue(
+            _await(lambda: self._window_of(self.other_harness) not in
+                   self._tmux("list-windows", "-a", "-F", "#{window_id}").stdout.split(),
+                   timeout=20.0),
+            "the chat was marked closed and its window is still on the server")
+        self.assertFalse(state.was_closed(self.here),
+                         "closing the other tab marked the chat the operator was in")
+        self.assertEqual(chats.of_workspace(self.WS), [self.here])
+
+    def test_the_chat_the_operator_is_in_keeps_its_window_and_its_frame(self):
+        """The other half of "one chat": a close aimed at another tab moves nobody.
+
+        `_hand_the_client_a_frame` is deliberately silent unless the closed chat was the
+        presser's own — a switch here would drag the operator off the chat they were reading
+        to answer a question they did not ask.
+        """
+        window = self._current_window(self.WS)
+        pane = self._menu_about(
+            self.first,
+            lambda: self._click(self.bar,
+                                col=self._column_of(self.bar, f" {self.first}"),
+                                button=2))
+        self._confirmation_on(pane)
+        os.write(self.fd, b"\r")
+        self.assertTrue(_await(lambda: state.was_closed(self.first), timeout=20.0))
+        time.sleep(2.0)
+
+        self.assertEqual(self._current_window(self.WS), window,
+                         "closing another tab moved the client off the chat it was on")
+        self.assertIn(self.harness, self._panes(self.WS),
+                      "closing another tab took this chat's harness with it")
+
+
+@unittest.skipUnless(_HAS_TMUX, "no tmux on this machine")
+class TheMinusStopsTheChatItWasPressedIn(_TwoLiveChatsWithTheSecondOnScreen,
+                                        unittest.TestCase):
+    """`slots.CLOSE_CHAT` with a sibling chat on the strip beside it.
+
+    The `-` is *"byte for byte the argv the right press builds, with the frame's own chat
+    where `tab_at` would have put the tab under the pointer"* — so with two chats on the
+    strip the two gestures aim at DIFFERENT chats, and this is the case that says the `-`
+    aims at the one the operator is in rather than at whichever tab is drawn first.
+    """
+
+    def test_it_names_and_stops_the_chat_the_operator_is_in(self):
+        pane = self._menu_about(
+            self.here, lambda: self._click(self.bar, col=self._minus()))
+
+        shown = self._confirmation_on(pane)
+        self._says_only(shown, self.here, self.first)
+
+        os.write(self.fd, b"\r")
+        self.assertTrue(_await(lambda: state.was_closed(self.here), timeout=20.0),
+                        "the `-` route never reached `state.record_closed`")
+        self.assertFalse(state.was_closed(self.first),
+                         "the `-` marked the tab the operator was not on")
+        self.assertEqual(chats.of_workspace(self.WS), [self.first])
+
+    def test_the_frame_comes_back_on_the_chat_the_operator_lands_on(self):
+        """**The operator's third symptom, and it is not a crash** — #933.
+
+        *"after again closing it — charter seems closing fully and showing pure claude code
+        session."* The frame is laid out on one chat at a time (`cmd_chat`'s step 2 is
+        `_apply_arrangement(<chat being left>, want=[])`), so every chat the operator is not
+        on is a window holding its harness and nothing else. A `kill-window` moves them onto
+        one of those without going through `cmd_chat`, and what they see is the harness
+        filling the screen with no strips, no attention row and no `F2` hint — charter
+        having exited, reached by pressing the row that says *stop it and do not bring it
+        back*.
+
+        `state.panes` is the record `_split_panels` writes last, so a chat that has it has
+        been laid out — the same observable `test_the_click_leaves_the_keyboard_on_a_harness`
+        waits for, because it is the same switch reached through the same front door.
+        """
+        self.assertEqual(state.panes(self.first), {},
+                         "the surviving chat already has panels, so this case would pass "
+                         "on the state it exists to create")
+        pane = self._menu_about(
+            self.here, lambda: self._click(self.bar, col=self._minus()))
+        self._confirmation_on(pane)
+
+        os.write(self.fd, b"\r")
+        self.assertTrue(_await(lambda: state.was_closed(self.here), timeout=20.0))
+        self.assertTrue(
+            _await(lambda: bool(state.panes(self.first)), timeout=25.0),
+            f"the chat the operator was handed has no frame: {state.panes(self.first)!r}")
+
+
+@unittest.skipUnless(_HAS_TMUX, "no tmux on this machine")
+class AWindowOnANOTHERPlaneIsNotThisPlanesChat(PersonaIso, unittest.TestCase):
+    """`_chat_seats`, against two real planes on ONE real server — the wrong-target defect.
+
+    **One tmux server carries every plane on the machine** (§3.3), and chat ids collide by
+    construction: `default` is `config.DEFAULT_WORKSPACE_FALLBACK` and `default.1` is the id
+    every plane's first chat gets. Measured on the reporting operator's own socket while
+    this was written: three planes, each with a `default.1` in its frame root.
+
+    `_plane_live` turns the listing into `windows[server][chat]` — one entry per id, **last
+    row wins** — and `_stop_chats` aims `kill-window` by it. So before this change a close on
+    one plane could kill another plane's window, which is a destructive act on a target the
+    operator never named. This is the case that would have gone red, and it needs no client
+    and no pointer: it is about what one command asks a server and what it does with the
+    answer.
+
+    **The marker is a veto and never a finder**, which is `_plane_session`'s rule and the
+    reason the second case here matters as much as the first: a session an older charter
+    created carries no marker, so reading "unmarked" as "not mine" would make every
+    pre-marker frame read as dead — and a quit that read a live plane as empty would record
+    nothing and kill nothing while telling the operator it had done both.
+    """
+
+    WS = "default"
+
+    def setUp(self) -> None:
+        super().setUp()
+        from charter.frame import tmuxctl
+
+        from tests import _tmuxreap
+        v = tmuxctl.version()
+        if v is None or v < tmuxctl.FLOOR:
+            self.skipTest(f"the frame's floor is tmux {tmuxctl.FLOOR[0]}."
+                          f"{tmuxctl.FLOOR[1]}; this machine has {v}")
+        self.socket = _tmuxreap.name("twoplanes")
+        self.addCleanup(lambda: self._tmux("kill-server"))
+        self.plane = make_plane(self, "schema = 1\n")
+        self.chat = f"{self.WS}.1"
+
+    def _tmux(self, *args: str):
+        import subprocess
+        return subprocess.run(["tmux", "-L", self.socket, *args], capture_output=True,
+                              text=True, timeout=20)
+
+    def _session(self, name: str, *, chat: str, plane: str) -> str:
+        """One session holding one chat window, marked for *plane*.
+
+        The two options are written the way charter writes them — `@charter_chat` on the
+        WINDOW and `@charter_plane` on the SESSION, both aimed at the harness pane, which is
+        `_chat_option_argv`'s and `_plane_option_argv`'s own targeting.
+        """
+        made = self._tmux("-f", "/dev/null", "new-session", "-d", "-s", name,
+                          "-P", "-F", "#{pane_id}", "cat")
+        self.assertEqual(made.returncode, 0, made.stderr)
+        pane = made.stdout.strip()
+        self.assertEqual(self._tmux("set-option", "-w", "-t", pane,
+                                    commands_frame._CHAT_OPTION, chat).returncode, 0)
+        if plane:
+            self.assertEqual(self._tmux("set-option", "-t", pane,
+                                        commands_frame._PLANE_OPTION, plane).returncode, 0)
+        return pane
+
+    def _chat_on_this_plane(self, pane: str) -> None:
+        state.frame_dir(self.chat, create=True)
+        state.record_workspace(self.chat, self.WS)
+        state.record_server(self.chat, self.socket)
+        state.record_harness_pane(self.chat, pane)
+        state.record_identity(self.chat, {"CHARTER_HARNESS": "claude-code"})
+
+    def test_only_this_planes_window_is_a_seat(self):
+        mine = self._session("mine", chat=self.chat,
+                             plane=commands_frame._this_plane())
+        theirs = self._session("theirs", chat=self.chat, plane="/somewhere/else/.charter")
+
+        seats = commands_frame._chat_seats(self.socket)
+
+        self.assertEqual([w for _c, w, _a in seats], [self._window_id(mine)],
+                         f"another plane's window is a seat on this plane: {seats!r}")
+        self.assertNotIn(self._window_id(theirs), [w for _c, w, _a in seats])
+
+    def test_an_unmarked_session_is_still_this_planes(self):
+        """The control the veto needs. A filter that dropped every window it could not
+        positively claim would pass the case above and break every frame launched by a
+        charter that predates the marker."""
+        older = self._session("older", chat=self.chat, plane="")
+
+        seats = commands_frame._chat_seats(self.socket)
+
+        self.assertEqual([w for _c, w, _a in seats], [self._window_id(older)])
+
+    def test_a_close_leaves_the_other_planes_window_standing(self):
+        """**The whole defect, end to end**: the id is the same, the server is the same, and
+        the window that dies is this plane's."""
+        mine = self._session("mine", chat=self.chat,
+                             plane=commands_frame._this_plane())
+        theirs = self._session("theirs", chat=self.chat, plane="/somewhere/else/.charter")
+        self._chat_on_this_plane(mine)
+
+        rc = commands_frame.cmd_close(SimpleNamespace(chat_id=self.chat, chat=""))
+
+        self.assertEqual(rc, 0)
+        self.assertTrue(state.was_closed(self.chat))
+        alive = self._tmux("list-windows", "-a", "-F", "#{window_id}").stdout.split()
+        self.assertIn(self._window_id(theirs), alive,
+                      "closing this plane's chat killed another plane's window")
+        self.assertNotIn(self._window_id(mine), alive,
+                         "this plane's own window survived, so the kill went elsewhere")
+
+    def _window_id(self, pane: str) -> str:
+        return self._tmux("display-message", "-p", "-t", pane,
+                          "#{window_id}").stdout.strip()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_the_close_confirmation_names_the_chat_it_stops.py
+++ b/tests/test_the_close_confirmation_names_the_chat_it_stops.py
@@ -45,8 +45,9 @@ import os
 import time
 import unittest
 from types import SimpleNamespace
+from unittest import mock
 
-from charter import commands_frame, config
+from charter import commands_frame
 from charter.frame import chats, leave, slots, state
 
 from tests._isolation import PersonaIso, make_plane
@@ -394,6 +395,86 @@ class AWindowOnANOTHERPlaneIsNotThisPlanesChat(PersonaIso, unittest.TestCase):
     def _window_id(self, pane: str) -> str:
         return self._tmux("display-message", "-p", "-t", pane,
                           "#{window_id}").stdout.strip()
+
+
+class WhichChatACloseHandsYou(PersonaIso, unittest.TestCase):
+    """`_hand_the_client_a_frame`, asked directly — the three branches a real frame cannot
+    all turn red.
+
+    The tmux class above measures the outcome an operator sees, and it is the one that
+    matters; what it cannot do is distinguish "the switch was skipped" from "the switch ran
+    and happened to land where the client already was". Two of these branches are exactly
+    that shape, so they are asked here, of the function, with `cmd_chat` standing in for the
+    switch it would start.
+    """
+
+    WS = "alpha"
+
+    def setUp(self):
+        super().setUp()
+        self.asked = []
+        self.enterContext(mock.patch.object(
+            commands_frame, "cmd_chat",
+            side_effect=lambda args: self.asked.append(args.chat_id)))
+
+    def _plant(self, *chats_):
+        for chat in chats_:
+            state.frame_dir(chat, create=True)
+            state.record_workspace(chat, self.WS)
+
+    def test_closing_your_own_chat_hands_you_the_first_surviving_tab(self):
+        self._plant(f"{self.WS}.1", f"{self.WS}.2")
+
+        commands_frame._hand_the_client_a_frame(f"{self.WS}.1", fid=f"{self.WS}.1")
+
+        self.assertEqual(self.asked, [f"{self.WS}.2"])
+
+    def test_the_chat_being_closed_is_never_what_you_are_handed(self):
+        """**The mark has not been written yet when this runs**, deliberately — the switch
+        has to go before the kill, and `state.record_closed` goes with the kill. So the
+        chat about to stop is still on `chats.of_workspace`'s list (#930 drops it from the
+        moment it is marked, which is later), and it is dropped here by name.
+
+        The case closes the FIRST tab, because that is the only one where the difference
+        shows: with the closed chat second, the first survivor is the right answer whether
+        or not anything filtered it out, and `chats.check` would then refuse the switch as
+        *already here* — silently, on a row nobody can read.
+        """
+        self._plant(f"{self.WS}.1", f"{self.WS}.2", f"{self.WS}.3")
+
+        commands_frame._hand_the_client_a_frame(f"{self.WS}.1", fid=f"{self.WS}.1")
+
+        self.assertEqual(self.asked, [f"{self.WS}.2"])
+
+    def test_closing_another_tab_hands_you_nothing(self):
+        """A close aimed at a chat you are not in moves nobody. Without this branch the
+        switch would fire on every close and drag the operator off the chat they were
+        reading — and on the two-chat frame above it would land them where they already
+        were, which is the shape no end-to-end case can see."""
+        self._plant(f"{self.WS}.1", f"{self.WS}.2")
+
+        commands_frame._hand_the_client_a_frame(f"{self.WS}.1", fid=f"{self.WS}.2")
+
+        self.assertEqual(self.asked, [])
+
+    def test_the_workspaces_last_chat_hands_you_nothing(self):
+        """Killing a session's last window ends the session and gives the client its
+        terminal back, which is the right outcome and not one to switch away from."""
+        self._plant(f"{self.WS}.1")
+
+        commands_frame._hand_the_client_a_frame(f"{self.WS}.1", fid=f"{self.WS}.1")
+
+        self.assertEqual(self.asked, [])
+
+    def test_a_chat_with_no_recorded_workspace_hands_you_nothing(self):
+        """`state.own_workspace` answers ``None`` for the migration case (`leave.plane_chats`
+        is the scan that exists for it), and a workspace charter cannot name has no roster to
+        pick a survivor from. Nothing is guessed at."""
+        state.frame_dir(f"{self.WS}.1", create=True)
+
+        commands_frame._hand_the_client_a_frame(f"{self.WS}.1", fid=f"{self.WS}.1")
+
+        self.assertEqual(self.asked, [])
 
 
 if __name__ == "__main__":

--- a/tests/test_the_close_confirmation_names_the_chat_it_stops.py
+++ b/tests/test_the_close_confirmation_names_the_chat_it_stops.py
@@ -496,7 +496,13 @@ class WhichChatACloseHandsYou(PersonaIso, unittest.TestCase):
     def test_a_chat_with_no_recorded_workspace_hands_you_nothing(self):
         """`state.own_workspace` answers ``None`` for the migration case (`leave.plane_chats`
         is the scan that exists for it), and a workspace charter cannot name has no roster to
-        pick a survivor from. Nothing is guessed at."""
+        pick a survivor from. Nothing is guessed at.
+
+        **No guard stands behind this and it is measured rather than guarded**:
+        `chats.of_workspace` answers ``[]`` for ``None`` and for ``""`` alike, so the roster
+        is empty and the one survivor guard answers. An `if ws` in front of it read as a
+        second refusal and the sweep found it idle — see `_hand_the_client_a_frame`.
+        """
         state.frame_dir(f"{self.WS}.1", create=True)
 
         commands_frame._hand_the_client_a_frame(f"{self.WS}.1", fid=f"{self.WS}.1")

--- a/tests/test_the_close_confirmation_names_the_chat_it_stops.py
+++ b/tests/test_the_close_confirmation_names_the_chat_it_stops.py
@@ -466,6 +466,33 @@ class WhichChatACloseHandsYou(PersonaIso, unittest.TestCase):
 
         self.assertEqual(self.asked, [])
 
+    def test_a_switch_that_raises_never_costs_the_close(self):
+        """**The courtesy runs in front of a teardown**, so an exception escaping it would
+        leave the chat open, unmarked and un-killed while the operator watched their
+        confirmation disappear — *"after choosing close it's not closing"*, the report this
+        area is answering, reintroduced by the fix for another half of it.
+
+        Asked of `cmd_close` rather than of the helper, because "the close still happens" is
+        a fact about the command and the helper alone cannot say it.
+        """
+        self._plant(f"{self.WS}.1", f"{self.WS}.2")
+        for chat in (f"{self.WS}.1", f"{self.WS}.2"):
+            state.record_server(chat, commands_frame.SOCKET)
+            state.record_harness_pane(chat, "%1")
+        live = ({f"{self.WS}.1", f"{self.WS}.2"},
+                {commands_frame.SOCKET: {f"{self.WS}.1": "@0", f"{self.WS}.2": "@1"}},
+                set())
+        commands_frame.cmd_chat.side_effect = RuntimeError("the switch blew up")
+
+        with mock.patch.object(commands_frame, "_plane_live", return_value=live), \
+                mock.patch.object(commands_frame, "_stop_chats", return_value=1):
+            rc = commands_frame.cmd_close(
+                SimpleNamespace(chat_id=f"{self.WS}.1", chat=f"{self.WS}.1"))
+
+        self.assertEqual(rc, 0)
+        self.assertTrue(state.was_closed(f"{self.WS}.1"),
+                        "a switch that raised took the close's own marker with it")
+
     def test_a_chat_with_no_recorded_workspace_hands_you_nothing(self):
         """`state.own_workspace` answers ``None`` for the migration case (`leave.plane_chats`
         is the scan that exists for it), and a workspace charter cannot name has no roster to


### PR DESCRIPTION
Closes #933.

Third report on `chat: close`. It arrived as one defect and turned out to be three, and
the one it was reported as is not among them.

## The target is not re-resolved, and that is measured rather than argued

The screenshots show a menu headed `chat default.1` and — the operator's account — a
confirmation one Enter later reading `close default.2`, the chat that was active. Four
reproductions say the doorway does not do that: in-process, and on a real tmux with two
live chats and the client on the *second* one, driven by both gestures that open the menu.
Menu, confirmation, `closed` marker and dead window are one chat in every route.

The reporting plane settles it arithmetically. With its own frame directories and the live
set its server actually reports, `leave.plan(only="default.1")` produces `close default.1`;
screenshot 2's text is reachable only from `only="default.2"` or a plane-wide plan with
`default.2` the only live chat, and that plane's third live chat rules the second out. Two
gestures in two chats.

**Why nobody could tell:** every assertion this surface had about its confirmation said the
surface *appeared*. #932's own case records why it could not say more — its fixture's plan
is empty, so `leave.confirm_rows` drew its nothing-left-to-stop row and the case passed on
the heading. A confirmation about the wrong chat passed all of them. That is #930's finding
one layer up, and every case here asserts the chat by NAME and then follows it to
`state.was_closed` and to the window's death.

## What could genuinely kill the wrong window

`_chat_seats` asked the shared server for every window carrying `@charter_chat` and filtered
by nothing. One tmux server carries every plane on the machine (§3.3) and chat ids collide
by construction — `default` is the fallback workspace name, so `default.1` is the id every
plane's first chat gets. Measured on the reporting machine: three planes, each with one.
`_plane_live` folds that listing into `windows[server][chat]`, one entry per id, last row
wins, and `_stop_chats` aims `kill-window` by it.

**On `origin/main`, with two planes on one server and a `default.1` in each, a close on one
plane kills the other plane's window and leaves its own standing.** That case is in this
branch and it is red without the change.

`@charter_plane` has been on the wire since `_plane_session` was written and this reader
never asked for it. The rule is that function's rather than a second one: a marker naming a
different plane is a veto, and an ABSENT marker decides nothing — a session an older charter
created carries none, and reading that as "not mine" would make every pre-marker frame read
as dead.

## "charter seems closing fully"

The frame is laid out on one chat at a time, so every chat the operator is not on is a
window holding its harness and nothing else. A `kill-window` moves them onto one of those
without going through `cmd_chat`, and what they see is the harness filling the screen with
no strips, no attention row and no `F2` hint — reached by pressing the row that says *stop
it and do not bring it back*. It is the state on the reporter's live server right now: the
chat they are not on records `panes: {}` while its window is alive.

A close that takes the operator's own chat now hands them a surviving one first, through the
same `charter frame-chat` a tab click uses, BEFORE the mark and the kill — `cmd_chat`
establishes where the asking chat is standing before it aims anything and refuses when that
window is gone, so the same call afterwards is a call written to refuse, and going first
means the bare window is never on screen.

## Not fixed, and said rather than left to be found

The drawer's placement. `chat: close` gives its pane back to the frame (#927) and that pane
is the one split off the harness, so on a frame with panels below the harness the drawer
sits above them with frame content underneath. That is what "broken layout" was; the frame
is intact and the confirmation is simply not at the foot of the window. Filed in #933.

## The `-` is not reverted, and reverting it would have hidden this

It resolves its target correctly in every route driven here, it closes nothing on the press,
and it is byte for byte what a right press on that tab opens. Every defect above is on
`chat: close` itself, which `F2 → chat: close` reaches too — so removing the affordance would
have left all three in place on the route the operator would then have been told to use.

## Tests

`tests/test_the_close_confirmation_names_the_chat_it_stops.py` — 12 cases. Three are red on
`origin/main`. The fixture has two chats that are both LIVE (`@charter_chat` on each window,
which is what makes `leave.plan` produce real rows rather than #932's empty one) with the
client on the second, so "the chat the menu names" and "the chat I am in" are different
strings throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nxe3F6JuG1QB765acvD4eH
