### PR TITLE
The suite is green in the clone and the worktree CONTRIBUTING asks for (#944)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,15 +31,15 @@ command.
   a checkout inside a control plane resolves to *that* plane, so `tests/_planeguard.py`
   refuses any write into the real `.charter/` — and into the real `charter.toml`, the one
   file outside that directory whose loss changes what your next launch draws (#726) — and
-  fails the test that tried. Anywhere but the plane root — a **workspace clone**, a **linked
-  worktree**, or a worktree cut from a clone, which is what `charter wt add` builds — the
-  same file pins the suite to the checkout it was loaded from. It has to: `root._plane_of`
-  sends a worktree's plane back to the tree it was cut from and `root.find_root` hops outward
-  through `workspaces/`, so in all three `config.ROOT` is the operator's plane, and a suite
-  reading it asserts against their uncommitted `charter.toml` instead of the branch's
-  committed one (#785, #944). A case that wants this repository's own committed config reads the file off
-  disk from the repository root, as `test_frame_config._COMMITTED` does, never through
-  `config`. The same file
+  fails the test that tried. Anywhere inside or cut from a plane, on a branch that carries the
+  committed `charter.toml` — a **workspace clone**, a **linked worktree**, or a worktree cut
+  from a clone, which is what `charter wt add` builds — the same file pins the suite to the
+  checkout it was loaded from. It has to: `root._plane_of` sends a worktree's plane back to
+  the tree it was cut from and `root.find_root` hops outward through `workspaces/`, so in all
+  three `config.ROOT` is the operator's plane, and a suite reading it asserts against their
+  uncommitted `charter.toml` instead of the branch's committed one (#785, #944). A case that
+  wants this repository's own committed config reads the file off disk from the repository
+  root, as `test_frame_config._COMMITTED` does, never through `config`. The same file
   refuses one kind of *read*: a setting your own `charter.toml` declares — today
   `[update] channel` — because a test that reads it is asserting against a fixture written
   by whoever happens to run the suite. `tests/_envguard.py` is the third of the same

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,11 +31,13 @@ command.
   a checkout inside a control plane resolves to *that* plane, so `tests/_planeguard.py`
   refuses any write into the real `.charter/` — and into the real `charter.toml`, the one
   file outside that directory whose loss changes what your next launch draws (#726) — and
-  fails the test that tried. Working in a **linked worktree** the same file pins the suite
-  to the checkout it was loaded from, because `root._plane_of` sends a worktree's plane back
-  to the clone it was cut from: right for charter, wrong for a suite, whose assertions would
-  otherwise read the operator's uncommitted `charter.toml` instead of the branch's committed
-  one (#785). A case that wants this repository's own committed config reads the file off
+  fails the test that tried. Anywhere but the plane root — a **workspace clone**, a **linked
+  worktree**, or a worktree cut from a clone, which is what `charter wt add` builds — the
+  same file pins the suite to the checkout it was loaded from. It has to: `root._plane_of`
+  sends a worktree's plane back to the tree it was cut from and `root.find_root` hops outward
+  through `workspaces/`, so in all three `config.ROOT` is the operator's plane, and a suite
+  reading it asserts against their uncommitted `charter.toml` instead of the branch's
+  committed one (#785, #944). A case that wants this repository's own committed config reads the file off
   disk from the repository root, as `test_frame_config._COMMITTED` does, never through
   `config`. The same file
   refuses one kind of *read*: a setting your own `charter.toml` declares — today

--- a/docs/news/unreleased-the-suite-is-green-where-contributing-tells-you-to-work.md
+++ b/docs/news/unreleased-the-suite-is-green-where-contributing-tells-you-to-work.md
@@ -1,0 +1,48 @@
+---
+version: unreleased
+headline: The test suite comes back clean in a workspace clone and in a worktree cut from one — the two places CONTRIBUTING sends you
+---
+
+**CONTRIBUTING says "work in a workspace clone, not in the plane root", and doing that
+turned four tests red on unmodified code.** `python3 -m unittest` reported `FAILED
+(failures=2, errors=2)` out of ~11.9k in a clone under `workspaces/<ws>/`, and the same four
+in a worktree cut from one — what `charter wt add <repo> <piece> -w <ws>` builds. They were
+green in the plane root and green on CI, so nobody had been looking at them, and a
+contributor arriving at four reds could not tell them from their own breakage. Two
+implementers hit the same four independently in one day.
+
+They were two unrelated defects that happened to show up together.
+
+**The suite was not pinned to its own checkout.** `tests/_planeguard.py` moves the suite's
+committed settings to the tree it was loaded from, so a run asserts against the branch
+rather than against whoever's `charter.toml` happens to be on the machine. It asked one
+question — `root.tree_of(config.ROOT, <this checkout>)` — which matches a linked worktree of
+the plane's own repo and, correctly and by design, nothing else. A workspace clone is a
+different repository, and `root.find_root` hops outward through `workspaces/`, so
+`config.ROOT` was the outer plane and the two operands were never equal. Nothing was pinned:
+the suite read the operator's own file, one case failed loudly against it and another passed
+because that file happened to satisfy it. The pin now asks `root.nested_plane_in` as well —
+the sibling detector written for exactly this arrangement — and then asks `tree_of` again
+about what it found, which lands the clone and any worktree cut from it. Both planes it
+moves away from, the clone and the outer one, are folded into the spawn tripwire, so the
+refusal gets wider and never narrower.
+
+**The status line's crash guard rendered against whatever plane you had.** Those cases
+render against the real plane on purpose and redirect only `config.STATE_DIR` to a tempdir —
+and that redirect is what armed a fork, because the background forge refresh keeps its
+cooldown lock and its cache there and a fresh tempdir always looks stale. What decided the
+outcome was whether the active workspace held any clones: none in the plane root and none on
+a CI checkout, seven in a workspace. Where there were clones, the render forked `charter
+gl-refresh` at the developer's live plane and the suite's own tripwire refused it. The cases
+now stop the spawners they never wanted, and say so.
+
+Both are pinned by tests that ask the question of a fixture instead of of the machine the
+suite is running on, since asking the machine is how a defect this shape stays invisible for
+a release: one builds a plane, a clone inside its `workspaces/`, and a worktree of that clone
+out of plain directories, and one runs the render guard against a plane that has a clone in
+it. The trigger for the pin is being cut from a nested *plane*, not a path with `workspaces/`
+in it, so a worktree placed anywhere on disk is covered and a charter checkout that has
+nothing to do with your plane is left alone.
+
+Nothing to adopt — this is charter's own suite. If you contribute to charter, the clone and
+the worktree CONTRIBUTING asks for now come back clean.

--- a/tests/_planeguard.py
+++ b/tests/_planeguard.py
@@ -460,7 +460,9 @@ class _RefusesToBeRead(dict):
 #: PLURAL in a second sense since #785: run from a linked worktree, the suite reads its own
 #: checkout (:func:`_pin_the_suite_to_its_own_tree`) and the plane it was redirected away
 #: from is still a real plane a spawned child would resolve — so both are in here, and the
-#: refusals below reach a child aimed at either.
+#: refusals below reach a child aimed at either. Up to THREE since #944: from a worktree of a
+#: workspace clone there are two planes behind the checkout, the clone and the outer plane,
+#: and a child resolves the outer one by walking and the clone from ``$CHARTER_ROOT``.
 _REAL_ROOT: tuple[str, ...] = ()
 
 
@@ -533,23 +535,84 @@ def _pin_the_suite_to_its_own_tree(config) -> tuple[str, ...]:
     from two directories". A worktree cut from a branch that predates the committed
     ``charter.toml`` has no committed settings to pin to, and pinning to it would hand the
     suite a plane-less root — a different wrong answer, not a fix.
+
+    **WHICH checkout, and which planes it moves away from, is
+    :func:`_the_tree_the_suite_is_in`'s question** — and it is a separate function because
+    this one can only ever be asked about the machine it is running on. #785 pinned a
+    worktree of the plane and #944 found the two arrangements one level down still open: a
+    workspace clone, which is CONTRIBUTING's first instruction, and a worktree cut from one,
+    which is what `charter wt add` builds. A pin that can only be measured by standing
+    somewhere is a pin nobody measures.
     """
     global _TREE_PIN, _PINNED_PLANE
     if _PINNED_PLANE is not None:         # idempotent; see :data:`_PINNED_PLANE`
         return _PINNED_PLANE
-    try:
-        tree = _root.tree_of(config.ROOT, Path(__file__).resolve().parents[1])
-        if tree is not None and not (tree / _root.MARKER).is_file():
-            tree = None
-    except (OSError, RuntimeError):       # never raise at suite boot; see `install`
-        tree = None
+    tree, planes = _the_tree_the_suite_is_in(config.ROOT,
+                                             Path(__file__).resolve().parents[1])
     if tree is None:
         _PINNED_PLANE = ()
         return _PINNED_PLANE
-    _PINNED_PLANE = _both_spellings(config.ROOT)
+    _PINNED_PLANE = tuple(dict.fromkeys(s for p in planes for s in _both_spellings(p)))
     _TREE_PIN = config.in_tree(tree)
     _TREE_PIN.__enter__()
     return _PINNED_PLANE
+
+
+def _the_tree_the_suite_is_in(plane, here) -> tuple[Path | None, tuple[Path, ...]]:
+    """``(the checkout *here* is, the planes that pinning to it moves away from)`` — or
+    ``(None, ())`` when there is nothing to move.
+
+    Split out of :func:`_pin_the_suite_to_its_own_tree` so the question can be asked of a
+    *fixture*: the function above can only ever be asked about the machine the suite happens
+    to be running on, which is exactly how the arrangement below went unnoticed (#944).
+
+    **Two routes, because there are two ways to be somewhere other than the plane's own
+    tree, and one detector cannot see both.**
+
+    1. `root.tree_of` — a linked WORKTREE of the plane's own repo. #785's arrangement, and
+       narrow on purpose: it matches on the worktree's main tree *being* the plane.
+    2. `root.nested_plane_in` — a CLONE under the plane's ``workspaces/``, which is a
+       different repository that happens to carry a tracked ``charter.toml``. Its ``.git``
+       is a real directory, so route 1 answers ``None`` for it and must keep doing so
+       (#809 is where that pair was drawn); asking route 2 and then route 1 *again about
+       what it found* also lands a worktree cut from that clone.
+
+    Route 2 is what CONTRIBUTING's own first instruction lands in — "work in a **workspace
+    clone**, not in the plane root" — and `charter wt add <repo> <piece> -w <ws>` puts a
+    piece one level below that again. Both were unpinned: `find_root` returns
+    ``_outermost(_plane_of(here))`` and the ``workspaces/`` hop (#200) puts ``config.ROOT``
+    one level further out than the clone, so route 1's two operands were never equal and
+    the suite read the operator's own `charter.toml` instead of the branch's (#944).
+
+    **The trigger is being cut from a nested PLANE, never a path with ``workspaces/`` in
+    it.** `nested_plane_in` walks the chain of enclosing planes, so a worktree of the clone
+    placed anywhere on disk is pinned, and a charter checkout that has nothing to do with
+    this plane is not.
+
+    Both planes come back for route 2, and that half is not optional: the clone and the
+    outer plane are each a plane a child charter can resolve — the outer from a bare walk,
+    the clone from ``$CHARTER_ROOT`` — so both are folded into :data:`_REAL_ROOT` beside
+    the tree. #527's hole is reopened by any version of this that merely *swaps* which root
+    counts as real.
+    """
+    try:
+        tree = _root.tree_of(plane, here)
+        planes: tuple[Path, ...] = (Path(plane),)
+        if tree is None:
+            nested = _root.nested_plane_in(plane, here)
+            if nested is not None:
+                # The clone itself when nothing finer is standing in it; `tree_of` asked a
+                # second time is what finds the worktree cut from it.
+                tree = _root.tree_of(nested, here) or nested
+                if tree != nested:
+                    planes += (nested,)
+        if tree is not None and not (tree / _root.MARKER).is_file():
+            tree = None
+    except (OSError, RuntimeError):       # never raise at suite boot; see `install`
+        return None, ()
+    if tree is None:
+        return None, ()
+    return tree, planes
 
 
 def _guard_reads(config, *also: str) -> None:
@@ -1675,8 +1738,9 @@ def install() -> None:
     # makes the directory a plane at all, a lost `[[frame.component]]` changes what the next
     # launch draws, and no test has any business writing the real one — the fixtures write
     # `config.ROOT / "charter.toml"` under `PersonaIso`, where `config.ROOT` is a tmp dir.
-    # Both markers, because in a worktree the two are different files and the wrong one to
-    # write is the one nobody is looking at.
+    # Every marker the pin moved past, because in a worktree they are different files and
+    # the wrong one to write is the one nobody is looking at. Two from a worktree of the
+    # plane; three from a worktree of a workspace clone (#944).
     markers = tuple(dict.fromkeys(
         m for r in (str(config.ROOT), *plane)
         for m in _both_spellings(Path(r) / _root.MARKER)))

--- a/tests/_planeguard.py
+++ b/tests/_planeguard.py
@@ -598,14 +598,20 @@ def _the_tree_the_suite_is_in(plane, here) -> tuple[Path | None, tuple[Path, ...
     try:
         tree = _root.tree_of(plane, here)
         planes: tuple[Path, ...] = (Path(plane),)
-        if tree is None:
-            nested = _root.nested_plane_in(plane, here)
-            if nested is not None:
-                # The clone itself when nothing finer is standing in it; `tree_of` asked a
-                # second time is what finds the worktree cut from it.
-                tree = _root.tree_of(nested, here) or nested
-                if tree != nested:
-                    planes += (nested,)
+        # Asked whether or not route 1 answered, and allowed to overrule it. Route 2 starts
+        # at the nearest marker, which is the checkout's OWN, so when it answers at all it
+        # names the checkout the suite was loaded from; route 1 walks up for any ancestor
+        # whose main tree is the plane, and for a clone sitting inside a worktree of the
+        # plane that names the worktree around it. Gating this on `tree is None` was
+        # indistinguishable in every arrangement charter builds and wrong in that one —
+        # `test_the_answer_is_the_checkout_itself_not_a_worktree_around_it`.
+        nested = _root.nested_plane_in(plane, here)
+        if nested is not None:
+            # The clone itself when nothing finer is standing in it; `tree_of` asked a
+            # second time is what finds the worktree cut from it.
+            tree = _root.tree_of(nested, here) or nested
+            if tree != nested:
+                planes += (nested,)
         if tree is not None and not (tree / _root.MARKER).is_file():
             tree = None
     except (OSError, RuntimeError):       # never raise at suite boot; see `install`

--- a/tests/_planeguard.py
+++ b/tests/_planeguard.py
@@ -593,25 +593,40 @@ def _the_tree_the_suite_is_in(plane, here) -> tuple[Path | None, tuple[Path, ...
     outer plane are each a plane a child charter can resolve — the outer from a bare walk,
     the clone from ``$CHARTER_ROOT`` — so both are folded into :data:`_REAL_ROOT` beside
     the tree. #527's hole is reopened by any version of this that merely *swaps* which root
-    counts as real.
+    counts as real. For the same reason a tree route 1 named and route 2 overruled comes
+    back too: `main` pinned the suite there, so it was inside the refusal, and naming the
+    checkout instead must not quietly take it out (#949 review).
+
+    **Route 2 overrules only with the checkout itself, carrying its committed marker.** Its
+    walk starts at the nearest marker ABOVE *here*, and for a markerless checkout that
+    marker is somebody else's — the clone a worktree of the plane was placed in, or a
+    worktree of the clone — so what it finds is a checkout the suite was not loaded from,
+    and the marker check would read THAT `charter.toml` and pass. A markerless checkout has
+    nothing committed to pin to, so it leaves route 1's answer standing exactly as it stood
+    before #944 — including where route 1's own ancestor walk names a worktree around it —
+    rather than replacing it with an answer the marker check then discards along with the
+    tree it displaced.
     """
     try:
+        here = Path(here).resolve()       # both routes answer in resolved spellings
         tree = _root.tree_of(plane, here)
         planes: tuple[Path, ...] = (Path(plane),)
-        # Asked whether or not route 1 answered, and allowed to overrule it. Route 2 starts
-        # at the nearest marker, which is the checkout's OWN, so when it answers at all it
-        # names the checkout the suite was loaded from; route 1 walks up for any ancestor
-        # whose main tree is the plane, and for a clone sitting inside a worktree of the
-        # plane that names the worktree around it. Gating this on `tree is None` was
-        # indistinguishable in every arrangement charter builds and wrong in that one —
-        # `test_the_answer_is_the_checkout_itself_not_a_worktree_around_it`.
+        # Asked whether or not route 1 answered, and allowed to overrule it: route 1 walks up
+        # for any ancestor whose main tree is the plane, and for a clone sitting inside a
+        # worktree of the plane that names the worktree around it. Gating this on `tree is
+        # None` was indistinguishable in every arrangement charter builds and wrong in that
+        # one — `test_the_answer_is_the_checkout_itself_not_a_worktree_around_it`.
         nested = _root.nested_plane_in(plane, here)
         if nested is not None:
             # The clone itself when nothing finer is standing in it; `tree_of` asked a
             # second time is what finds the worktree cut from it.
-            tree = _root.tree_of(nested, here) or nested
-            if tree != nested:
-                planes += (nested,)
+            found = _root.tree_of(nested, here) or nested
+            if found == here and (found / _root.MARKER).is_file():
+                if tree is not None:
+                    planes += (tree,)
+                if found != nested:
+                    planes += (nested,)
+                tree = found
         if tree is not None and not (tree / _root.MARKER).is_file():
             tree = None
     except (OSError, RuntimeError):       # never raise at suite boot; see `install`

--- a/tests/test_no_test_forks_a_background_charter.py
+++ b/tests/test_no_test_forks_a_background_charter.py
@@ -32,14 +32,21 @@ exit is a tripwire whoever hits it next deletes.
 from __future__ import annotations
 
 import ast
+import shutil
 import subprocess
+import tempfile
 import unittest
 from pathlib import Path
 from unittest import mock
 
-from charter import glstate, update
-from tests import _planeguard
-from tests._isolation import PersonaIso, make_plane, no_background_refresh
+from charter import config, glstate, root, statusline, update
+from tests import _envguard, _planeguard
+# The MODULE, never the class: `from … import RenderNeverCrashesCase` would bind a TestCase
+# subclass in this module's namespace, and `TestLoader` collects by namespace — the borrowed
+# fixture would then run a second time in every suite run, under this file's name.
+from tests import test_statusline_crash_guard
+from tests._isolation import (PersonaIso, isolate_state_dir, make_plane,
+                              no_background_refresh)
 
 
 class WhatIsRefused(unittest.TestCase):
@@ -157,6 +164,87 @@ class StoppingTheSpawnerIsTheOtherWayOut(PersonaIso):
         make_plane(self)
         with self.assertRaises(_planeguard.BackgroundCharterChild):
             glstate.maybe_spawn([self.tmp], "default")
+
+
+class _ARenderThatOnlyRedirectsTheStateDir(unittest.TestCase):
+    """The positive control: the fixture `RenderNeverCrashesCase` had at #944, kept so the
+    probe below is known to SEE a fork rather than merely to report none.
+
+    Its probe method is deliberately not named ``test_*``. Discovery collects this class (a
+    leading underscore does not hide it from `TestLoader`) and would otherwise fork for
+    real, out of whatever plane the suite resolved, every single run.
+    """
+
+    def setUp(self) -> None:
+        _envguard.unset_all()
+        isolate_state_dir(self)
+
+    def runProbe(self) -> None:
+        statusline.render({"session_id": "t"})
+
+
+class ARenderAgainstTheRealPlaneForksNothing(unittest.TestCase):
+    """#944 half two: `no_background_refresh` exists, and a case still has to CALL it.
+
+    `test_statusline_crash_guard.RenderNeverCrashesCase` renders against the real plane on
+    purpose — its own comment says so — and redirected only `config.STATE_DIR`. **That
+    redirect is what arms the fork.** `glstate.maybe_spawn` reads its cooldown lock and its
+    cache out of `STATE_DIR`, so in a fresh tempdir there is never a lock, never a cache
+    entry, and every directory it is handed looks stale. All that was left deciding the
+    outcome was ``dirs`` — the active workspace's clones. Recorded on unmodified code:
+    ``n_dirs=0`` at the plane root and on a CI checkout, which has no ``workspaces/<ws>/``
+    holding clones, so ``any([])`` is False and nothing forks; ``n_dirs=7`` in a workspace
+    clone and in a worktree of one, so it forked and the guard refused it.
+
+    So the case was green where CONTRIBUTING says not to work and red where it says to, and
+    what decided which was **whether the person running it had ever cloned a repo**. It is
+    asked here of a plane that HAS one, so the answer is the same on every machine.
+    """
+
+    def _run_against_a_plane_holding_a_clone(self, case_class, method) -> unittest.TestResult:
+        """Run one real test method with the ambient plane pointed at a sentinel that has a
+        workspace with a clone in it, and hand back what the run recorded.
+
+        A sentinel plane, never the real one: a RED run of this module must not commit the
+        very fork it exists to forbid. `charter.toml` is present so `HAS_CONTROL_PLANE` is
+        what it is on a developer's machine — both spawners refuse outright without a plane
+        — and the clone is a bare ``.git`` DIRECTORY, which is the whole of
+        `workspace.is_clone`'s test.
+        """
+        sentinel = Path(tempfile.mkdtemp(prefix="charter-944-sentinel-")).resolve()
+        self.addCleanup(shutil.rmtree, sentinel, True)
+        (sentinel / root.MARKER).write_text("schema = 1\n")
+        (sentinel / "workspaces" / "default" / "charter" / ".git").mkdir(parents=True)
+        outer = config.use(sentinel)
+        try:
+            result = unittest.TestResult()
+            case_class(method).run(result)
+            return result
+        finally:
+            config.restore(outer)
+
+    @staticmethod
+    def _what_it_said(result: unittest.TestResult) -> str:
+        return "\n".join(text for _, text in (*result.errors, *result.failures))
+
+    def test_the_probe_can_see_a_render_fork(self):
+        """Without this, the case below would pass just as well if the probe were blind —
+        and blind is the failure mode that already happened once here, since the whole
+        defect was a spawn nobody's machine attempted."""
+        said = self._what_it_said(
+            self._run_against_a_plane_holding_a_clone(
+                _ARenderThatOnlyRedirectsTheStateDir, "runProbe"))
+        self.assertIn("BackgroundCharterChild", said)
+
+    def test_the_render_crash_guard_forks_nothing(self):
+        """The case itself, run against a plane with a clone in it. It is about `render()`
+        not propagating an exception, so nothing in it ever wanted a child."""
+        for method in ("test_a_broken_repo_row_does_not_crash_render",
+                       "test_a_broken_persona_chips_call_does_not_crash_render"):
+            with self.subTest(method=method):
+                result = self._run_against_a_plane_holding_a_clone(
+                    test_statusline_crash_guard.RenderNeverCrashesCase, method)
+                self.assertTrue(result.wasSuccessful(), self._what_it_said(result))
 
 
 class EveryCharterCharterStartsForItselfIsDetached(PersonaIso):

--- a/tests/test_plane_write_guard.py
+++ b/tests/test_plane_write_guard.py
@@ -206,16 +206,29 @@ class WhereTheSuiteIsAllowedToBeRun(unittest.TestCase):
         committed `charter.toml` has no committed settings to pin to, and pinning to it
         would hand the suite a plane-less root.
 
-        Asked on the two arrangements where each route actually FINDS the markerless tree,
-        because those are the only ones that reach the check. A markerless worktree of the
-        clone placed beside the plane is declined earlier by both routes on their own —
+        Asked on the arrangements where a route actually FINDS the markerless tree, because
+        those are the only ones that reach the check. A markerless worktree of the clone
+        placed beside the plane is declined earlier by both routes on their own —
         `nested_plane_in` walks up for a marker and finds none — so a case built on that
-        alone stayed green with the check deleted, measured by removing it."""
+        alone stayed green with the check deleted, measured by removing it.
+
+        The last two are the ones the check could not see at all, found in review (#949): a
+        markerless worktree of the PLANE placed inside the clone's own `.worktrees/`, and one
+        placed inside a worktree of the clone. Route 2 walks up to the nearest marker — the
+        clone's, or its worktree's — and names THAT, a checkout the suite was not loaded from,
+        so the check read the wrong `charter.toml`, passed, and pinned. `main` had left both
+        unpinned."""
         for route, bare in (
                 ("tree_of — a worktree of the plane itself",
                  self._worktree(self.plane, self.tmp / "before-the-marker", marker=False)),
                 ("nested_plane_in — a worktree of the clone, inside the clone",
                  self._worktree(self.clone, self.clone / "sub" / "before-the-marker",
+                                marker=False)),
+                ("both — a worktree of the plane, inside the clone's .worktrees/",
+                 self._worktree(self.plane, self.clone / ".worktrees" / "old-of-plane",
+                                marker=False)),
+                ("both — a worktree of the plane, inside a worktree of the clone",
+                 self._worktree(self.plane, self.piece / "sub" / "old-of-plane-in-a-piece",
                                 marker=False))):
             with self.subTest(route=route):
                 self.assertEqual((None, ()),
@@ -231,13 +244,46 @@ class WhereTheSuiteIsAllowedToBeRun(unittest.TestCase):
         Hand-built — charter's own `clone` resolves the outermost plane and never puts a
         clone there — which is why nothing noticed: in every arrangement charter builds, the
         two routes never both answer. Asking the second route only when the first came back
-        empty was indistinguishable from asking it always, until this."""
+        empty was indistinguishable from asking it always, until this.
+
+        The worktree it overrules stays guarded (#949 review). `main` pinned the suite THERE,
+        so that worktree and its `charter.toml` were inside the refusal, and a child handed
+        `$CHARTER_ROOT=<that worktree>` still resolves it. Naming the clone instead must not
+        quietly drop them: the rule `_pin_the_suite_to_its_own_tree` states is that the guard
+        gets wider, never narrower."""
         around = self._worktree(self.plane, self.plane / "workspaces" / "ws"
                                 / ".worktrees" / "plane" / "piece")
         inside = self._plane(around / "workspaces" / "ws2" / "charter", repo=True)
         tree, planes = _planeguard._the_tree_the_suite_is_in(self.plane, inside)
         self.assertEqual(inside, tree)
         self.assertIn(self.plane, planes)
+        self.assertIn(around, planes, "the worktree `main` pinned to fell out of the guard")
+
+    def test_a_worktree_the_pin_does_not_overrule_is_still_guarded(self):
+        """The arrangement above with a MARKERLESS checkout in it: a worktree of that inner
+        clone, cut from a branch that predates `charter.toml`. There is nothing committed to
+        pin the suite to, so there is nothing to overrule `main`'s answer with — and whatever
+        this answers, the worktree `main` guarded must still be guarded. Overruling first
+        and letting the marker check discard the result afterwards loses both: the pin, which
+        is right, and the worktree's place in the refusal, which is not."""
+        around = self._worktree(self.plane, self.plane / "workspaces" / "ws"
+                                / ".worktrees" / "plane" / "piece")
+        inner = self._plane(around / "workspaces" / "ws2" / "charter", repo=True)
+        bare = self._worktree(inner, inner / "sub" / "before-the-marker", marker=False)
+        tree, planes = _planeguard._the_tree_the_suite_is_in(self.plane, bare)
+        self.assertIn(around, {tree, *planes},
+                      "a worktree `main` refused writes and spawns for fell out of the guard")
+
+    def test_a_checkout_named_through_a_symlink_is_the_same_checkout(self):
+        """`tree_of` and `nested_plane_in` resolve what they are handed, so what they answer
+        is always the resolved spelling, and the overrule compares that answer with the
+        checkout. Compared with the spelling as given instead, a clone reached through a
+        symlink — macOS's `/tmp`, a symlinked home — never equals it, route 2 never overrules,
+        and the suite is left unpinned exactly where #944 found it."""
+        link = self.tmp / "a-symlink-to-the-clone"
+        link.symlink_to(self.clone, target_is_directory=True)
+        self.assertEqual((self.clone, (self.plane,)),
+                         _planeguard._the_tree_the_suite_is_in(self.plane, link))
 
 
 class _FakePlane(unittest.TestCase):

--- a/tests/test_plane_write_guard.py
+++ b/tests/test_plane_write_guard.py
@@ -202,12 +202,42 @@ class WhereTheSuiteIsAllowedToBeRun(unittest.TestCase):
                          _planeguard._the_tree_the_suite_is_in(self.plane, other))
 
     def test_a_checkout_carrying_no_committed_marker_is_left_alone(self):
-        """`_plane_of`'s own condition read the other way round, and it has to survive the
-        second route: a branch that predates the committed `charter.toml` has no committed
-        settings to pin to, and pinning to it would hand the suite a plane-less root."""
-        bare = self._worktree(self.clone, self.tmp / "before-the-marker", marker=False)
-        self.assertEqual((None, ()),
-                         _planeguard._the_tree_the_suite_is_in(self.plane, bare))
+        """`_plane_of`'s own condition read the other way round: a branch that predates the
+        committed `charter.toml` has no committed settings to pin to, and pinning to it
+        would hand the suite a plane-less root.
+
+        Asked on the two arrangements where each route actually FINDS the markerless tree,
+        because those are the only ones that reach the check. A markerless worktree of the
+        clone placed beside the plane is declined earlier by both routes on their own —
+        `nested_plane_in` walks up for a marker and finds none — so a case built on that
+        alone stayed green with the check deleted, measured by removing it."""
+        for route, bare in (
+                ("tree_of — a worktree of the plane itself",
+                 self._worktree(self.plane, self.tmp / "before-the-marker", marker=False)),
+                ("nested_plane_in — a worktree of the clone, inside the clone",
+                 self._worktree(self.clone, self.clone / "sub" / "before-the-marker",
+                                marker=False))):
+            with self.subTest(route=route):
+                self.assertEqual((None, ()),
+                                 _planeguard._the_tree_the_suite_is_in(self.plane, bare))
+
+    def test_the_answer_is_the_checkout_itself_not_a_worktree_around_it(self):
+        """What the pin promises is *the checkout these modules were loaded from*, and the
+        two routes can disagree about that. `tree_of` walks up for ANY ancestor whose main
+        tree is the plane, so a clone sitting inside a worktree of the plane gets that
+        worktree named — a directory the suite was not loaded from. `nested_plane_in` starts
+        at the nearest marker, which is the checkout's own, and names the clone.
+
+        Hand-built — charter's own `clone` resolves the outermost plane and never puts a
+        clone there — which is why nothing noticed: in every arrangement charter builds, the
+        two routes never both answer. Asking the second route only when the first came back
+        empty was indistinguishable from asking it always, until this."""
+        around = self._worktree(self.plane, self.plane / "workspaces" / "ws"
+                                / ".worktrees" / "plane" / "piece")
+        inside = self._plane(around / "workspaces" / "ws2" / "charter", repo=True)
+        tree, planes = _planeguard._the_tree_the_suite_is_in(self.plane, inside)
+        self.assertEqual(inside, tree)
+        self.assertIn(self.plane, planes)
 
 
 class _FakePlane(unittest.TestCase):

--- a/tests/test_plane_write_guard.py
+++ b/tests/test_plane_write_guard.py
@@ -106,6 +106,110 @@ class WhatIsGuarded(unittest.TestCase):
                               f"reach the real plane unseen")
 
 
+class WhereTheSuiteIsAllowedToBeRun(unittest.TestCase):
+    """`_the_tree_the_suite_is_in`, asked of a FIXTURE rather than of this machine.
+
+    The three cases above can only ever report where the suite happens to be standing, and
+    that is precisely how #944 survived: the pin was written for a worktree of the plane
+    (#785), CONTRIBUTING's own first instruction is to work in a **workspace clone**, and
+    nobody ever asked the question one level down. On unmodified code the suite came back
+    ``FAILED (failures=2, errors=2)`` in the clone and in a worktree of it, green in the
+    plane root, and green on CI — so the four reds looked like the contributor's own
+    breakage.
+
+    Every arrangement charter can put a checkout in is built here out of directories, with
+    no git: a linked worktree is a ``.git`` FILE naming its main tree, which is all
+    `root.main_worktree_of` reads, and a plane is a directory with a ``charter.toml`` in it.
+    """
+
+    def setUp(self) -> None:
+        # `.resolve()` once, here: on macOS `/tmp` is a symlink to `/private/tmp`, and the
+        # gitdir pointer written below has to name the same spelling `main_worktree_of`
+        # resolves to or the two never compare equal.
+        self.tmp = Path(tempfile.mkdtemp(prefix="guard-nested-")).resolve()
+        self.addCleanup(shutil.rmtree, self.tmp, True)
+        self.plane = self._plane(self.tmp / "plane")
+        self.clone = self._plane(self.plane / "workspaces" / "ws" / "charter", repo=True)
+        self.piece = self._worktree(self.clone, self.plane / "workspaces" / "ws"
+                                    / ".worktrees" / "charter" / "piece")
+
+    @staticmethod
+    def _plane(where: Path, repo: bool = False) -> Path:
+        """A control plane: a directory with a marker. ``repo`` gives it a real ``.git``
+        directory too, which is what makes it a CLONE rather than a worktree — and what
+        makes `root.tree_of` answer ``None`` for it, correctly and permanently."""
+        where.mkdir(parents=True)
+        (where / root.MARKER).write_text("schema = 1\n")
+        if repo:
+            (where / ".git").mkdir()
+        return where
+
+    @staticmethod
+    def _worktree(main: Path, where: Path, marker: bool = True) -> Path:
+        """A linked worktree of *main*: the ``.git`` file git writes, plus the tracked
+        marker that gets checked out with everything else."""
+        where.mkdir(parents=True)
+        (where / ".git").write_text(f"gitdir: {main / '.git' / 'worktrees' / where.name}\n")
+        if marker:
+            (where / root.MARKER).write_text("schema = 1\n")
+        return where
+
+    def test_a_worktree_of_the_plane_itself_is_still_what_the_suite_pins_to(self):
+        """#785's own arrangement, kept as the control: the first route must still fire,
+        and it must not start naming a second plane that is not there."""
+        wt = self._worktree(self.plane, self.tmp / "cut-from-the-plane")
+        self.assertEqual((wt, (self.plane,)),
+                         _planeguard._the_tree_the_suite_is_in(self.plane, wt))
+
+    def test_a_workspace_clone_is_the_checkout_the_suite_must_read(self):
+        """CONTRIBUTING's first instruction. `find_root` hops outward through
+        ``workspaces/`` (#200), so standing in a clone the suite asserted against the
+        OPERATOR's `charter.toml` — uncommitted edits and all — instead of the branch's."""
+        self.assertEqual((self.clone, (self.plane,)),
+                         _planeguard._the_tree_the_suite_is_in(self.plane, self.clone))
+
+    def test_a_worktree_of_a_workspace_clone_is_too_and_names_both_planes(self):
+        """What `charter wt add <repo> <piece> -w <ws>` builds, and the two hops that hid
+        it: `main_worktree_of(here)` is the CLONE while `config.ROOT` is one level further
+        out, so `tree_of` — narrow on purpose — can never match and answered ``None``.
+
+        Both planes come back, because pinning moves the suite away from both and the rule
+        `_pin_the_suite_to_its_own_tree` states for one level holds for two: the guard gets
+        wider, never narrower. A child charter forked from here resolves the outer plane;
+        `$CHARTER_ROOT=<the clone>` resolves the clone."""
+        self.assertEqual((self.piece, (self.plane, self.clone)),
+                         _planeguard._the_tree_the_suite_is_in(self.plane, self.piece))
+
+    def test_the_trigger_is_being_cut_from_a_nested_plane_not_a_path_with_workspaces_in_it(self):
+        """The control that keeps the fix off path arithmetic. `git worktree add` puts a
+        worktree wherever it is told, and one cut from the clone but placed outside the
+        plane entirely reads the clone's committed files just the same — so it is pinned
+        just the same. `root.nested_plane_in` keys on the chain of enclosing planes, which
+        this checkout is in and its directory name says nothing about."""
+        off = self._worktree(self.clone, self.tmp / "nowhere-near-the-plane")
+        self.assertEqual((off, (self.plane, self.clone)),
+                         _planeguard._the_tree_the_suite_is_in(self.plane, off))
+
+    def test_a_checkout_with_nothing_to_do_with_this_plane_is_left_alone(self):
+        """The other control, and the reason this is not "pin to wherever you are". A
+        charter checkout somewhere else on disk is not this plane seen from a second
+        directory; pinning to it would hand the suite settings nobody asked for."""
+        other = self._plane(self.tmp / "someone-elses-charter", repo=True)
+        stranger = self._worktree(other, self.tmp / "someone-elses-piece")
+        self.assertEqual((None, ()),
+                         _planeguard._the_tree_the_suite_is_in(self.plane, stranger))
+        self.assertEqual((None, ()),
+                         _planeguard._the_tree_the_suite_is_in(self.plane, other))
+
+    def test_a_checkout_carrying_no_committed_marker_is_left_alone(self):
+        """`_plane_of`'s own condition read the other way round, and it has to survive the
+        second route: a branch that predates the committed `charter.toml` has no committed
+        settings to pin to, and pinning to it would hand the suite a plane-less root."""
+        bare = self._worktree(self.clone, self.tmp / "before-the-marker", marker=False)
+        self.assertEqual((None, ()),
+                         _planeguard._the_tree_the_suite_is_in(self.plane, bare))
+
+
 class _FakePlane(unittest.TestCase):
     """A throwaway directory installed as "the real plane" for the duration of one test."""
 

--- a/tests/test_statusline_crash_guard.py
+++ b/tests/test_statusline_crash_guard.py
@@ -19,6 +19,7 @@ from unittest import mock
 
 from charter import statusline
 from tests import _envguard
+from tests._isolation import no_background_refresh
 
 
 class RenderNeverCrashesCase(unittest.TestCase):
@@ -28,14 +29,25 @@ class RenderNeverCrashesCase(unittest.TestCase):
         # (#519, #521, #528).
         _envguard.unset_all()
 
+        # These render against the REAL plane on purpose, so the plane they get is
+        # whoever's is running the suite — and #944 is what that cost. `render()` calls
+        # both background spawners on its own path, and the STATE_DIR redirect below is
+        # what arms them: the cooldown lock and the forge cache live there, and a fresh
+        # tempdir has neither, so every clone in the active workspace looks stale. On a
+        # plane with clones the render forked `charter gl-refresh` at the operator's own
+        # plane and `tests._planeguard` refused it — two errors for every contributor
+        # following CONTRIBUTING's "work in a workspace clone", and green at the plane
+        # root and on CI only because there were no clones to be stale. This case is
+        # about `render()` not propagating an exception; it never wanted a child.
+        no_background_refresh(self)
+
         from charter import config
         self.tmp = Path(tempfile.mkdtemp(prefix="edm-renderguard-"))
         self._orig = config.SESSIONS_DIR
         config.SESSIONS_DIR = self.tmp / "sessions"
-        # Also redirect STATE_DIR: these render against the REAL plane on purpose,
-        # and the render path now writes a vault-health cache under it. A test that
-        # writes into the developer's own `.charter/` is the bug this suite fixed
-        # once already (see `EveryRootDerivedPathIsIsolated`).
+        # Also redirect STATE_DIR: the render path writes a vault-health cache under it,
+        # and a test that writes into the developer's own `.charter/` is the bug this
+        # suite fixed once already (see `EveryRootDerivedPathIsIsolated`).
         _state = config.STATE_DIR
         config.STATE_DIR = self.tmp / ".charter"
         self.addCleanup(lambda: setattr(config, "STATE_DIR", _state))


### PR DESCRIPTION
Closes #944.

## The failure this prevents

CONTRIBUTING's first instruction is **"work in a workspace clone, not in the plane root"**,
and `charter wt add <repo> <piece> -w <ws>` puts a piece under
`workspaces/<ws>/.worktrees/<repo>/<piece>`. On unmodified code both of those arrangements
reported `FAILED (failures=2, errors=2)` out of ~11.9k. They were green in the plane root and
green on CI, so nobody had been looking at them — and a contributor who followed the
instructions arrived at four reds they could not tell from their own breakage. Two
implementers hit the same four independently in one day; #943's own description records them.

What that costs is not only the noise. One of the four *passed* in the plane root because the
operator's uncommitted `charter.toml` happened to satisfy it, which is the quiet half: the
suite was asserting against whoever's machine it was on instead of against the branch.

They are **two independent defects** that happened to show up together.

## Defect one — nothing pinned the suite to its own checkout

`tests/_planeguard._pin_the_suite_to_its_own_tree` asked exactly one question:

```python
tree = _root.tree_of(config.ROOT, Path(__file__).resolve().parents[1])
```

`root.tree_of` is narrow by design — its own docstring says the match is on *the worktree's
own main tree BEING the plane*. For a worktree of a workspace clone the two operands are two
hops apart: `main_worktree_of(here)` is the **clone**, while `find_root` returns
`_outermost(_plane_of(d))`, whose `workspaces/` hop (#200) puts `config.ROOT` one level
further **out**. Measured from such a worktree: `tree_of` returns `None`, `_PINNED_PLANE` is
`()`, nothing is pinned, and `_REAL_ROOT` names the operator's plane alone. That is exactly
the state #785 closed one level up, still open one level down.

`root.nested_plane_in` (#809) is `tree_of`'s deliberate sibling for precisely this
arrangement and was never consulted. The question now lives in `_the_tree_the_suite_is_in`,
which asks `tree_of`, then `nested_plane_in`, then `tree_of` **again about what that found** —
landing the clone and any worktree cut from it, with no new path arithmetic. Route 2 may
overrule route 1 **only with the checkout itself, carrying its committed marker**. Every root
the pin moves away from — the outer plane, the clone, and a worktree route 1 named and route 2
overruled — is folded into `_REAL_ROOT`, because each is a plane a child charter can resolve
(the outer by walking, the others from `$CHARTER_ROOT`). The guard gets wider, never narrower —
#527's hole is what any version that merely *swapped* which root counts as real would reopen.

**The trigger is being cut from a nested PLANE, not a path containing `workspaces/`.**
`nested_plane_in` walks the chain of enclosing planes, so the issue's off-plane control row is
covered too and a charter checkout with nothing to do with your plane is left alone.

## Defect two — the render guard rendered against whatever plane you had

`tests/test_statusline_crash_guard.RenderNeverCrashesCase` is **not worktree-related at all**:
it fires in a plain workspace clone. It renders against the real plane on purpose and
redirects only `config.STATE_DIR` to a tempdir — and that redirect is what arms the fork,
because `glstate.maybe_spawn` keeps its cooldown lock and its cache there and a fresh tempdir
always looks stale. What was left deciding the outcome was `dirs`, the active workspace's
clones. Recorded `maybe_spawn` calls on unmodified code:

| where | `dirs` | outcome |
| --- | --- | --- |
| plane root | `n_dirs=0` | `stale = any([])` is False — nothing forks. **Green by luck.** |
| CI checkout | `n_dirs=0` | no `workspaces/<ws>/` holding clones. Green for the same non-reason. |
| clone / worktree | `n_dirs=7` | forks `charter gl-refresh`; `RealPlaneSpawn` refuses it. |

So the case was red for everyone who followed CONTRIBUTING and green only where CONTRIBUTING
says not to work, and what decided which was *whether the person running it had ever cloned a
repo*. It now calls `tests._isolation.no_background_refresh(self)` (#943's helper, not a
second copy of it) and says so: the case is about `render()` not propagating an exception, so
it never wanted a child.

## Test evidence

Both halves are pinned by cases that ask a **fixture** rather than the machine the suite
happens to be running on — asking the machine is precisely how a defect this shape survives a
release.

* `test_plane_write_guard.WhereTheSuiteIsAllowedToBeRun` builds a plane, a clone inside its
  `workspaces/`, and a linked worktree of that clone out of plain directories (a worktree is a
  `.git` **file** naming its main tree, which is all `root.main_worktree_of` reads — no git
  needed). Nine cases: the clone, the worktree of the clone, and controls — a worktree of the
  plane itself (#785's route must still fire), a worktree of the clone placed **off-plane**
  (the trigger is nesting, not the path), a stranger checkout that must be left alone, a
  markerless branch in the four arrangements that reach the marker check, a clone inside a
  worktree of the plane (pinned to itself, with the worktree around it still guarded), a
  markerless checkout in that same spot, and a checkout named through a symlink. On unmodified
  code the first commit's six went 3 failing, 3 controls passing; each case added since failed
  on the code before it, except the symlink case, which pins a line this PR adds and goes red
  when that line is deleted.
* `test_no_test_forks_a_background_charter.ARenderAgainstTheRealPlaneForksNothing` runs the
  render guard's own methods against a sentinel plane that **has** a clone, so the answer is
  the same on every machine, with `_ARenderThatOnlyRedirectsTheStateDir` as the positive
  control that proves the probe can see a fork. On unmodified code it fails naming
  `charter gl-refresh` — the exact mechanism above.

### Every guard the pin adds is one the suite notices losing

`tools/sweep.py` sweeps `charter/` only, and this diff is `tests/` and docs, so it applied 0
mutations and says so — which it rightly calls a record of a question nobody asked. The
deletion check was therefore run by hand, one guard at a time, against
`WhereTheSuiteIsAllowedToBeRun`. The first pass had **two survivors**, and the second commit
is what they found:

* **`if tree is None:`**, gating the nested-plane route on the worktree route coming back
  empty. Identical in every arrangement charter builds — and wrong in the one where both routes
  answer: for a clone sitting inside a worktree of the plane, `tree_of` names the worktree
  *around* the checkout while `nested_plane_in`, starting at the checkout's own marker, names
  the checkout. The nested route is now asked always and allowed to overrule; the new case
  failed on the gated code.
* **The marker check**, whose case never reached it: a markerless worktree of the clone beside
  the plane is declined by both routes on their own. The case now asks arrangements that do
  reach it.

### Review round 1

An independent review built 12 layouts with real git and approved, with three corrections.
Each was measured before anything changed — 11 layouts, comparing `main`, the previous head,
the review's suggested expression, and the rule taken here.

1. **`or nested` could pin a checkout the suite was not loaded from.** A markerless worktree of
   the plane placed in `clone/.worktrees/` has no marker of its own, so `nested_plane_in` walks
   up to the clone's; the fallback named the clone, and the marker check read the clone's
   `charter.toml` and passed. `main` had left it unpinned. The review's expression,
   `tree_of(nested, here) or (nested if here == nested else None)`, fixes that layout and not
   its sibling — the same worktree placed inside a *worktree of the clone*, where
   `tree_of(nested, here)` walks up to that worktree before the fallback is reached, and still
   pins it. So the rule is stated rather than patched: **route 2 overrules only with the
   checkout itself, carrying its committed marker.** Both layouts are subtests of the marker
   case and failed on the previous head.
2. **"Wider, never narrower" was not true for a clone inside a worktree of the plane.** `main`
   guarded that worktree and its `charter.toml`; overruling it dropped both. The overruled
   route-1 tree now comes back in `planes`, asserted. Measuring that found a second
   arrangement narrowing under every candidate, the review's included: a markerless checkout
   in the same spot, where overruling and then discarding the answer at the marker check threw
   route 1's tree away too. With the marker half of the overrule, route 1's answer stands there
   exactly as on `main`, and a case asserts the worktree stays guarded.
3. **CONTRIBUTING** said "anywhere but the plane root" pins the suite; a CI checkout, a stranger
   checkout and a markerless branch are not pinned. It now says anywhere inside or cut from a
   plane, on a branch that carries the committed `charter.toml`, and is rewrapped.

Deletion check on the final code: **15 mutants** of `_the_tree_the_suite_is_in` against
`WhereTheSuiteIsAllowedToBeRun`, **every one killed** — including the review's own expression,
red on the two layouts above. Across the 11 layouts, nothing is narrower than `main`, and every
pin names the checkout itself except where `main`'s own answer stands unchanged.

## The matrix

`python3 -m unittest tests.test_plane_write_guard tests.test_statusline_crash_guard`, from
three locations built from `f67be7a`, each one given a clone in its active workspace so the
render-guard half is load-bearing everywhere rather than green by luck. "Before" is the three
files as they are on `main`:

| where the checkout is | before | after |
| --- | --- | --- |
| a checkout that IS the plane (the plane root / CI) | `FAILED (errors=2)` | `OK` (23 → 30 tests) |
| a clone under `workspaces/<ws>/` | `FAILED (failures=2, errors=2)` | `OK` |
| a worktree cut from that clone, under `workspaces/<ws>/.worktrees/` | `FAILED (failures=2, errors=2)` | `OK` |

The plane-root row goes red without the fix in that same location, so it is green for the
stated reason rather than for want of a clone.

Full suite from a worktree cut from a workspace clone — the arrangement the issue is about —
`python3 -m unittest discover -s tests` on `f67be7a`, before the review round: **Ran 11893
tests — OK (skipped=9)**. The same worktree reported `FAILED (failures=2, errors=2)` on
unmodified `main` before any change. After the review round, `python3 -m unittest
tests.test_plane_write_guard tests.test_no_test_forks_a_background_charter
tests.test_statusline_crash_guard`: **Ran 51 tests — OK**.

Docs move with the code: CONTRIBUTING's "working in a linked worktree the same file pins the
suite" was false one level down and now names where the pin holds and what it needs, and
`docs/news/unreleased-the-suite-is-green-where-contributing-tells-you-to-work.md` ships with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
