### PR TITLE
A chat is born locked to the workspace it was opened in, and briefed for it (#936)

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,8 +87,9 @@ they share a checkout you spend the day stashing.
 ![A control plane holds an inventory of every repo in the org, personas each with their own memory and vault, and one workspace directory per task. Each workspace holds repo clones on their own branches, and a clone can be split into git worktrees so parallel sub-agents each get a branch of the same repo.](docs/assets/model.svg)
 
 A **workspace** is one directory of clones per task (`workspaces/<task>/<repo>`), each repo
-on its own branch. Moving between tasks is `charter workspace use <name>` and nothing
-follows you across — no stash, no context bleed, no half-applied branch from yesterday.
+on its own branch. Moving between tasks is `charter workspace use <name>` in a terminal, or
+a chat opened in that workspace inside the frame, and nothing follows you across — no stash,
+no context bleed, no half-applied branch from yesterday.
 
 **Two sub-agents that need the same repo** is the case that breaks everything else.
 Cloning it twice wastes the disk and they still collide. A **worktree** splits one clone

--- a/charter/commands_frame.py
+++ b/charter/commands_frame.py
@@ -4683,24 +4683,24 @@ def _pin_workspace(ws: str, fid: str, picked: bool) -> None:
     again, and being refused by a dead frame's lock on a name the operator just typed is
     not a refusal worth having.
 
-    **Picking IS the confirmation that locks, and #518 asks that this be decided and
-    SAID.** `set_active`'s contract is that confirming a workspace locks the session to it,
-    and the picker is a confirmation — the alternative would be a launch that writes the
-    pointer and leaves the lock off, which is a third behaviour for `charter workspace use`
-    to disagree with. What makes it liveable is that the lock has its own way out, named in
-    the sentence that announces it: `charter workspace unlock`, typed in the frame's own
-    shell, so the operator is not stuck with a choice they just made at a prompt. Printed
+    **Picking IS the confirmation, and #518 asks that this be decided and SAID.** Printed
     here rather than in the picker, because it describes what the LAUNCH did with the
     answer, not what the answer was.
 
-    **That sentence used to lead with `F2 → workspace` and no longer can** (§4j/§4b). The
-    escape it named was `switch.to_workspace` overriding the lock — and that switch no
-    longer touches the lock at all, because what it moves is the tmux client rather than
-    the chat: after it the operator is looking at another workspace and this session is
-    still locked to the one its commands act on. The argument above is unchanged because
-    the OTHER escape was always the one that does the work: `unlock` releases the lock
-    without moving the chat, which is exactly what a lock the operator wants gone needs
-    and all it needs.
+    **The lock it announces is no longer this write's to take, and #936 is why.** A chat
+    used to be locked only here, so a silent launch (`--workspace`, a pointer, a reopen)
+    left a chat with no lock at all. Charter's own SessionStart then told that chat to run
+    `charter workspace use`, and in that chat the command SUCCEEDED, moving its commands to
+    another workspace while its tab stayed in this one. A chat's lock is now its launch
+    record (`workspace.launch_lock`), so a picked launch and a silent one hold the same lock,
+    and the lock file written below restates a value the record already holds.
+
+    **So the sentence no longer names `charter workspace unlock`.** It named it as the way
+    out, and it cannot be one: `unlock` deletes a file, and a lock read off the launch record
+    is not a file. §4j says what the way out is instead: a conversation wanted elsewhere is
+    a new chat. The sentence says that. It had already stopped naming `F2 → workspace` as a
+    release, because a workspace switch moves the tmux client and leaves every chat locked
+    where it is. That same property is what makes it the way to open a chat elsewhere.
 
     **This write is a lock, not a membership move, which is why §4j leaves it standing.**
     The pointer lands under a chat whose workspace is *ws* already — this launch is what
@@ -4712,8 +4712,8 @@ def _pin_workspace(ws: str, fid: str, picked: bool) -> None:
     if not picked:
         return
     workspace.set_active(ws, session_id=fid, force=True)
-    util.info(f"Workspace '{contain.one_line(ws)}' — 🔒 locked for this frame's "
-              f"session. `charter workspace unlock` releases it.")
+    util.info(f"Workspace '{contain.one_line(ws)}' — 🔒 this chat is locked to it for life. "
+              f"To work in another workspace, open a chat there (its tab, or F2 → workspace).")
 
 
 def _focus_workspace(session_id: str, chat: str, *, ws: str, picked: bool) -> int:

--- a/charter/commands_workspace.py
+++ b/charter/commands_workspace.py
@@ -153,7 +153,8 @@ def cmd_workspace_create(args) -> int:
 
     if args.use:
         before = workspace.is_locked()
-        scope = workspace.set_active(args.name, force=getattr(args, "force", False))
+        scope = workspace.set_active(args.name, force=getattr(args, "force", False),
+                                     terminal_id=_terminal_for_selection())
         if scope == "locked":
             util.err(_locked_msg(args.name))
             # Inside a chat the refusal has already named how to work there. "Start a new
@@ -214,7 +215,8 @@ def cmd_workspace_use(args) -> int:
 
     workspace.ensure(args.name)
     before = workspace.is_locked()
-    scope = workspace.set_active(args.name, force=getattr(args, "force", False))
+    scope = workspace.set_active(args.name, force=getattr(args, "force", False),
+                                 terminal_id=_terminal_for_selection())
     if scope == "locked":
         util.err(_locked_msg(args.name))
         return 2
@@ -957,12 +959,14 @@ def _scope_note(scope: str) -> str:
     review round 3). The note named the built-in `default` in two places the ladder does not
     reach it:
 
-    * **Inside a chat, at either scope.** A new chat resolves by its own launch record
-      (`workspace.for_frame`), which outranks the terminal pointer and the declared default,
-      and a closed chat's session pointer is reaped with it (`frame/state._forget_session`),
-      so a reopened one starts clean. "A new session starts at 'default'" and "kept across
-      closing/reopening Claude" were both false there: no new chat resolves by what `use`
-      wrote in this one.
+    * **Inside a chat.** What `use` writes there is the session pointer and the lock under
+      the chat's id, and no terminal pointer (:func:`_terminal_for_selection`). A new chat
+      resolves by its own launch record (`workspace.for_frame`), which outranks the terminal
+      pointer and the declared default, and a closed chat's session files are reaped with it
+      (`frame/state._forget_session`), so a reopened one starts clean. "A new session starts at
+      'default'" and "kept across closing/reopening Claude" were both false there. So, until
+      review round 4, was "this chat only": a harness that inherited the launching terminal's
+      `$TERM_SESSION_ID` wrote that terminal's pointer, and the next launch from it read that.
     * **On a plane with a nominated default** (`charter workspace default`). A new session
       with no pointer and no pane id lands on it, and the note named `default` regardless.
       `commands_persona._scope_note` already reads its plane's default for the same sentence.
@@ -994,13 +998,14 @@ def _lock_words(name: str, locked: str | None, *, after_switch: bool = False) ->
     **Who asks this, exactly.** Every sentence that reports how the lock stands once a
     workspace command has succeeded: `use` and `create --use` (through
     :func:`_announce_selection`), `current`, and `rename`'s session line. Those four cannot
-    answer differently. Three other places name a lock in their own words and are not this
+    answer differently. Four other places name a lock in their own words and are not this
     function's to decide: a refusal names the lock that refused it (:func:`_locked_msg`, and
     `unlock` inside a chat, both read from `workspace.launch_lock` or `workspace.is_locked`);
-    `unlock` outside a chat reports the file it just deleted or found absent; and
-    `commands_frame._pin_workspace` names the lock its own picked launch takes. `cli.py`'s
-    help and the SessionStart nudge say what confirming a workspace does, not what a command
-    just did.
+    `unlock` outside a chat reports the file it just deleted or found absent;
+    `commands_frame._pin_workspace` names the lock its own picked launch takes; and
+    `harness/codex.py`'s `session-lock` deficit says what the lock falls back to in a Codex
+    shell, which no per-session id reaches. `cli.py`'s help and the SessionStart nudge say
+    what confirming a workspace does, not what a command just did.
 
     *after_switch* is for the sentence after a selection that did NOT move the lock (a
     forced pointer inside a chat): there the elsewhere case says what the switch did and did
@@ -1013,6 +1018,29 @@ def _lock_words(name: str, locked: str | None, *, after_switch: bool = False) ->
     if after_switch:
         return f"this session's commands only; 🔒 still locked to '{locked}'"
     return f"🔒 locked to '{locked}'"
+
+
+def _terminal_for_selection() -> str | None:
+    """The `terminal_id` that `use` and `create --use` hand `workspace.set_active`: ``""``
+    inside a chat, and ``None`` (this process's own terminal) everywhere else (#936, review
+    round 4).
+
+    **A chat speaks for no terminal.** `set_active` keys its terminal pointer on
+    `session.terminal()`, which ranks `$TERM_SESSION_ID` first, and `commands_frame._frame_env`
+    strips `TMUX`, `TMUX_PANE` and the size variables and nothing else of that kind. So a
+    harness started from Terminal.app or iTerm2 without tmux carries the LAUNCHING terminal's
+    id, and a `use` in the chat wrote that terminal's pointer. Measured: after `use gamma
+    --force` in a chat, the launching shell's `workspace.chosen()` answered `gamma`, which is
+    what `commands_frame._choose_workspace` reads, so the next `charter claude` there opened in
+    `gamma` with no picker. An unforced `use` of the chat's own workspace moved it as well.
+
+    Writing none costs the chat nothing: whatever resolves by the chat's id meets its session
+    pointer and its launch record before the terminal rung. It is also what makes
+    :func:`_scope_note`'s "this chat only" true. `frame/switch.py` hands `persona.set_active`
+    the same empty string, for #411's reason: a process inside a frame cannot trust the
+    terminal id it inherited.
+    """
+    return "" if workspace.launch_lock() else None
 
 
 def _announce_selection(name: str, scope: str, locked: str | None, *,

--- a/charter/commands_workspace.py
+++ b/charter/commands_workspace.py
@@ -111,20 +111,13 @@ def cmd_workspace_list(args) -> int:
 def cmd_workspace_current(args) -> int:
     name = workspace.resolve()
     print(name)
-    locked = workspace.is_locked()
-    if not locked:
-        lock_note = ", unlocked"
-    elif locked == name:
-        lock_note = ", 🔒 locked for this session"
-    else:
-        # Name the divergence instead of the happier half of it (ADR 0013). Since #936 a
-        # chat's lock is the workspace it was LAUNCHED in, and `resolve` can legitimately
-        # answer another: a sub-agent standing in another workspace's tree (the flow #794
-        # protects), or a `--force`d pointer. "Locked for this session" beside that name
-        # claimed a lock on the workspace charter would in fact refuse to switch to.
-        lock_note = f", 🔒 locked to '{locked}'"
+    # The lock is named relative to what RESOLVED, by the one function every workspace
+    # sentence asks (#936). A sub-agent standing in another workspace's tree, or a forced
+    # pointer, resolves somewhere the lock is not, and "locked for this session" beside
+    # that name claimed a lock on the workspace charter would refuse to switch to.
+    lock = _lock_words(name, workspace.is_locked())
     mode = "LIVE (committed + shared)" if workspace.is_live(name) else "LOCAL (private)"
-    util.info(f"{mode} · resolved via {workspace.source()}{lock_note}")
+    util.info(f"{mode} · resolved via {workspace.source()}, {lock}")
     vision = workspace.read_vision(name)
     if vision:
         util.info(f"Vision: {vision.splitlines()[0].strip()}")
@@ -171,7 +164,8 @@ def cmd_workspace_create(args) -> int:
                 util.info(f"Workspace '{args.name}' was created; start a new session to use it, "
                           f"or re-run with --force.")
             return 2
-        util.ok(f"Active workspace set to '{args.name}'{_scope_note(scope)} — 🔒 locked for this session.")
+        _announce_selection(args.name, scope, workspace.is_locked(),
+                            forced=getattr(args, "force", False))
         _warn_env_override(args.name)
 
     if tree_path is not None:
@@ -223,23 +217,8 @@ def cmd_workspace_use(args) -> int:
     if scope == "locked":
         util.err(_locked_msg(args.name))
         return 2
-    locked = workspace.is_locked()
-    if locked and locked != args.name:
-        # `--force` moved this session's commands and not the lock: inside a chat the lock is
-        # the launch record, which no command moves (#936). Announcing "re-locked to 'gamma'
-        # … 🔒 locked for this session" named a lock charter does not hold, one command
-        # before the next refusal named the real one — ADR 0013's divergence rule.
-        util.ok(f"Active workspace set to '{args.name}'{_scope_note(scope)} — this session's "
-                f"commands only; 🔒 still locked to '{locked}'.")
-    elif locked:
-        verb = "re-locked to" if getattr(args, "force", False) else "set to"
-        util.ok(f"Active workspace {verb} '{args.name}'{_scope_note(scope)} — 🔒 locked for this session.")
-    else:
-        # No session to key a lock on — a plain shell with no harness id. `set_active`
-        # wrote a terminal pointer and no lock, so nothing here may announce one: this
-        # said "🔒 locked for this session" to a session that was not locked at all, which
-        # is the same false claim, one branch over (ADR 0013).
-        util.ok(f"Active workspace set to '{args.name}'{_scope_note(scope)}.")
+    _announce_selection(args.name, scope, workspace.is_locked(),
+                        forced=getattr(args, "force", False))
     _warn_env_override(args.name)
     return 0
 
@@ -974,6 +953,58 @@ def _scope_note(scope: str) -> str:
         return (f" (this session only — this terminal reports no pane id, so a new "
                 f"session starts at '{config.DEFAULT_WORKSPACE}')")
     return ""
+
+
+def _lock_words(name: str, locked: str | None, *, after_switch: bool = False) -> str:
+    """How the lock stands relative to the workspace *name* — said here and nowhere else.
+
+    **Three sites used to decide this for themselves, and they drifted** (#936, review
+    round 2). `use` learned to name a chat's launch lock while `create --use` went on
+    announcing "🔒 locked for this session" beside a workspace that was not the lock —
+    measured, `create delta --use --force` in a chat launched in `north` said so while
+    `is_locked()` was `north` — and `workspace current` carried a third copy. A lock is one
+    of three things relative to the workspace a sentence names: absent, that workspace, or
+    another one. Every workspace sentence asks this function which, so no two of them can
+    answer differently again.
+
+    *after_switch* is for the sentence after a selection that did NOT move the lock (a
+    forced pointer inside a chat): there the elsewhere case says what the switch did and did
+    not do, where `current`, which switched nothing, only names the lock.
+    """
+    if not locked:
+        return "unlocked"
+    if locked == name:
+        return "🔒 locked for this session"
+    if after_switch:
+        return f"this session's commands only; 🔒 still locked to '{locked}'"
+    return f"🔒 locked to '{locked}'"
+
+
+def _announce_selection(name: str, scope: str, locked: str | None, *, forced: bool) -> None:
+    """Say what a selection DID — the one announcement `use` and `create --use` share.
+
+    Built from what `workspace.set_active` actually wrote (*scope*, as it reports it) and
+    the lock that stands afterwards (*locked*), never from what the command was asked to
+    do. ADR 0013's rule; each clause below is a place the sentence was measured lying:
+
+    * **`none` wrote nothing.** No session id and no pane id means no pointer and no lock,
+      and this said "Active workspace set to 'gamma'." while the next command resolved to
+      `default`. It warns instead, and names the two routes that need no pointer.
+    * **The lock is named by :func:`_lock_words`.** A chat's lock is its launch record, so
+      a forced switch moves the chat's commands and not its lock; a shell with no session
+      id gets a pointer and no lock at all. Both were told "🔒 locked for this session".
+    * **"re-locked to" only where the lock now names this workspace.** Outside a chat
+      `--force` really moves the lock; inside one it cannot, and "re-locked" there was the
+      first half of review round 1's finding.
+    """
+    if scope == "none":
+        util.warn(f"Nothing was persisted: this process has no session id and no pane id, so "
+                  f"there is nowhere to keep '{name}' selected. Pass `--workspace {name}` "
+                  f"per command, or set `$CHARTER_WORKSPACE={name}`.")
+        return
+    verb = "re-locked to" if forced and locked == name else "set to"
+    util.ok(f"Active workspace {verb} '{name}'{_scope_note(scope)} — "
+            f"{_lock_words(name, locked, after_switch=True)}.")
 
 
 def cmd_workspace_reconcile(args) -> int:

--- a/charter/commands_workspace.py
+++ b/charter/commands_workspace.py
@@ -152,6 +152,7 @@ def cmd_workspace_create(args) -> int:
                   f'{args.name}/workspace.md, the living charter a fork inherits).')
 
     if args.use:
+        before = workspace.is_locked()
         scope = workspace.set_active(args.name, force=getattr(args, "force", False))
         if scope == "locked":
             util.err(_locked_msg(args.name))
@@ -164,8 +165,7 @@ def cmd_workspace_create(args) -> int:
                 util.info(f"Workspace '{args.name}' was created; start a new session to use it, "
                           f"or re-run with --force.")
             return 2
-        _announce_selection(args.name, scope, workspace.is_locked(),
-                            forced=getattr(args, "force", False))
+        _announce_selection(args.name, scope, workspace.is_locked(), before=before)
         _warn_env_override(args.name)
 
     if tree_path is not None:
@@ -213,12 +213,12 @@ def cmd_workspace_use(args) -> int:
         return 1
 
     workspace.ensure(args.name)
+    before = workspace.is_locked()
     scope = workspace.set_active(args.name, force=getattr(args, "force", False))
     if scope == "locked":
         util.err(_locked_msg(args.name))
         return 2
-    _announce_selection(args.name, scope, workspace.is_locked(),
-                        forced=getattr(args, "force", False))
+    _announce_selection(args.name, scope, workspace.is_locked(), before=before)
     _warn_env_override(args.name)
     return 0
 
@@ -359,7 +359,13 @@ def cmd_workspace_rename(args) -> int:
         # function.
         util.info(f"{len(moved)} chat(s) in '{old}' followed the rename → '{new}'.")
     if workspace.resolve() == new and workspace.source() in ("session", "active-file"):
-        util.info(f"This session's active workspace followed the rename → '{new}' (still 🔒 locked).")
+        # The lock clause is `_lock_words`', the one `current` prints (#936, review round 3).
+        # This wrote "(still 🔒 locked)" itself and asked nothing, and three reachable states
+        # made it false: `use gamma --force` in a chat launched in `north` (the lock is
+        # `north`), a pointer SessionStart's reconcile seeded (no lock), and `use` then
+        # `unlock` (no lock).
+        util.info(f"This session's active workspace followed the rename → '{new}' "
+                  f"({_lock_words(new, workspace.is_locked())}).")
 
     if not was_live:
         util.info(f"'{new}' is LOCAL (private) — nothing committed.")
@@ -946,26 +952,55 @@ def _scope_note(scope: str) -> str:
     selection is gone the moment the session is, and saying so is the whole point: the
     reader who is not told goes looking for a bug the next time the status line says
     `default`.
+
+    **Where a new session starts is `workspace.chosen`'s ladder, not a constant** (#936,
+    review round 3). The note named the built-in `default` in two places the ladder does not
+    reach it:
+
+    * **Inside a chat, at either scope.** A new chat resolves by its own launch record
+      (`workspace.for_frame`), which outranks the terminal pointer and the declared default,
+      and a closed chat's session pointer is reaped with it (`frame/state._forget_session`),
+      so a reopened one starts clean. "A new session starts at 'default'" and "kept across
+      closing/reopening Claude" were both false there: no new chat resolves by what `use`
+      wrote in this one.
+    * **On a plane with a nominated default** (`charter workspace default`). A new session
+      with no pointer and no pane id lands on it, and the note named `default` regardless.
+      `commands_persona._scope_note` already reads its plane's default for the same sentence.
     """
+    if scope not in ("terminal", "session"):
+        return ""
+    if workspace.launch_lock():
+        return " (this chat only — a new chat starts at the workspace it is opened in)"
     if scope == "terminal":
         return " (this terminal only — kept across closing/reopening Claude)"
-    if scope == "session":
-        return (f" (this session only — this terminal reports no pane id, so a new "
-                f"session starts at '{config.DEFAULT_WORKSPACE}')")
-    return ""
+    starts = workspace.declared_default() or config.DEFAULT_WORKSPACE
+    return (f" (this session only — this terminal reports no pane id, so a new "
+            f"session starts at '{starts}')")
 
 
 def _lock_words(name: str, locked: str | None, *, after_switch: bool = False) -> str:
-    """How the lock stands relative to the workspace *name* — said here and nowhere else.
+    """How the lock stands relative to the workspace *name*.
 
-    **Three sites used to decide this for themselves, and they drifted** (#936, review
-    round 2). `use` learned to name a chat's launch lock while `create --use` went on
-    announcing "🔒 locked for this session" beside a workspace that was not the lock —
-    measured, `create delta --use --force` in a chat launched in `north` said so while
-    `is_locked()` was `north` — and `workspace current` carried a third copy. A lock is one
-    of three things relative to the workspace a sentence names: absent, that workspace, or
-    another one. Every workspace sentence asks this function which, so no two of them can
-    answer differently again.
+    **Sites that decided this for themselves drifted** (#936, review rounds 2 and 3). `use`
+    learned to name a chat's launch lock while `create --use` went on announcing "🔒 locked
+    for this session" beside a workspace that was not the lock — measured, `create delta
+    --use --force` in a chat launched in `north` said so while `is_locked()` was `north` —
+    and `workspace current` carried a third copy. `rename` kept a fourth, "(still 🔒
+    locked)", which asked nothing and was measured false in three states: after `use gamma
+    --force` in a chat launched in `north`, after SessionStart's reconcile seeded the
+    pointer, and after `use` then `unlock`. A lock is one of three things relative to the
+    workspace a sentence names: absent, that workspace, or another one.
+
+    **Who asks this, exactly.** Every sentence that reports how the lock stands once a
+    workspace command has succeeded: `use` and `create --use` (through
+    :func:`_announce_selection`), `current`, and `rename`'s session line. Those four cannot
+    answer differently. Three other places name a lock in their own words and are not this
+    function's to decide: a refusal names the lock that refused it (:func:`_locked_msg`, and
+    `unlock` inside a chat, both read from `workspace.launch_lock` or `workspace.is_locked`);
+    `unlock` outside a chat reports the file it just deleted or found absent; and
+    `commands_frame._pin_workspace` names the lock its own picked launch takes. `cli.py`'s
+    help and the SessionStart nudge say what confirming a workspace does, not what a command
+    just did.
 
     *after_switch* is for the sentence after a selection that did NOT move the lock (a
     forced pointer inside a chat): there the elsewhere case says what the switch did and did
@@ -980,12 +1015,14 @@ def _lock_words(name: str, locked: str | None, *, after_switch: bool = False) ->
     return f"🔒 locked to '{locked}'"
 
 
-def _announce_selection(name: str, scope: str, locked: str | None, *, forced: bool) -> None:
+def _announce_selection(name: str, scope: str, locked: str | None, *,
+                        before: str | None) -> None:
     """Say what a selection DID — the one announcement `use` and `create --use` share.
 
-    Built from what `workspace.set_active` actually wrote (*scope*, as it reports it) and
-    the lock that stands afterwards (*locked*), never from what the command was asked to
-    do. ADR 0013's rule; each clause below is a place the sentence was measured lying:
+    Built from what `workspace.set_active` actually wrote (*scope*, as it reports it), the
+    lock that stood before the call (*before*) and the lock that stands after it (*locked*),
+    never from what the command was asked to do. ADR 0013's rule; each clause below is a
+    place the sentence was measured lying:
 
     * **`none` wrote nothing.** No session id and no pane id means no pointer and no lock,
       and this said "Active workspace set to 'gamma'." while the next command resolved to
@@ -993,16 +1030,18 @@ def _announce_selection(name: str, scope: str, locked: str | None, *, forced: bo
     * **The lock is named by :func:`_lock_words`.** A chat's lock is its launch record, so
       a forced switch moves the chat's commands and not its lock; a shell with no session
       id gets a pointer and no lock at all. Both were told "🔒 locked for this session".
-    * **"re-locked to" only where the lock now names this workspace.** Outside a chat
-      `--force` really moves the lock; inside one it cannot, and "re-locked" there was the
-      first half of review round 1's finding.
+    * **"re-locked to" only where this call moved a lock that stood before it.** The verb
+      used to read `--force`, which is what was ASKED. Inside a chat `--force` cannot move
+      the lock (review round 1). `create --use --force` in a session that had never been
+      locked answered "re-locked to 'beta'" beside a lock that did not exist a moment earlier
+      (review round 3). And forcing the workspace the lock already names moves nothing.
     """
     if scope == "none":
         util.warn(f"Nothing was persisted: this process has no session id and no pane id, so "
                   f"there is nowhere to keep '{name}' selected. Pass `--workspace {name}` "
                   f"per command, or set `$CHARTER_WORKSPACE={name}`.")
         return
-    verb = "re-locked to" if forced and locked == name else "set to"
+    verb = "re-locked to" if before and locked != before else "set to"
     util.ok(f"Active workspace {verb} '{name}'{_scope_note(scope)} — "
             f"{_lock_words(name, locked, after_switch=True)}.")
 

--- a/charter/commands_workspace.py
+++ b/charter/commands_workspace.py
@@ -231,9 +231,15 @@ def cmd_workspace_use(args) -> int:
         # before the next refusal named the real one — ADR 0013's divergence rule.
         util.ok(f"Active workspace set to '{args.name}'{_scope_note(scope)} — this session's "
                 f"commands only; 🔒 still locked to '{locked}'.")
-    else:
+    elif locked:
         verb = "re-locked to" if getattr(args, "force", False) else "set to"
         util.ok(f"Active workspace {verb} '{args.name}'{_scope_note(scope)} — 🔒 locked for this session.")
+    else:
+        # No session to key a lock on — a plain shell with no harness id. `set_active`
+        # wrote a terminal pointer and no lock, so nothing here may announce one: this
+        # said "🔒 locked for this session" to a session that was not locked at all, which
+        # is the same false claim, one branch over (ADR 0013).
+        util.ok(f"Active workspace set to '{args.name}'{_scope_note(scope)}.")
     _warn_env_override(args.name)
     return 0
 

--- a/charter/commands_workspace.py
+++ b/charter/commands_workspace.py
@@ -152,8 +152,14 @@ def cmd_workspace_create(args) -> int:
         scope = workspace.set_active(args.name, force=getattr(args, "force", False))
         if scope == "locked":
             util.err(_locked_msg(args.name))
-            util.info(f"Workspace '{args.name}' was created; start a new session to use it, "
-                      f"or re-run with --force.")
+            # Inside a chat the refusal has already named how to work there. "Start a new
+            # session, or --force" would contradict it with exactly the two routes a chat's
+            # launch lock exists to replace (#936).
+            if workspace.launch_lock():
+                util.info(f"Workspace '{args.name}' was created.")
+            else:
+                util.info(f"Workspace '{args.name}' was created; start a new session to use it, "
+                          f"or re-run with --force.")
             return 2
         util.ok(f"Active workspace set to '{args.name}'{_scope_note(scope)} — 🔒 locked for this session.")
         _warn_env_override(args.name)
@@ -216,7 +222,19 @@ def cmd_workspace_use(args) -> int:
 def cmd_workspace_unlock(args) -> int:
     """Release this session's workspace lock so a different one can be selected.
     The escape hatch for the mid-session switch guard — use sparingly; a fresh
-    session is the clean way to pick another workspace."""
+    session is the clean way to pick another workspace.
+
+    **Not inside a chat** (#936). A chat's lock is the workspace it was launched in
+    (`workspace.launch_lock`), which is a record and not the file `workspace.unlock` deletes.
+    Left to run, this answered "unlocked" in a picked chat and "nothing to unlock" in a silent
+    one, beside a lock that refused the very next switch in both. So it refuses, deletes
+    nothing, and names the way a chat works elsewhere."""
+    held = workspace.launch_lock()
+    if held:
+        util.err(f"This chat is 🔒 locked to '{held}', the workspace it was launched in, and "
+                 f"nothing unlocks that: a chat belongs to its workspace for life. "
+                 + _open_a_chat_there())
+        return 2
     if workspace.unlock():
         util.ok("Workspace unlocked for this session — `charter workspace use <name>` can switch now.")
     else:
@@ -224,7 +242,29 @@ def cmd_workspace_unlock(args) -> int:
     return 0
 
 
+def _open_a_chat_there(target: str = "<name>") -> str:
+    """How to work in another workspace from inside a chat, said once for every refusal (#936).
+
+    §4j's "a conversation wanted elsewhere is a new chat", made concrete. A workspace's tab
+    and `F2 → workspace` both open that workspace, or focus the chat already open there; the
+    `+` then opens another chat in it. The last clause is for the caller that can press
+    neither, which is a sub-agent: `--workspace` names one workspace for one command and
+    writes no pointer, so it moves no chat.
+    """
+    return ("To work in another workspace, open a chat there: its tab on the workspace strip, "
+            f"or F2 → workspace. For one command, pass `--workspace {target}`.")
+
+
 def _locked_msg(target: str) -> str:
+    held = workspace.launch_lock()
+    if held:
+        # A chat. `unlock` releases nothing here and "start a new session" is not how a chat
+        # moves, so neither is offered (#936). `--force` still works and is deliberately not
+        # offered either: the split it makes, commands in one workspace and the chat drawn in
+        # another, is what charter's own SessionStart used to recommend to every chat.
+        return (f"Workspace is 🔒 locked to '{held}', the workspace this chat was launched in. "
+                f"Switching its commands to '{target}' would leave the chat itself in '{held}' "
+                f"(a chat belongs to its workspace for life). " + _open_a_chat_there(target))
     locked = workspace.is_locked() or "?"
     return (f"Workspace is 🔒 locked to '{locked}' for this session — switching to '{target}' "
             f"mid-session is disabled (never mix workspaces). Start a new session to pick another, "

--- a/charter/commands_workspace.py
+++ b/charter/commands_workspace.py
@@ -16,7 +16,7 @@ import sys
 import time
 from types import SimpleNamespace
 
-from . import (change, config, contain, gitpolicy, gitstate, planegit, tui, util,
+from . import (change, config, contain, gitpolicy, gitstate, planegit, session, tui, util,
                workspace, worktree)
 from .commands import (_cred_flag, _git, _origin_https, cmd_clone, commit_memory_reactive,
                        commit_push)
@@ -112,7 +112,17 @@ def cmd_workspace_current(args) -> int:
     name = workspace.resolve()
     print(name)
     locked = workspace.is_locked()
-    lock_note = ", 🔒 locked for this session" if locked else ", unlocked"
+    if not locked:
+        lock_note = ", unlocked"
+    elif locked == name:
+        lock_note = ", 🔒 locked for this session"
+    else:
+        # Name the divergence instead of the happier half of it (ADR 0013). Since #936 a
+        # chat's lock is the workspace it was LAUNCHED in, and `resolve` can legitimately
+        # answer another: a sub-agent standing in another workspace's tree (the flow #794
+        # protects), or a `--force`d pointer. "Locked for this session" beside that name
+        # claimed a lock on the workspace charter would in fact refuse to switch to.
+        lock_note = f", 🔒 locked to '{locked}'"
     mode = "LIVE (committed + shared)" if workspace.is_live(name) else "LOCAL (private)"
     util.info(f"{mode} · resolved via {workspace.source()}{lock_note}")
     vision = workspace.read_vision(name)
@@ -213,8 +223,17 @@ def cmd_workspace_use(args) -> int:
     if scope == "locked":
         util.err(_locked_msg(args.name))
         return 2
-    verb = "re-locked to" if getattr(args, "force", False) else "set to"
-    util.ok(f"Active workspace {verb} '{args.name}'{_scope_note(scope)} — 🔒 locked for this session.")
+    locked = workspace.is_locked()
+    if locked and locked != args.name:
+        # `--force` moved this session's commands and not the lock: inside a chat the lock is
+        # the launch record, which no command moves (#936). Announcing "re-locked to 'gamma'
+        # … 🔒 locked for this session" named a lock charter does not hold, one command
+        # before the next refusal named the real one — ADR 0013's divergence rule.
+        util.ok(f"Active workspace set to '{args.name}'{_scope_note(scope)} — this session's "
+                f"commands only; 🔒 still locked to '{locked}'.")
+    else:
+        verb = "re-locked to" if getattr(args, "force", False) else "set to"
+        util.ok(f"Active workspace {verb} '{args.name}'{_scope_note(scope)} — 🔒 locked for this session.")
     _warn_env_override(args.name)
     return 0
 
@@ -953,8 +972,28 @@ def _scope_note(scope: str) -> str:
 
 def cmd_workspace_reconcile(args) -> int:
     """Internal (SessionStart hook): seed this Claude session's workspace pointer
-    from its terminal pane's selection, so a reopened session resumes its workspace."""
-    sid = os.environ.get("CLAUDE_CODE_SESSION_ID")
+    from its terminal pane's selection, so a reopened session resumes its workspace.
+
+    **Keyed on the session the rest of charter resolves by** (#936). This read
+    `$CLAUDE_CODE_SESSION_ID`, then the payload's `session_id`, and inside a frame both name
+    the HARNESS — while `workspace.chosen` resolves by `session.current()`, which is the
+    CHAT's id there (ADR 0019), and `frame/state._forget_session` reaps `<chat id>.*`. So
+    the pointer it wrote was read by nothing and reaped by nothing, in the one SessionStart
+    workspace question that WRITES. `session.current()` is the question every reader asks;
+    the payload stays underneath it for a harness that exports no id at all, which is the
+    only case it ever answered.
+
+    **And inside a chat it seeds nothing.** A chat's workspace is its launch record — what
+    `workspace.for_frame` resolves and what :func:`workspace.launch_lock` locks it to. The
+    pane this would seed FROM is one charter created for the harness, so on a recycled pane
+    id the seed is another frame's selection; and a pointer under the chat id outranks the
+    launch record in `chosen`, which would move the chat's own commands off the workspace it
+    was launched in. Re-keying without this would have replaced an unread write with a
+    silent one, which is the failure #936 exists to end.
+    """
+    if workspace.launch_lock():
+        return 0
+    sid = session.current()
     if not sid:
         try:
             sid = (json.load(sys.stdin) or {}).get("session_id")

--- a/charter/frame/state.py
+++ b/charter/frame/state.py
@@ -1029,6 +1029,15 @@ def own_workspace(fid: str) -> str | None:
     ``{workspace}-{hash}`` is identity, not a property, and a pointer written by whoever
     last typed a command is the definition of a property.
 
+    **#936 added the refusal on top, and this function is what it reads.** Dropping the
+    rung stopped `ws use` moving the chat and left it moving the chat's COMMANDS, and
+    charter's own SessionStart advised the command to every chat launched without the
+    picker. So a chat's lock is now the answer here (`workspace.launch_lock`), and
+    `set_active` refuses an unforced switch out of it. No frame test is involved, which was
+    #794's objection. A sub-agent inheriting the chat's id is refused because the pointer it
+    would write is its parent chat's, and the work it does by cwd or by `--workspace` writes
+    no pointer at all.
+
     Two consequences, both deliberate. `docs/frame.md` no longer promises that `ws use`
     "moves the panels too", because it no longer does. And a chat with a pointer used to
     follow a workspace RENAME while a chat without one was orphaned; dropping the rung made
@@ -1188,11 +1197,12 @@ def workspace_for(fid: str) -> str:
     **`charter workspace use <name>` typed at the agent no longer moves the panels, and
     that is #791 rather than an oversight.** It wrote the per-session pointer under the
     CHAT's id, so the rung it moved was a membership rung and the command re-homed the
-    chat — #733 and #788 line for line, through a door neither issue named. The pointer is
-    still written and every `charter` command in that session still acts on the new name;
-    the panels draw the chat's own workspace, which is the one thing about a chat that does
-    not move. `docs/frame.md` is corrected to say so. See :func:`own_workspace` for why a
-    refusal was rejected instead.
+    chat — #733 and #788 line for line, through a door neither issue named. Where the switch
+    is allowed the pointer is still written and every `charter` command in that session acts
+    on the new name; the panels draw the chat's own workspace, which is the one thing about a
+    chat that does not move. `docs/frame.md` is corrected to say so. See :func:`own_workspace`
+    for why #791 dropped the rung rather than refuse, and for the refusal #936 added on top:
+    inside a chat, a switch out of its own workspace now needs `--force`.
 
     Rung 0 and the pin inside :func:`own_workspace` hold the same value on an ordinary
     launch — `_frame_identity_env` puts the launcher's `$CHARTER_WORKSPACE` on the pane's

--- a/charter/frame/state.py
+++ b/charter/frame/state.py
@@ -2319,6 +2319,14 @@ def _forget_session(fid: str) -> None:
     the operator who had just launched with `--workspace alpha`. Minting a new id is not
     isolation; reaping the state keyed on the old one is.
 
+    **Half of that measurement is now unreachable, and the other half is why this stays.**
+    Since #936 a chat's lock is its launch record, which outranks any `.lock` left under its
+    id, so the relaunch above can no longer be refused its own workspace
+    (`tests/test_a_reaped_chat_leaves_its_session_behind` was restaged onto the FILE for
+    exactly that reason). What the reap still prevents is the first half: the stale
+    `.workspace` pointer outranks the launch record in `workspace.chosen`, so an unreaped
+    one still moves the new chat's commands to its predecessor's workspace.
+
     **The prefix, not a list of suffixes**, and that is `workspace._prune`'s lesson taken
     at its word rather than re-learned (#366): it enumerated five marker families,
     drifted three times, and was replaced by "every file in the directory". Eight

--- a/charter/hooks.py
+++ b/charter/hooks.py
@@ -5317,6 +5317,35 @@ def _autosync_version_lock() -> str | None:
         return None
 
 
+def _workspace_session(data: dict) -> str | None:
+    """The id a hook asks WORKSPACE questions by: the chat's inside a frame, else the payload's.
+
+    **Two ids reach a hook inside a frame, and they key different things.** The payload's
+    `session_id` is the harness's own, and it still keys everything it keyed here before:
+    the tool-gate snapshot, the trace, the memory-cadence counter, and the chat → harness
+    mapping `_record_harness_session` writes out of both. The workspace pointer, the lock
+    and the launch record are keyed on the CHARTER session instead, which inside a frame is
+    the chat (ADR 0019). `charter workspace use` typed in the chat's shell writes under
+    `session.current()`, and there `$CHARTER_SESSION_ID` is the rung that answers.
+
+    **Handing the payload id to `workspace` was #936.** `session.current` ranks an explicit
+    id above the environment, so the payload id shadowed the chat's and every rung keyed on
+    the chat missed: the pointer, the lock, and `workspace.for_frame`, the rung #597 added
+    for #524. That fixed #524 for every caller except SessionStart, the one #524 named, because
+    it is the one caller that passes a different id explicitly. Measured: a chat launched in
+    `north` was briefed with `default`'s todos, shown `north` as "another workspace", and
+    told to confirm a workspace the frame had already recorded. `_record_harness_session`
+    reads the chat id in the same handler, before this block resolved by the other one.
+
+    `_chat_id` with no frame-record check, for `_record_harness_session`'s reason:
+    whatever `$CHARTER_SESSION_ID` holds is the id this session's own `charter` commands
+    write under, and a hook reading a different key from the one the CLI writes IS the
+    defect. Outside a frame it is unset and the payload id is the only session there is.
+    opencode's plugin sets both to its own session id, so there the two already agree.
+    """
+    return _chat_id() or data.get("session_id")
+
+
 def _context_parts(data: dict, piece_note, live: bool) -> list[str]:
     """The blocks a session needs to know who and where it is.
 
@@ -5331,7 +5360,10 @@ def _context_parts(data: dict, piece_note, live: bool) -> list[str]:
     binary because it regenerated some context is not something anybody asked for.
     """
     from . import persona
-    sid = data.get("session_id")
+    # Every call below that takes an id asks a WORKSPACE question, so it takes the chat's id
+    # inside a frame and the payload's outside one. See `_workspace_session`, and #936 for
+    # what the payload id alone cost: a chat briefed for `default`.
+    ws_sid = _workspace_session(data)
     parts: list[str] = []
     if live:
         # Conform this machine to the control plane's version lock, if it declares one.
@@ -5339,7 +5371,7 @@ def _context_parts(data: dict, piece_note, live: bool) -> list[str]:
         sync = _autosync_version_lock()
         if sync:
             parts.append(sync)
-    ws = _workspace_confirm_nudge(sid, _unattended(data))
+    ws = _workspace_confirm_nudge(ws_sid, _unattended(data))
     if ws:
         parts.append(ws)  # first: the start-of-session action gate
 
@@ -5396,7 +5428,7 @@ def _context_parts(data: dict, piece_note, live: bool) -> list[str]:
     # additive by construction: it cannot shorten, reorder or truncate the role, the
     # memory digest or the workspace gate above it, whatever it contains. Last because
     # it is a reminder, not a gate — nothing here should push the confirm nudge down.
-    todo = _todo_digest(sid)
+    todo = _todo_digest(ws_sid)
     if todo:
         parts.append(todo)
 
@@ -5404,7 +5436,7 @@ def _context_parts(data: dict, piece_note, live: bool) -> list[str]:
     # only block here that is about somewhere else, so it reads last among the standing
     # signals — and like the todo digest it is appended as its own part, which cannot
     # shorten or reorder anything above it whatever it contains.
-    neighbours = _other_workspaces_digest(sid)
+    neighbours = _other_workspaces_digest(ws_sid)
     if neighbours:
         parts.append(neighbours)
 
@@ -5702,9 +5734,12 @@ def posttooluse() -> int:
         # not the first clone edit (or LOCAL) → fall through to the recurring cadence nudge
 
     # (C) cadence: substantial work without a recorded memory → re-surface the habit.
+    # The counter stays keyed on the payload id above; the store the nudge suggests is a
+    # WORKSPACE question, so it asks by the chat's id inside a frame (#936).
     if count and count % _MEM_NUDGE_EVERY == 0:
         _emit({"hookSpecificOutput": {"hookEventName": "PostToolUse",
-                                      "additionalContext": _mem_cadence_nudge(sid, count)}})
+                                      "additionalContext": _mem_cadence_nudge(
+                                          _workspace_session(data), count)}})
     return 0
 
 

--- a/charter/hooks.py
+++ b/charter/hooks.py
@@ -5341,7 +5341,13 @@ def _workspace_session(data: dict) -> str | None:
     whatever `$CHARTER_SESSION_ID` holds is the id this session's own `charter` commands
     write under, and a hook reading a different key from the one the CLI writes IS the
     defect. Outside a frame it is unset and the payload id is the only session there is.
-    opencode's plugin sets both to its own session id, so there the two already agree.
+
+    **opencode is the exception, and it is not the benign kind.** Its plugin overwrites
+    `$CHARTER_SESSION_ID` with opencode's OWN session id in every shell and hook subprocess
+    it spawns (`charter/harness/opencode.py`), so inside a frame the two ids do agree — on a
+    value that names no chat. `frame/state.own_workspace` answers ``None`` for it, so an
+    opencode chat holds no launch lock, is still briefed for `default`, and its
+    `workspace use <other>` still succeeds. Pre-existing, untouched here, filed as #946.
     """
     return _chat_id() or data.get("session_id")
 

--- a/charter/workspace.py
+++ b/charter/workspace.py
@@ -77,11 +77,16 @@ def for_session(sid: str) -> str | None:
     two has to give: a chat belongs to its workspace for life, so what a pointer moves is
     the session's work and never the chat's identity.
 
-    **Refusing the command inside a frame was the alternative and it was rejected on
+    **Refusing the command inside a frame was the alternative, and #791 rejected it on
     evidence**: the only test for "inside a frame" is `session.current()`, and every agent
     spawned from a frame inherits `$CHARTER_SESSION_ID` — so the refusal would fire on
     agents doing ordinary CLI work in isolated worktrees. Nothing here changed; the reader
-    that stopped asking was `own_workspace`.
+    that stopped asking was `own_workspace`. **#936 then refused it after all, by another
+    route and with no frame test**: a chat's lock is its launch record (:func:`launch_lock`),
+    so `set_active` refuses an unforced switch out of it. That is right for an inherited id
+    too. The pointer a sub-agent's `workspace use` writes is this file under its PARENT
+    chat's id, and the sub-agent's own work goes by the tree it stands in or by
+    `--workspace`, neither of which writes here.
 
     Still public, still read by :func:`chosen` and :func:`source`, and still keyed on an id
     handed in rather than resolved — the caller is not always the session being described.
@@ -124,13 +129,16 @@ def for_frame(sid: str | None) -> str | None:
     * **Below the per-session pointer.** `charter workspace use <name>` typed inside the
       frame writes that pointer under the frame's id, so an operator's explicit choice
       still wins **for this session's own commands** — the direction #517 asks for. The
-      launcher's answer is a SEED, never a pin; nothing here takes `ws use` away from a
-      framed session, which is exactly what handing the harness `$CHARTER_WORKSPACE` would
-      have done. What the pointer no longer moves is the frame's PANELS (#791): that read
+      launcher's answer is a SEED, never a pin: handing the harness `$CHARTER_WORKSPACE`
+      would have ranked the launch above every pointer and above the tree a sub-agent
+      stands in. What the pointer no longer moves is the frame's PANELS (#791): that read
       goes through `frame/state.own_workspace`, which is also what decides a chat's
       membership of a workspace, and a command deciding a chat's identity is what §4j
       forbids. This rung's position is unaffected — the two readers were always different
-      functions, and only one of them stopped asking.
+      functions, and only one of them stopped asking. Since #936 an unforced `ws use
+      <other>` in a chat is refused by the chat's lock (:func:`launch_lock`), so inside a
+      chat this pointer outranks the rung below only when somebody passed `--force`. That
+      is still an explicit choice for this session's commands, and they still act on it.
     * **Above the per-terminal pointer.** That rung is not merely absent inside a frame,
       it is *wrong*: it is keyed on `$TMUX_PANE`, and the harness's pane is one charter
       created — not the operator's terminal, whose pointer it would otherwise read or
@@ -647,22 +655,70 @@ def _lock_file(sid: str) -> Path:
     return config.SESSIONS_DIR / f"{sid}.lock"
 
 
+def launch_lock(session_id: str | None = None) -> str | None:
+    """The workspace this session's CHAT was launched for, which is its lock, or ``None``
+    when this session is not a chat (#936).
+
+    **A chat's lock is its launch record, not a file anybody writes.** Until #936 a chat was
+    locked only when the operator PICKED at launch: `commands_frame._pin_workspace` writes
+    the lock and returns early otherwise (#518). So a chat launched with `--workspace`, from
+    a pointer, or by a reopen had no lock at all. Charter's own SessionStart told every such
+    chat to run `charter workspace use <name>`, and there it SUCCEEDED: the chat's commands
+    moved to the other workspace, the frame kept drawing it in its own, and `workspace use
+    <own>` to undo that was refused as locked to the new one. A picked chat was refused the
+    same advice. Two launch paths, two outcomes, one sentence recommending both.
+
+    `frame/state.own_workspace` is the answer because it already is the one ladder for
+    "which workspace does this chat belong to": the pin it was launched under, then what the
+    launch resolved (#733, #791). §4j settles that a chat belongs to its workspace for life.
+    Read and never written, so #518's "a launch that resolved silently … must keep writing
+    none" holds to the letter, and a picked chat and a silent one hold the same lock.
+
+    **Keyed on the id `session.current` answers, which every sub-agent inherits.** That is
+    why #794 rejected refusing `workspace use` inside a frame, and it is why refusing is
+    right. The pointer a sub-agent's `workspace use` writes lands under that same id, its
+    PARENT chat's, so a sub-agent that succeeded would move the chat it serves. The routes a
+    sub-agent does its work by write no pointer and are untouched: the tree it stands in
+    (the cwd rung outranks every pointer) and `--workspace` per command.
+
+    ``None`` for a session that is not a chat, because no frame directory exists under its
+    id and both rungs of `own_workspace` answer nothing. ``None`` for no session at all
+    too, answered by `contain.segment_ok` refusing the empty name; a second guard here would
+    be one no test can turn red.
+    """
+    from .frame import state as _state
+    return _state.own_workspace(_session_id(session_id))
+
+
 def is_locked(session_id: str | None = None) -> str | None:
-    """The workspace this session is **locked** to (i.e. confirmed via ``workspace
-    use``/``create --use``), or ``None`` if the session hasn't confirmed one yet.
+    """The workspace this session is **locked** to, or ``None`` if it has no lock yet.
 
     A lock is what forbids switching *mid-session*: once set, ``set_active`` refuses
-    to move to a different workspace unless ``force=True``. It's keyed by the Claude
-    session id, so every new session starts unlocked and gets to choose afresh."""
+    to move to a different workspace unless ``force=True``.
+
+    **Two sources, and a chat's launch outranks the file** (#936). Inside a frame the lock
+    is the workspace the chat was launched for (:func:`launch_lock`), whether or not anyone
+    picked it. Outside one it is the file ``workspace use``/``create --use`` wrote, keyed by
+    the session id, so every new session starts unlocked and gets to choose afresh.
+
+    The launch comes first because the file under a chat's id can disagree with it only
+    after a forced switch. If the file won, that chat could not go home: `workspace use
+    <own>` would be refused as locked to the workspace it was forced into, which is the undo
+    #936 measured failing. With the launch first, leaving the chat's workspace takes
+    `--force` every time and returning to it takes nothing."""
     sid = _session_id(session_id)
     if not sid:
         return None
-    return _read(_lock_file(sid))
+    return launch_lock(sid) or _read(_lock_file(sid))
 
 
 def unlock(session_id: str | None = None) -> bool:
-    """Drop this session's lock (an explicit escape hatch). Returns True if one was
-    cleared. Used by ``workspace unlock``; ``set_active(..., force=True)`` re-locks."""
+    """Drop this session's lock FILE (an explicit escape hatch). Returns True if one was
+    cleared. Used by ``workspace unlock``; ``set_active(..., force=True)`` re-locks.
+
+    A chat's lock is not that file, so this cannot release it. :func:`is_locked` answers a
+    chat's launch record first (:func:`launch_lock`, #936), and ``workspace unlock``
+    refuses inside a chat rather than report a release that did not happen."""
     sid = _session_id(session_id)
     if not sid:
         return False

--- a/docs/adr/0019-the-frame-owns-the-surface.md
+++ b/docs/adr/0019-the-frame-owns-the-surface.md
@@ -139,7 +139,9 @@ read that pointer the command also re-homed the chat — the ladder the panels r
 one that decides which chats a workspace has (`frame/state.own_workspace`), which spec §4j
 forbids a typed command from moving. So membership and the panels now read the launch's
 own records, and `ws use` moves what the session's commands act on. The collision itself is
-unchanged and still load-bearing for everything above.
+unchanged and still load-bearing for everything above. (**Narrowed by #936:** a chat's lock
+is now its launch record, so inside a chat `ws use` moves the session's commands only when
+forced.)
 
 **Kept, deliberately: one variable, one meaning — "the charter session this process
 belongs to". Inside a frame, that is the frame.** Every process the frame contains — the
@@ -165,6 +167,12 @@ has a consequence the comfortable version hides:
   carried over.
 * **What still keys on Claude Code's own id is what arrives by payload and never reads the
   environment**: the token-usage history this ADR keeps alive, and the session trace.
+* **A hook receives both ids, and a hook that asks a workspace question with the payload's
+  gets the wrong session's answer.** `session.current` ranks an explicit id above the
+  environment, so the payload id shadows the frame's in that one direction. SessionStart
+  did exactly that, and every chat was briefed for `default` and told to pick a workspace
+  (#936). Workspace questions in a hook are asked by the frame's id; the payload id keeps
+  keying what it keyed before.
 
 Pinned by `tests/test_frame_owns_the_surface.py`, which asserts that a panel follows a
 `ws use` made under the frame's id and does *not* follow one made under any other — on a

--- a/docs/adr/0019-the-frame-owns-the-surface.md
+++ b/docs/adr/0019-the-frame-owns-the-surface.md
@@ -172,7 +172,10 @@ has a consequence the comfortable version hides:
   environment, so the payload id shadows the frame's in that one direction. SessionStart
   did exactly that, and every chat was briefed for `default` and told to pick a workspace
   (#936). Workspace questions in a hook are asked by the frame's id; the payload id keeps
-  keying what it keyed before.
+  keying what it keyed before. That covers the one hook that WRITES, too: `charter workspace
+  _reconcile` seeds a session's pointer from its terminal's, and inside a chat it now seeds
+  nothing at all — a pointer under the chat's id would outrank the launch record and move
+  the chat's own commands off the workspace it was launched in.
 
 Pinned by `tests/test_frame_owns_the_surface.py`, which asserts that a panel follows a
 `ws use` made under the frame's id and does *not* follow one made under any other — on a

--- a/docs/frame.md
+++ b/docs/frame.md
@@ -1418,8 +1418,9 @@ answers from your cwd or your terminal's pointer, while a panel's cwd is the pan
 its terminal id is its own tmux pane, so it would fall all the way through to `default` —
 and did (#512). The launcher writes the answer into the frame's own state directory
 instead. Nothing is pinned into the environment to achieve it, deliberately: exporting
-`$CHARTER_WORKSPACE` would rank above every pointer and take `charter workspace use` away
-from every framed session.
+`$CHARTER_WORKSPACE` would rank above every pointer and above the directory an agent is
+standing in, so not even `charter workspace use --force` could move a framed session's
+commands.
 
 So the order the panels read is: `$CHARTER_WORKSPACE` if you pinned one, then what the
 launch recorded — the pin it was launched under, then the workspace it resolved — then
@@ -1427,9 +1428,10 @@ whatever the panel can resolve for itself (a frame launched by an older charter,
 running across the upgrade).
 
 **`charter workspace use <name>` typed at the agent does not move the panels, and this
-line used to say the opposite.** It writes the per-session pointer under the frame's id,
-which is what makes every `charter` command in that shell act on the new name — `charter
-clone`, `charter repos`, `charter ws current`, all of it. What it does *not* do is change
+line used to say the opposite.** Where it is allowed (the next paragraph says where), it
+writes the per-session pointer under the frame's id, which is what makes every `charter`
+command in that shell act on the new name — `charter clone`, `charter repos`, `charter ws
+current`, all of it. What it does *not* do is change
 which workspace the chat is in, and for one release it did: that pointer was a rung of the
 ladder the panels read, and the same ladder decides which chats a workspace has. So the
 command quietly re-homed the chat — the chat beside it in the same tmux session could no
@@ -1438,6 +1440,26 @@ palette then refused to open. **A chat belongs to its workspace for life** (spec
 conversation wanted elsewhere is a new chat, opened with `charter <harness>` in that
 workspace. If you want the panels on another workspace, `F2 → workspace` moves your
 terminal to it and leaves every chat where it is.
+
+**Inside a chat, `charter workspace use <other>` is refused, and the refusal says where to
+go instead.** A chat is locked to the workspace it was launched in, whether you picked that
+workspace at the prompt or the launch resolved it for you (`--workspace`, a pointer, a
+reopen). Until #936 only a picked chat was locked. Charter's own session briefing then told
+every other chat to confirm a workspace with `charter workspace use`, and there the command
+succeeded: the chat's commands moved to another workspace while its tab stayed where it
+was, and `charter workspace use <own>` to put it back was refused. The briefing now names
+the chat's own workspace and asks nothing. To work in another workspace, open a chat there
+(its tab on the workspace strip, or `F2 → workspace`, then `+` for another chat once you
+are in it). For one command, `--workspace <name>` names a workspace without moving
+anything. `charter workspace use <own>` still succeeds. `--force` still moves a chat's
+commands for anyone who means it, and never the chat, so going back needs no second
+`--force`.
+
+**The same lock holds for an agent the chat spawns, and that is on purpose.** The agent
+inherits the chat's session id, so the pointer its `workspace use` would write is the
+chat's own: an agent that succeeded would move the chat it is working for. An agent's work
+goes by the directory it stands in, which outranks every pointer, or by `--workspace` on
+each command, and neither writes anything to refuse.
 
 **Renaming a workspace does not orphan its chats, and that is not an exception to §4j.**
 For one release it did: a chat's workspace is fixed at launch, so `charter workspace rename
@@ -2696,13 +2718,14 @@ before any column is measured (#472), so it is exactly one row on screen; and th
 re-checks it against the same alphabet `charter workspace use` does, so a name charter would
 not accept is refused with a message rather than acted on.
 
-**The session lock is released by `charter workspace unlock`, and by nothing on the
-palette.** `charter workspace use` locks the session to what it selected so a workspace
-cannot be swapped out from under a running task, and a launch that asked you to pick one
-takes the same lock. `F2 → workspace` used to override it — that was the frame's way out
-while a workspace switch was a thing a frame could do — and now there is nothing to
-override, so the way out is the one the launch names on the line that takes the lock:
-`charter workspace unlock`, typed in the frame's own shell.
+**A chat's workspace lock is released by nothing, on the palette or off it.** A chat is
+locked to the workspace it was launched in, so a workspace cannot be swapped out from under
+a running task. `F2 → workspace` used to override that lock, back when a workspace switch
+was a thing a frame could do, and `charter workspace unlock` used to release it. Neither
+does now (#936): the lock is the chat's launch record rather than a file either of them
+could remove, and `unlock` says so instead of reporting a release. What the palette offers
+is the way to work elsewhere: `F2 → workspace` takes your terminal to another workspace,
+where a chat of that workspace does the work.
 
 **Pressing `F2` again while the palette is open REOPENS it.** `bind -n` is tmux's root key
 table, so tmux matches the key before any byte reaches the palette's pane — the same
@@ -2824,12 +2847,11 @@ the workspace alphabet, and asks `create <name> and switch to it? [y/N]` — any
 `y` goes back to the list, and a cancelled picker creates nothing at all. `q`, Ctrl-C or a
 closed stdin end the launch having started nothing; the exit code is 130.
 
-**Picking is the confirmation that locks.** That is what selecting a workspace has always
-meant — `charter workspace use` locks the session to what it selected — and the launch
-says so on the line after your answer, naming the way out in the same sentence: `charter
-workspace unlock`, in the frame's own shell. (It used to name `F2 → workspace` first; that
-route no longer releases a lock — a workspace switch moves your terminal to another session
-and leaves this one locked to the workspace its commands act on.)
+**The chat is locked to what you picked, and would have been either way.** Every chat is
+locked to the workspace it was launched in, picked or not (#936). The launch says so on the
+line after your answer, and names the way to work anywhere else in the same sentence: open
+a chat there. (It used to name `charter workspace unlock`, and before that `F2 → workspace`,
+as ways to release the lock. A chat's lock is its launch record, and neither releases it.)
 
 **It never asks twice, and it never asks a script.** Your choice is written as the
 terminal's own pointer, so the next launch from that terminal has an answer and goes

--- a/docs/frame.md
+++ b/docs/frame.md
@@ -1461,6 +1461,14 @@ chat's own: an agent that succeeded would move the chat it is working for. An ag
 goes by the directory it stands in, which outranks every pointer, or by `--workspace` on
 each command, and neither writes anything to refuse.
 
+**Two limits, both deliberate and both worth knowing.** A chat launched from a shell with
+`$CHARTER_WORKSPACE` set is locked to that **pin** rather than to the workspace the launch
+resolved — the pin outranks the launch record here exactly as it outranks every pointer
+elsewhere. And **opencode chats are not covered at all**: its plugin replaces
+`$CHARTER_SESSION_ID` with opencode's own session id in every shell and hook it spawns, so
+inside a frame charter cannot tell which chat it is in. Such a chat holds no lock and is
+still asked to confirm a workspace (#946).
+
 **Renaming a workspace does not orphan its chats, and that is not an exception to §4j.**
 For one release it did: a chat's workspace is fixed at launch, so `charter workspace rename
 alpha alpha2` left every chat in it still recording `alpha` — invisible to `alpha2`, and
@@ -1479,7 +1487,10 @@ next chat in that workspace very often gets the same *name* — and a pointer, a
 persona selection or a tool-gate marker left under it would be inherited by a conversation
 that never chose any of them. What that cost, before it was fixed, was a chat launched with
 `--workspace alpha` whose every command acted on `gamma` and which refused
-`charter workspace use alpha` as **locked** (#731). So reaping a chat removes
+`charter workspace use alpha` as **locked** (#731). The refusal half can no longer happen —
+since #936 a chat's lock is the workspace it was launched in, and that outranks any lock
+file left under its id — so what reaping still prevents is the first half: a stale pointer
+moving the new chat's commands to its predecessor's workspace. So reaping a chat removes
 `.charter/sessions/<chat id>.*` along with `.charter/frame/<chat id>/`. Sessions that are
 not chats — a bare harness outside a frame, keyed by its own id — are untouched, and so is
 every live chat.

--- a/docs/news/unreleased-a-chat-is-briefed-for-its-own-workspace.md
+++ b/docs/news/unreleased-a-chat-is-briefed-for-its-own-workspace.md
@@ -30,7 +30,9 @@ The chat's commands then acted on the other workspace while its tab stayed in it
 ## What is true now
 
 - **A chat is locked to the workspace it was launched in**, picked or not. Its briefing
-  shows that workspace's todos, never lists it as another one, and asks nothing.
+  shows that workspace's todos, never lists it as another one, and asks nothing. If the
+  shell that opened the chat had `$CHARTER_WORKSPACE` set, the chat is locked to that pin
+  instead, which is the precedence that variable has everywhere else in charter.
 - **`charter workspace use <other>` inside a chat is refused**, and says what to do: open a
   chat in that workspace (its tab, or `F2 → workspace`), or pass `--workspace <other>` for
   a single command. `charter workspace use <own>` still succeeds.
@@ -44,3 +46,9 @@ its `workspace use` would have written the chat's own pointer. Agents work by th
 they stand in, which outranks every pointer, or by `--workspace`, and neither is affected.
 
 Outside a frame nothing changes. A session is still locked by the workspace it confirms.
+
+**Not opencode yet.** Its plugin replaces `$CHARTER_SESSION_ID` with opencode's own session
+id in every shell and hook it spawns, so inside a frame charter cannot tell which chat it is
+in. An opencode chat holds no lock, is still told to pick a workspace, and
+`charter workspace use <other>` in it still succeeds. That is pre-existing, and it is
+tracked as #946.

--- a/docs/news/unreleased-a-chat-is-briefed-for-its-own-workspace.md
+++ b/docs/news/unreleased-a-chat-is-briefed-for-its-own-workspace.md
@@ -1,0 +1,46 @@
+---
+version: unreleased
+headline: A chat is briefed for the workspace it was opened in, and is never told to pick one
+---
+
+Every new chat in a charter frame started its session with the wrong picture of where it
+was. Measured on 0.60.0, in a chat launched in one workspace, its first context:
+
+- told it **"Confirm the workspace before any repo work. No workspace is locked for this
+  session yet (it would otherwise default to `default`)"**,
+- listed `default`'s open todos as its own, and
+- listed its own workspace among the *other* workspaces on the plane.
+
+## Two ids, and the briefing asked by the wrong one
+
+Inside a frame, a hook sees two session ids: the chat's, and the harness's own, which
+arrives in the hook's payload. The workspace pointer, the lock and the record of what the
+chat was launched for are all keyed on the chat's. The session briefing looked them up by
+the harness's, missed every one, and fell through to `default`. The memory reminder that
+fires after a run of edits made the same mistake.
+
+## And following the advice split the chat
+
+Only a chat whose workspace you *picked* at launch was locked. Every other chat had no lock:
+`charter claude -w api`, a launch that took its workspace from a pointer, a reopened chat.
+So `charter workspace use <name>`, the command the briefing recommended, succeeded there.
+The chat's commands then acted on the other workspace while its tab stayed in its own, and
+`charter workspace use <own>` to put it back was refused.
+
+## What is true now
+
+- **A chat is locked to the workspace it was launched in**, picked or not. Its briefing
+  shows that workspace's todos, never lists it as another one, and asks nothing.
+- **`charter workspace use <other>` inside a chat is refused**, and says what to do: open a
+  chat in that workspace (its tab, or `F2 → workspace`), or pass `--workspace <other>` for
+  a single command. `charter workspace use <own>` still succeeds.
+- **`charter workspace unlock` inside a chat refuses** instead of reporting a release that
+  did not happen.
+- `--force` still moves a chat's commands for anyone who means it. It never moves the chat,
+  and going back needs no second `--force`.
+
+An agent spawned from a chat inherits the chat's session id, so the lock holds for it too:
+its `workspace use` would have written the chat's own pointer. Agents work by the directory
+they stand in, which outranks every pointer, or by `--workspace`, and neither is affected.
+
+Outside a frame nothing changes. A session is still locked by the workspace it confirms.

--- a/docs/news/unreleased-a-chat-is-briefed-for-its-own-workspace.md
+++ b/docs/news/unreleased-a-chat-is-briefed-for-its-own-workspace.md
@@ -1,6 +1,6 @@
 ---
 version: unreleased
-headline: A chat is briefed for the workspace it was opened in, and is never told to pick one
+headline: A Claude Code chat is briefed for the workspace it was opened in, instead of being told to pick one
 ---
 
 Every new chat in a charter frame started its session with the wrong picture of where it

--- a/docs/workspaces.md
+++ b/docs/workspaces.md
@@ -139,6 +139,17 @@ pointer its `workspace use` would write is the chat's own. It works by the direc
 stands in, which outranks every pointer, or by `--workspace` on each command. See
 `docs/frame.md` for why (#936).
 
+Two limits:
+
+- **A pinned launcher pins the chat.** If `$CHARTER_WORKSPACE` was set in the shell that
+  opened the chat, the chat is locked to that pin rather than to the workspace the launch
+  resolved — including one named with `--workspace`. That is the precedence the pin has
+  everywhere else in charter.
+- **Not opencode, yet.** Its plugin replaces `$CHARTER_SESSION_ID` with opencode's own
+  session id, so inside a frame charter cannot tell which chat it is in. An opencode chat
+  holds no lock, is still asked to confirm a workspace, and `charter workspace use <other>`
+  in it still succeeds (#946).
+
 ## workspace.md, memory, and workspace.json
 
 Three stores, three jobs. Putting a thing in the wrong one is the common mistake:

--- a/docs/workspaces.md
+++ b/docs/workspaces.md
@@ -113,6 +113,32 @@ Three ways past it, in the order you should reach for them:
 - `charter workspace unlock` — release the lock, then select;
 - `charter workspace use <name> --force` — switch and re-lock in one step.
 
+### Inside a chat
+
+A chat in a charter frame is locked to the workspace it was launched in. It makes no
+difference whether you picked that workspace at the launch prompt or it came from
+`--workspace`, a pointer or a reopen. There is nothing to confirm, and the session briefing
+does not ask. `charter workspace use <other>` there is refused with a different message:
+
+    Workspace is 🔒 locked to 'billing', the workspace this chat was launched in.
+    Switching its commands to 'search' would leave the chat itself in 'billing'
+    (a chat belongs to its workspace for life). To work in another workspace, open
+    a chat there: its tab on the workspace strip, or F2 → workspace. For one
+    command, pass `--workspace search`.
+
+Of the three ways past the lock above, one changes and one is gone:
+
+- **start a new session** becomes **open a chat in that workspace**;
+- `charter workspace unlock` refuses, because the lock is the chat's launch record and
+  there is nothing to release;
+- `charter workspace use <name> --force` still moves the chat's **commands**. It never
+  moves the chat, and `charter workspace use <own>` takes you back with no second `--force`.
+
+An agent the chat spawns inherits the chat's session id, so the same lock holds for it: the
+pointer its `workspace use` would write is the chat's own. It works by the directory it
+stands in, which outranks every pointer, or by `--workspace` on each command. See
+`docs/frame.md` for why (#936).
+
 ## workspace.md, memory, and workspace.json
 
 Three stores, three jobs. Putting a thing in the wrong one is the common mistake:

--- a/tests/test_a_chat_belongs_to_its_workspace_for_life.py
+++ b/tests/test_a_chat_belongs_to_its_workspace_for_life.py
@@ -54,6 +54,12 @@ worktrees, none of which is in a frame in any meaningful sense. So the pointer i
 written and `workspace use` still works everywhere; what changed is that
 `state.own_workspace` no longer reads it, and membership is the launch records alone.
 
+**#936 later refused the unforced switch in a chat after all**, through the chat's lock
+(`workspace.launch_lock`) rather than a frame test. Every case below that writes the
+pointer already forces it, as `charter workspace use --force` does, so none of them moved.
+Why that refusal survives #794's evidence is in
+`tests/test_a_chat_is_locked_to_the_workspace_it_was_launched_for.py`.
+
 **No tmux here, deliberately** — the strand is a state defect and reproduces on two
 directories. `tests/test_frame_chat_switch.TheSwitchEstablishesTheWindowItIsMovingTo`
 keeps the tmux half: a plane that arrived in the split state by some other route (a

--- a/tests/test_a_chat_is_locked_to_the_workspace_it_was_launched_for.py
+++ b/tests/test_a_chat_is_locked_to_the_workspace_it_was_launched_for.py
@@ -51,7 +51,7 @@ from unittest import mock
 from charter import commands_frame, commands_workspace, config, hooks, todos, workspace
 from charter.frame import state
 
-from tests._isolation import PersonaIso, PlaneIso, run_hook
+from tests._isolation import PersonaIso, PlaneIso, no_background_refresh, run_hook
 from tests.test_a_chat_records_where_it_was_started import _DrivesTheLauncher
 
 #: The chat, as the launcher names it, and what `$CHARTER_SESSION_ID` holds inside it.
@@ -350,6 +350,11 @@ class SessionStartBriefsTheChatForItsOwnWorkspace(PlaneIso):
         # A hook inside a chat refreshes that frame's gather in the background. Nothing
         # here is about the gather, and the suite spends no child it was not asked to.
         self.enterContext(mock.patch("charter.frame.notify.plane_changed"))
+        # And SessionStart forks `charter _version-check` since #938 (`update.maybe_spawn`),
+        # which a test plane's fresh STATE_DIR always looks stale enough to fire. Nothing
+        # here is about the version check. Without this the suite's guard refuses the fork:
+        # green on this branch alone, seven errors on the PR's merge with that `main`.
+        no_background_refresh(self)
         for n in (config.DEFAULT_WORKSPACE, "north", "gamma"):
             workspace.ensure(n)
         todos.add(config.DEFAULT_WORKSPACE, "A TODO IN THE DEFAULT WORKSPACE")
@@ -392,6 +397,7 @@ class OutsideAFrameThePayloadIdStillDecides(PlaneIso):
 
     def setUp(self) -> None:
         super().setUp()
+        no_background_refresh(self)   # SessionStart's version-check fork; see the class above
         for n in (config.DEFAULT_WORKSPACE, "gamma"):
             workspace.ensure(n)
         todos.add(config.DEFAULT_WORKSPACE, "A TODO IN THE DEFAULT WORKSPACE")
@@ -440,6 +446,7 @@ class AChatOpenedInANamedWorkspaceIsBornLockedToIt(_DrivesTheLauncher, PlaneIso)
 
     def setUp(self) -> None:
         super().setUp()
+        no_background_refresh(self)   # its briefing case runs SessionStart; see above
         workspace.ensure("gamma")
         calls = self._launch()
         self.assertEqual(calls["rc"], 0)

--- a/tests/test_a_chat_is_locked_to_the_workspace_it_was_launched_for.py
+++ b/tests/test_a_chat_is_locked_to_the_workspace_it_was_launched_for.py
@@ -1,0 +1,367 @@
+"""#936: a framed chat was briefed for `default` and told to pick its workspace.
+
+Two defects, and the issue measured why neither fix is enough without the other.
+
+**The id.** SessionStart resolved the workspace by the harness's own session id, the
+`session_id` in its stdin payload, while ADR 0019 makes the CHAT id (`$CHARTER_SESSION_ID`)
+the charter session. `session.current` ranks an explicit id first, so the payload id won,
+and every rung keyed on the chat missed: the per-session pointer, the lock, and
+`workspace.for_frame` (#597's answer to #524). The chat's first context therefore held
+`default`'s todos, listed its own workspace as "another", and asked it to confirm a
+workspace. The PostToolUse memory nudge made the same call with the same id.
+
+**The lock.** A chat was locked only when the operator PICKED at launch
+(`commands_frame._pin_workspace` returns early otherwise, #518). So resolving by the chat
+id alone makes the nudge name the right workspace and still ask the question. Following it
+in a silent-launch chat SUCCEEDED: the chat's commands moved to the other workspace while
+the frame kept drawing it in its own, and `workspace use <own>` to undo that was refused.
+
+**What is true now.** A chat's launch record is its lock (`state.own_workspace`: the pin
+it was launched under, then the workspace the launch resolved). Deriving it writes
+nothing, so #518's "a launch that resolved silently must keep writing none" holds to the
+letter. `charter workspace use <other>` inside a chat is refused and names the fix:
+opening a chat in that workspace.
+
+**#794 rejected exactly this refusal, and why it is right now is pinned here too.** Its
+evidence was that every agent spawned from a frame inherits `$CHARTER_SESSION_ID`, so a
+refusal keyed on it fires on sub-agents doing ordinary CLI work. That is still true, and a
+sub-agent's `workspace use` is the same call with the same id as the chat's own. It is
+refused for the same reason: the pointer it would write is its PARENT chat's, so a
+sub-agent that succeeded would move the chat it serves. The routes a sub-agent does its
+work by stay open, because neither writes anything: the tree it stands in (the cwd rung
+outranks every pointer) and `--workspace <name>` per command.
+
+**`charter handoff` is why the launch case is here.** That command opens a chat in a named
+workspace through `cmd_launch(workspace=W)` with no picker, and the new chat has to start
+working at once. That needs a chat BORN locked to W and briefed for it, so this module
+drives the launcher itself rather than planting the record.
+"""
+
+from __future__ import annotations
+
+import io
+import os
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from types import SimpleNamespace
+from unittest import mock
+
+from charter import commands_frame, commands_workspace, config, hooks, todos, workspace
+from charter.frame import state
+
+from tests._isolation import PersonaIso, PlaneIso, run_hook
+from tests.test_a_chat_records_where_it_was_started import _DrivesTheLauncher
+
+#: The chat, as the launcher names it, and what `$CHARTER_SESSION_ID` holds inside it.
+CHAT = "north.1"
+#: Claude Code's own session id: what arrives as `session_id` in every hook payload, and
+#: never the chat's. The issue's fixtures used one id for both sides, so the two could not
+#: differ there; they differ here on purpose.
+HARNESS_SID = "497f0e5a-0000-4000-8000-000000000936"
+
+
+def _plant(fid: str, *, ws: str, pin: str = "") -> None:
+    """Make *fid* a chat charter launched into *ws*, WITHOUT the picker.
+
+    The production writers and never a hand-written file, which is
+    `tests/test_frame_chat_switch._plant`'s rule. `pin` is the `$CHARTER_WORKSPACE` the
+    launcher had: `_frame_identity_env` records an empty value for an unpinned launch, which
+    is the case the issue measured.
+    """
+    state.frame_dir(fid, create=True)
+    state.record_workspace(fid, ws)
+    state.record_identity(fid, {"CHARTER_HARNESS": "Claude Code",
+                                "CHARTER_WORKSPACE": pin, "CHARTER_PERSONA": ""})
+
+
+def _context(r) -> str:
+    return (r or {}).get("hookSpecificOutput", {}).get("additionalContext", "")
+
+
+def _neighbours(ctx: str) -> str:
+    """The other-workspaces block of a briefing, or ``""``. Parts are joined by a blank
+    line and that block holds none of its own, so it is the part that opens with its mark."""
+    return next((p for p in ctx.split("\n\n") if p.startswith("⬡")), "")
+
+
+class AChatsLaunchIsItsLock(PersonaIso, unittest.TestCase):
+    """`workspace.is_locked`, asked about a chat."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        for n in ("north", "gamma"):
+            workspace.ensure(n)
+        _plant(CHAT, ws="north")
+
+    def test_a_chat_launched_without_the_picker_is_locked_to_its_workspace(self):
+        """The silent launch. Measured before: `is_locked` → `None`, under either id."""
+        self.assertFalse((config.SESSIONS_DIR / f"{CHAT}.lock").exists(),
+                         "the fixture wrote a lock, so this would measure the file")
+        self.assertEqual(workspace.is_locked(CHAT), "north")
+
+    def test_deriving_the_lock_writes_nothing(self):
+        """#518, to the letter: a launch that resolved silently writes no pointer and no
+        lock. Green before the fix, deliberately. A fix that made every launch WRITE a lock
+        would pass the case above and fail this one."""
+        workspace.is_locked(CHAT)
+        left = (sorted(p.name for p in config.SESSIONS_DIR.iterdir())
+                if config.SESSIONS_DIR.is_dir() else [])
+        self.assertEqual(left, [])
+
+    def test_a_pinned_chat_is_locked_to_its_pin(self):
+        """`state.own_workspace`'s first rung. A chat launched under `$CHARTER_WORKSPACE`
+        draws and acts on the pin, so the pin is what it is locked to, whatever the launch
+        resolved beside it."""
+        _plant("north.2", ws="north", pin="gamma")
+        self.assertEqual(workspace.is_locked("north.2"), "gamma")
+
+    def test_the_launch_outranks_a_lock_written_under_the_chats_id(self):
+        """A forced `workspace use gamma` writes a lock file saying `gamma`. If that file
+        outranked the launch, the chat could not go home: `workspace use north` would be
+        refused as locked to `gamma`, which is the undo the issue measured failing."""
+        workspace.set_active("gamma", session_id=CHAT, terminal_id="", force=True)
+        self.assertEqual(workspace.is_locked(CHAT), "north")
+        self.assertEqual(workspace.set_active("north", session_id=CHAT, terminal_id=""),
+                         "session")
+
+    def test_a_session_that_is_not_a_chat_is_locked_by_what_it_confirmed(self):
+        """Outside a frame nothing changes: no launch record, so only a confirmation locks."""
+        self.assertIsNone(workspace.is_locked(HARNESS_SID))
+        workspace.set_active("gamma", session_id=HARNESS_SID, terminal_id="")
+        self.assertEqual(workspace.is_locked(HARNESS_SID), "gamma")
+
+
+class WorkspaceUseInsideAChat(PersonaIso, unittest.TestCase):
+    """`charter workspace use`, typed in the chat or run by a sub-agent inside it.
+
+    **Those are one call**: a sub-agent inherits `$CHARTER_SESSION_ID`, and the command
+    takes no id of its own, so the id `set_active` keys on is the chat's either way. That is
+    why no case here passes `session_id=`.
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.enterContext(mock.patch.dict(os.environ, {"CHARTER_SESSION_ID": CHAT}))
+        for n in ("north", "gamma"):
+            workspace.ensure(n)
+        _plant(CHAT, ws="north")
+
+    def _run(self, fn, **kw) -> tuple[int, str]:
+        out, err = io.StringIO(), io.StringIO()
+        with redirect_stdout(out), redirect_stderr(err):
+            rc = fn(SimpleNamespace(**kw))
+        return rc, err.getvalue()
+
+    def _use(self, name: str, *, force: bool = False) -> tuple[int, str]:
+        return self._run(commands_workspace.cmd_workspace_use,
+                         name=name, force=force, create=False)
+
+    def test_another_workspace_is_refused(self):
+        """Measured before: rc 0, and the chat's commands then acted on `gamma` while the
+        frame drew it in `north`."""
+        rc, _ = self._use("gamma")
+        self.assertEqual(rc, 2)
+        self.assertEqual(workspace.resolve(cwd=config.ROOT), "north")
+        self.assertIsNone(workspace.for_session(CHAT), "the refusal wrote the pointer anyway")
+
+    def test_the_refusal_names_opening_a_chat_there(self):
+        """A conversation wanted elsewhere is a new chat (§4j), so the way out is a chat in
+        `gamma`. `unlock` is not named because it releases nothing here."""
+        _rc, err = self._use("gamma")
+        self.assertIn("open a chat", err)
+        self.assertIn("F2 → workspace", err)
+        self.assertNotIn("workspace unlock", err)
+
+    def test_the_refusal_names_the_route_a_subagent_has(self):
+        """A sub-agent cannot press a tab or open the palette. One command in another
+        workspace is `--workspace`, which writes nothing and so moves no chat."""
+        _rc, err = self._use("gamma")
+        self.assertIn("--workspace gamma", err)
+
+    def test_its_own_workspace_is_a_successful_no_op(self):
+        rc, _ = self._use("north")
+        self.assertEqual(rc, 0)
+        self.assertEqual(workspace.resolve(cwd=config.ROOT), "north")
+        self.assertEqual(workspace.is_locked(), "north")
+
+    def test_force_still_moves_the_sessions_commands_and_never_the_chat(self):
+        """#794's protection, kept: `set_active` still writes the pointer when asked to, and
+        every `charter` command in the session acts on it. What it never moves is the chat,
+        and the lock stays the chat's own, so going home needs no second `--force`."""
+        rc, _ = self._use("gamma", force=True)
+        self.assertEqual(rc, 0)
+        self.assertEqual(workspace.resolve(cwd=config.ROOT), "gamma")
+        self.assertEqual(state.own_workspace(CHAT), "north")
+        self.assertEqual(workspace.is_locked(), "north")
+        self.assertEqual(self._use("north")[0], 0)
+
+    def test_the_routes_a_subagent_works_by_are_untouched(self):
+        """What #794 feared the refusal would break, asked after a refusal. Green before the
+        fix, deliberately: a sub-agent in `workspaces/gamma/…` acts on `gamma` because it
+        stands there, and `--workspace gamma` names it outright. Neither writes a pointer, so
+        neither is refused."""
+        self._use("gamma")
+        tree = config.WORKSPACES_DIR / "gamma" / "api"
+        tree.mkdir(parents=True, exist_ok=True)
+        self.assertEqual(workspace.resolve(cwd=tree), "gamma")
+        self.assertEqual(workspace.resolve("gamma"), "gamma")
+
+    def test_create_with_use_makes_the_workspace_and_names_the_same_fix(self):
+        """`create --use` goes through the same `set_active`, so it meets the same lock. The
+        workspace is still made: a refusal to SWITCH is not a refusal to create."""
+        rc, err = self._run(commands_workspace.cmd_workspace_create,
+                            name="delta", use=True, force=False, repos=[])
+        self.assertEqual(rc, 2)
+        self.assertTrue((config.WORKSPACES_DIR / "delta").is_dir())
+        self.assertIn("open a chat", err)
+        self.assertNotIn("start a new session", err)
+
+    def test_unlock_says_the_launch_holds_it_and_releases_nothing(self):
+        """Measured before: rc 0 and "No workspace lock was set for this session", in a
+        chat that is now locked. A command that answers "nothing to unlock" beside a lock
+        that refuses the next switch is two answers to one question."""
+        rc, err = self._run(commands_workspace.cmd_workspace_unlock)
+        self.assertEqual(rc, 2)
+        self.assertIn("open a chat", err)
+        self.assertEqual(workspace.is_locked(), "north")
+
+    def test_a_picked_launch_names_no_unlock_either(self):
+        """`_pin_workspace`'s announcement named `charter workspace unlock` as the way out
+        of the lock it takes. Under a lock the launch holds, that is a promise the command
+        cannot keep."""
+        said: list[str] = []
+        with mock.patch("charter.util.info", side_effect=said.append):
+            commands_frame._pin_workspace("north", "north.2", True)
+        self.assertEqual(len(said), 1, said)
+        self.assertNotIn("workspace unlock", said[0])
+        self.assertIn("open a chat", said[0])
+
+
+class SessionStartBriefsTheChatForItsOwnWorkspace(PlaneIso):
+    """The briefing, with a chat id and a DIFFERENT payload id, as Claude Code sends it."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.enterContext(mock.patch.dict(os.environ, {"CHARTER_SESSION_ID": CHAT}))
+        # A hook inside a chat refreshes that frame's gather in the background. Nothing
+        # here is about the gather, and the suite spends no child it was not asked to.
+        self.enterContext(mock.patch("charter.frame.notify.plane_changed"))
+        for n in (config.DEFAULT_WORKSPACE, "north", "gamma"):
+            workspace.ensure(n)
+        todos.add(config.DEFAULT_WORKSPACE, "A TODO IN THE DEFAULT WORKSPACE")
+        todos.add("north", "A TODO IN NORTH")
+        _plant(CHAT, ws="north")
+
+    def _briefing(self) -> str:
+        return _context(run_hook(hooks.sessionstart, {"session_id": HARNESS_SID}))
+
+    def test_a_chat_is_not_told_to_pick_a_workspace(self):
+        """Measured before: "No workspace is locked for this session yet (it would
+        otherwise default to `default`)"."""
+        self.assertNotIn("Confirm the workspace", self._briefing())
+
+    def test_a_picked_launch_is_not_told_either(self):
+        """The picked launch's lock sat under the chat id and the hook looked under the
+        payload id, so it was told it had no workspace and to run a command that is
+        refused."""
+        workspace.set_active("north", session_id=CHAT, terminal_id="", force=True)
+        self.assertNotIn("Confirm the workspace", self._briefing())
+
+    def test_the_todo_digest_is_the_chats_workspace(self):
+        ctx = self._briefing()
+        self.assertIn("A TODO IN NORTH", ctx)
+        self.assertNotIn("A TODO IN THE DEFAULT WORKSPACE", ctx)
+
+    def test_its_own_workspace_is_not_listed_as_another(self):
+        """Measured before: the chat's own workspace among "17 other workspaces on this
+        plane"."""
+        block = _neighbours(self._briefing())
+        self.assertIn("`gamma`", block, "the block this case reads was not found")
+        self.assertNotIn("`north`", block)
+
+class OutsideAFrameThePayloadIdStillDecides(PlaneIso):
+    """The fallback. A harness outside a frame has no chat id, and its payload id is the only
+    session it has. There is no `$CHARTER_SESSION_ID` here at all: `PlaneIso` starts from an
+    environment that never saw charter, so the payload id is the only id either rung can
+    read. Green before the fix, deliberately: a fix that read the chat id alone would pass
+    every case above and fail these."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        for n in (config.DEFAULT_WORKSPACE, "gamma"):
+            workspace.ensure(n)
+        todos.add(config.DEFAULT_WORKSPACE, "A TODO IN THE DEFAULT WORKSPACE")
+
+    def _briefing(self) -> str:
+        return _context(run_hook(hooks.sessionstart, {"session_id": HARNESS_SID}))
+
+    def test_an_unconfirmed_session_is_still_asked(self):
+        self.assertIn("Confirm the workspace", self._briefing())
+
+    def test_a_lock_confirmed_under_the_payload_id_still_silences_it(self):
+        workspace.set_active("gamma", session_id=HARNESS_SID, terminal_id="")
+        ctx = self._briefing()
+        self.assertNotIn("Confirm the workspace", ctx)
+        self.assertNotIn("A TODO IN THE DEFAULT WORKSPACE", ctx)
+
+
+class ThePostToolUseMemoryNudgeAsksTheChatToo(PlaneIso):
+    """`_mem_cadence_nudge` resolved by the payload id as well. The issue read it from code;
+    this runs it. It names the workspace only when that workspace is LIVE, so `north` is the
+    one live workspace here and `default`, where the payload id fell through to, is not."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.enterContext(mock.patch.dict(os.environ, {"CHARTER_SESSION_ID": CHAT}))
+        self.enterContext(mock.patch("charter.frame.notify.plane_changed"))
+        self.enterContext(mock.patch.object(workspace, "is_live",
+                                            side_effect=lambda w: w == "north"))
+        for n in (config.DEFAULT_WORKSPACE, "north"):
+            workspace.ensure(n)
+        _plant(CHAT, ws="north")
+
+    def test_the_cadence_nudge_names_the_chats_workspace(self):
+        payload = {"session_id": HARNESS_SID, "tool_name": "Edit",
+                   "tool_input": {"file_path": str(config.ROOT / "notes" / "scratch.txt")}}
+        said = [run_hook(hooks.posttooluse, payload) for _ in range(hooks._MEM_NUDGE_EVERY)]
+        self.assertIn("workspace **north**", _context(said[-1]))
+
+
+class AChatOpenedInANamedWorkspaceIsBornLockedToIt(_DrivesTheLauncher, PlaneIso):
+    """`cmd_launch` with `--workspace` and no picker: the call `charter handoff` makes.
+
+    `_DrivesTheLauncher` launches into `alpha` with stdin not a terminal, so `_picker_wanted`
+    answers no and `_pin_workspace` writes nothing. That is the path whose chat had no lock.
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+        workspace.ensure("gamma")
+        calls = self._launch()
+        self.assertEqual(calls["rc"], 0)
+        made = sorted(d.name for d in state._root().iterdir() if d.is_dir())
+        self.assertEqual(made, ["alpha.1"])
+        self.fid = made[0]
+
+    def test_it_is_locked_to_the_workspace_it_was_opened_in(self):
+        self.assertEqual(workspace.is_locked(self.fid), "alpha")
+        self.assertIsNone(workspace.for_session(self.fid),
+                          "no picker ran, so the launch must have written nothing (#518)")
+
+    def test_its_first_briefing_asks_nothing(self):
+        with mock.patch.dict(os.environ, {"CHARTER_SESSION_ID": self.fid}), \
+                mock.patch("charter.frame.notify.plane_changed"):
+            ctx = _context(run_hook(hooks.sessionstart, {"session_id": HARNESS_SID}))
+        self.assertNotIn("Confirm the workspace", ctx)
+
+    def test_it_cannot_be_moved_to_another_workspace_by_a_command(self):
+        err = io.StringIO()
+        with mock.patch.dict(os.environ, {"CHARTER_SESSION_ID": self.fid}), \
+                redirect_stdout(io.StringIO()), redirect_stderr(err):
+            rc = commands_workspace.cmd_workspace_use(
+                SimpleNamespace(name="gamma", force=False, create=False))
+        self.assertEqual(rc, 2, err.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_a_chat_is_locked_to_the_workspace_it_was_launched_for.py
+++ b/tests/test_a_chat_is_locked_to_the_workspace_it_was_launched_for.py
@@ -40,7 +40,9 @@ drives the launcher itself rather than planting the record.
 from __future__ import annotations
 
 import io
+import json
 import os
+import sys
 import unittest
 from contextlib import redirect_stderr, redirect_stdout
 from types import SimpleNamespace
@@ -195,16 +197,46 @@ class WorkspaceUseInsideAChat(PersonaIso, unittest.TestCase):
         self.assertEqual(workspace.is_locked(), "north")
         self.assertEqual(self._use("north")[0], 0)
 
-    def test_the_routes_a_subagent_works_by_are_untouched(self):
-        """What #794 feared the refusal would break, asked after a refusal. Green before the
-        fix, deliberately: a sub-agent in `workspaces/gamma/…` acts on `gamma` because it
-        stands there, and `--workspace gamma` names it outright. Neither writes a pointer, so
-        neither is refused."""
-        self._use("gamma")
+    def test_the_routes_a_subagent_works_by_outrank_the_pointer(self):
+        """What #794 feared the refusal would break. A sub-agent in `workspaces/delta/…`
+        acts on `delta` because it stands there, and `--workspace delta` names it outright.
+
+        **A pointer to a THIRD workspace is written first, and that is the whole case.**
+        Asked after a refusal alone, this asserted only that the cwd rung answers — there
+        was no pointer for it to outrank, because the refused command wrote none. So the
+        forced switch to `gamma` puts one there, and `delta` still wins from both routes."""
+        workspace.ensure("delta")
+        self._use("gamma", force=True)
+        self.assertEqual(workspace.for_session(CHAT), "gamma",
+                         "the pointer this case is about was never written")
+        tree = config.WORKSPACES_DIR / "delta" / "api"
+        tree.mkdir(parents=True, exist_ok=True)
+        self.assertEqual(workspace.resolve(cwd=tree), "delta")
+        self.assertEqual(workspace.resolve("delta"), "delta")
+
+    def test_a_forced_switch_does_not_claim_a_lock_charter_does_not_hold(self):
+        """ADR 0013: charter names a divergence between its own records rather than
+        printing the happier one.
+
+        Measured before: `workspace use gamma --force` answered *"Active workspace
+        re-locked to 'gamma' … 🔒 locked for this session"*, and the very next
+        `workspace use delta` answered *"locked to 'north'"*. Two commands, two answers, and
+        the first one was the wrong one: `--force` moves this session's commands and never
+        the chat, so the lock is still the workspace the chat was launched in."""
+        _rc, err = self._use("gamma", force=True)
+        self.assertIn("north", err, "the lock that actually stands was not named")
+        self.assertNotIn("re-locked", err)
+
+    def test_workspace_current_names_the_lock_it_is_not_resolving_to(self):
+        """The same divergence on the command that exists to explain the resolution, and
+        the flow #794 protected: a sub-agent standing in another workspace's tree resolves
+        by its cwd, which is right, while the lock is still the chat's own."""
         tree = config.WORKSPACES_DIR / "gamma" / "api"
         tree.mkdir(parents=True, exist_ok=True)
-        self.assertEqual(workspace.resolve(cwd=tree), "gamma")
-        self.assertEqual(workspace.resolve("gamma"), "gamma")
+        with mock.patch("os.getcwd", return_value=str(tree)):
+            rc, err = self._run(commands_workspace.cmd_workspace_current)
+        self.assertEqual(rc, 0)
+        self.assertIn("locked to 'north'", err)
 
     def test_create_with_use_makes_the_workspace_and_names_the_same_fix(self):
         """`create --use` goes through the same `set_active`, so it meets the same lock. The
@@ -235,6 +267,64 @@ class WorkspaceUseInsideAChat(PersonaIso, unittest.TestCase):
         self.assertEqual(len(said), 1, said)
         self.assertNotIn("workspace unlock", said[0])
         self.assertIn("open a chat", said[0])
+
+
+class TheSessionStartReconcileAsksTheChatToo(PersonaIso, unittest.TestCase):
+    """`charter workspace _reconcile`, the FOURTH SessionStart workspace question.
+
+    It is a real hook (`charter/cli.py`, asserted shipped by `tests/test_plugin.py`), and it
+    read `$CLAUDE_CODE_SESSION_ID` or the payload's `session_id` and seeded a pointer under
+    it. Inside a frame that is the HARNESS's id, and nothing on this plane reads it:
+    `workspace.chosen` resolves by `session.current()`, which is the CHAT's id there, and
+    `frame/state._forget_session` reaps `<chat id>.*`. So the write was unread and unreaped —
+    the same miskey as #936's other three, in the one hook that WRITES.
+
+    Seeding under the chat id instead is not the fix either, and this class pins that too. A
+    chat's workspace is its launch record; a pointer seeded from the pane charter itself
+    created for the harness would outrank that record in `chosen` and move the chat's
+    commands off it, silently, which is the failure #936 is about.
+    """
+
+    PANE = "%7"
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.enterContext(mock.patch.dict(
+            os.environ, {"CHARTER_SESSION_ID": CHAT, "TMUX_PANE": self.PANE}))
+        for n in ("north", "gamma"):
+            workspace.ensure(n)
+        _plant(CHAT, ws="north")
+        # What the reconcile seeds FROM: a selection left on this pane. Written the way
+        # `tests/test_workspace_lock` writes one, through the id `session.terminal` mints.
+        tid = workspace._terminal_id(self.PANE)
+        config.TERMINALS_DIR.mkdir(parents=True, exist_ok=True)
+        (config.TERMINALS_DIR / f"{tid}.workspace").write_text("gamma\n")
+
+    def _reconcile(self) -> None:
+        old = sys.stdin
+        sys.stdin = io.StringIO(json.dumps({"session_id": HARNESS_SID}))
+        try:
+            with redirect_stdout(io.StringIO()), redirect_stderr(io.StringIO()):
+                commands_workspace.cmd_workspace_reconcile(SimpleNamespace())
+        finally:
+            sys.stdin = old
+
+    def test_no_pointer_lands_under_the_harness_id(self):
+        """The file the old key wrote: `.charter/sessions/<harness uuid>.workspace`, which
+        nothing resolves by and no reap collects."""
+        self._reconcile()
+        self.assertFalse((config.SESSIONS_DIR / f"{HARNESS_SID}.workspace").exists())
+
+    def test_no_pointer_lands_under_the_chat_id_either(self):
+        """Keying it on the chat would be worse than useless: the chat's own commands would
+        move to the pane's leftover workspace, outranking the launch record."""
+        self._reconcile()
+        self.assertFalse((config.SESSIONS_DIR / f"{CHAT}.workspace").exists())
+
+    def test_the_chat_still_resolves_and_is_locked_to_its_launch(self):
+        self._reconcile()
+        self.assertEqual(workspace.resolve(cwd=config.ROOT), "north")
+        self.assertEqual(workspace.is_locked(), "north")
 
 
 class SessionStartBriefsTheChatForItsOwnWorkspace(PlaneIso):

--- a/tests/test_a_chat_is_locked_to_the_workspace_it_was_launched_for.py
+++ b/tests/test_a_chat_is_locked_to_the_workspace_it_was_launched_for.py
@@ -238,6 +238,20 @@ class WorkspaceUseInsideAChat(PersonaIso, unittest.TestCase):
                       "the lock that actually stands was not named")
         self.assertNotIn("re-locked", err)
 
+    def test_create_use_force_in_a_chat_does_not_claim_the_lock_either(self):
+        """Review round 2, measured: `create delta --use --force` in this chat printed
+        "Active workspace set to 'delta' … locked for this session" while `is_locked()` was
+        `north`, and `use gamma --force` one line later said "still locked to 'north'". The
+        two success paths now say one thing, because one helper says it for both."""
+        rc, err = self._run(commands_workspace.cmd_workspace_create,
+                            name="delta", use=True, force=True, repos=[])
+        self.assertEqual(rc, 0, err)
+        self.assertEqual(workspace.is_locked(), "north")
+        self.assertIn("Active workspace set to 'delta'", err)
+        self.assertIn("this session's commands only", err)
+        self.assertIn("still locked to 'north'", err)
+        self.assertNotIn("locked for this session", err)
+
     def test_workspace_current_names_the_lock_it_is_not_resolving_to(self):
         """The same divergence on the command that exists to explain the resolution, and
         the flow #794 protected: a sub-agent standing in another workspace's tree resolves
@@ -248,6 +262,8 @@ class WorkspaceUseInsideAChat(PersonaIso, unittest.TestCase):
             rc, err = self._run(commands_workspace.cmd_workspace_current)
         self.assertEqual(rc, 0)
         self.assertIn("locked to 'north'", err)
+        # `current` switched nothing, so it names the lock and does not narrate a switch.
+        self.assertNotIn("still", err)
 
     def test_create_with_use_makes_the_workspace_and_names_the_same_fix(self):
         """`create --use` goes through the same `set_active`, so it meets the same lock. The

--- a/tests/test_a_chat_is_locked_to_the_workspace_it_was_launched_for.py
+++ b/tests/test_a_chat_is_locked_to_the_workspace_it_was_launched_for.py
@@ -224,7 +224,11 @@ class WorkspaceUseInsideAChat(PersonaIso, unittest.TestCase):
         the first one was the wrong one: `--force` moves this session's commands and never
         the chat, so the lock is still the workspace the chat was launched in."""
         _rc, err = self._use("gamma", force=True)
-        self.assertIn("north", err, "the lock that actually stands was not named")
+        # The PHRASE, not just the name: `'{locked}'` is interpolated, so asserting only
+        # `north` passes against any sentence at all — measured, a re-spelling of this line
+        # survived the whole module.
+        self.assertIn("still locked to 'north'", err,
+                      "the lock that actually stands was not named")
         self.assertNotIn("re-locked", err)
 
     def test_workspace_current_names_the_lock_it_is_not_resolving_to(self):

--- a/tests/test_a_chat_is_locked_to_the_workspace_it_was_launched_for.py
+++ b/tests/test_a_chat_is_locked_to_the_workspace_it_was_launched_for.py
@@ -283,22 +283,58 @@ class WorkspaceUseInsideAChat(PersonaIso, unittest.TestCase):
         self.assertNotIn(f"'{config.DEFAULT_WORKSPACE}'", err)
         self.assertNotIn("reports no pane id", err)
 
-    def test_a_pane_pointer_written_in_a_chat_is_not_promised_to_the_next_session(self):
-        """The same sentence with a pane id, which is the ordinary case: tmux sets `$TMUX_PANE`
-        in every process it starts, a chat's harness included. The note said "kept across
-        closing/reopening Claude" beside a forced `gamma`, and the next chat in `north` does
-        not resolve to it: its launch record answers before the pane pointer is read."""
-        with mock.patch.object(workspace, "_terminal_id", return_value="pane-f"):
+    #: What a harness inherits when `charter claude` is typed in Terminal.app or iTerm2 without
+    #: tmux. `commands_frame._frame_env` strips `TMUX`, `TMUX_PANE` and the size variables and
+    #: nothing else of this kind, and `session.terminal` ranks this variable first.
+    LAUNCHER = "w0t0p0:0A1B2C3D-0936"
+
+    def _launcher_chose(self) -> str | None:
+        """What the shell `charter claude` was typed in answers: the same terminal id, and no
+        chat id. `commands_frame._choose_workspace` asks exactly this, and opens the picker
+        only when it answers `None`."""
+        with mock.patch.dict(os.environ, {"TERM_SESSION_ID": self.LAUNCHER}):
+            os.environ.pop("CHARTER_SESSION_ID", None)
+            return workspace.chosen(cwd=config.ROOT)
+
+    def test_use_in_a_chat_writes_no_pointer_for_the_terminal_that_launched_it(self):
+        """Review round 4, measured: with `$TERM_SESSION_ID` inherited, `use gamma --force`
+        here wrote `terminals/<launcher>.workspace` = `gamma` and printed "(this chat only …)".
+        The launching shell's `workspace.chosen()` then answered `gamma` through the terminal
+        rung, and the next `charter claude` from that terminal opened in `gamma` with no picker.
+
+        Nothing is mocked. Round 3's case patched `_terminal_id`, the seam this state goes
+        through, and asserted the pane pointer WAS written, which is the defect itself."""
+        before = self._launcher_chose()
+        with mock.patch.dict(os.environ, {"TERM_SESSION_ID": self.LAUNCHER}):
+            self.assertTrue(workspace._terminal_id(),
+                            "the chat reports no terminal id, so this measures nothing")
             rc, err = self._use("gamma", force=True)
-            _plant("north.2", ws="north")
-            nxt = workspace.resolve(session_id="north.2", cwd=config.ROOT)
+            here = workspace.resolve(cwd=config.ROOT)
         self.assertEqual(rc, 0, err)
-        self.assertTrue(workspace._terminal_file("pane-f").exists(),
-                        "no pane pointer was written, so this measures nothing")
-        self.assertEqual(nxt, "north", "the pane pointer did reach the next session")
-        self.assertNotIn("kept across closing/reopening Claude", err)
+        self.assertEqual(here, "gamma", "the chat's own commands stopped following the switch")
+        written = (sorted(p.name for p in config.TERMINALS_DIR.iterdir())
+                   if config.TERMINALS_DIR.is_dir() else [])
+        self.assertEqual(written, [], "a chat wrote a terminal pointer")
+        self.assertEqual(self._launcher_chose(), before,
+                         "the launching terminal's resolution moved")
         self.assertIn("(this chat only — a new chat starts at the workspace it is opened in)",
                       err)
+
+    def test_even_an_unforced_use_in_a_chat_leaves_the_launching_terminal_alone(self):
+        """The same write with no `--force`. `use north` is this chat's own workspace, which the
+        lock allows, and it rewrote the pointer of the terminal that launched the chat. That
+        terminal had chosen `delta` for itself, the pointer `_pin_workspace` leaves a launcher."""
+        workspace.ensure("delta")
+        with mock.patch.dict(os.environ, {"TERM_SESSION_ID": self.LAUNCHER}):
+            os.environ.pop("CHARTER_SESSION_ID", None)
+            self.assertEqual(workspace.set_active("delta"), "terminal",
+                             "the launcher's own pointer was not planted")
+        self.assertEqual(self._launcher_chose(), "delta")
+        with mock.patch.dict(os.environ, {"TERM_SESSION_ID": self.LAUNCHER}):
+            rc, err = self._use("north")
+        self.assertEqual(rc, 0, err)
+        self.assertEqual(self._launcher_chose(), "delta",
+                         "a chat moved the choice of the terminal that launched it")
 
     def test_workspace_current_names_the_lock_it_is_not_resolving_to(self):
         """The same divergence on the command that exists to explain the resolution, and

--- a/tests/test_a_chat_is_locked_to_the_workspace_it_was_launched_for.py
+++ b/tests/test_a_chat_is_locked_to_the_workspace_it_was_launched_for.py
@@ -170,6 +170,11 @@ class WorkspaceUseInsideAChat(PersonaIso, unittest.TestCase):
         """A conversation wanted elsewhere is a new chat (§4j), so the way out is a chat in
         `gamma`. `unlock` is not named because it releases nothing here."""
         _rc, err = self._use("gamma")
+        # This sentence's OWN words, not only the shared way-out clause below it: asserting
+        # the clause alone leaves the lead free to say anything at all, which is how a
+        # re-spelling of it survived the whole module when measured.
+        self.assertIn("locked to 'north', the workspace this chat was launched in", err)
+        self.assertIn("would leave the chat itself in 'north'", err)
         self.assertIn("open a chat", err)
         self.assertIn("F2 → workspace", err)
         self.assertNotIn("workspace unlock", err)
@@ -227,6 +232,7 @@ class WorkspaceUseInsideAChat(PersonaIso, unittest.TestCase):
         # The PHRASE, not just the name: `'{locked}'` is interpolated, so asserting only
         # `north` passes against any sentence at all — measured, a re-spelling of this line
         # survived the whole module.
+        self.assertIn("this session's commands only", err)
         self.assertIn("still locked to 'north'", err,
                       "the lock that actually stands was not named")
         self.assertNotIn("re-locked", err)
@@ -249,6 +255,7 @@ class WorkspaceUseInsideAChat(PersonaIso, unittest.TestCase):
                             name="delta", use=True, force=False, repos=[])
         self.assertEqual(rc, 2)
         self.assertTrue((config.WORKSPACES_DIR / "delta").is_dir())
+        self.assertIn("Workspace 'delta' was created.", err)
         self.assertIn("open a chat", err)
         self.assertNotIn("start a new session", err)
 
@@ -258,6 +265,8 @@ class WorkspaceUseInsideAChat(PersonaIso, unittest.TestCase):
         that refuses the next switch is two answers to one question."""
         rc, err = self._run(commands_workspace.cmd_workspace_unlock)
         self.assertEqual(rc, 2)
+        self.assertIn("locked to 'north', the workspace it was launched in", err)
+        self.assertIn("nothing unlocks that", err)
         self.assertIn("open a chat", err)
         self.assertEqual(workspace.is_locked(), "north")
 

--- a/tests/test_a_chat_is_locked_to_the_workspace_it_was_launched_for.py
+++ b/tests/test_a_chat_is_locked_to_the_workspace_it_was_launched_for.py
@@ -252,6 +252,54 @@ class WorkspaceUseInsideAChat(PersonaIso, unittest.TestCase):
         self.assertIn("still locked to 'north'", err)
         self.assertNotIn("locked for this session", err)
 
+    def test_a_rename_after_a_forced_switch_names_the_lock_that_stands(self):
+        """Review round 3, state G, measured: `use gamma --force` here, then `rename gamma
+        gamma2`, printed "followed the rename → 'gamma2' (still 🔒 locked)" while `is_locked()`
+        was `north`, and `workspace current` in the same chat said "🔒 locked to 'north'".
+        `rename` wrote its own lock clause and asked nothing; it now asks what `current` asks,
+        so the two commands give one answer."""
+        self._use("gamma", force=True)
+        rc, err = self._run(commands_workspace.cmd_workspace_rename,
+                            old="gamma", new="gamma2", message=None)
+        self.assertEqual(rc, 0, err)
+        self.assertEqual(workspace.is_locked(), "north")
+        self.assertIn("followed the rename → 'gamma2' (🔒 locked to 'north')", err)
+        self.assertNotIn("still 🔒 locked", err)
+        _rc, said = self._run(commands_workspace.cmd_workspace_current)
+        self.assertIn("🔒 locked to 'north'", said)
+
+    def test_the_scope_note_names_where_the_chats_next_session_starts(self):
+        """Review round 3, minor 2: with no pane id, `use north` here said "this terminal
+        reports no pane id, so a new session starts at 'default'". Inside a frame a new chat
+        resolves by its own launch record (`workspace.for_frame`, which outranks the terminal
+        pointer and the declared default), so it starts at the workspace it is opened in, and a
+        missing pane id is not the reason. Not "starts at 'north'": a chat opened on another
+        workspace's tab starts there."""
+        with mock.patch.object(workspace, "_terminal_id", return_value=None):
+            rc, err = self._use("north")
+        self.assertEqual(rc, 0, err)
+        self.assertIn("(this chat only — a new chat starts at the workspace it is opened in)",
+                      err)
+        self.assertNotIn(f"'{config.DEFAULT_WORKSPACE}'", err)
+        self.assertNotIn("reports no pane id", err)
+
+    def test_a_pane_pointer_written_in_a_chat_is_not_promised_to_the_next_session(self):
+        """The same sentence with a pane id, which is the ordinary case: tmux sets `$TMUX_PANE`
+        in every process it starts, a chat's harness included. The note said "kept across
+        closing/reopening Claude" beside a forced `gamma`, and the next chat in `north` does
+        not resolve to it: its launch record answers before the pane pointer is read."""
+        with mock.patch.object(workspace, "_terminal_id", return_value="pane-f"):
+            rc, err = self._use("gamma", force=True)
+            _plant("north.2", ws="north")
+            nxt = workspace.resolve(session_id="north.2", cwd=config.ROOT)
+        self.assertEqual(rc, 0, err)
+        self.assertTrue(workspace._terminal_file("pane-f").exists(),
+                        "no pane pointer was written, so this measures nothing")
+        self.assertEqual(nxt, "north", "the pane pointer did reach the next session")
+        self.assertNotIn("kept across closing/reopening Claude", err)
+        self.assertIn("(this chat only — a new chat starts at the workspace it is opened in)",
+                      err)
+
     def test_workspace_current_names_the_lock_it_is_not_resolving_to(self):
         """The same divergence on the command that exists to explain the resolution, and
         the flow #794 protected: a sub-agent standing in another workspace's tree resolves

--- a/tests/test_a_chat_is_locked_to_the_workspace_it_was_launched_for.py
+++ b/tests/test_a_chat_is_locked_to_the_workspace_it_was_launched_for.py
@@ -232,6 +232,7 @@ class WorkspaceUseInsideAChat(PersonaIso, unittest.TestCase):
         # The PHRASE, not just the name: `'{locked}'` is interpolated, so asserting only
         # `north` passes against any sentence at all — measured, a re-spelling of this line
         # survived the whole module.
+        self.assertIn("Active workspace set to 'gamma'", err)
         self.assertIn("this session's commands only", err)
         self.assertIn("still locked to 'north'", err,
                       "the lock that actually stands was not named")

--- a/tests/test_a_frame_answers_for_the_frames_workspace.py
+++ b/tests/test_a_frame_answers_for_the_frames_workspace.py
@@ -123,9 +123,15 @@ class TheHarnessAnswersForTheFrameItRunsIn(FramedCase):
         """The direction #517 asks for, and the promise `charter ws use` already makes.
         The launcher's answer is a SEED, never a pin: pinning the session to the frame is
         the option #524 weighs and rejects, because it would take `ws use` away from every
-        framed session."""
+        framed session.
+
+        **Forced since #936.** A chat's lock is now its launch record, so an unforced switch
+        out of it is refused. That is a lock and not a pin, and this case is the
+        difference: `--force` still moves this session's commands, where a pinned
+        `$CHARTER_WORKSPACE` would outrank the pointer and make even a forced switch not
+        stick."""
         with self.inside_the_frame():
-            workspace.set_active(OTHER, terminal_id="")
+            workspace.set_active(OTHER, terminal_id="", force=True)
             self.assertEqual(workspace.resolve(), OTHER)
             self.assertEqual(workspace.source(), "session")
 

--- a/tests/test_a_reaped_chat_leaves_its_session_behind.py
+++ b/tests/test_a_reaped_chat_leaves_its_session_behind.py
@@ -21,9 +21,11 @@ the pointer (`workspace.resolve`, `for_session`) and the files themselves; none 
 reproduces the refusal, because nothing can.
 
 #794 closed the visible half: the panels draw `alpha` and the chat belongs to `alpha`,
-because `state.own_workspace` no longer reads that pointer. What that leaves is worse to
-read than a wrong label — the panels and the commands now disagree, and the operator is
-told `locked` by a lock nobody in this chat set.
+because `state.own_workspace` no longer reads that pointer. What that left was worse to
+read than a wrong label: the panels and the commands disagreed, and the operator was told
+`locked` by a lock nobody in that chat had set. #936 took the refusal away. What an unreaped
+id still costs is the first half, the new chat's commands following its predecessor's
+pointer.
 
 **The sweep is the directory prefix, not a list of two suffixes**, and that is
 `workspace._prune`'s lesson taken at its word rather than re-learned (#366): its allowlist
@@ -109,7 +111,7 @@ class ARecycledOrdinalStartsFromNothing(_ReapedChat):
         self.assertIsNone(workspace.for_session(again))
 
     def test_the_lock_does_not_outlive_the_frame(self):
-        """The half that survived #794, and the one the operator meets as a refusal.
+        """The half that survived #794, and the one the operator met as a refusal until #936.
 
         **Restaged by #936.** This asserted `is_locked` → `gamma` before the reap and
         `None` after it. A chat's lock is now its launch record, which outranks the file, so

--- a/tests/test_a_reaped_chat_leaves_its_session_behind.py
+++ b/tests/test_a_reaped_chat_leaves_its_session_behind.py
@@ -127,17 +127,23 @@ class ARecycledOrdinalStartsFromNothing(_ReapedChat):
         """`charter claude --workspace alpha`, then `charter workspace use alpha` — the
         exact sequence #731 reports, and the one that answered `locked`.
 
-        Since #936 this holds even with the predecessor's lock file left behind, because
-        a chat's launch record outranks it. The reap itself is measured by
-        `test_the_lock_does_not_outlive_the_frame`, which asserts the file."""
+        **The select itself can no longer fail**, because a chat's launch record outranks a
+        stale lock file (#936) — so the case asserts the state the relaunch starts FROM,
+        which the reap decides and which nothing else here asserts in this order: the
+        predecessor's pointer is gone before the new chat runs a command. The lock file's
+        own reap is `test_the_lock_does_not_outlive_the_frame`."""
         fid = self.open_chat()
         self.choose(fid, "gamma")
 
         self.reap_all()
         again = self.open_chat()
 
+        self.assertEqual(again, fid, "the ordinal must be recycled or this measures nothing")
+        self.assertIsNone(workspace.for_session(again),
+                          "the relaunch started from its predecessor's pointer")
         self.assertEqual(
             workspace.set_active("alpha", session_id=again, terminal_id=""), "session")
+        self.assertEqual(workspace.resolve(session_id=again, cwd=config.ROOT), "alpha")
 
     def test_resolution_in_the_new_chats_shell_is_not_the_old_chats_choice(self):
         """`workspace.resolve` is what every `charter` command in the frame's own shell

--- a/tests/test_a_reaped_chat_leaves_its_session_behind.py
+++ b/tests/test_a_reaped_chat_leaves_its_session_behind.py
@@ -63,6 +63,16 @@ class _ReapedChat(PersonaIso):
         state.record_workspace(fid, ws)
         return fid
 
+    def choose(self, fid: str, ws: str) -> None:
+        """A selection made inside the chat that disagrees with its launch, as the
+        predecessor on a recycled ordinal made it.
+
+        **Forced, since #936.** A chat's lock is its launch record, so an unforced switch
+        out of its own workspace is refused and writes nothing, and every case below would
+        reap markers that were never there. `--force` is the one way a chat still writes a
+        pointer and a lock naming another workspace, so it is the state #731 is about."""
+        workspace.set_active(ws, session_id=fid, terminal_id="", force=True)
+
     def reap_all(self) -> list[str]:
         # `config.STATE_DIR` is asserted, not assumed: this test's whole subject is a
         # recursive delete under the state directory, and `PersonaIso` repointing it is
@@ -83,7 +93,7 @@ class ARecycledOrdinalStartsFromNothing(_ReapedChat):
 
     def test_the_workspace_pointer_does_not_outlive_the_frame(self):
         fid = self.open_chat()
-        workspace.set_active("gamma", session_id=fid, terminal_id="")
+        self.choose(fid, "gamma")
         self.assertEqual(workspace.for_session(fid), "gamma")
 
         self.reap_all()
@@ -93,21 +103,35 @@ class ARecycledOrdinalStartsFromNothing(_ReapedChat):
         self.assertIsNone(workspace.for_session(again))
 
     def test_the_lock_does_not_outlive_the_frame(self):
-        """The half that survived #794, and the one the operator meets as a refusal."""
+        """The half that survived #794, and the one the operator meets as a refusal.
+
+        **Restaged by #936.** This asserted `is_locked` → `gamma` before the reap and
+        `None` after it. A chat's lock is now its launch record, which outranks the file, so
+        `is_locked` answers `alpha` on both sides of the reap and can no longer see the file
+        go. The file is what #731 is about, so the file is what is asserted, and `is_locked`
+        is asserted for what the operator meets: the relaunch is locked to the workspace it
+        was launched with."""
         fid = self.open_chat()
-        workspace.set_active("gamma", session_id=fid, terminal_id="")
-        self.assertEqual(workspace.is_locked(fid), "gamma")
+        self.choose(fid, "gamma")
+        lock = config.SESSIONS_DIR / f"{fid}.lock"
+        self.assertTrue(lock.exists(), "the fixture wrote no lock, so this measures nothing")
 
         self.reap_all()
         again = self.open_chat()
 
-        self.assertIsNone(workspace.is_locked(again))
+        self.assertEqual(again, fid, "the ordinal must be recycled or this measures nothing")
+        self.assertFalse(lock.exists())
+        self.assertEqual(workspace.is_locked(again), "alpha")
 
     def test_the_new_chat_can_select_the_workspace_it_was_launched_with(self):
         """`charter claude --workspace alpha`, then `charter workspace use alpha` — the
-        exact sequence #731 reports, and the one that answered `locked`."""
+        exact sequence #731 reports, and the one that answered `locked`.
+
+        Since #936 this holds even with the predecessor's lock file left behind, because
+        a chat's launch record outranks it. The reap itself is measured by
+        `test_the_lock_does_not_outlive_the_frame`, which asserts the file."""
         fid = self.open_chat()
-        workspace.set_active("gamma", session_id=fid, terminal_id="")
+        self.choose(fid, "gamma")
 
         self.reap_all()
         again = self.open_chat()
@@ -119,7 +143,7 @@ class ARecycledOrdinalStartsFromNothing(_ReapedChat):
         """`workspace.resolve` is what every `charter` command in the frame's own shell
         acts on — `charter clone`, `charter repos`, `charter ws current`."""
         fid = self.open_chat()
-        workspace.set_active("gamma", session_id=fid, terminal_id="")
+        self.choose(fid, "gamma")
         self.assertEqual(workspace.resolve(session_id=fid), "gamma")
 
         self.reap_all()
@@ -215,20 +239,22 @@ class TheWholeFamilyGoesNotTwoSuffixes(_ReapedChat):
         """The direction that would cost the operator their working state: reaping is
         keyed on the directory that was actually removed, never on the sweep running."""
         kept = self.open_chat()
-        workspace.set_active("gamma", session_id=kept, terminal_id="")
+        self.choose(kept, "gamma")
 
         self.assertIn("edm-test-", str(config.STATE_DIR))
         with mock.patch.object(state, "_launcher_is_alive", return_value=False):
             self.assertEqual(state.reap({kept}, server=SERVER), [])
 
         self.assertEqual(workspace.for_session(kept), "gamma")
-        self.assertEqual(workspace.is_locked(kept), "gamma")
+        # The lock FILE, not `is_locked`: since #936 a chat's lock is its launch record,
+        # which outranks this file and answers `alpha` whether or not the file survived.
+        self.assertTrue((config.SESSIONS_DIR / f"{kept}.lock").exists())
 
     def test_a_frame_on_another_server_keeps_its_selection(self):
         """`reap` is scoped to one server (#381); the marker sweep inherits that scope
         because it happens only where the directory was removed."""
         fid = self.open_chat()
-        workspace.set_active("gamma", session_id=fid, terminal_id="")
+        self.choose(fid, "gamma")
 
         self.assertIn("edm-test-", str(config.STATE_DIR))
         with mock.patch.object(state, "_launcher_is_alive", return_value=False):
@@ -248,7 +274,7 @@ class AFilesystemThatRefuses(_ReapedChat):
 
     def test_a_sessions_directory_that_cannot_be_listed_costs_nothing_else(self):
         fid = self.open_chat()
-        workspace.set_active("gamma", session_id=fid, terminal_id="")
+        self.choose(fid, "gamma")
 
         self.assertIn("edm-test-", str(config.STATE_DIR))
         real = state.Path.iterdir
@@ -269,7 +295,7 @@ class AFilesystemThatRefuses(_ReapedChat):
 
     def test_one_marker_that_cannot_be_unlinked_does_not_strand_the_rest(self):
         fid = self.open_chat()
-        workspace.set_active("gamma", session_id=fid, terminal_id="")
+        self.choose(fid, "gamma")
         stuck = config.SESSIONS_DIR / f"{fid}.lock"
         real = state.Path.unlink
 

--- a/tests/test_a_reaped_chat_leaves_its_session_behind.py
+++ b/tests/test_a_reaped_chat_leaves_its_session_behind.py
@@ -9,10 +9,16 @@ name mean a new chat is reaping the state keyed on the old one.
 `reap` removed `.charter/frame/<fid>/` and nothing else. Everything charter keys on the
 charter session id lives one directory over, in `.charter/sessions/<fid>.*` — and inside
 a frame the frame **is** the charter session (ADR 0019), so `<fid>` is that key. The
-measured result, reproduced below without tmux: a relaunched `alpha.1` whose predecessor
-had selected `gamma` comes up `is_locked: gamma`, `workspace.resolve: gamma`, and
-`charter workspace use alpha` — typed by the operator who just launched with
-`--workspace alpha` — is **refused as locked**.
+measured result, as #731 reported it: a relaunched `alpha.1` whose predecessor had selected
+`gamma` came up `is_locked: gamma`, `workspace.resolve: gamma`, and `charter workspace use
+alpha` — typed by the operator who had just launched with `--workspace alpha` — was
+**refused as locked**.
+
+**Only the pointer half of that is still reachable, and it is what these cases measure.**
+Since #936 a chat's lock is its launch record, which outranks any `.lock` file left under
+its id, so the relaunch can no longer be refused its own workspace. The cases below assert
+the pointer (`workspace.resolve`, `for_session`) and the files themselves; none of them
+reproduces the refusal, because nothing can.
 
 #794 closed the visible half: the panels draw `alpha` and the chat belongs to `alpha`,
 because `state.own_workspace` no longer reads that pointer. What that leaves is worse to
@@ -122,28 +128,6 @@ class ARecycledOrdinalStartsFromNothing(_ReapedChat):
         self.assertEqual(again, fid, "the ordinal must be recycled or this measures nothing")
         self.assertFalse(lock.exists())
         self.assertEqual(workspace.is_locked(again), "alpha")
-
-    def test_the_new_chat_can_select_the_workspace_it_was_launched_with(self):
-        """`charter claude --workspace alpha`, then `charter workspace use alpha` — the
-        exact sequence #731 reports, and the one that answered `locked`.
-
-        **The select itself can no longer fail**, because a chat's launch record outranks a
-        stale lock file (#936) — so the case asserts the state the relaunch starts FROM,
-        which the reap decides and which nothing else here asserts in this order: the
-        predecessor's pointer is gone before the new chat runs a command. The lock file's
-        own reap is `test_the_lock_does_not_outlive_the_frame`."""
-        fid = self.open_chat()
-        self.choose(fid, "gamma")
-
-        self.reap_all()
-        again = self.open_chat()
-
-        self.assertEqual(again, fid, "the ordinal must be recycled or this measures nothing")
-        self.assertIsNone(workspace.for_session(again),
-                          "the relaunch started from its predecessor's pointer")
-        self.assertEqual(
-            workspace.set_active("alpha", session_id=again, terminal_id=""), "session")
-        self.assertEqual(workspace.resolve(session_id=again, cwd=config.ROOT), "alpha")
 
     def test_resolution_in_the_new_chats_shell_is_not_the_old_chats_choice(self):
         """`workspace.resolve` is what every `charter` command in the frame's own shell

--- a/tests/test_frame_owns_the_surface.py
+++ b/tests/test_frame_owns_the_surface.py
@@ -395,8 +395,11 @@ class PanelFollowsWorkspaceUseOnAFrameWithNoRecord(PersonaIso, unittest.TestCase
         workspace.ensure("alpha")
         workspace.ensure("beta")
         state.record_workspace(fid, "alpha")
+        # Forced: with a launch record this frame is a chat, and since #936 a chat's lock
+        # refuses an unforced switch out of its own workspace, which would leave no pointer
+        # for this case to show the panel ignoring.
         with mock.patch.dict(os.environ, {"CHARTER_SESSION_ID": fid}, clear=True):
-            workspace.set_active("beta")
+            workspace.set_active("beta", force=True)
             self.assertEqual(workspace.for_session(fid), "beta",
                              "the pointer this case is about was not written")
         self.assertIn("alpha", self._top(fid))

--- a/tests/test_frame_pickers.py
+++ b/tests/test_frame_pickers.py
@@ -434,9 +434,14 @@ class ARefusedSwitchSaysSoOnScreen(_Frame, unittest.TestCase):
         taking the lock at launch was that the frame has a way out, and it named `F2 →
         workspace` first — so the property asserted here is the one that argument now
         rests on: the lock a launch or an agent took is still standing after the keypress,
-        untouched, and `charter workspace unlock` is what releases it. Silently moving it
-        would be worse than either: the agent's next command would act on a workspace
-        nobody was told about."""
+        untouched. Silently moving it would be worse than either: the agent's next command
+        would act on a workspace nobody was told about.
+
+        **Since #936 `is_locked` cannot see a keypress that rewrote the lock file.** A
+        chat's lock is its launch record, which outranks the file, and `charter workspace
+        unlock` no longer releases it either. So the pointer is asserted as well: a switch
+        that wrote `beta` under this chat would move what its commands act on, which is the
+        silent move this case is about."""
         workspace.set_active("alpha", session_id=self.FID)
         roster = choose.roster(choose.WORKSPACE, self.FID)
         row = next(r for r in roster.rows if roster.name_of(r) == "beta")
@@ -444,6 +449,7 @@ class ARefusedSwitchSaysSoOnScreen(_Frame, unittest.TestCase):
         self.assertTrue(out.ok, out.message)
         self.assertEqual(state.workspace_for(self.FID), "alpha")
         self.assertEqual(workspace.is_locked(self.FID), "alpha")
+        self.assertEqual(workspace.for_session(self.FID), "alpha")
 
 
 class APinnedFrameIsToldBeforeItPressesAnything(_Frame, unittest.TestCase):

--- a/tests/test_frame_slots.py
+++ b/tests/test_frame_slots.py
@@ -473,7 +473,12 @@ class EveryPanelDrawsTheFramesOwnWorkspace(PersonaIso, unittest.TestCase):
         """
         state.record_workspace("f-1", self.OTHER)
         with mock.patch.dict(os.environ, {"CHARTER_SESSION_ID": "f-1"}):
-            self.assertNotEqual(workspace.set_active("chosen-later", force=True), "locked")
+            workspace.set_active("chosen-later", force=True)
+        # The pointer, not `set_active`'s return: forced, it cannot answer "locked", so
+        # asserting that it did not was a guard nothing could turn red. What must be true
+        # for this case to mean anything is that the switch really wrote the pointer the
+        # panels are then shown to ignore.
+        self.assertEqual(workspace.for_session("f-1"), "chosen-later")
         out = self._render("top")
         self.assertIn(self.OTHER, out)
         self.assertNotIn("chosen-later", out,

--- a/tests/test_frame_slots.py
+++ b/tests/test_frame_slots.py
@@ -467,10 +467,13 @@ class EveryPanelDrawsTheFramesOwnWorkspace(PersonaIso, unittest.TestCase):
         writer as before — the real `workspace.set_active` with the frame's id in the
         environment, because that is exactly what `charter workspace use` does — and the
         assertion is the one that is now true.
+
+        **Forced since #936.** A chat's lock is its launch record, so an unforced switch
+        out of its own workspace is refused and writes nothing for the panels to ignore.
         """
         state.record_workspace("f-1", self.OTHER)
         with mock.patch.dict(os.environ, {"CHARTER_SESSION_ID": "f-1"}):
-            self.assertNotEqual(workspace.set_active("chosen-later"), "locked")
+            self.assertNotEqual(workspace.set_active("chosen-later", force=True), "locked")
         out = self._render("top")
         self.assertIn(self.OTHER, out)
         self.assertNotIn("chosen-later", out,
@@ -483,15 +486,15 @@ class EveryPanelDrawsTheFramesOwnWorkspace(PersonaIso, unittest.TestCase):
         `charter clone`, `charter repos` and `charter ws current` in the agent's own shell
         then acts on.
 
-        Refusing the command inside a frame was the alternative and it is rejected on
-        evidence: the only test for "inside a frame" is `session.current()`, and every
-        agent spawned from a frame inherits `$CHARTER_SESSION_ID` — so the refusal would
-        fire on agents doing ordinary CLI work in isolated worktrees. The pointer is
-        written, the panels ignore it, and those are two different questions rather than
-        one broken answer."""
+        **Forced since #936.** #791 rejected refusing the command inside a frame; #936
+        refused the unforced switch after all, through the chat's lock rather than a frame
+        test (`workspace.launch_lock`, measured in
+        `tests/test_a_chat_is_locked_to_the_workspace_it_was_launched_for.py`). What
+        survives is this: when the switch is made, the pointer is written, the panels
+        ignore it, and those are two different questions rather than one broken answer."""
         state.record_workspace("f-1", self.OTHER)
         with mock.patch.dict(os.environ, {"CHARTER_SESSION_ID": "f-1"}):
-            workspace.set_active("chosen-later")
+            workspace.set_active("chosen-later", force=True)
             self.assertEqual(workspace.resolve(cwd=config.ROOT), "chosen-later")
         self.assertEqual(workspace.for_session("f-1"), "chosen-later")
 
@@ -502,8 +505,11 @@ class EveryPanelDrawsTheFramesOwnWorkspace(PersonaIso, unittest.TestCase):
         clone = config.WORKSPACES_DIR / "chosen-later" / "arepo"
         (clone / ".git").mkdir(parents=True)
         state.record_workspace("f-1", self.OTHER)
+        # Forced, and the pointer asserted: since #936 an unforced switch is refused by the
+        # chat's lock, and a table that did not follow a choice nobody made measures nothing.
         with mock.patch.dict(os.environ, {"CHARTER_SESSION_ID": "f-1"}):
-            workspace.set_active("chosen-later")
+            workspace.set_active("chosen-later", force=True)
+        self.assertEqual(workspace.for_session("f-1"), "chosen-later")
         self.assertEqual(slots.repos_rows_wanted("f-1", pane_cols=200), 0)
 
     def test_the_pane_is_sized_from_the_frames_workspace_too(self):

--- a/tests/test_workspace_lock.py
+++ b/tests/test_workspace_lock.py
@@ -196,6 +196,49 @@ class TestCommandLayer(WorkspaceLockBase):
         self.assertTrue((config.WORKSPACES_DIR / "beta").exists())
         self.assertEqual(workspace.is_locked(), "alpha")
 
+    # #936 gave a CHAT its own answers in three places, each behind `workspace.launch_lock()`:
+    # the refusal, the line `create --use` adds after one, and `unlock`. The deletion sweep
+    # forced each of those branches on and nothing went red, because no test said what a
+    # session that is NOT a chat hears. These three do. This fixture's session has no frame
+    # directory under its id, so `launch_lock` answers `None` here.
+
+    def _said(self, fn, **kw):
+        """Every refusal and hint these handlers print goes to stderr, so capture that."""
+        err = io.StringIO()
+        with redirect_stdout(io.StringIO()), redirect_stderr(err):
+            rc = fn(SimpleNamespace(**kw))
+        return rc, err.getvalue()
+
+    def test_outside_a_chat_the_refusal_is_still_the_sessions_sentence(self):
+        """A chat is told it was launched in its workspace and to open a chat elsewhere. A
+        session that is not a chat has real ways out that a chat does not (`unlock`,
+        `--force`, a new session), so it keeps the sentence that names them. With the chat
+        branch forced on, it would be told it is locked to `'None'`, the workspace a chat
+        it is not was launched in."""
+        self._run(commands.cmd_workspace_use, name="alpha", force=False, create=True)
+        rc, err = self._said(commands.cmd_workspace_use, name="beta", force=False, create=True)
+        self.assertEqual(rc, 2)
+        self.assertIn("locked to 'alpha' for this session", err)
+        self.assertNotIn("launched in", err)
+
+    def test_outside_a_chat_create_use_still_names_a_new_session(self):
+        """Inside a chat the "start a new session, or --force" line is dropped, because the
+        refusal above it has already named opening a chat. Outside one it is the only place
+        the two real routes are named."""
+        self._run(commands.cmd_workspace_use, name="alpha", force=False, create=True)
+        rc, err = self._said(commands.cmd_workspace_create,
+                             name="beta", use=True, force=False, repos=[])
+        self.assertEqual(rc, 2)
+        self.assertIn("start a new session to use it, or re-run with --force", err)
+
+    def test_outside_a_chat_unlock_still_releases_the_lock(self):
+        """`unlock` refuses inside a chat, whose lock is its launch record. Outside one the lock
+        is a file and releasing it is this command's whole job."""
+        self._run(commands.cmd_workspace_use, name="alpha", force=False, create=True)
+        rc, err = self._said(commands.cmd_workspace_unlock)
+        self.assertEqual(rc, 0, err)
+        self.assertIsNone(workspace.is_locked())
+
 
 # imported late so the module-under-test picks up the patched config at call time
 from charter import commands_workspace as commands  # noqa: E402

--- a/tests/test_workspace_lock.py
+++ b/tests/test_workspace_lock.py
@@ -230,7 +230,50 @@ class TestCommandLayer(WorkspaceLockBase):
         rc, err = self._said(commands.cmd_workspace_create,
                              name="beta", use=True, force=False, repos=[])
         self.assertEqual(rc, 2)
-        self.assertIn("start a new session to use it, or re-run with --force", err)
+        self.assertIn("Workspace 'beta' was created; start a new session to use it, "
+                      "or re-run with --force", err)
+
+    def test_workspace_current_says_whether_this_session_is_locked(self):
+        """`ws current` exists to explain the resolution, and the lock note is half that
+        answer. #936 split it three ways — unlocked, locked to what resolved, locked to
+        something else — and the first two had no test at all: re-spelling either left the
+        suite green."""
+        rc, err = self._said(commands.cmd_workspace_current)
+        self.assertEqual(rc, 0, err)
+        self.assertIn(", unlocked", err)
+
+        self._run(commands.cmd_workspace_use, name="alpha", force=False, create=True)
+        rc, err = self._said(commands.cmd_workspace_current)
+        self.assertEqual(rc, 0, err)
+        self.assertIn("🔒 locked for this session", err)
+
+    def test_the_first_use_of_a_session_says_it_set_and_locked_the_workspace(self):
+        """The ordinary path, whose sentence nothing asserted. Both guards on that line
+        were survivors: with the `locked and` conjunct dropped, a session that had never
+        been locked was told "🔒 still locked to 'None'"; with the verb conditional
+        collapsed, its first selection was announced as "re-locked to"."""
+        rc, err = self._said(commands.cmd_workspace_use, name="alpha", force=False, create=True)
+        self.assertEqual(rc, 0, err)
+        self.assertIn("Active workspace set to 'alpha'", err)
+        self.assertIn("🔒 locked for this session", err)
+        self.assertNotIn("re-locked", err)
+        self.assertNotIn("still locked", err)
+
+    def test_a_session_with_no_id_is_told_of_no_lock_because_none_was_written(self):
+        """`set_active` writes the lock under a session id, so a shell with no harness id
+        gets a terminal pointer and no lock at all. Announcing "🔒 locked for this session"
+        there named a lock nothing holds — the same false claim as the chat case, one branch
+        over. It is also what pins the `locked and` conjunct above: without it, `None !=
+        'alpha'` is true and the announcement became "🔒 still locked to 'None'"."""
+        with mock.patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("CLAUDE_CODE_SESSION_ID", None)
+            rc, err = self._said(commands.cmd_workspace_use,
+                                 name="alpha", force=False, create=True)
+            self.assertIsNone(workspace.is_locked(), "the fixture wrote a lock after all")
+        self.assertEqual(rc, 0, err)
+        self.assertIn("Active workspace set to 'alpha'", err)
+        self.assertNotIn("🔒", err)
+        self.assertNotIn("still locked", err)
 
     def test_outside_a_chat_a_forced_switch_still_says_it_re_locked(self):
         """The other side of the sentence #936 changed. Outside a chat `--force` really does
@@ -239,7 +282,7 @@ class TestCommandLayer(WorkspaceLockBase):
         self._run(commands.cmd_workspace_use, name="alpha", force=False, create=True)
         rc, err = self._said(commands.cmd_workspace_use, name="beta", force=True, create=True)
         self.assertEqual(rc, 0, err)
-        self.assertIn("re-locked to 'beta'", err)
+        self.assertIn("Active workspace re-locked to 'beta'", err)
         self.assertIn("🔒 locked for this session", err)
         self.assertEqual(workspace.is_locked(), "beta")
 

--- a/tests/test_workspace_lock.py
+++ b/tests/test_workspace_lock.py
@@ -19,6 +19,7 @@ import unittest
 from contextlib import redirect_stderr, redirect_stdout
 from pathlib import Path
 from types import SimpleNamespace
+from unittest import mock
 
 from charter import config, hooks, workspace
 from tests import _envguard
@@ -230,6 +231,53 @@ class TestCommandLayer(WorkspaceLockBase):
                              name="beta", use=True, force=False, repos=[])
         self.assertEqual(rc, 2)
         self.assertIn("start a new session to use it, or re-run with --force", err)
+
+    def test_outside_a_chat_a_forced_switch_still_says_it_re_locked(self):
+        """The other side of the sentence #936 changed. Outside a chat `--force` really does
+        move the lock, so the announcement says so and names where it moved to. Inside a
+        chat it moves the commands and not the lock, and says that instead."""
+        self._run(commands.cmd_workspace_use, name="alpha", force=False, create=True)
+        rc, err = self._said(commands.cmd_workspace_use, name="beta", force=True, create=True)
+        self.assertEqual(rc, 0, err)
+        self.assertIn("re-locked to 'beta'", err)
+        self.assertIn("🔒 locked for this session", err)
+        self.assertEqual(workspace.is_locked(), "beta")
+
+    def _reconcile_with_payload(self, payload_id: str) -> None:
+        """`charter workspace _reconcile` as the SessionStart hook runs it: a JSON payload
+        on stdin, and whatever the environment says about this session."""
+        old = sys.stdin
+        sys.stdin = io.StringIO(json.dumps({"session_id": payload_id}))
+        try:
+            with redirect_stdout(io.StringIO()), redirect_stderr(io.StringIO()):
+                commands.cmd_workspace_reconcile(SimpleNamespace())
+        finally:
+            sys.stdin = old
+
+    def _pane_holding(self, name: str) -> None:
+        tid = workspace._terminal_id("myterm")
+        config.TERMINALS_DIR.mkdir(parents=True, exist_ok=True)
+        (config.TERMINALS_DIR / f"{tid}.workspace").write_text(name + "\n")
+        os.environ["TERM_SESSION_ID"] = "myterm"
+        self.addCleanup(os.environ.pop, "TERM_SESSION_ID", None)
+
+    def test_reconcile_seeds_the_id_the_rest_of_charter_resolves_by(self):
+        """The pointer has to land under the id `workspace.chosen` reads back, which is
+        `session.current()` — the environment's, ahead of any payload. Keyed on the payload
+        instead, the file was written where nothing looks (#936, round 1)."""
+        self._pane_holding("gamma")
+        self._reconcile_with_payload("a-different-harness-uuid")
+        self.assertEqual(workspace.for_session(self.SID), "gamma")
+        self.assertFalse((config.SESSIONS_DIR / "a-different-harness-uuid.workspace").exists())
+
+    def test_a_harness_that_exports_no_id_still_seeds_from_its_payload(self):
+        """The fallback, and the reason the payload is still read: a harness that puts no
+        session id in the environment has nothing else to say who it is."""
+        self._pane_holding("gamma")
+        with mock.patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("CLAUDE_CODE_SESSION_ID", None)
+            self._reconcile_with_payload("payload-only-session")
+        self.assertEqual(workspace.for_session("payload-only-session"), "gamma")
 
     def test_outside_a_chat_unlock_still_releases_the_lock(self):
         """`unlock` refuses inside a chat, whose lock is its launch record. Outside one the lock

--- a/tests/test_workspace_lock.py
+++ b/tests/test_workspace_lock.py
@@ -248,10 +248,9 @@ class TestCommandLayer(WorkspaceLockBase):
         self.assertIn("🔒 locked for this session", err)
 
     def test_the_first_use_of_a_session_says_it_set_and_locked_the_workspace(self):
-        """The ordinary path, whose sentence nothing asserted. Both guards on that line
-        were survivors: with the `locked and` conjunct dropped, a session that had never
-        been locked was told "🔒 still locked to 'None'"; with the verb conditional
-        collapsed, its first selection was announced as "re-locked to"."""
+        """The ordinary path, whose sentence nothing asserted. It goes red when
+        `_lock_words`' `locked == name` branch is skipped (the first selection is told
+        "🔒 still locked to 'alpha'") and when the verb is collapsed to "re-locked to"."""
         rc, err = self._said(commands.cmd_workspace_use, name="alpha", force=False, create=True)
         self.assertEqual(rc, 0, err)
         self.assertIn("Active workspace set to 'alpha'", err)
@@ -263,8 +262,9 @@ class TestCommandLayer(WorkspaceLockBase):
         """`set_active` writes the lock under a session id, so a shell with no harness id
         gets a terminal pointer and no lock at all. Announcing "🔒 locked for this session"
         there named a lock nothing holds — the same false claim as the chat case, one branch
-        over. It is also what pins the `locked and` conjunct above: without it, `None !=
-        'alpha'` is true and the announcement became "🔒 still locked to 'None'"."""
+        over. It is also what pins `_lock_words`' `if not locked`: without it, `None` falls
+        through to the elsewhere case and the announcement became "🔒 still locked to
+        'None'"."""
         # The pane is STATED: with none, `set_active` writes nothing at all, which is a
         # different sentence (the case below). A runner has no pane id and a laptop shell
         # usually does, so leaving it to the environment made this two tests.
@@ -394,6 +394,65 @@ class TestCommandLayer(WorkspaceLockBase):
         rc, err = self._said(commands.cmd_workspace_unlock)
         self.assertEqual(rc, 0, err)
         self.assertIsNone(workspace.is_locked())
+
+    def test_a_forced_selection_with_no_lock_before_it_says_set_not_re_locked(self):
+        """Review round 3, minor 1: `create --use --force` in a session that had never been
+        locked answered "Active workspace re-locked to 'beta'". The verb read `--force`, which
+        is what was asked. "re-" names a lock that stood before the call, and none did. The
+        forced `create --use` case above starts from a lock, so it could not see this."""
+        rc, err = self._said(commands.cmd_workspace_create,
+                             name="beta", use=True, force=True, repos=[])
+        self.assertEqual(rc, 0, err)
+        self.assertEqual(workspace.is_locked(), "beta")
+        self.assertIn("Active workspace set to 'beta'", err)
+        self.assertIn("🔒 locked for this session", err)
+        self.assertNotIn("re-locked", err)
+
+    def test_forcing_the_workspace_a_session_is_already_locked_to_re_locks_nothing(self):
+        """The other half of that verb. The lock named `alpha` before the call and names
+        `alpha` after it, so nothing moved, whatever flag was passed."""
+        self._run(commands.cmd_workspace_use, name="alpha", force=False, create=True)
+        rc, err = self._said(commands.cmd_workspace_use, name="alpha", force=True, create=True)
+        self.assertEqual(rc, 0, err)
+        self.assertIn("Active workspace set to 'alpha'", err)
+        self.assertNotIn("re-locked", err)
+
+    # `rename`'s session line, review round 3. It printed "(still 🔒 locked)" itself, asking
+    # nothing about the lock. K and L are two states it named a lock nobody held in (G is in
+    # the chat module); the first case is the one where the lock does stand.
+
+    def test_a_rename_of_the_locked_workspace_says_the_lock_followed_it(self):
+        self._run(commands.cmd_workspace_use, name="alpha", force=False, create=True)
+        rc, err = self._said(commands.cmd_workspace_rename,
+                             old="alpha", new="alpha2", message=None)
+        self.assertEqual(rc, 0, err)
+        self.assertEqual(workspace.is_locked(), "alpha2")
+        self.assertIn("followed the rename → 'alpha2' (🔒 locked for this session)", err)
+
+    def test_a_rename_of_a_pointer_the_reconcile_seeded_claims_no_lock(self):
+        """State K: SessionStart's reconcile copies the pane's selection into the session
+        pointer and writes no lock, and `rename` answered "(still 🔒 locked)" there."""
+        workspace.ensure("alpha")
+        self._pane_holding("alpha")
+        self._reconcile_with_payload("payload-uuid")
+        self.assertEqual(workspace.for_session(self.SID), "alpha", "the reconcile seeded nothing")
+        self.assertIsNone(workspace.is_locked(), "the reconcile wrote a lock after all")
+        rc, err = self._said(commands.cmd_workspace_rename,
+                             old="alpha", new="alpha2", message=None)
+        self.assertEqual(rc, 0, err)
+        self.assertIn("followed the rename → 'alpha2' (unlocked)", err)
+        self.assertNotIn("🔒", err)
+
+    def test_a_rename_after_unlock_claims_no_lock(self):
+        """State L: `use` then `unlock` leaves the pointer standing and the lock gone."""
+        self._run(commands.cmd_workspace_use, name="alpha", force=False, create=True)
+        self._said(commands.cmd_workspace_unlock)
+        self.assertIsNone(workspace.is_locked(), "unlock left the lock standing")
+        rc, err = self._said(commands.cmd_workspace_rename,
+                             old="alpha", new="alpha2", message=None)
+        self.assertEqual(rc, 0, err)
+        self.assertIn("followed the rename → 'alpha2' (unlocked)", err)
+        self.assertNotIn("🔒", err)
 
 
 # imported late so the module-under-test picks up the patched config at call time

--- a/tests/test_workspace_lock.py
+++ b/tests/test_workspace_lock.py
@@ -280,6 +280,20 @@ class TestCommandLayer(WorkspaceLockBase):
         self.assertNotIn("🔒", err)
         self.assertNotIn("still locked", err)
 
+    def test_outside_a_chat_create_use_force_says_it_re_locked(self):
+        """`create --use --force` hands the helper its own `forced`, and nothing read it: the
+        chat case cannot tell the verbs apart (the lock stays the launch record either way),
+        so the deletion sweep re-spelt the `"force"` literal on that call and the whole suite
+        stayed green. Outside a chat the forced switch really moves the lock, and the
+        sentence has to say so."""
+        self._run(commands.cmd_workspace_use, name="alpha", force=False, create=True)
+        rc, err = self._said(commands.cmd_workspace_create,
+                             name="beta", use=True, force=True, repos=[])
+        self.assertEqual(rc, 0, err)
+        self.assertEqual(workspace.is_locked(), "beta")
+        self.assertIn("Active workspace re-locked to 'beta'", err)
+        self.assertIn("🔒 locked for this session", err)
+
     def test_create_use_in_a_shell_with_no_session_id_claims_no_lock_either(self):
         """The third success path, and review round 2's finding: `create --use` announced
         "🔒 locked for this session" unconditionally while `use` had stopped. Codex's shells

--- a/tests/test_workspace_lock.py
+++ b/tests/test_workspace_lock.py
@@ -265,15 +265,52 @@ class TestCommandLayer(WorkspaceLockBase):
         there named a lock nothing holds — the same false claim as the chat case, one branch
         over. It is also what pins the `locked and` conjunct above: without it, `None !=
         'alpha'` is true and the announcement became "🔒 still locked to 'None'"."""
-        with mock.patch.dict(os.environ, {}, clear=False):
+        # The pane is STATED: with none, `set_active` writes nothing at all, which is a
+        # different sentence (the case below). A runner has no pane id and a laptop shell
+        # usually does, so leaving it to the environment made this two tests.
+        with mock.patch.dict(os.environ, {}, clear=False), \
+                mock.patch.object(workspace, "_terminal_id", return_value="pane-a"):
             os.environ.pop("CLAUDE_CODE_SESSION_ID", None)
             rc, err = self._said(commands.cmd_workspace_use,
                                  name="alpha", force=False, create=True)
             self.assertIsNone(workspace.is_locked(), "the fixture wrote a lock after all")
         self.assertEqual(rc, 0, err)
         self.assertIn("Active workspace set to 'alpha'", err)
+        self.assertIn("unlocked", err)
         self.assertNotIn("🔒", err)
         self.assertNotIn("still locked", err)
+
+    def test_create_use_in_a_shell_with_no_session_id_claims_no_lock_either(self):
+        """The third success path, and review round 2's finding: `create --use` announced
+        "🔒 locked for this session" unconditionally while `use` had stopped. Codex's shells
+        are this case (`harness/codex.py`: no per-session id reaches them)."""
+        with mock.patch.dict(os.environ, {}, clear=False), \
+                mock.patch.object(workspace, "_terminal_id", return_value="pane-e"):
+            os.environ.pop("CLAUDE_CODE_SESSION_ID", None)
+            rc, err = self._said(commands.cmd_workspace_create,
+                                 name="epsilon", use=True, force=False, repos=[])
+            self.assertIsNone(workspace.is_locked(), "the fixture wrote a lock after all")
+        self.assertEqual(rc, 0, err)
+        self.assertIn("Active workspace set to 'epsilon'", err)
+        self.assertIn("unlocked", err)
+        self.assertNotIn("locked for this session", err)
+
+    def test_a_process_with_no_session_and_no_pane_is_told_nothing_was_persisted(self):
+        """`set_active` keys its pointers on a session id and a pane id; with neither it
+        writes nothing and reports scope `none`. This answered "Active workspace set to
+        'gamma'." — and the next command still resolved to `default`."""
+        with mock.patch.dict(os.environ, {}, clear=False), \
+                mock.patch.object(workspace, "_terminal_id", return_value=None):
+            os.environ.pop("CLAUDE_CODE_SESSION_ID", None)
+            rc, err = self._said(commands.cmd_workspace_use,
+                                 name="gamma", force=False, create=True)
+            resolved = workspace.resolve(cwd=config.ROOT)
+        self.assertEqual(rc, 0, err)
+        self.assertEqual(resolved, config.DEFAULT_WORKSPACE, "something was persisted after all")
+        self.assertIn("Nothing was persisted", err)
+        self.assertIn("no session id and no pane id", err)
+        self.assertIn("--workspace gamma", err)
+        self.assertNotIn("Active workspace set to", err)
 
     def test_outside_a_chat_a_forced_switch_still_says_it_re_locked(self):
         """The other side of the sentence #936 changed. Outside a chat `--force` really does
@@ -304,14 +341,28 @@ class TestCommandLayer(WorkspaceLockBase):
         os.environ["TERM_SESSION_ID"] = "myterm"
         self.addCleanup(os.environ.pop, "TERM_SESSION_ID", None)
 
-    def test_reconcile_seeds_the_id_the_rest_of_charter_resolves_by(self):
-        """The pointer has to land under the id `workspace.chosen` reads back, which is
-        `session.current()` — the environment's, ahead of any payload. Keyed on the payload
-        instead, the file was written where nothing looks (#936, round 1)."""
+    def test_reconcile_seeds_the_environments_id_ahead_of_the_payload(self):
+        """An id in the environment outranks the payload's. This holds under the old key
+        and the new one alike — `$CLAUDE_CODE_SESSION_ID` came first in both — so it pins the
+        ordering and NOT the round-1 miskey; the case below is the one that measures that."""
         self._pane_holding("gamma")
         self._reconcile_with_payload("a-different-harness-uuid")
         self.assertEqual(workspace.for_session(self.SID), "gamma")
         self.assertFalse((config.SESSIONS_DIR / "a-different-harness-uuid.workspace").exists())
+
+    def test_reconcile_keys_on_the_chat_id_when_the_chat_has_no_launch_record(self):
+        """The round-1 miskey, measured on its own. Inside a chat WITH a launch record the
+        early return decides first, so it never reaches the key; a frame with no record (the
+        migration case) does. There `$CHARTER_SESSION_ID` is the session every other reader
+        resolves by, and the old key — `$CLAUDE_CODE_SESSION_ID` first — seeded the harness's
+        id instead, where nothing looks and nothing reaps."""
+        self._pane_holding("gamma")
+        with mock.patch.dict(os.environ, {"CHARTER_SESSION_ID": "nolaunch.1"}):
+            self.assertIsNone(workspace.launch_lock(), "the fixture has a launch record")
+            self._reconcile_with_payload("payload-uuid")
+        self.assertEqual(workspace.for_session("nolaunch.1"), "gamma")
+        self.assertFalse((config.SESSIONS_DIR / f"{self.SID}.workspace").exists())
+        self.assertFalse((config.SESSIONS_DIR / "payload-uuid.workspace").exists())
 
     def test_a_harness_that_exports_no_id_still_seeds_from_its_payload(self):
         """The fallback, and the reason the payload is still read: a harness that puts no

--- a/tests/test_workspace_scope_honesty.py
+++ b/tests/test_workspace_scope_honesty.py
@@ -146,6 +146,19 @@ class TestTheMessageFollowsTheScope(ScopeBase):
         """A limit the reader has to discover by losing their workspace was concealed."""
         self.assertIn(config.DEFAULT_WORKSPACE, _scope_note("session"))
 
+    def test_session_scope_names_the_workspace_a_new_session_really_starts_at(self):
+        """A plane that nominated a default (`charter workspace default`) starts a new session
+        there, not at the built-in, and the note named the built-in regardless: the claim
+        about the next session this suite exists to keep true. `commands_persona._scope_note`
+        already reads its plane's declared default for the same sentence."""
+        workspace.set_declared_default("alpha")
+        with mock.patch.object(workspace, "_terminal_id", return_value=None):
+            self.assertEqual(workspace.resolve(session_id="a-different-session"), "alpha",
+                             "the declared default is not where a new session starts")
+        note = _scope_note("session")
+        self.assertIn("so a new session starts at 'alpha'", note)
+        self.assertNotIn(f"'{config.DEFAULT_WORKSPACE}'", note)
+
     def test_nothing_written_promises_nothing(self):
         self.assertEqual(_scope_note("none"), "")
 


### PR DESCRIPTION
Closes #936.

## The failure

Inside a charter frame, SessionStart built a chat's workspace briefing for `default`, the bottom of the resolution ladder, instead of the workspace the chat was launched in. Then it told the chat to pick a workspace, and in a chat launched without the picker nothing refused the pick.

Measured live with `python3 -m charter`, in a throwaway plane: a chat `north.1` recorded for `north` with no picker, SessionStart fed a payload `session_id` that is not the chat's, as Claude Code sends it.

On `main` (`98686c3`):

```
SessionStart   confirm-nudge present: True
               todo shown: LIVE DEFAULT TODO
               neighbours list north as other: True
workspace use gamma    rc=0  ✓ Active workspace set to 'gamma' … 🔒 locked for this session.
workspace unlock       rc=0  ✓ Workspace unlocked for this session — `charter workspace use <name>` can switch now.
```

On this branch, same plane:

```
SessionStart   confirm-nudge present: False
               todo shown: LIVE NORTH TODO
               neighbours list north as other: False
workspace use gamma    rc=2  ✗ Workspace is 🔒 locked to 'north', the workspace this chat was launched in. Switching its commands to 'gamma' would leave the chat itself in 'north' (a chat belongs to its workspace for life). To work in another workspace, open a chat there: its tab on the workspace strip, or F2 → workspace. For one command, pass `--workspace gamma`.
workspace current      resolved via frame, 🔒 locked for this session
workspace unlock       rc=2  ✗ This chat is 🔒 locked to 'north', the workspace it was launched in, and nothing unlocks that: …
workspace use north    rc=0
a sub-agent standing in workspaces/gamma/api: resolved via cwd
outside a frame: workspace use gamma   rc=0   (unchanged)
```

## Two halves, and neither is enough alone

**The id.** `hooks._context_parts` passed the payload's `session_id`, which is the harness's own id, to `_workspace_confirm_nudge`, `_todo_digest` and `_other_workspaces_digest`. `session.current` ranks an explicit id above `$CHARTER_SESSION_ID`, so every rung keyed on the chat missed: the pointer, the lock, and `workspace.for_frame`, the rung #597 added for #524. The new `hooks._workspace_session(data)` answers `_chat_id() or data.get("session_id")`. That is the key `charter workspace use` in the chat's own shell writes under. Those three calls use it, and so does PostToolUse's `_mem_cadence_nudge`. The payload id keeps keying everything it keyed before: the tool-gate snapshot, the trace, the memory-cadence counter and the chat → harness mapping.

**The lock.** The id alone makes the nudge name `north` and still ask, because a chat was locked only when the operator picked at launch (`_pin_workspace` returns early otherwise). The new `workspace.launch_lock(session_id)` answers `frame/state.own_workspace(sid)`: the pin the chat was launched under, then the workspace the launch resolved. `workspace.is_locked` asks it first and the lock file second. It writes nothing, so #518's "a launch that resolved silently must keep writing none" holds to the letter, and a picked launch and a silent one now hold the same lock. With both halves in, the nudge never fires in a chat.

**The refusal names the fix.** Inside a chat, `commands_workspace._locked_msg` says the chat was launched in `<own>`, that switching its commands to `<other>` would leave the chat itself behind, and to open a chat in the other workspace: its tab on the workspace strip, or `F2 → workspace`. For one command it names `--workspace <other>`. `charter workspace unlock` inside a chat refuses with rc 2 and deletes nothing, instead of reporting a release. `create --use` inside a chat drops its "start a new session, or re-run with --force" line, which contradicted the refusal above it. `_pin_workspace`'s announcement no longer names `unlock`.

## The four readers of `is_locked`, each checked against a derived lock

- `commands_workspace.cmd_workspace_current`: a chat now reports `🔒 locked for this session`, which is true.
- `commands_workspace._locked_msg`: asks `launch_lock` first and says the chat sentence. The session sentence is unchanged outside a chat.
- `hooks._workspace_confirm_nudge`: never fires in a chat, including the unattended "STOP" variant, because a chat always holds a lock.
- `workspace.set_active`: refuses an unforced switch out of a chat's workspace. A forced one still writes the pointer and the lock file, and the trace still records `forced=True`, because `locked != name` is now true for a chat forced away from its launch.

## Why the launch outranks the lock file

The file under a chat's id can disagree with the chat's launch only after `--force`. If the file won, the chat could not go home: `workspace use <own>` would be refused as locked to the workspace it was forced into, which is the undo the issue measured failing. With the launch first, leaving the chat's workspace takes `--force` every time and returning takes nothing.

## What #791/#794 protected, and how each flow still holds

#794 rejected refusing `workspace use` inside a frame because every agent spawned from one inherits `$CHARTER_SESSION_ID`, so a refusal "fires on agents doing ordinary CLI work in isolated worktrees". This change adds no frame test; the lock is keyed on the same id, and here is every flow #794 named.

| Flow #794 protected | Now |
|---|---|
| Sub-agents doing ordinary CLI work in isolated worktrees | Untouched. The cwd rung outranks every pointer, so an agent in `workspaces/<ws>/…` acts on `<ws>`, and `--workspace` names one per command. Neither writes a pointer, so neither meets the lock. Pinned by `test_the_routes_a_subagent_works_by_outrank_the_pointer`, which forces a pointer to a third workspace first so the cwd rung has something to outrank, and live above. |
| A sub-agent's own `charter workspace use <other>` | Refused, on purpose. The pointer it writes lands under its PARENT chat's id, so success would move the chat it serves: every `charter` command in that chat and its other sub-agents would switch workspace behind its back. The refusal names `--workspace <other>`, the route a sub-agent can take. |
| `workspace use` still writes the pointer, and `clone`, `repos` and `ws current` act on it | Holds with `--force`, and never moves the chat: `test_force_still_moves_the_sessions_commands_and_never_the_chat`. `TheOtherDoorMovesNoChatEither` already forced and is unchanged. |
| A pointer never decides membership (#733, #788) | Unchanged. `own_workspace` reads no pointer; the lock only reads it. |
| A chat launched under `$CHARTER_WORKSPACE` | Locked to its pin, which is what it draws and acts on: `test_a_pinned_chat_is_locked_to_its_pin`. |
| A frame with no launch record (the migration case) | No launch lock, so `workspace use` behaves exactly as before and still moves its panels. `PanelFollowsWorkspaceUseOnAFrameWithNoRecord`'s first two cases are unchanged. |
| A recycled ordinal inherits nothing (#731) | Still reaped, and still asserted, now on the lock file itself (see below). |
| Outside a frame | Unchanged. No frame directory under the id, so only a confirmation locks: `test_a_session_that_is_not_a_chat_is_locked_by_what_it_confirmed`, `OutsideAFrameThePayloadIdStillDecides`, and all of `tests/test_workspace_lock.py`. |

## `charter handoff`

That command will open a chat in a named workspace through `cmd_launch(workspace=W)` with no picker. `AChatOpenedInANamedWorkspaceIsBornLockedToIt` drives the real launcher (`_DrivesTheLauncher`, every tmux call answered) and pins that the chat is born locked to `W` with no pointer written, that its SessionStart under a different payload id asks nothing, and that `workspace use <other>` inside it is refused.

## Rulings

- **`--force` still overrides, and the in-chat refusal does not offer it.** The issue left this open. Keeping it is the smaller change and keeps #794's "the command still does its job" true for anyone who means it. Not advertising it is because the split `--force` makes is exactly what charter's own briefing used to recommend. `docs/workspaces.md` documents it.
- **The hook takes `$CHARTER_SESSION_ID` with no frame-record check.** The proposal said "naming a chat with a frame record". Whatever that variable holds is the key the session's own CLI writes under, so the hook reads the same key, the way `_record_harness_session` already does. The frame record is consulted where it decides something: in `launch_lock`.
- **The refusal names a workspace's tab and `F2 → workspace`, not the `+`.** The `+` opens another chat in the workspace you are already in (`docs/frame.md`, "The chat bar ends in a `+`"). The tab and `F2 → workspace` open or focus the other one. The docs mention `+` for once you are there.
- **`unlock` inside a chat refuses with rc 2 and deletes nothing**, rather than deleting a file whose loss changes nothing `is_locked` answers.
- **`_pin_workspace` still writes for a picked launch.** The launching terminal's pointer is #518's "never asks twice"; only the sentence changed.

## Existing tests restaged, each saying why

Eleven cases staged "this chat switched to another workspace" with an unforced `set_active` on a chat that has a launch record, which the lock now refuses. Each now forces the switch, because `--force` is the one way a chat still writes a disagreeing pointer. Three more still passed but had stopped measuring anything, and are restaged the same way.

- `tests/test_a_reaped_chat_leaves_its_session_behind.py`: a `choose()` helper forces the predecessor's choice. `test_the_lock_does_not_outlive_the_frame` and `test_a_chat_that_is_still_live_keeps_its_selection` now assert the lock FILE, because `is_locked` answers the chat's launch on both sides of a reap and can no longer see the file go. `test_the_new_chat_can_select_the_workspace_it_was_launched_with` was deleted in review round 2: the launch record makes its select pass whether or not the reap ran, and its one reap-sensitive assertion duplicated `test_the_workspace_pointer_does_not_outlive_the_frame`.
- `tests/test_frame_slots.py`: all three `EveryPanelDrawsTheFramesOwnWorkspace` switches are forced. `test_the_frames_repo_table_does_not_follow_that_choice_either` was passing on a choice that was refused, and now asserts the pointer was written first.
- `tests/test_frame_owns_the_surface.py`, `tests/test_a_frame_answers_for_the_frames_workspace.py`: forced, with the lock-versus-pin difference stated.
- `tests/test_frame_pickers.py`: `is_locked` cannot see a keypress that rewrote the lock file, so the pointer is asserted as well.
- Docstrings that recorded "a refusal was rejected" now also record #936, in `workspace.for_session`, `workspace.for_frame`, `frame/state.own_workspace`, `frame/state.workspace_for` and `tests/test_a_chat_belongs_to_its_workspace_for_life.py`.

## Docs, moved with the code

- `docs/frame.md`: a paragraph on the in-chat refusal and what to do instead, and one on why the lock holds for an agent the chat spawns. The unlock passage and the picker passage are corrected: neither `unlock` nor `F2 → workspace` releases a chat's lock. The line saying a pinned `$CHARTER_WORKSPACE` would "take `ws use` away" now says what it would actually take away.
- `docs/workspaces.md`: a new "Inside a chat" section under the lock, with the refusal text, and with what happens to each of the three ways past the lock.
- ADR 0019: a #936 note on the #791 correction, and a consequence bullet: a hook that asks a workspace question by the payload id gets the wrong session's answer.
- `README.md`: moving between tasks is `workspace use` in a terminal, or a chat opened in that workspace inside the frame.
- `docs/news/unreleased-a-chat-is-briefed-for-its-own-workspace.md`, which charter's own reader accepts (`news.entry_errors` returns `[]`).

## Review round 1 (`c26dee9`)

Three Important findings, all real:

- **A fourth SessionStart workspace question, and the only one that writes.** `charter workspace _reconcile` read `$CLAUDE_CODE_SESSION_ID` or the payload id, so inside a frame it seeded `.charter/sessions/<harness uuid>.workspace` — a key nothing resolves by (`chosen` asks `session.current()`, the chat id) and no reap collects (`_forget_session` reaps `<chat id>.*`). It now asks `session.current()`, with the payload as the fallback for a harness that exports no id. **Inside a chat it seeds nothing**: a pointer under the chat id outranks the launch record, so re-keying alone would have replaced an unread write with a silent move of the chat's own commands.
- **Two messages announced a lock charter does not hold** (ADR 0013). `workspace use gamma --force` in a chat launched in `north` said *"re-locked to 'gamma' … 🔒 locked for this session"*, one command before the next refusal named `north`; `workspace current` in a sub-agent standing in `workspaces/gamma/api` said *"locked for this session"* beside `gamma`. Both now name the lock when it differs, and "re-locked to" survives only where `--force` really moved it — pinned from the other side by a non-chat case.
- **The opencode gap is stated rather than implied benign.** Its plugin overwrites `$CHARTER_SESSION_ID` with its own session id, so a framed opencode chat holds no launch lock and is still briefed for `default`. `_workspace_session`'s docstring said the two ids "already agree" — they agree on a value that names no chat. Corrected there, in `docs/frame.md`, `docs/workspaces.md` and the news entry, each citing #946.

Measured live with `python3 -m charter`, in a throwaway plane, in a chat recorded for `north` whose pane pointer says `gamma`:

```
workspace _reconcile (payload id differs)   rc=0   session pointers written: []
workspace use gamma --force                 ✓ Active workspace set to 'gamma' … — this session's commands only; 🔒 still locked to 'north'.
workspace current, from workspaces/gamma/api   • LOCAL (private) · resolved via cwd, 🔒 locked to 'north'
outside a frame, use beta --force           ✓ Active workspace re-locked to 'beta' … — 🔒 locked for this session.   (unchanged)
```

Five Minor findings: #731's half-unreachable measurement corrected in `state._forget_session` and `docs/frame.md`; three tests that could not fail restaged (the cwd rung now outranks a real pointer; the reaped-ordinal case asserts the state the relaunch starts from; a forced switch's return value replaced by the pointer it writes); and the born-locked property's pinned-launcher limit documented in the news entry and `docs/workspaces.md`.

## Review round 2 (`868c0e9`)

- **One helper owns every sentence about a selection and its lock.** `create --use` still said "🔒 locked for this session" unconditionally. `create delta --use --force` in a chat launched in `north` printed it while `is_locked()` was `north`, and in a shell with no session id (Codex's case) it claimed a lock nothing wrote. `_lock_words` now decides once how the lock stands relative to a workspace — absent, that workspace, or another. `_announce_selection` builds the sentence after a selection from what `set_active` actually wrote plus that lock. `use`, `create --use` and `current`'s note all go through them. Pinned by `create --use --force` in a launched chat and by `create --use` in a no-id shell; ten hand mutations of the two helpers each go red on the case that names them.
- **A process with no session id and no pane id is told nothing was persisted.** `set_active` writes nothing there (scope `none`), and this said "Active workspace set to 'gamma'." while `resolve` stayed `default`. It now warns and names `--workspace` and `$CHARTER_WORKSPACE`.
- **The news headline says what it is true for:** "A Claude Code chat is briefed for the workspace it was opened in, instead of being told to pick one". opencode is #946, and Codex was not verified.
- **Minor.** Round 1's `session.current()` key in `_reconcile` is now pinned on its own, by a chat id with no launch record: the pointer lands under the chat id, not the harness's. `test_reconcile_seeds_the_environments_id_ahead_of_the_payload` no longer claims to measure that miskey. The reaped-chat module no longer says it reproduces `is_locked: gamma` or a refusal, and its near-vacuous select case is deleted.
- **Measured live** with `python3 -m charter` at `a3efe49`, in a throwaway plane with a chat `north.1` recorded for `north`:

  ```
  create delta --use --force, in north.1       ✓ Active workspace set to 'delta' (…) — this session's commands only; 🔒 still locked to 'north'.
  create epsilon --use, no session id, a pane  ✓ Active workspace set to 'epsilon' (this terminal only …) — unlocked.
  use gamma, no session id and no pane         ! Nothing was persisted: … Pass `--workspace gamma` per command, or set `$CHARTER_WORKSPACE=gamma`.
                                                 (current then resolves: default)
  create beta --use --force, outside a frame   ✓ Active workspace re-locked to 'beta' (…) — 🔒 locked for this session.
  ```
- **Covering tests at `a3efe49`:** 31 modules. That is round 1's 15 (SessionStart, plugin wiring, docs and news readers included) plus every test module that references an amended symbol (`launch_lock`, `is_locked(`, `cmd_workspace_{use,create,current,reconcile,unlock}`, `_pin_workspace`, `_workspace_session`, `own_workspace`, `_mem_cadence_nudge`, or the phrase `locked for this session`). Result: `Ran 1509 tests in 104.075s`, `OK`.
  ```
  env -u PYTHONSAFEPATH python3 -m unittest tests.test_a_chat_belongs_to_its_workspace_for_life tests.test_a_chat_is_locked_to_the_workspace_it_was_launched_for tests.test_a_command_run_anywhere_reaches_every_frame tests.test_a_frame_answers_for_the_frames_workspace tests.test_a_quit_records_the_plane_before_it_kills tests.test_a_real_click_on_a_real_tab_bar_switches tests.test_a_reaped_chat_leaves_its_session_behind tests.test_a_renamed_workspace_keeps_its_chats_and_a_gone_one_says_so tests.test_a_reopen_says_what_it_cannot_bring_back tests.test_a_second_launch_focuses_instead_of_dragging tests.test_a_workspace_tab_opens_what_it_names tests.test_docs tests.test_forget_is_reactive tests.test_frame_chat_switch tests.test_frame_launcher tests.test_frame_owns_the_surface tests.test_frame_pickers tests.test_frame_slots tests.test_frame_state tests.test_frame_switch tests.test_hooks tests.test_news_ordering tests.test_plugin tests.test_the_close_confirmation_names_the_chat_it_stops tests.test_the_workspace_tabs_lead_with_the_working_set tests.test_workspace_charter tests.test_workspace_default tests.test_workspace_lock tests.test_workspace_optimize tests.test_workspace_scope_honesty tests.test_workspace_selection_is_traced
  ```
- **Sweep on `868c0e9`:** baseline `Ran 11896 tests — OK`, then **15 pinned and 1 survivor** — CI's merge-ref sweep and the local one agree on it. `commands_workspace.py:168`: re-spelling the `"force"` literal in `create --use`'s call to `_announce_selection` changed nothing across all 11,925 tests. The only `create --use --force` case ran inside a chat, where the lock stays the launch record whichever verb is chosen. Fixed in `a3efe49` with a non-chat case that goes red under exactly that mutation.
- **Sweep on `a3efe49`:** CI's merge-ref sweep (run 34486049607) completed with its verdict job named `no survivors`. Local `python3 tools/sweep.py`: baseline `Ran 11897 tests — OK`, then 16 mutations applied, **16 pinned, 0 survived, 0 unresolved**, exit 0.

## Review round 3 (`ac5f749`, `61a8823`)

- **`rename` names the lock through `_lock_words`, the way `current` does.** It printed "(still 🔒 locked)" itself and asked nothing. Measured with `python3 -m charter` in a throwaway plane, once against an export of `a5fbce5` and once against this branch, in the three reachable states the review named:

  ```
  G  chat north.1 (launched in north): use gamma --force, then rename gamma gamma2
     a5fbce5   • This session's active workspace followed the rename → 'gamma2' (still 🔒 locked).
               • LOCAL (private) · resolved via session, 🔒 locked to 'north'     ← `current`, same chat
     now       • This session's active workspace followed the rename → 'gamma2' (🔒 locked to 'north').
  K  not a chat; the pointer came from SessionStart's `_reconcile` (`current`: unlocked); rename alpha alpha2
     a5fbce5   • … followed the rename → 'alpha2' (still 🔒 locked).
     now       • … followed the rename → 'alpha2' (unlocked).
  L  not a chat: use beta, unlock, rename beta beta2
     a5fbce5   • … followed the rename → 'beta2' (still 🔒 locked).
     now       • … followed the rename → 'beta2' (unlocked).
  ```

  Pinned by `test_a_rename_after_a_forced_switch_names_the_lock_that_stands` (G, in the chat module, which also asserts `current` in the same chat), `test_a_rename_of_a_pointer_the_reconcile_seeded_claims_no_lock` (K) and `test_a_rename_after_unlock_claims_no_lock` (L), plus `test_a_rename_of_the_locked_workspace_says_the_lock_followed_it` for the state where the lock does stand. All four failed at `a5fbce5`.

- **"re-locked" only when the call moved a lock that stood before it.** The verb read `--force`, which is what was asked. `_announce_selection` now takes `before`, the lock `use` and `create --use` read ahead of `set_active`, in place of `forced`. It says `re-locked to` exactly when `before and locked != before`. `forced` is gone because it adds nothing: `set_active` refuses a switch away from a lock unless it is forced.

  ```
  create delta --use --force, never locked    a5fbce5  ✓ Active workspace re-locked to 'delta' …
                                              now      ✓ Active workspace set to 'delta' …
  create epsilon --use --force, locked delta  now      ✓ Active workspace re-locked to 'epsilon' …   (as before)
  ```

  Pinned by `test_a_forced_selection_with_no_lock_before_it_says_set_not_re_locked`, the finding's no-prior-lock case, and by `test_forcing_the_workspace_a_session_is_already_locked_to_re_locks_nothing`. That second case goes one step past the finding: `use alpha` then `use alpha --force` also said "re-locked to 'alpha'", beside a lock that named `alpha` before the call and after it. A lock that existed and did not move was not re-locked either.

- **The scope note says where a new session really starts.**
  - **Inside a chat, at either scope.** It said "(this session only — this terminal reports no pane id, so a new session starts at 'default')", or, with a pane id, "(this terminal only — kept across closing/reopening Claude)". Neither is true in a chat. A chat ends when its harness exits (the harness pane's `pane-died[1]` is `kill-window`). A closed chat's `.charter/sessions/<fid>.*` is reaped (`state._forget_session`). A new chat, a reopened one included, resolves by its own launch record, which outranks the terminal pointer and the declared default. It now says "(this chat only — a new chat starts at the workspace it is opened in)". That replaces "the next one starts at 'north'", which the stalled draft of this round asserted, because a chat opened on another workspace's tab starts there.
  - **On a plane with a nominated default** (`charter workspace default`). A new session with no pointer and no pane id starts at that default, and the note named `default`. It now names the declared default, as `commands_persona._scope_note` already does for personas. The review did not list this case. It is the same sentence making the same false claim, and the stalled draft had already written the failing test, so it is kept.

  ```
  chat north.1, no pane id: use north              a5fbce5  (this session only — … so a new session starts at 'default')
                                                   now      (this chat only — a new chat starts at the workspace it is opened in)
  chat north.1, TMUX_PANE set: use gamma2 --force  a5fbce5  (this terminal only — kept across closing/reopening Claude)
                                                   now      (this chat only — a new chat starts at the workspace it is opened in)
  plane default alpha2, no pane id: use beta2      a5fbce5  (… so a new session starts at 'default')
                                                   now      (… so a new session starts at 'alpha2')
                                                   a new session there resolves to: alpha2
  ```

  Pinned by `test_the_scope_note_names_where_the_chats_next_session_starts`, by `test_a_pane_pointer_written_in_a_chat_is_not_promised_to_the_next_session`, and by `test_session_scope_names_the_workspace_a_new_session_really_starts_at`. The pane-pointer case also resolves a second chat planted in `north` and asserts the forced pane pointer did not reach it.

- **`_lock_words`' docstring now claims only what is true.** "Every workspace sentence asks this function" was false. It now names the four success sentences that ask it: `use`, `create --use`, `current` and `rename`'s session line. It also names the three places that state a lock in their own words: the refusals (`_locked_msg`, `unlock` inside a chat), `unlock` outside a chat, and `commands_frame._pin_workspace`.

- **The grep.** `grep -rn -E "🔒|[^a-z_]locked|re-locked|unlocked|kept across|followed the rename|Active workspace|workspace set to|reset to|now active|starts at" charter/ --include='*.py'`, every hit read. These are the sentences that state a lock or a persisted selection, and where each stands:

  | Site | Now |
  |---|---|
  | `use`, `create --use` (`_announce_selection`) | lock clause from `_lock_words`; the verb from the lock before and after the call (this round) |
  | `current` | `_lock_words` |
  | `rename`'s session line | `_lock_words` (this round) |
  | `_scope_note` | the chat case and the declared-default case (this round) |
  | `unlock` outside a chat: "unlocked for this session", "No workspace lock was set" | reports the lock file it just deleted, or found absent; true |
  | `_locked_msg`, and `unlock` inside a chat | refusals, naming the lock that refused; true |
  | `commands_frame._pin_workspace`: "🔒 this chat is locked to it for life" | the lock the picked launch takes; true. Both launch paths call it before `state.record_workspace`, so the docstring does not say it names an existing record |
  | `workspace default`: "sessions land here when nothing else has decided" | true; the same line names the rungs above it |
  | `remove`: "Active workspace reset to 'default'." | left for later, recorded on #922 |
  | `cli.py` help (`:488`, `:512`), the SessionStart nudge (`hooks.py:4930`) | say what confirming a workspace does, not what a command just did; left unchanged |

  No other workspace success sentence names a lock. The remaining hits are other nouns: charter's version lock (`instance`, `commands_update`, `commands.py`, `doctor`'s version check, `statusline`, `hooks.py:5275+`), a GitLab merge request's `locked` state, a git index lock in `doctor`, and "starts at" in docstrings about something else.

- **Nits.** `tests/test_workspace_lock.py`'s two docstrings no longer cite the `locked and` conjunct that round 2 deleted. Each now names the `_lock_words` branch it pins, and both claims were measured red by hand (below). `tests/test_a_reaped_chat_leaves_its_session_behind.py` no longer says, in the present tense, that the operator "is told `locked`" or "meets" a refusal.
- **Unchanged, on purpose:** the line in `docs/workspaces.md` and the news entry saying an opencode chat is still asked to confirm a workspace. It is true: `hooks.context_block` → `_context_parts` → `_workspace_confirm_nudge`.
- **Left for later, not this PR:** `remove` in a chat resetting to `default`, and the dead `"active-file"` guards (#922); a rename in a framed chat that follows the rename printing no line, because its `source()` is `frame`; a stale prototype fixture nothing reads.

**Round 3 evidence.**

- **RED**, before any production change. These are the nine new cases, run by name (`python3 -m unittest …`):
  ```
  Ran 9 tests in 0.078s
  FAILED (failures=9)
  ```
  Every failure is an assertion that quotes the old sentence, for example `"followed the rename → 'gamma2' (🔒 locked to 'north')" not found in "… (still 🔒 locked).…"` and `"Active workspace set to 'beta'" not found in "… re-locked to 'beta' …"`.
- **GREEN**, the four amended modules: `Ran 100 tests in 0.908s`, `OK`.
- **Covering tests at `61a8823`**, the same 31 modules as round 2, whose command is above: `Ran 1518 tests in 97.679s`, `OK`.
- **Hand mutations** (`python3 -B`, source restored after each, `git diff --quiet` afterwards): 13 applied, 13 red. The `rename` clause put back gives 4 red. `before and` dropped from the verb gives 2, `locked != before` dropped gives 3, the verb always "re-locked" gives 7, and always "set" gives 2. The scope note's chat branch never taken gives 2, always taken gives 4; the declared default ignored gives 1; the no-scope guard removed gives 1. `_lock_words`' `if not locked` skipped gives 5, and its `locked == name` skipped gives 6. Those last two include the cases the rewritten nit docstrings name. `use`, or `create --use`, not reading the lock before the call gives 1 each.
- **Full suite at `61a8823`** (`python3 -m unittest discover -s tests`, from this worktree): `Ran 11946 tests in 819.106s`, `OK (skipped=9)`. Earlier full-suite runs from this worktree recorded four failures that depend on where a checkout sits. Before this round the branch was rebased onto `cd32ec1`, which carries #949, their fix. The hashes the earlier sections cite predate that rebase.
- **Sweep on `61a8823`** (`python3 tools/sweep.py`): baseline `Ran 11946 tests — OK` · mutations applied 19 · pinned 19 · SURVIVED 0 · UNRESOLVED 0 (21.2 min), closing with *"Every mutation this diff offered goes red."* No survivor, so no case was added after it.
- **CI on `61a8823` agrees.** `deletion sweep` on the merge ref (run 34511246984) passed, with its verdict job named `no survivors`. `tests` passed on 3.11, 3.12, 3.13 and 3.14 for both `push` (34511244249) and `pull_request` (34511246958), and so did CodeQL (34511243511).

## Review round 4 (`0baab89`)

The round-3 re-review marked all four findings addressed. It re-measured G, K, L and the "re-locked" cases, and confirmed both changes that went past its list: the declared-default scope note, and "set to" for a forced `use` of the workspace the lock already names. It also found one Important issue, in the sentence round 3 introduced, and one nit.

- **Inside a chat, `use` and `create --use` no longer write the pointer of the terminal that launched it.** "(this chat only — a new chat starts at the workspace it is opened in)" was false whenever the harness inherited `$TERM_SESSION_ID`. That is every chat started with `charter claude` from Terminal.app or iTerm2 without tmux: `_frame_env` strips `TMUX`, `TMUX_PANE` and the size variables and nothing else of that kind, and `session.terminal` ranks `$TERM_SESSION_ID` first. So a `use` in the chat wrote `terminals/<launcher>.workspace`. The launching shell's `workspace.chosen()` then answered the chat's workspace, which is what `_choose_workspace` reads, and the next `charter claude` from that terminal opened in it with no picker.

  Both commands now hand `set_active` `terminal_id=""` inside a chat. That comes from `_terminal_for_selection`, which asks `workspace.launch_lock()`, and it is the route `frame/switch.py:343` already takes for #411. Whatever resolves by the chat's id meets its session pointer and launch record before the terminal rung, so the chat's own commands lose nothing. `set_active` now reports scope `session` there, and the note is unchanged and true.

  Measured with `python3 -m charter` in a throwaway plane, against an export of `61a8823` and against this branch. A launching terminal had chosen `delta`, and chat `north.1`'s harness inherited that terminal's `$TERM_SESSION_ID`:

  ```
                                   61a8823                            0baab89
  launcher: use delta              launcher resolves delta            launcher resolves delta
  chat: use gamma --force          terminal pointer → gamma           terminal pointer stays delta
                                   launcher resolves gamma            launcher resolves delta
                                   the chat resolves gamma            the chat resolves gamma
  chat: use north, no --force      terminal pointer → north           terminal pointer stays delta
                                   launcher resolves north            launcher resolves delta
  ```

- **Round 3's pane-pointer case is replaced, because it pinned the defect.** It patched `_terminal_id` and asserted the pane pointer WAS written. Two cases with nothing mocked replace it:
  - `test_use_in_a_chat_writes_no_pointer_for_the_terminal_that_launched_it` sets `$TERM_SESSION_ID` in the chat and runs `use gamma --force`. It asserts that no file lands in the terminals directory, that the launching shell's `workspace.chosen()` is what it was before, and that the chat itself still resolves `gamma`.
  - `test_even_an_unforced_use_in_a_chat_leaves_the_launching_terminal_alone` plants the launcher's own pointer at `delta` through `set_active`, runs `use north` in the chat, and asserts the launcher still answers `delta`.

  On `61a8823` both fail on the defect: `['w0t0p0-0A1B2C3D-0936.workspace'] != []` and `'north' != 'delta'`.
- **Docstrings.** `_terminal_for_selection` records the measurement. `_scope_note`'s chat bullet now says what `use` writes in a chat, and that "this chat only" was false until this round. Neither docstring claims that nothing inside a chat reads a terminal pointer: `statusline.render` resolves by the payload's `session_id`, which is the harness's own, and that path was not examined here.
- **Nit.** `_lock_words`' docstring now lists `harness/codex.py`'s `session-lock` deficit among the places that name a lock in their own words.
- **Not in this PR, being filed separately:**
  - `commands_persona._scope_note` promises "kept across closing/reopening Claude" inside a chat, and `persona use` writes the launching terminal's pointer the same way.
  - The Codex no-session-id case.
  - `workspace default --clear` without a name clears nothing.

**Round 4 evidence.**

- **RED** on `61a8823`'s production code, the two new cases by name: `Ran 2 tests`, `FAILED (failures=2)`, with the two assertions above.
- **GREEN**: the two cases, `Ran 2 tests`, `OK`; the four amended modules, `Ran 101 tests in 0.434s`, `OK`.
- **Covering tests on the tree committed as `0baab89`**, the same 31 modules as rounds 2 and 3, whose command is in round 2: `Ran 1519 tests in 93.525s`, `OK`.
- **Sweep on `0baab89`** (`python3 tools/sweep.py`): baseline `Ran 11947 tests — OK` · mutations applied 23 · pinned 23 · SURVIVED 0 · UNRESOLVED 0 (18.5 min), closing with *"Every mutation this diff offered goes red."* The new helper's conditional, `"" if workspace.launch_lock() else None`, was mutated both ways, to `""` always and to `None` always, and both went red.
- **CI on `0baab89` agrees.** `deletion sweep` on the merge ref (run 34516525897) passed, with its verdict job named `no survivors`. `tests` passed on 3.11, 3.12, 3.13 and 3.14 for both `push` (34516521833) and `pull_request` (34516525859), and so did CodeQL and both Analyze jobs.

## Test evidence

**RED**, before any production change:

```
$ python3 -m unittest tests.test_a_chat_is_locked_to_the_workspace_it_was_launched_for
Ran 23 tests in 0.195s
FAILED (failures=18)
```

Every one is an assertion failure naming the defect: `is_locked(CHAT)`: `None != 'north'`; `cmd_workspace_use gamma`: `0 != 2`; `'Confirm the workspace' unexpectedly found in '… (it would otherwise default to `default`)'`; ``'`north`' unexpectedly found in "⬡ **2 other workspaces on this plane** … • `north` · 1 todo"``; `'workspace unlock' unexpectedly found in "… `charter workspace unlock` releases it."`. The handoff launch fixture itself built `alpha.1` with rc 0, so the red is not a broken fixture. Five cases passed, by design: nothing is written, a non-chat session, `use <own>`, the sub-agent routes, and the payload fallback. That last one was split into two cases after RED, so the final module has 24.

**GREEN**:

```
$ python3 -m unittest tests.test_a_chat_is_locked_to_the_workspace_it_was_launched_for
Ran 24 tests in 0.202s
OK
```

The new module plus the 20 modules around the lock, the launcher, the pickers, reaping and SessionStart: `Ran 1134 tests in 8.614s`, `OK`. The README readers, after the README edit: `Ran 96 tests`, `OK`.

**Hand mutations** (`python3 -B`), one at a time, against the new module and its neighbours, with the source restored after each. Baseline OK, and every mutation goes red on the case that names it:

| Mutation | Red |
|---|---|
| hook asks workspace questions by the payload id (the id half) | 6 |
| hook asks by the chat id alone, with no payload fallback | 1 |
| `is_locked` ignores the launch (the lock half) | 14 |
| the lock file outranks the launch | 2 |
| `launch_lock` reads the launch record and not the pin | 1 |
| `unlock` does not refuse inside a chat | 1 |
| the in-chat refusal is the session sentence | 3 |
| `create --use` in a chat says "start a new session" | 1 |
| the PostToolUse memory nudge asks by the payload id | 1 |
| the picked launch's announcement names `unlock` | 1 |
| `create --use`'s `launch_lock()` branch forced on | 1, after the second commit (0 before) |
| `unlock`'s `if held:` forced on | 1, after the second commit (0 before) |
| `_locked_msg`'s `if held:` forced on | 1, after the second commit (0 before) |

The last three rows came from the deletion sweep. It forced `create --use`'s branch on, and nothing went red. Forcing either `if held:` on did the same, because no case read what a session that is *not* a chat hears. The second commit adds three `TestCommandLayer` cases to `tests/test_workspace_lock.py`, one per branch. Each goes red under exactly its own mutation and passes on the real code.

**Full suite on the committed branch, outside any plane** (the deletion sweep's unmutated baseline, in its own sandbox): `Ran 11896 tests — OK in 1072s` on `868c0e9`, `Ran 11890 tests — OK in 1025s` on `ac7fbbb`, and `Ran 11879 tests — OK in 654s` on `d6573ed` before review added cases.

**CI on this PR**: on `a3efe49`, both `tests` runs pass — `pull_request` (the merge ref) and `push` — and the same on `868c0e9`. `main` has since moved to `cd32ec1` (#949), which touches none of this PR's files. `git merge-tree` still merges `a3efe49` cleanly, and the eight amended test modules pass on that merge result (`Ran 327 tests`, `OK`). On `41c2b5f`, `test` passed on 3.11, 3.12, 3.13 and 3.14, and so did CodeQL, both Analyze jobs and the sweep's sizing job; same on every head before it (`ac7fbbb`, `4d98515`, `d6573ed`).

**The merge ref failed once, and the branch never did.** On `5141b42` the `push` run passed and its `pull_request` twin on the same commit errored seven times. Meanwhile `main` had gained #943, which makes SessionStart fork `charter _version-check` through `update.maybe_spawn`; the PR's merge ref includes that call and this branch does not. This module's three SessionStart classes never stubbed the spawner, so on the merge the suite's guard refused the fork. CI's sweep on that merge ref reported *"no verdict: 1 shard refused: the baseline is red"* for the same reason. Reproduced on the merge result built with `git merge-tree HEAD origin/main` — seven errors — then fixed with `tests._isolation.no_background_refresh(self)`, as #943 did for `test_workspace_lock`: 61 tests OK on the merge result, and OK on the branch alone. **On `77cb9c7` the `pull_request` run passes on 3.11, 3.12, 3.13 and 3.14.** Locally, the new module and the seven restaged or related modules also pass on 3.12 (`Ran 309 tests`, `OK`).

**Full suite from this worktree** (`python3 -m unittest discover -s tests`): `Ran 11879 tests in 649.537s`, `FAILED (failures=2, errors=2, skipped=9)`. All four failures predate this change and depend on where the checkout sits: `test_plane_write_guard.WhatIsGuarded` ×2 and `test_statusline_crash_guard.RenderNeverCrashesCase` ×2. The worktree lives inside a live plane (`workspaces/chat-handoff/.worktrees/…`), so `_planeguard._REAL_ROOT` resolves to the outer plane, which is #785's neighbourhood. Measured: the same two modules, in the same worktree, with only this branch's five production files swapped back to `98686c3`, give the same `FAILED (failures=2, errors=2)`.

**Deletion sweep** on `d6573ed` (5 files, 184 added lines, 7 mutations). A first local run before the commit applied 0 mutations: the sweep charges committed lines against the merge-base, so that zero is not evidence.

- **CI** (`sweep.yml`, run 34465440544): `6 pinned, 0 unpinned, 0 unresolved, 1 out of time`. The one out of time was `charter/commands_workspace.py:158`, *"does nothing change when this condition always holds?"*: `create --use`'s `launch_lock()` branch forced on. The run was then cancelled, superseded by this PR's next push.
- **Local** (`python3 tools/sweep.py`): pinned the same six. On the seventh it went to a full-suite re-check, which is what the sweep does for a mutation that survives the modules traced to it. Verdict: `baseline Ran 11879 tests — OK · mutations applied 7 · pinned 6 · SURVIVED 1 · UNRESOLVED 0` (25.3 min). The survivor is the same line: `charter/commands_workspace.py:158`, `workspace.launch_lock()` → `True`, with the full suite still green.
- **Resolved in `4d98515`.** Forcing that branch on left every existing test green, and so did forcing `_locked_msg`'s or `unlock`'s `if held:` on. That was measured by hand in a copy of the tree. The three new `TestCommandLayer` cases each go red under exactly one of the three (the last three rows of the table above).
- **Confirmed by a second sweep, on `4d98515`:** `baseline Ran 11882 tests — OK · mutations applied 7 · pinned 7 · SURVIVED 0 · UNRESOLVED 0` (16.3 min), closing with *"Every mutation this diff offered goes red."* The line that survived is now pinned from both directions — `always holds` and `never holds` — and inside its three traced modules, without a full-suite re-check.
- **CI agrees** (`sweep.yml`, run 34467271003 on `4d98515`): the run completed successfully and its verdict job is named `no survivors`.
- **Round 1 grew the diff to 243 added lines and 19 mutations, and cost five more survivors — all of the same shape.** An assertion that names only an interpolated value, or only the way-out clause every in-chat message ends with, cannot fail on the sentence around it. Re-spelling `_locked_msg`'s lead, the `unlock` refusal's lead, `create --use`'s "was created." line, the forced switch's first half, or its "still locked to '{locked}'" tail each left the module green. Found by hand — the sweep was re-checking four of them against the full suite at the time — and fixed in `ac7fbbb` and `41c2b5f`, where each case now asserts what its own sentence says and goes red under exactly its own re-spelling.
- **A second wave, found by the sweep rather than by hand.** CI's sweep on `41c2b5f` reported **4 survivors, all masked-cluster pairs** — two guards in sequence, each hiding the other: in `cmd_workspace_current`, forcing `if not locked:` or `elif locked == name:` false changed nothing, because no test read either sentence; in `cmd_workspace_use`, dropping the `locked and` conjunct or collapsing `"re-locked to" if force else "set to"` changed nothing either. A scan of every string literal this diff adds to `commands_workspace.py` found three more unpinned message prefixes at the same time.
- **Pinning them surfaced one more false claim, of the family review round 1 named.** `set_active` writes the lock under a session id, so a plain shell with no harness id gets a terminal pointer and **no lock** — and charter announced "🔒 locked for this session" to it anyway. That branch now says what it did. Fixed in `5141b42`, with all four CI survivors and both directions of the new branch measured red by hand on the amended code.
- **Sweep on `5141b42`:** `baseline Ran 11893 tests — OK · mutations applied 21 · pinned 21 · SURVIVED 0 · UNRESOLVED 0`. `77cb9c7` after it changed only a test file. Review round 2 then reworked these messages, and its sweeps are listed in that section above.

**Live**: `python3 -m charter` in throwaway planes, before and after, as shown at the top of this description. The news entry parses through charter's own reader, and `news.entry_errors` returns `[]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
