### PR TITLE
On the dev channel, `charter version` names what it compared, and `version bump` pins only what it fetched (#937)

### DIFF
--- a/charter/cli.py
+++ b/charter/cli.py
@@ -345,7 +345,8 @@ def build_parser() -> argparse.ArgumentParser:
     vbp = vsub.add_parser("bump",
                           help="Move the pin: install + verify the target, then write "
                                "charter.toml. Affects every teammate, so in that order.")
-    vbp.add_argument("--to", help="Version to pin (default: the latest published).")
+    vbp.add_argument("--to", help="Version to pin (default: the latest published, as PyPI "
+                                  "answers this command; refuses if it does not answer).")
     vbp.add_argument("--push", action="store_true",
                      help="Also commit + push the lock, so teammates conform on their "
                           "next session.")

--- a/charter/commands.py
+++ b/charter/commands.py
@@ -3151,18 +3151,12 @@ def cmd_version(args) -> int:
     # contradictory and, when PyPI's GET failed, installed the stale number (#937).
     newer = update.newer_than(installed)
     if newer and channel.is_dev():
+        # One sentence and one next step, both from `update`, because `report send` prints
+        # the same two for the same state (#937). The label is deliberately one line rather
+        # than a branch: which command moves this charter is `dev_remedy`'s question, and
+        # asking it a second time here is how the two surfaces drifted apart the first time.
         util.info(f"{update.dev_verdict(newer)}.")
-        if channel.running_inside(config.ROOT):
-            # `charter update` is an INSTALLER's remedy, and it refuses to install over the
-            # tree it is running from: it answers "the charter you are running IS this tree
-            # … it moves by git rather than by an installer: charter version", which is this
-            # command. Naming it here sent a reader working in a charter clone around that
-            # circle, so this branch names what actually moves that tree. Same question,
-            # same function, as `commands_update._update_dev_on_a_checkout`'s own gate.
-            util.info(f"  this tree IS the charter you are running; it moves by git:  "
-                      f"git -C {channel.package_dir().parent} pull")
-        else:
-            util.info(f"  install `{update.DEV_BRANCH}`:  charter update")
+        util.info(f"  move this charter onto `{update.DEV_BRANCH}`:  {update.dev_remedy()}")
         return 0
     if newer:
         util.info(f"A newer charter is published ({newer}).")

--- a/charter/commands.py
+++ b/charter/commands.py
@@ -3129,11 +3129,10 @@ def sync_to(version: str) -> tuple[bool, str]:
 
 def cmd_version(args) -> int:
     """Show the lock, what is installed, and what to run next."""
-    from . import instance as _instance, update
+    from . import channel, instance as _instance, update
     cfg = _instance.load(config.ROOT)
     locked = _instance.locked_version(cfg)
     installed = _installed_version()
-    latest = (update.load().get("latest") or "").strip() or None
 
     print(f"  installed  {installed}")
     print(f"  locked     {locked or '— (this control plane pins no version)'}")
@@ -3144,8 +3143,26 @@ def cmd_version(args) -> int:
         util.info(f"  {update.SHARED_INSTALL_NOTE}")
         util.info(f"  conform this machine:  charter version sync")
         return 1
-    if latest and update.newer_than(installed):
-        util.info(f"A newer charter is published ({latest}).")
+    # The verdict prints the value its condition compared, and nothing else. It used to be
+    # gated on the cached PyPI `latest` and to print that number, while on the dev channel
+    # `newer_than` compares `main`'s head instead. So a dev plane on the 0.60.0 wheel read
+    # "A newer charter is published (0.58.0)" beside a `latest` row calling 0.58.0 stale. It
+    # was then sent to `version bump --push`, which writes a pin its own session start calls
+    # contradictory and, when PyPI's GET failed, installed the stale number (#937).
+    newer = update.newer_than(installed)
+    if newer and channel.is_dev():
+        mine = channel.installed_commit()
+        if mine:
+            # Unequal, and not which is ahead: a cache can predate the build it is read by.
+            util.info(f"this plane follows `{update.DEV_BRANCH}`, and the head cached for it "
+                      f"({newer}) is not the commit this build was installed from "
+                      f"({mine[:7]}).")
+        else:
+            util.info(f"{update.NOT_INSTALLED_FROM_MAIN}.")
+        util.info(f"  install `{update.DEV_BRANCH}`:  charter update")
+        return 0
+    if newer:
+        util.info(f"A newer charter is published ({newer}).")
         util.info(f"  update, commit and push the lock:  charter version bump --push")
         return 0
     util.ok("up to date." if not locked else f"in sync with the lock ({locked}).")
@@ -3233,8 +3250,12 @@ def cmd_version_bump(args) -> int:
     from . import instance as _instance, update
     target = (getattr(args, "to", None) or "").strip()
     if not target:
-        update.fetch_and_store()
-        target = (update.load().get("latest") or "").strip()
+        # What THIS call fetched, never the cache re-read after it. `fetch_and_store` leaves
+        # `latest` untouched when PyPI's GET fails, so the re-read found whatever an earlier
+        # fetch had left: the refusal below fired only on an empty cache, and a stale one
+        # was installed over the running build and pushed as the team's pin. Measured on a
+        # 0.60.0 wheel with 0.58.0 cached (#937).
+        target = (update.fetch_and_store() or "").strip()
         if not target:
             util.err("could not determine the latest version (offline?). "
                      "Pass one explicitly: charter version bump --to X.Y.Z")

--- a/charter/commands.py
+++ b/charter/commands.py
@@ -3151,15 +3151,18 @@ def cmd_version(args) -> int:
     # contradictory and, when PyPI's GET failed, installed the stale number (#937).
     newer = update.newer_than(installed)
     if newer and channel.is_dev():
-        mine = channel.installed_commit()
-        if mine:
-            # Unequal, and not which is ahead: a cache can predate the build it is read by.
-            util.info(f"this plane follows `{update.DEV_BRANCH}`, and the head cached for it "
-                      f"({newer}) is not the commit this build was installed from "
-                      f"({mine[:7]}).")
+        util.info(f"{update.dev_verdict(newer)}.")
+        if channel.running_inside(config.ROOT):
+            # `charter update` is an INSTALLER's remedy, and it refuses to install over the
+            # tree it is running from: it answers "the charter you are running IS this tree
+            # … it moves by git rather than by an installer: charter version", which is this
+            # command. Naming it here sent a reader working in a charter clone around that
+            # circle, so this branch names what actually moves that tree. Same question,
+            # same function, as `commands_update._update_dev_on_a_checkout`'s own gate.
+            util.info(f"  this tree IS the charter you are running; it moves by git:  "
+                      f"git -C {channel.package_dir().parent} pull")
         else:
-            util.info(f"{update.NOT_INSTALLED_FROM_MAIN}.")
-        util.info(f"  install `{update.DEV_BRANCH}`:  charter update")
+            util.info(f"  install `{update.DEV_BRANCH}`:  charter update")
         return 0
     if newer:
         util.info(f"A newer charter is published ({newer}).")
@@ -3257,7 +3260,12 @@ def cmd_version_bump(args) -> int:
         # 0.60.0 wheel with 0.58.0 cached (#937).
         target = (update.fetch_and_store() or "").strip()
         if not target:
-            util.err("could not determine the latest version (offline?). "
+            # NOT "(offline?)". `fetch_and_store` also answers None when PyPI DID reply and
+            # the cache write failed, so naming the network is a cause charter has not
+            # verified — ADR 0009, whose whole point is that a confident wrong diagnosis
+            # tells the reader to stop looking. Both candidates are offered as candidates.
+            util.err("no version came back from PyPI to pin: either it did not answer, "
+                     "or its answer could not be cached. "
                      "Pass one explicitly: charter version bump --to X.Y.Z")
             return 1
     if target != _installed_version():

--- a/charter/commands_report.py
+++ b/charter/commands_report.py
@@ -288,14 +288,18 @@ def _warn_if_stale() -> None:
     `charter update` has moved this machine's binary past this plane's cache (#127). The
     nudge itself stays, for the reason `update.newer_head`'s docstring gives; both dev cases
     print `update.dev_verdict`, which is the sentence `charter version` prints for the same
-    state.
+    state, and `update.dev_remedy`, which is the next step it names. The remedy is shared
+    for the same reason the sentence is: this line used to say `charter update` to a reader
+    working in a charter clone, where that command refuses the tree and sends them to
+    `charter version` — the surface that had already learned to say `git` instead.
     """
     try:
         from . import channel, statusline, update
         latest = update.newer_than(__version__)
         if latest:
             if channel.is_dev():
-                said = f"{update.dev_verdict(latest)} — `charter update` moves it"
+                said = (f"{update.dev_verdict(latest)} — "
+                        f"`{update.dev_remedy()}` moves it")
             else:
                 said = f"{latest} is out — this may already be fixed"
             # `util.color_enabled()`, not the chip's ANSI default: this is the one caller

--- a/charter/commands_report.py
+++ b/charter/commands_report.py
@@ -280,17 +280,22 @@ def _warn_if_stale() -> None:
     `statusline._dev_chip` exists to resolve, and #457 already made it one function so a
     third surface can call it rather than re-derive `channel.is_dev()` and its try/except.
 
-    **A dev plane whose build records no commit is nudged without a comparison** (#937).
-    `newer_head` returns the cached head for such a build on purpose, so the nudge stays.
-    What it may not do is call that head "out" and a fix "may already" be in it. Measured:
-    `9d18d55` was named that way to a 0.60.0 wheel that already contained it.
+    **On the dev channel it now claims no direction at all** (#937). `newer_head` answers
+    with the cached head for a build that records no commit, and for one whose commit merely
+    DIFFERS from that head. Neither is a measurement of which side is ahead, and "is out"
+    with "may already be fixed" claimed it of both: the first was said to a 0.60.0 wheel
+    that already contained `9d18d55`, and the second is reachable whenever another plane's
+    `charter update` has moved this machine's binary past this plane's cache (#127). The
+    nudge itself stays, for the reason `update.newer_head`'s docstring gives; both dev cases
+    print `update.dev_verdict`, which is the sentence `charter version` prints for the same
+    state.
     """
     try:
         from . import channel, statusline, update
         latest = update.newer_than(__version__)
         if latest:
-            if channel.is_dev() and not channel.installed_commit():
-                said = f"{update.NOT_INSTALLED_FROM_MAIN} — `charter update` moves it"
+            if channel.is_dev():
+                said = f"{update.dev_verdict(latest)} — `charter update` moves it"
             else:
                 said = f"{latest} is out — this may already be fixed"
             # `util.color_enabled()`, not the chip's ANSI default: this is the one caller

--- a/charter/commands_report.py
+++ b/charter/commands_report.py
@@ -279,18 +279,26 @@ def _warn_if_stale() -> None:
     between *a release was cut* and *main moved*. That is the exact ambiguity
     `statusline._dev_chip` exists to resolve, and #457 already made it one function so a
     third surface can call it rather than re-derive `channel.is_dev()` and its try/except.
+
+    **A dev plane whose build records no commit is nudged without a comparison** (#937).
+    `newer_head` returns the cached head for such a build on purpose, so the nudge stays.
+    What it may not do is call that head "out" and a fix "may already" be in it. Measured:
+    `9d18d55` was named that way to a 0.60.0 wheel that already contained it.
     """
     try:
-        from . import statusline, update
+        from . import channel, statusline, update
         latest = update.newer_than(__version__)
         if latest:
+            if channel.is_dev() and not channel.installed_commit():
+                said = f"{update.NOT_INSTALLED_FROM_MAIN} — `charter update` moves it"
+            else:
+                said = f"{latest} is out — this may already be fixed"
             # `util.color_enabled()`, not the chip's ANSI default: this is the one caller
             # that is not a terminal surface, and `util.warn` gates its own glyph the same
             # way. The call stays INSIDE the f-string on purpose — `test_version_shows_
             # channel`'s AST property looks for it in the same `JoinedStr` as the version.
             color = util.color_enabled()
             util.warn(f"you are on charter {__version__}{statusline._dev_chip(color)}; "
-                      f"{latest} is out — this may already be fixed. Reporting anyway is "
-                      "fine.")
+                      f"{said}. Reporting anyway is fine.")
     except Exception:  # noqa: BLE001 - a staleness check must never block a report
         pass

--- a/charter/update.py
+++ b/charter/update.py
@@ -132,6 +132,19 @@ def _parse(v: str) -> tuple:
     return tuple(out)
 
 
+#: What the dev channel may say about a build that records no commit, and all it may say.
+#:
+#: `newer_head` nudges such a build on purpose, and its docstring says why. A nudge is not
+#: a comparison, though. A cached head of `main` and a wheel's version number are not on
+#: one axis, so charter cannot tell which is newer. `charter version` printed the cached
+#: PyPI number as "published" and newer, and `report send` said "9d18d55 is out — this may
+#: already be fixed", both to a 0.60.0 wheel that already contained `9d18d55` (#937). This
+#: sentence claims only what the install record shows. Both surfaces print it, so they
+#: cannot drift into describing one state two different ways.
+NOT_INSTALLED_FROM_MAIN = (f"this plane follows `{DEV_BRANCH}`, but this build was not "
+                           f"installed from a commit of it")
+
+
 def newer_head() -> str | None:
     """The dev channel's answer to "is there anything newer?" — a short commit, or None.
 

--- a/charter/update.py
+++ b/charter/update.py
@@ -170,6 +170,28 @@ def dev_verdict(head: str) -> str:
             f"not the commit this build was installed from ({mine[:7]})")
 
 
+def dev_remedy() -> str:
+    """The command that moves THIS charter onto ``main`` — one answer for every surface.
+
+    Beside :func:`dev_verdict`, and for the same reason. Two surfaces that describe one
+    state with one sentence and then prescribe two different next steps have the same defect
+    one line further down the message — which is exactly how it shipped: `charter version`
+    learned about the checkout case and `report send` went on naming the installer.
+
+    ``charter update`` refuses to install over the tree it is running from. It answers "the
+    charter you are running IS this tree … it moves by git rather than by an installer:
+    charter version", which is `commands.cmd_version` — so a reader working in a charter
+    clone was handed a loop between two commands, each naming the other. The gate is the
+    question `commands_update` already asks, :func:`channel.running_inside`, and that answer
+    names the tree, because a bare ``git pull`` typed somewhere else moves something else.
+    """
+    from . import channel
+
+    if channel.running_inside(config.ROOT):
+        return f"git -C {channel.package_dir().parent} pull"
+    return "charter update"
+
+
 def newer_head() -> str | None:
     """The dev channel's answer to "is there anything newer?" — a short commit, or None.
 

--- a/charter/update.py
+++ b/charter/update.py
@@ -145,6 +145,31 @@ NOT_INSTALLED_FROM_MAIN = (f"this plane follows `{DEV_BRANCH}`, but this build w
                            f"installed from a commit of it")
 
 
+def dev_verdict(head: str) -> str:
+    """What a dev plane may say about *head*, the short commit :func:`newer_head` returned.
+
+    One comparison, and never a direction. `charter version` and `charter report send` both
+    print this: one state described two different ways on two surfaces is how #937 started,
+    and a constant shared by only ONE of the two cases below would leave the other free to
+    drift back.
+
+    **The build that has a commit is the case that looks safe and is not.** "``<head>`` is
+    out" reads as *``main`` has moved past you*, which charter has not checked. The cache is
+    per plane (:data:`config.STATE_DIR`) while the binary is one machine-global install
+    (#127), so ``charter update`` run in plane A moves this build to a commit that plane B's
+    cache has never heard of. B's cached head is then an ANCESTOR of what is running, and
+    "is out" is exactly backwards — the same claim, in the same direction, that #937 is
+    about. Unequal is all that was measured, so unequal is all this says.
+    """
+    from . import channel
+
+    mine = channel.installed_commit()
+    if not mine:
+        return NOT_INSTALLED_FROM_MAIN
+    return (f"this plane follows `{DEV_BRANCH}`, and the head cached for it ({head}) is "
+            f"not the commit this build was installed from ({mine[:7]})")
+
+
 def newer_head() -> str | None:
     """The dev channel's answer to "is there anything newer?" — a short commit, or None.
 

--- a/docs/control-plane.md
+++ b/docs/control-plane.md
@@ -445,6 +445,16 @@ verifies the target *before* writing the lock, so you cannot pin colleagues to a
 have not run; `--push` commits and pushes, and everyone conforms on their next session.
 charter only ever *shows* you that command — it never bumps on its own.
 
+**With no `--to`, it pins what PyPI tells that same command.** If PyPI does not answer, it
+refuses and asks for `--to`. It does not fall back to the cached reading `charter version`
+shows, which can be days old and older than the charter you are running. Before #937 it
+did fall back, and a failed request installed that older release over the running one and
+pushed it to the team as the pin.
+
+On a plane that declares the [dev channel](install.md#4-the-dev-channel--trying-main-without-cutting-a-release),
+`charter version` never suggests this command, because a pin and the dev channel cannot
+both be declared. It names `charter update` instead.
+
 ## `[harness].default` — bare `charter`
 
 **Opt-in.** Absent, `charter` on its own prints the usage list, exactly as it always has.

--- a/docs/install.md
+++ b/docs/install.md
@@ -223,14 +223,18 @@ update`. Auto-installing unreviewed merges is committed content reaching executi
 a moment of consent, which is the one thing charter will not do to you.
 
 **`charter version` says what it compared, and on this channel that is a commit.** On a
-git build whose commit differs from the cached head of `main`, it names both commits. It
-does not say which is newer, because the cache can be older than your install. A build that
-records no commit, such as the PyPI wheel before your first `charter update`, has nothing
-to compare. For that build it says only that this plane follows `main` and this build was
-not installed from a commit of it. `charter report send` says the same about that build.
-Both name `charter update` as the next step. Neither names a published release as newer on
-this channel. Before #937 both did: a 0.60.0 wheel was told that 0.58.0 was newer, and that
-a commit it already contained might hold a fix.
+git build whose commit differs from the cached head of `main`, it names both commits and
+does not say which is newer. It cannot: this cache belongs to this plane while the `charter`
+binary is shared by every plane on the machine, so an update run in another plane can leave
+the head cached here an *ancestor* of the build you are running. A build that records no
+commit, such as the PyPI wheel before your first `charter update`, has nothing to compare at
+all; for it the line says only that this plane follows `main` and this build was not
+installed from a commit of it. `charter report send` says the same sentence, in both cases.
+The next step they name is `charter update` — or a `git pull`, when the charter you are
+running is a clone you are working in, since `charter update` will not install over that
+tree. Neither surface calls a published release newer on this channel. Before #937 both did:
+a 0.60.0 wheel was told that 0.58.0 was newer, and that a commit it already contained might
+hold a fix.
 
 **A plane cannot ask for both a pin and the dev channel.** `[charter] version` names a
 published release the whole team conforms to; `main` has no such number. Declare both and

--- a/docs/install.md
+++ b/docs/install.md
@@ -222,6 +222,16 @@ remembered to stamp.
 update`. Auto-installing unreviewed merges is committed content reaching execution without
 a moment of consent, which is the one thing charter will not do to you.
 
+**`charter version` says what it compared, and on this channel that is a commit.** On a
+git build whose commit differs from the cached head of `main`, it names both commits. It
+does not say which is newer, because the cache can be older than your install. A build that
+records no commit, such as the PyPI wheel before your first `charter update`, has nothing
+to compare. For that build it says only that this plane follows `main` and this build was
+not installed from a commit of it. `charter report send` says the same about that build.
+Both name `charter update` as the next step. Neither names a published release as newer on
+this channel. Before #937 both did: a 0.60.0 wheel was told that 0.58.0 was newer, and that
+a commit it already contained might hold a fix.
+
 **A plane cannot ask for both a pin and the dev channel.** `[charter] version` names a
 published release the whole team conforms to; `main` has no such number. Declare both and
 charter installs neither, and says so at session start.

--- a/docs/news/unreleased-version-on-dev-says-what-it-compared.md
+++ b/docs/news/unreleased-version-on-dev-says-what-it-compared.md
@@ -1,0 +1,31 @@
+---
+version: unreleased
+headline: On the dev channel, `charter version` stops calling an older release newer, and `version bump` pins only what it fetched
+---
+
+On a plane that declares `[update] channel = "dev"` while running the PyPI wheel,
+`charter version` printed this on one screen:
+
+```
+• A newer charter is published (0.58.0).
+•   update, commit and push the lock:  charter version bump --push
+  installed  0.60.0
+  latest     — (cached 0.58.0 is stale: it predates the 0.60.0 you are running)
+```
+
+The check compared `main`'s cached head with this build's commit. The headline printed the
+cached PyPI number instead, which that check never looked at. The next step it named does
+not suit a dev plane either: it writes a pin that the plane's own session start reports as
+contradictory.
+
+Now the verdict names only what was compared. On a git build it names the cached head and
+your commit when they differ, and does not say which is newer. On a build that records no
+commit it says that this plane follows `main` and this build was not installed from a commit
+of it. Either way it names `charter update`. `charter report send` stops telling that same
+build that a commit it already contains "may already" hold a fix. The stable channel's
+output is unchanged.
+
+`charter version bump` with no `--to` now pins only the version PyPI returned to that same
+command. Before, it re-read the cache after fetching, and a failed request leaves the cache
+as it was. So instead of refusing as "offline?", it installed the stale cached release over
+the running one and pushed that pin to the team.

--- a/docs/news/unreleased-version-on-dev-says-what-it-compared.md
+++ b/docs/news/unreleased-version-on-dev-says-what-it-compared.md
@@ -19,11 +19,14 @@ not suit a dev plane either: it writes a pin that the plane's own session start 
 contradictory.
 
 Now the verdict names only what was compared. On a git build it names the cached head and
-your commit when they differ, and does not say which is newer. On a build that records no
-commit it says that this plane follows `main` and this build was not installed from a commit
-of it. Either way it names `charter update`. `charter report send` stops telling that same
-build that a commit it already contains "may already" hold a fix. The stable channel's
-output is unchanged.
+your commit when they differ, and does not say which is newer: this cache is this plane's,
+the binary is the machine's, so another plane's `charter update` can leave the head cached
+here behind the build you are running. On a build that records no commit it says that this
+plane follows `main` and this build was not installed from a commit of it. Either way it
+names `charter update`, or a `git pull` when the charter you run is a clone you are working
+in. `charter report send` prints the same sentence, so neither surface tells a dev build
+that a commit it may already contain holds the fix. The stable channel's output is
+unchanged.
 
 `charter version bump` with no `--to` now pins only the version PyPI returned to that same
 command. Before, it re-read the cache after fetching, and a failed request leaves the cache

--- a/docs/news/unreleased-version-on-dev-says-what-it-compared.md
+++ b/docs/news/unreleased-version-on-dev-says-what-it-compared.md
@@ -24,9 +24,10 @@ the binary is the machine's, so another plane's `charter update` can leave the h
 here behind the build you are running. On a build that records no commit it says that this
 plane follows `main` and this build was not installed from a commit of it. Either way it
 names `charter update`, or a `git pull` when the charter you run is a clone you are working
-in. `charter report send` prints the same sentence, so neither surface tells a dev build
-that a commit it may already contain holds the fix. The stable channel's output is
-unchanged.
+in — `charter update` will not install over that tree. `charter report send` prints the same
+sentence and names the same next step, so neither surface tells a dev build that a commit it
+may already contain holds the fix, and neither hands a clone a command that refuses it. The
+stable channel's output is unchanged.
 
 `charter version bump` with no `--to` now pins only the version PyPI returned to that same
 command. Before, it re-read the cache after fetching, and a failed request leaves the cache

--- a/tests/test_version_on_dev_says_what_it_compared.py
+++ b/tests/test_version_on_dev_says_what_it_compared.py
@@ -1,0 +1,276 @@
+"""#937: on the dev channel, `charter version` called an older release newer.
+
+Measured on the 0.60.0 wheel, on a plane declaring ``[update] channel = "dev"``, with a
+cache holding ``latest: 0.58.0`` and a ``head`` from inside v0.59.0. One screen said:
+
+    • A newer charter is published (0.58.0).
+    •   update, commit and push the lock:  charter version bump --push
+      installed  0.60.0
+      latest     — (cached 0.58.0 is stale: it predates the 0.60.0 you are running)
+
+The condition asked the dev channel (`update.newer_than` hands off to `newer_head`, which
+nudges any build that records no commit), and the message answered with the PyPI cache,
+a number that condition had never compared with anything. Three things were wrong, and
+each class below pins one of them:
+
+* **The headline printed a value its condition did not test.** On dev the verdict now
+  names what was compared: the cached head against this build's commit, or, where there is
+  no commit, the fact that this build did not come from `main`. It never prints a PyPI
+  number, and its remedy is `charter update`. That is the dev channel's command. `version
+  bump --push` writes a pin that this plane's own session start calls contradictory.
+* **`report send` claimed the same comparison.** ``9d18d55 is out — this may already be
+  fixed`` was said to a build that `9d18d55` predates. The nudge is kept, because
+  `newer_head`'s docstring explains why it is deliberate. Only what it claims changed.
+* **`version bump` pinned a version it had not fetched.** It called `fetch_and_store` and
+  then re-read the cache, which a failed GET leaves untouched. So the "offline?" refusal
+  fired only on an empty cache, and a stale one was installed over the running build and
+  pushed to the team.
+
+ADR 0013: do not present as checked what was not checked.
+
+Nothing here reaches the network or installs anything: `NoNetwork` refuses every route
+out, the two GETs are stubbed where a test needs an answer, and `sync_to`,
+`set_locked_version` and `commit_push` are recorders.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+from contextlib import redirect_stderr, redirect_stdout
+from types import SimpleNamespace
+from unittest import mock
+
+from charter import __version__, commands, commands_report, update, util
+from tests._isolation import PersonaIso, pin_update_channel
+from tests.test_dev_channel import NoNetwork
+
+#: Older than any charter that can be running this suite. The field report's cache held
+#: 0.58.0 under a 0.60.0 wheel, and the exact numbers are not the point.
+_STALE = "0.0.1"
+#: The report's cached head, `9d18d55`, which is contained in v0.59.0. It is older than
+#: the wheel it was offered to, and nothing in charter can know that from a wheel.
+_HEAD = "9d18d55" + "0" * 33
+_MINE = "a" * 40
+
+
+def _cache(**record) -> None:
+    p = update._cache_file()
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(json.dumps(record))
+
+
+def _run(fn, args) -> tuple[int, str]:
+    out, err = io.StringIO(), io.StringIO()
+    with redirect_stdout(out), redirect_stderr(err):
+        rc = fn(args)
+    return rc, out.getvalue() + err.getvalue()
+
+
+def _verdict(printed: str) -> str:
+    """Everything `charter version` printed except its three table rows.
+
+    The `latest` row legitimately carries the cached PyPI number, as "cached 0.0.1 is
+    stale", and that row was right all along. Filtering it out is what lets "no PyPI number
+    in the verdict" be asserted at all, rather than weakened to "no word 'published'".
+    """
+    rows = ("installed ", "locked ", "latest ")
+    return "\n".join(l for l in printed.splitlines() if not l.lstrip().startswith(rows))
+
+
+class VersionOnDevSaysWhatItCompared(NoNetwork, PersonaIso):
+    def setUp(self):
+        super().setUp()
+        pin_update_channel(self, "dev")
+        # Not vacuous: the fixture is only the report's shape if the cached release really
+        # is older than the build running the test.
+        self.assertLess(update._parse(_STALE), update._parse(__version__))
+
+    def _version(self, *, commit):
+        with mock.patch("charter.channel.installed_commit", return_value=commit):
+            return _run(commands.cmd_version, SimpleNamespace())
+
+    def test_an_older_cached_release_is_not_called_newer_on_a_build_with_no_commit(self):
+        """The report, line for line: a wheel on a dev plane and a stale PyPI cache."""
+        _cache(latest=_STALE, head=_HEAD, ts=1.0)
+        rc, printed = self._version(commit=None)
+        self.assertEqual(rc, 0)
+        # The table read the same cache, so an absent number below is not a missing cache.
+        self.assertIn(f"cached {_STALE} is stale", printed)
+        verdict = _verdict(printed)
+        self.assertNotIn("published", verdict)
+        self.assertNotIn(_STALE, verdict, "the verdict printed a PyPI number it never compared")
+        self.assertNotIn("version bump", verdict,
+                         "the dev channel was told to pin a published release")
+        # No commit means no comparison, so the head is not offered as newer either: here
+        # it is OLDER than the wheel, and charter has no way to know that.
+        self.assertNotIn(_HEAD[:7], verdict)
+        self.assertIn(update.NOT_INSTALLED_FROM_MAIN, verdict)
+        self.assertIn("charter update", verdict)
+
+    def test_a_newer_cached_release_is_not_announced_on_dev_either(self):
+        """The same defect when the number happens to be higher. The dev condition never
+        compared it, so printing it is still printing something nobody checked."""
+        _cache(latest="99.0.0", head=_HEAD, ts=1.0)
+        _, printed = self._version(commit=None)
+        verdict = _verdict(printed)
+        self.assertNotIn("99.0.0", verdict)
+        self.assertNotIn("published", verdict)
+
+    def test_a_build_with_a_commit_names_both_commits_and_calls_neither_newer(self):
+        """A commit makes a comparison possible, but only an unequal one. The cached head
+        can be older than a build `charter update` installed after the cache was written,
+        so the verdict says the two differ and not which one is ahead."""
+        _cache(latest=_STALE, head=_HEAD, ts=1.0)
+        rc, printed = self._version(commit=_MINE)
+        self.assertEqual(rc, 0)
+        verdict = _verdict(printed)
+        self.assertIn(_HEAD[:7], verdict)
+        self.assertIn(_MINE[:7], verdict)
+        self.assertNotIn("newer", verdict.lower())
+        self.assertNotIn(_STALE, verdict)
+        self.assertNotIn("version bump", verdict)
+        self.assertIn("charter update", verdict)
+
+    def test_the_dev_verdict_is_not_gated_on_a_pypi_reading(self):
+        """The old condition was `latest and newer_than(...)`, so a PyPI field decided
+        whether a dev plane heard about `main` at all. With no release cached, a wheel on
+        a dev plane was told it was up to date."""
+        _cache(head=_HEAD, ts=1.0)
+        _, printed = self._version(commit=None)
+        verdict = _verdict(printed)
+        self.assertNotIn("up to date", verdict)
+        self.assertIn(update.NOT_INSTALLED_FROM_MAIN, verdict)
+
+    def test_a_build_on_the_cached_head_is_up_to_date(self):
+        _cache(latest=_STALE, head=_MINE, ts=1.0)
+        rc, printed = self._version(commit=_MINE)
+        self.assertEqual(rc, 0)
+        verdict = _verdict(printed)
+        self.assertIn("up to date", verdict)
+        self.assertNotIn("charter update", verdict)
+
+
+class VersionOnStableIsUnchanged(NoNetwork, PersonaIso):
+    """The stable channel's verdict was correct, and it must survive the dev fix as it was."""
+
+    def setUp(self):
+        super().setUp()
+        pin_update_channel(self, "stable")
+
+    def test_a_newer_published_release_is_named_with_the_bump(self):
+        _cache(latest="99.0.0", head=_HEAD, ts=1.0)
+        rc, printed = _run(commands.cmd_version, SimpleNamespace())
+        self.assertEqual(rc, 0)
+        verdict = _verdict(printed)
+        self.assertIn("A newer charter is published (99.0.0).", verdict)
+        self.assertIn("charter version bump --push", verdict)
+        self.assertNotIn(update.NOT_INSTALLED_FROM_MAIN, verdict)
+
+    def test_an_older_cached_release_is_not_called_newer(self):
+        _cache(latest=_STALE, ts=1.0)
+        _, printed = _run(commands.cmd_version, SimpleNamespace())
+        verdict = _verdict(printed)
+        self.assertNotIn("published", verdict)
+        self.assertIn("up to date", verdict)
+
+
+class TheReportNudgeOnDevClaimsNoComparison(NoNetwork, PersonaIso):
+    def setUp(self):
+        super().setUp()
+        pin_update_channel(self, "dev")
+
+    def _nudge(self, *, commit, head=_HEAD) -> str:
+        _cache(latest=_STALE, head=head, ts=1.0)
+        buf = io.StringIO()
+        with mock.patch("charter.channel.installed_commit", return_value=commit), \
+             mock.patch.object(util, "_USE_COLOR", False), redirect_stderr(buf):
+            commands_report._warn_if_stale()
+        return buf.getvalue()
+
+    def test_a_build_with_no_commit_is_not_told_a_fix_may_already_exist(self):
+        """`9d18d55 is out — this may already be fixed`, said to a wheel `9d18d55` predates."""
+        said = self._nudge(commit=None)
+        # The nudge is deliberate (`newer_head`'s docstring), so it is still there...
+        self.assertIn(f"charter {__version__} dev", said)
+        # ...and it no longer claims a comparison nobody made.
+        self.assertNotIn("is out", said)
+        self.assertNotIn("may already be fixed", said)
+        self.assertNotIn(_HEAD[:7], said)
+        self.assertIn(update.NOT_INSTALLED_FROM_MAIN, said)
+        self.assertIn("charter update", said)
+
+    def test_a_build_with_a_commit_keeps_the_nudge_it_had(self):
+        """#937 changes what the no-commit case claims and nothing else."""
+        said = self._nudge(commit=_MINE)
+        self.assertIn(f"{_HEAD[:7]} is out", said)
+        self.assertNotIn(update.NOT_INSTALLED_FROM_MAIN, said)
+
+    def test_a_build_on_the_cached_head_is_not_nudged(self):
+        self.assertEqual(self._nudge(commit=_MINE, head=_MINE), "")
+
+
+class VersionBumpPinsOnlyWhatItFetched(NoNetwork, PersonaIso):
+    """`version bump` with no `--to` pins the version its own GET returned, or refuses."""
+
+    def setUp(self):
+        super().setUp()
+        self.calls: list[tuple] = []
+
+        def sync_to(v):
+            self.calls.append(("sync_to", v))
+            return True, v
+
+        def set_locked_version(root, v):
+            self.calls.append(("set_locked_version", v))
+            return True
+
+        def commit_push(root, add, message):
+            self.calls.append(("commit_push", message))
+            return 0
+
+        self.enterContext(mock.patch("charter.commands.sync_to", side_effect=sync_to))
+        self.enterContext(mock.patch("charter.instance.set_locked_version",
+                                     side_effect=set_locked_version))
+        self.enterContext(mock.patch("charter.commands.commit_push", side_effect=commit_push))
+
+    def _bump(self):
+        return _run(commands.cmd_version_bump, SimpleNamespace(to=None, push=True))
+
+    def test_a_failed_pypi_fetch_over_a_stale_cache_refuses(self):
+        """The downgrade. `fetch_and_store` leaves `latest` alone when its GET fails, and
+        the re-read found 0.58.0 there, installed it over 0.60.0 and pushed the pin."""
+        pin_update_channel(self, "stable")
+        _cache(latest=_STALE, ts=1.0)
+        with mock.patch.object(update, "_fetch_latest", return_value=None):
+            rc, printed = self._bump()
+        self.assertEqual(rc, 1)
+        self.assertEqual(self.calls, [], "bump acted on a version it did not fetch")
+        self.assertIn("offline", printed)
+
+    def test_a_dev_plane_whose_head_fetch_succeeds_refuses_the_same_way(self):
+        """The measured shape: on dev the branch GET can succeed while PyPI's fails, and a
+        partial fetch still writes the cache. The head is not a version, and the stale
+        `latest` beside it is not what this call fetched."""
+        pin_update_channel(self, "dev")
+        _cache(latest=_STALE, head=_HEAD, ts=1.0)
+        with mock.patch.object(update, "_fetch_latest", return_value=None), \
+             mock.patch.object(update, "_fetch_head", return_value="f" * 40):
+            rc, _ = self._bump()
+        self.assertEqual(rc, 1)
+        self.assertEqual(self.calls, [])
+
+    def test_a_successful_fetch_pins_what_it_fetched(self):
+        pin_update_channel(self, "stable")
+        _cache(latest=_STALE, ts=1.0)
+        with mock.patch.object(update, "_fetch_latest", return_value="99.0.0"):
+            rc, _ = self._bump()
+        self.assertEqual(rc, 0)
+        self.assertEqual(self.calls, [("sync_to", "99.0.0"),
+                                      ("set_locked_version", "99.0.0"),
+                                      ("commit_push", "charter: pin to 99.0.0")])
+
+
+if __name__ == "__main__":
+    import unittest
+    unittest.main()

--- a/tests/test_version_on_dev_says_what_it_compared.py
+++ b/tests/test_version_on_dev_says_what_it_compared.py
@@ -16,17 +16,20 @@ each class below pins one of them:
 * **The headline printed a value its condition did not test.** On dev the verdict now
   names what was compared: the cached head against this build's commit, or, where there is
   no commit, the fact that this build did not come from `main`. It never prints a PyPI
-  number, and its remedy is `charter update`. That is the dev channel's command. `version
-  bump --push` writes a pin that this plane's own session start calls contradictory.
-* **`report send` claimed the same comparison.** ``9d18d55 is out — this may already be
-  fixed`` was said to a build that `9d18d55` predates. The nudge is kept, because
-  `newer_head`'s docstring explains why it is deliberate. Only what it claims changed.
+  number, and its remedy is `charter update` — or `git`, where the charter running the
+  command IS the tree, because `charter update` sends that reader back to `charter
+  version`. `version bump --push` writes a pin that this plane's own session start calls
+  contradictory.
+* **`report send` claimed a direction nobody measured.** ``9d18d55 is out — this may
+  already be fixed`` was said to a build that `9d18d55` predates. The nudge is kept,
+  because `newer_head`'s docstring explains why it is deliberate, and both dev cases now
+  print `update.dev_verdict`, the same sentence `charter version` prints.
 * **`version bump` pinned a version it had not fetched.** It called `fetch_and_store` and
-  then re-read the cache, which a failed GET leaves untouched. So the "offline?" refusal
-  fired only on an empty cache, and a stale one was installed over the running build and
-  pushed to the team.
+  then re-read the cache, which a failed GET leaves untouched. So the refusal fired only
+  on an empty cache, and a stale one was installed over the running build and pushed.
 
-ADR 0013: do not present as checked what was not checked.
+ADR 0013: do not present as checked what was not checked. ADR 0009: an error may not
+assert a cause it did not verify, which is why that refusal no longer says "offline?".
 
 Nothing here reaches the network or installs anything: `NoNetwork` refuses every route
 out, the two GETs are stubbed where a test needs an answer, and `sync_to`,
@@ -142,6 +145,19 @@ class VersionOnDevSaysWhatItCompared(NoNetwork, PersonaIso):
         self.assertNotIn("up to date", verdict)
         self.assertIn(update.NOT_INSTALLED_FROM_MAIN, verdict)
 
+    def test_a_charter_run_out_of_this_tree_is_sent_to_git_not_the_installer(self):
+        """`charter update` refuses to install over the tree it is running from, and points
+        at `charter version` instead ("it moves by git rather than by an installer"). So
+        this command naming `charter update` there is a loop between two commands, each
+        naming the other. A checkout records no commit, so it lands in this branch.
+        """
+        _cache(latest=_STALE, head=_HEAD, ts=1.0)
+        with mock.patch("charter.channel.running_inside", return_value=True):
+            _, printed = self._version(commit=None)
+        verdict = _verdict(printed)
+        self.assertIn("pull", verdict)
+        self.assertNotIn("charter update", verdict)
+
     def test_a_build_on_the_cached_head_is_up_to_date(self):
         _cache(latest=_STALE, head=_MINE, ts=1.0)
         rc, printed = self._version(commit=_MINE)
@@ -200,11 +216,37 @@ class TheReportNudgeOnDevClaimsNoComparison(NoNetwork, PersonaIso):
         self.assertIn(update.NOT_INSTALLED_FROM_MAIN, said)
         self.assertIn("charter update", said)
 
-    def test_a_build_with_a_commit_keeps_the_nudge_it_had(self):
-        """#937 changes what the no-commit case claims and nothing else."""
+    def test_a_build_with_a_commit_is_not_told_the_head_is_out_either(self):
+        """The case the first fix left behind, and it is reachable rather than theoretical.
+
+        The cache is per plane (`config.STATE_DIR`) and the binary is one machine-global
+        install (#127). So `charter update` in plane A moves this build to H2 while plane
+        B's cache still holds H1, an ancestor of it. `newer_head` returns H1 because H1 is
+        not H2, and "H1 is out — this may already be fixed" then tells a build that
+        already contains H1 to go and get it. Unequal is the whole measurement.
+        """
         said = self._nudge(commit=_MINE)
-        self.assertIn(f"{_HEAD[:7]} is out", said)
-        self.assertNotIn(update.NOT_INSTALLED_FROM_MAIN, said)
+        self.assertIn(f"charter {__version__} dev", said)
+        self.assertNotIn("is out", said)
+        self.assertNotIn("may already be fixed", said)
+        # Both commits, as `charter version` names them.
+        self.assertIn(_HEAD[:7], said)
+        self.assertIn(_MINE[:7], said)
+        self.assertIn("charter update", said)
+
+    def test_both_surfaces_describe_a_build_with_a_commit_the_same_way(self):
+        """`update.dev_verdict` is one function for the reason #457 made `_dev_chip` one:
+        two surfaces describing a single state in two wordings is how #937 began, and a
+        constant shared by only one of the two cases would leave the other free to drift."""
+        _cache(latest=_STALE, head=_HEAD, ts=1.0)
+        with mock.patch("charter.channel.installed_commit", return_value=_MINE):
+            sentence = update.dev_verdict(_HEAD[:7])
+            _, printed = _run(commands.cmd_version, SimpleNamespace())
+            buf = io.StringIO()
+            with mock.patch.object(util, "_USE_COLOR", False), redirect_stderr(buf):
+                commands_report._warn_if_stale()
+        self.assertIn(sentence, _verdict(printed))
+        self.assertIn(sentence, buf.getvalue())
 
     def test_a_build_on_the_cached_head_is_not_nudged(self):
         self.assertEqual(self._nudge(commit=_MINE, head=_MINE), "")
@@ -266,7 +308,11 @@ class VersionBumpPinsOnlyWhatItFetched(NoNetwork, PersonaIso):
             rc, printed = self._bump()
         self.assertEqual(rc, 1)
         self.assertEqual(self.calls, [], "bump acted on a version it did not fetch")
-        self.assertIn("offline", printed)
+        self.assertIn("charter version bump --to", printed)
+        self.assertNotIn("offline", printed,
+                         "the refusal names a cause it did not check (ADR 0009): "
+                         "`fetch_and_store` also answers None when PyPI replied and the "
+                         "cache write failed")
 
     def test_a_dev_plane_whose_head_fetch_succeeds_refuses_the_same_way(self):
         """The measured shape: on dev the branch GET can succeed while PyPI's fails, and a

--- a/tests/test_version_on_dev_says_what_it_compared.py
+++ b/tests/test_version_on_dev_says_what_it_compared.py
@@ -248,6 +248,31 @@ class TheReportNudgeOnDevClaimsNoComparison(NoNetwork, PersonaIso):
         self.assertIn(sentence, _verdict(printed))
         self.assertIn(sentence, buf.getvalue())
 
+    def test_both_surfaces_name_the_same_next_step(self):
+        """One state, one sentence — and one remedy, for the same reason.
+
+        `charter update` refuses to install over the tree it is running from and points at
+        `charter version`, so a checkout has to be told about git instead. Fixing that on
+        the verdict alone left `report send` handing a clone user the command that answers
+        "the charter you are running IS this tree", which is the divergence
+        `update.dev_verdict` exists to prevent, one line further down the same message.
+        """
+        _cache(latest=_STALE, head=_HEAD, ts=1.0)
+        for inside in (True, False):
+            with self.subTest(running_inside=inside):
+                with mock.patch("charter.channel.installed_commit", return_value=None), \
+                     mock.patch("charter.channel.running_inside", return_value=inside):
+                    remedy = update.dev_remedy()
+                    _, printed = _run(commands.cmd_version, SimpleNamespace())
+                    buf = io.StringIO()
+                    with mock.patch.object(util, "_USE_COLOR", False), redirect_stderr(buf):
+                        commands_report._warn_if_stale()
+                self.assertIn(remedy, _verdict(printed))
+                self.assertIn(remedy, buf.getvalue())
+                # Not vacuous: the gate has to be what decides the answer, or both surfaces
+                # would agree on `charter update` everywhere and this would still pass.
+                self.assertEqual(inside, "pull" in remedy)
+
     def test_a_build_on_the_cached_head_is_not_nudged(self):
         self.assertEqual(self._nudge(commit=_MINE, head=_MINE), "")
 

--- a/tests/test_version_on_dev_says_what_it_compared.py
+++ b/tests/test_version_on_dev_says_what_it_compared.py
@@ -210,6 +210,26 @@ class TheReportNudgeOnDevClaimsNoComparison(NoNetwork, PersonaIso):
         self.assertEqual(self._nudge(commit=_MINE, head=_MINE), "")
 
 
+class TheReportNudgeOnStableIsUnchanged(NoNetwork, PersonaIso):
+    """A stable plane on the PyPI wheel also records no commit. So the no-commit sentence
+    has to be gated on the channel, or a real newer release stops being named. Every
+    dev-pinned test above passes with that gate deleted."""
+
+    def setUp(self):
+        super().setUp()
+        pin_update_channel(self, "stable")
+
+    def test_a_wheel_on_stable_is_still_told_the_release_is_out(self):
+        _cache(latest="99.0.0", ts=1.0)
+        buf = io.StringIO()
+        with mock.patch("charter.channel.installed_commit", return_value=None), \
+             mock.patch.object(util, "_USE_COLOR", False), redirect_stderr(buf):
+            commands_report._warn_if_stale()
+        said = buf.getvalue()
+        self.assertIn("99.0.0 is out — this may already be fixed", said)
+        self.assertNotIn(update.NOT_INSTALLED_FROM_MAIN, said)
+
+
 class VersionBumpPinsOnlyWhatItFetched(NoNetwork, PersonaIso):
     """`version bump` with no `--to` pins the version its own GET returned, or refuses."""
 
@@ -269,6 +289,16 @@ class VersionBumpPinsOnlyWhatItFetched(NoNetwork, PersonaIso):
         self.assertEqual(self.calls, [("sync_to", "99.0.0"),
                                       ("set_locked_version", "99.0.0"),
                                       ("commit_push", "charter: pin to 99.0.0")])
+
+    def test_a_padded_answer_is_trimmed_before_it_becomes_a_pin(self):
+        """The fetched value is trimmed the way `--to` is, and the cache read it replaced
+        was. It ends up on the right-hand side of `charter-cp==` and in a committed
+        `charter.toml`, and a trailing newline there is a pin nothing can install."""
+        pin_update_channel(self, "stable")
+        with mock.patch.object(update, "_fetch_latest", return_value=" 99.0.0\n"):
+            rc, _ = self._bump()
+        self.assertEqual(rc, 0)
+        self.assertEqual([v for _, v in self.calls[:2]], ["99.0.0", "99.0.0"])
 
 
 if __name__ == "__main__":

--- a/tests/test_version_shows_channel.py
+++ b/tests/test_version_shows_channel.py
@@ -117,9 +117,15 @@ class TheStalenessNudgeHonoursTheTerminal(unittest.TestCase):
 
     def _nudge(self, *, color: bool) -> str:
         buf = io.StringIO()
+        # `installed_commit` is pinned, not inherited: since #937 the sentence beside the
+        # chip depends on whether this build records a commit, so without this the branch
+        # exercised here would be decided by how the charter running the suite happened to
+        # be installed (CONTRIBUTING: a test pins what it depends on). `None` is the wheel,
+        # which is what a runner has.
         with mock.patch.object(config, "UPDATE", {"channel": "dev"}), \
              mock.patch.object(util, "_USE_COLOR", color), \
              mock.patch("charter.update.newer_than", lambda v: "9.9.9"), \
+             mock.patch("charter.channel.installed_commit", return_value=None), \
              contextlib.redirect_stderr(buf):
             commands_report._warn_if_stale()
         return buf.getvalue()


### PR DESCRIPTION
Closes #937.

## The failure this prevents

On a plane that declares `[update] channel = "dev"` while running the PyPI wheel, `charter version` printed this on one screen:

```
• A newer charter is published (0.58.0).
•   update, commit and push the lock:  charter version bump --push
  installed  0.60.0
  locked     — (this control plane pins no version)
  latest     — (cached 0.58.0 is stale: it predates the 0.60.0 you are running)
```

Its condition asked `update.newer_than`. On the dev channel that compares `main`'s cached head with the commit this build was installed from, and a build with no commit always looks behind. The message then printed the cached PyPI number, which the condition never compared with anything. It sent the reader to `version bump --push`, which writes a pin the plane's own session start calls contradictory.

The same state reached two other surfaces:

- `charter report send` said `9d18d55 is out — this may already be fixed` to a 0.60.0 wheel that already contains `9d18d55`.
- `charter version bump` with no `--to` fetched, then re-read the cache. A failed PyPI GET leaves `latest` untouched, so the refusal fired only on an empty cache. Given a stale cache, it installed 0.58.0 over 0.60.0 and pushed `charter: pin to 0.58.0`.

## What changed, and why

- **`cmd_version` prints the value its condition tested.** On dev it prints `update.dev_verdict`: with a commit, it names the cached head and this build's commit and does not say which is newer; with no commit, it says this plane follows `main` and this build was not installed from a commit of it. It then prints `update.dev_remedy`. The verdict is no longer gated on the cached `latest`, a PyPI field that decided whether a dev plane heard about `main` at all. Stable output is unchanged: there `newer_than` returns the same number the old code printed.
- **`_warn_if_stale` prints the same sentence and the same next step,** for both dev cases. The nudge is kept, as `newer_head`'s docstring asks; what it no longer does is claim a direction. Stable wording is untouched.
- **`cmd_version_bump` pins `fetch_and_store()`'s return value**, trimmed as `--to` is, instead of re-reading the cache. Its refusal names both candidates as candidates ("either it did not answer, or its answer could not be cached") rather than asserting the network, because that function also answers `None` when PyPI replied and the cache write failed (ADR 0009).
- **Docs move with it.** `docs/control-plane.md` says what bump pins with no `--to`, and that a dev plane is never pointed at it. `docs/install.md` says what `charter version` and `report send` say on the dev channel. `--to`'s help text changed to match. There is a news entry at `docs/news/unreleased-version-on-dev-says-what-it-compared.md`.

**One state, one sentence, one next step.** A cached head that merely differs from this build's commit does not say which is ahead: the cache is per plane (`config.STATE_DIR`) while the binary is one machine-global install (#127), so `charter update` in plane A moves this build to a commit plane B's cache has never seen, and B's cached head is then an *ancestor* of what runs. `update.dev_verdict` says only what was compared. `update.dev_remedy` answers what moves this charter — `charter update`, or `git -C <tree> pull` where the charter running the command *is* a tree you are working in, since `charter update` refuses that tree and points back at `charter version`. Both live in `update` because two surfaces describing one state in two wordings is how this issue began, and prescribing two different next steps for it is the same defect one line further down.

Out of scope here: #938 (nothing refreshes the cache) — this changes what the cache's readers say, not when it refreshes, and `update.maybe_spawn`, `charter/frame/gather.py` and the session-start hook are untouched. Also out of scope, and being filed separately: `charter version bump` run by hand on a dev plane still writes the pin session start rejects, `charter version sync` still recommends that pin, and `commands_update`'s own target-resolution refusal still says "(offline?)".

## Evidence

**RED, before the fix.** `python3 -m unittest tests.test_version_on_dev_says_what_it_compared` ran 13 tests: 7 failures and 2 errors. The failures reproduce the issue: `A newer charter is published (0.0.1)` on dev, `is out` in the report nudge, and `version bump` returning 0 after a failed fetch, on both channels.

**RED again for each review round.**
- Round 1, with the amended tests and the old code: that module plus `tests.test_version_shows_channel` ran 38 tests, 3 failures and 1 error — `'is out' unexpectedly found` for a build with a commit, `'pull' not found` for a charter run out of its own tree, `'offline' unexpectedly found` in the refusal, and no `update.dev_verdict` yet.
- Round 2, after `dev_remedy` existed and only `cmd_version` used it, the divergence itself failed: `'git -C …/fix-937-dev-channel-version-headline pull' not found in '! you are on charter 0.60.0 dev; … — `charter update` moves it.'`

**GREEN.**
- `tests.test_version_on_dev_says_what_it_compared`: 18/18.
- `tests.test_version_shows_channel`: 21/21.
- With `test_dev_channel`, `test_version_pin_honesty`, `test_version_lock` and the eight `test_news*` modules: 302/302.

**Full suite.** Locally, `python3 -m unittest discover -s tests` ran 11868 tests with 2 failures and 2 errors, all four in `test_plane_write_guard.WhatIsGuarded` and `test_statusline_crash_guard.RenderNeverCrashesCase`. None is caused by this diff:
- They fail the same way with base `charter/` checked out in the same worktree.
- They still fail with the frame's `CHARTER_*` and `TMUX*` variables removed.
- The `tests` workflow passed on main at 98686c3.
- Every sweep baseline below passed the whole suite in a sandbox outside the plane.

**Sweep.** `tools/sweep.py` on the first commit applied 10 mutations: 8 pinned, 2 survived.
- **`commands_report.py`, with `channel.is_dev()` dropped.** A stable plane on the wheel also records no commit, so without that gate it would lose `<version> is out`. Every nudge test was dev-pinned. `TheReportNudgeOnStableIsUnchanged` covers it.
- **`commands.py`, with `.strip()` swapped for `.lstrip()`.** The fetched version becomes the right-hand side of `charter-cp==` and a committed pin. `test_a_padded_answer_is_trimmed_before_it_becomes_a_pin` covers it.

Both fail under exactly those mutants and pass unmutated. Every sweep since has been clean, each over a full-suite baseline that passed in its sandbox: **10 pinned / 0 survived**, then **9 pinned / 0 survived** at 23b9428, then **8 pinned / 0 survived** at 1518d28 over 11873 tests. The last of those eight is `dev_remedy`'s `running_inside` gate.

**Live run.** From a checkout on this plane (cache: `latest` 0.58.0, head `9d18d55`, dev channel, no installed commit), both surfaces name the same next step:

```
• this plane follows `main`, but this build was not installed from a commit of it.
•   move this charter onto `main`:  git -C <tree> pull
  installed  0.60.0
  locked     — (this control plane pins no version)
  latest     — (cached 0.58.0 is stale: it predates the 0.60.0 you are running)
```

```
! you are on charter 0.60.0 dev; this plane follows `main`, but this build was not installed from a commit of it — `git -C <tree> pull` moves it. Reporting anyway is fine.
```

For an installed build `dev_remedy()` answers `charter update`, and with a commit `dev_verdict("9d18d55")` reads: `this plane follows `main`, and the head cached for it (9d18d55) is not the commit this build was installed from (aaaaaaa)`.

`version bump` was not run live, because it installs and pushes. Its tests stub the two GETs, `sync_to`, `set_locked_version` and `commit_push`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
