### PR TITLE
0.60.0 — a close names one chat, stops that one, and hands you back a frame

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "charter",
   "description": "Personas, workspaces and memory for coding agents across many repos \u2014 Claude Code, opencode and Codex",
-  "version": "0.59.0",
+  "version": "0.60.0",
   "author": {
     "name": "Aaron Yordanyan"
   },

--- a/charter/__init__.py
+++ b/charter/__init__.py
@@ -7,4 +7,4 @@ Run it as ``python3 -m charter`` (from the control plane root) or via the
 installed ``charter`` console script.
 """
 
-__version__ = "0.59.0"
+__version__ = "0.60.0"

--- a/docs/news/0.60.0-a-charged-file-with-no-mutation-is-nothing-to-sweep.md
+++ b/docs/news/0.60.0-a-charged-file-with-no-mutation-is-nothing-to-sweep.md
@@ -1,5 +1,5 @@
 ---
-version: unreleased
+version: 0.60.0
 headline: A charged file with no mutation is nothing to sweep, and a shard that refuses is not a shard that vanished
 ---
 

--- a/docs/news/0.60.0-a-close-names-one-chat-and-stops-that-one.md
+++ b/docs/news/0.60.0-a-close-names-one-chat-and-stops-that-one.md
@@ -1,6 +1,7 @@
 ---
-version: unreleased
+version: 0.60.0
 headline: A close names one chat, stops that one, and hands you back a frame
+lead: true
 ---
 
 *"the menu was about `default.1` and the confirmation is about `default.2`… showing broken
@@ -8,9 +9,9 @@ layout… after again closing it charter seems closing fully and showing pure cl
 session."*
 
 Third report on this surface. The first two were real and are fixed — a closed chat that
-stayed on the strip (0.59.0), and a cursor that opened on a row it could not run (0.59.0).
-This one turned out to be three separate things wearing one costume, and **the target was
-never re-resolved.**
+stayed on the strip, and a cursor that opened on a row it could not run, both in this
+release. This one turned out to be three separate things wearing one costume, and **the
+target was never re-resolved.**
 
 ## The confirmation was not naming the wrong chat
 
@@ -70,8 +71,8 @@ chat from another tab still moves nobody.
 
 ## The drawer
 
-`chat: close` gives its pane back to the frame rather than taking the window (0.59.0), which
-is right for a two-row question about one chat. The pane it gives back is the one split off
+`chat: close` gives its pane back to the frame rather than taking the window (in this
+release), which is right for a two-row question about one chat. The pane it gives back is the one split off
 the harness — so on a frame with panels below the harness, the drawer sits above them and
 there is frame content drawn underneath it. That is what "broken layout" was: the frame is
 intact, the confirmation is simply not at the foot of the window. It is unchanged here and

--- a/docs/news/0.60.0-a-closed-chat-stops-being-a-tab.md
+++ b/docs/news/0.60.0-a-closed-chat-stops-being-a-tab.md
@@ -1,5 +1,5 @@
 ---
-version: unreleased
+version: 0.60.0
 headline: A closed chat stops being a tab, so closing one finally looks like it worked
 ---
 

--- a/docs/news/0.60.0-the-cursor-opens-on-a-row-that-can-run.md
+++ b/docs/news/0.60.0-the-cursor-opens-on-a-row-that-can-run.md
@@ -1,5 +1,5 @@
 ---
-version: unreleased
+version: 0.60.0
 headline: The tab menu opens with Enter aimed at something it can actually do
 ---
 

--- a/docs/news/0.60.0-the-frame-says-how-to-close-a-chat-and-not-only-how-to-make-one.md
+++ b/docs/news/0.60.0-the-frame-says-how-to-close-a-chat-and-not-only-how-to-make-one.md
@@ -1,5 +1,5 @@
 ---
-version: unreleased
+version: 0.60.0
 headline: The frame says how to close a chat, and not only how to make one
 ---
 

--- a/docs/news/0.60.0-the-quit-confirmation-takes-the-pane-because-its-blast-radius-is-the-plane.md
+++ b/docs/news/0.60.0-the-quit-confirmation-takes-the-pane-because-its-blast-radius-is-the-plane.md
@@ -1,5 +1,5 @@
 ---
-version: unreleased
+version: 0.60.0
 headline: The quit confirmation takes the pane again, because its blast radius is the whole plane
 ---
 

--- a/docs/news/0.60.0-the-workspace-tabs-stop-rearranging-themselves-on-every-switch.md
+++ b/docs/news/0.60.0-the-workspace-tabs-stop-rearranging-themselves-on-every-switch.md
@@ -1,5 +1,5 @@
 ---
-version: unreleased
+version: 0.60.0
 headline: The workspace tabs stop rearranging themselves every time you switch
 ---
 

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -14,7 +14,7 @@
           },
           {
             "type": "command",
-            "command": "charter hook sessionstart --plugin-version 0.59.0",
+            "command": "charter hook sessionstart --plugin-version 0.60.0",
             "timeout": 5
           },
           {
@@ -35,7 +35,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook userpromptsubmit --plugin-version 0.59.0",
+            "command": "charter hook userpromptsubmit --plugin-version 0.60.0",
             "timeout": 5
           }
         ]
@@ -47,7 +47,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse --plugin-version 0.59.0",
+            "command": "charter hook pretooluse --plugin-version 0.60.0",
             "timeout": 10
           }
         ]
@@ -57,7 +57,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse-read --plugin-version 0.59.0",
+            "command": "charter hook pretooluse-read --plugin-version 0.60.0",
             "timeout": 5
           }
         ]
@@ -67,7 +67,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse-dispatch --plugin-version 0.59.0"
+            "command": "charter hook pretooluse-dispatch --plugin-version 0.60.0"
           }
         ]
       },
@@ -76,7 +76,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook pretooluse-edit --plugin-version 0.59.0",
+            "command": "charter hook pretooluse-edit --plugin-version 0.60.0",
             "timeout": 5
           }
         ]
@@ -88,7 +88,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse-bash --plugin-version 0.59.0",
+            "command": "charter hook posttooluse-bash --plugin-version 0.60.0",
             "timeout": 5
           }
         ]
@@ -98,7 +98,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse --plugin-version 0.59.0",
+            "command": "charter hook posttooluse --plugin-version 0.60.0",
             "timeout": 5
           }
         ]
@@ -108,7 +108,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse-skill --plugin-version 0.59.0",
+            "command": "charter hook posttooluse-skill --plugin-version 0.60.0",
             "timeout": 5
           }
         ]
@@ -118,7 +118,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse-dispatch --plugin-version 0.59.0",
+            "command": "charter hook posttooluse-dispatch --plugin-version 0.60.0",
             "timeout": 5
           }
         ]
@@ -128,7 +128,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook posttooluse-message --plugin-version 0.59.0",
+            "command": "charter hook posttooluse-message --plugin-version 0.60.0",
             "timeout": 5
           }
         ]
@@ -139,7 +139,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "charter hook stop --plugin-version 0.59.0",
+            "command": "charter hook stop --plugin-version 0.60.0",
             "timeout": 5
           },
           {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "charter-cp"
-version = "0.59.0"
+version = "0.60.0"
 description = "Personas, workspaces and memory for coding agents across many repos — Claude Code, opencode and Codex"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Cuts 0.60.0 — seven staged entries, four of them about closing a chat.

## The four numbers

All four move together, re-grepped for the old version afterwards:

| site | flags |
|---|---|
| `pyproject.toml` | 1 |
| `charter/__init__.py` | 1 |
| `.claude-plugin/plugin.json` | 1 |
| `hooks/hooks.json` | **12** `--plugin-version` |

`grep -n '0\.59\.0'` across all four returns nothing. `TestVersionsMoveInLockstep` is green.

## The lead

`lead: true` goes to **A close names one chat, stops that one, and hands you back a frame**.

Four of the seven entries are about the same surface, and this is the only one in the
release describing something that could destroy work the operator did not name. One tmux
server carries every plane on the machine and `default.1` is the id every plane's first
chat gets, so the listing a close aimed its `kill-window` by — filtered by nothing, one
entry per id, last row wins — could resolve to *another plane's* window. That is not a
rare race; it is what happens on any machine running more than one plane, which is the
machine that reported it.

Everything else in the release is a surface that did not say what it did. Real, and
recoverable by looking again. This one is not recoverable.

It also carries the arc rather than presupposing it: the entry opens by naming the two
earlier fixes, so a reader who stops after it still has pointers to the rest. Leading with
*The frame says how to close a chat* — the chronological opening — would put "the strip
draws a `-` beside its `+`" at the top of a release whose headline fact is a cross-plane
kill.

No entry declares `security:`; that field is the author's, and this is a scoping defect in
a destructive action rather than a vulnerability.

## Three stale version references, corrected

`0.60.0-a-close-names-one-chat-and-stops-that-one.md` credited three things to `(0.59.0)`:

- "a closed chat that stayed on the strip" — #930, **this release**
- "a cursor that opened on a row it could not run" — #932, **this release**
- "`chat: close` gives its pane back to the frame rather than taking the window" — #925,
  **this release**

All three merged *after* `v0.59.0` was tagged, and 0.59.0's three shipped entries are
about `charter save`, plane format versions and sweep shard sizing — none of them this
surface. Left alone, the published 0.60.0 notes would have credited 0.60.0's own entries
to the previous version, permanently. They now read "in this release", which is the
phrasing the sibling entries already use.

## Gates

- **Whole body**: 31,258 encoded bytes against `_BODY_BUDGET` of 122,000 — 90,742 of
  headroom. Measured as `"\n\n".join(_part(e) for e in for_version("0.60.0"))`, not as
  `render_body`'s return, which elides and so can never exceed its own budget.
  `render_body` returned that string byte-identical and the elision heading is absent, so
  **nothing was elided**.
- **`charter news --for 0.60.0`**: exit 0, empty stderr, lead renders first. No quoted
  headlines.
- **Asset freshness**: all four captures stay stamped `0.59.0`. Lag is exactly 1 minor,
  which `MAX_MINOR_LAG` allows. `tests/test_asset_freshness.py` is green and **nothing was
  regenerated**.
- **Suite**: `python -m unittest discover -s tests` — `Ran 11855 tests`, `OK (skipped=11)`.
  Trailer read, not inferred from an exit code.
- **Every merged PR has an entry**: #924, #925, #926, #928, #930, #932, #934 are the seven
  merged since `v0.59.0`, and they map one-to-one onto the seven entries. The only other
  commit on main is `cdb71b1c`, a `charter save` of persona memory, which ships no
  user-visible change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LAGNyU5r3ME1CXV1mJQhb1
