### PR TITLE
A harness argument ending in `;` reaches the harness whole, and a launch too long for tmux says how long

### DIFF
--- a/charter/commands_frame.py
+++ b/charter/commands_frame.py
@@ -3263,6 +3263,41 @@ def _panel_remain_on_exit_argv(*, socket: str, harness_pane: str) -> list[str]:
                                "remain-on-exit", "on")
 
 
+#: What a launch says when tmux refused to start its harness as too long (#957) — in tmux's
+#: own number, because the generic report pasted the whole command back, the long text
+#: included, and the one figure that explains the refusal was the one thing not on screen.
+#: *carried* is the harness's arguments alone: the rest of the limit is the window's own
+#: name, directory and identity, which is why a launch just under it can still be refused.
+TOO_LONG_FOR_TMUX = ("charter frame: tmux refused the command that starts this chat as too "
+                     "long — tmux takes at most {limit:,} bytes in one command, and this "
+                     "launch's harness arguments alone are {carried:,} bytes. Nothing was "
+                     "started; shorten them, or put the long text in a file and pass its "
+                     "path instead.")
+
+
+def _say_why_the_harness_did_not_start(action: str, cmd: list[str],
+                                       proc: subprocess.CompletedProcess,
+                                       harness_argv: list[str]) -> None:
+    """Report a refused harness start: tmux's length refusal by what it was, and anything
+    else exactly as `tmuxctl.report_failure` has always reported it.
+
+    Shared by both launch paths — `new-session`/`new-window` on charter's own server and
+    `respawn-pane` inside the operator's — for :func:`_same_harness_as`' reason: one
+    question, one answer. The cause is named only when tmux's own sentence says it
+    (`tmuxctl.refused_as_too_long`, ADR 0009).
+
+    `os.fsencode` and not `str.encode`, because that is how the argument reached `exec`: a
+    byte that is not UTF-8 arrives in `sys.argv` as a surrogate escape, and a strict encode
+    of it would raise in the middle of a failure report.
+    """
+    if tmuxctl.refused_as_too_long(proc.stderr):
+        util.err(TOO_LONG_FOR_TMUX.format(
+            limit=tmuxctl.MESSAGE_LIMIT,
+            carried=sum(len(os.fsencode(a)) for a in harness_argv)))
+        return
+    tmuxctl.report_failure(action, cmd, proc)
+
+
 def _launch_in_operator_tmux(socket: str, session: str, *, ws: str,
                              argv: list[str], h, v: tuple[int, int],
                              picked: bool) -> int | None:
@@ -3458,11 +3493,14 @@ def _launch_in_operator_tmux(socket: str, session: str, *, ws: str,
         util.warn("charter frame: continuing without it — this frame's window may "
                   "close before charter can read the harness's exit code")
 
-    started = tmuxctl.run(
-        "starting the harness in it",
-        layout.respawn_argv(socket=socket, harness_pane=harness_pane,
-                            env=_guest_harness_env(env), cwd=cwd, harness_argv=argv))
+    # `report=False`: a refusal is reported just below, once, by what it was
+    # (`_say_why_the_harness_did_not_start`).
+    start_cmd = layout.respawn_argv(socket=socket, harness_pane=harness_pane,
+                                    env=_guest_harness_env(env), cwd=cwd, harness_argv=argv)
+    started = tmuxctl.run("starting the harness in it", start_cmd, report=False)
     if started.returncode != 0:
+        _say_why_the_harness_did_not_start("starting the harness in it", start_cmd,
+                                            started, argv)
         # The placeholder is still running in a window the operator never asked for and
         # would never learn the purpose of. Take it back.
         _close_window()
@@ -5427,8 +5465,11 @@ def _launch(args) -> int:
             harness_argv=argv, chat=fid,
             env=_frame_identity_env(env) if v >= tmuxctl.SESSION_ENV_FLOOR else None)
         started_what = "starting the frame"
-    proc = tmuxctl.run(started_what, start_cmd, env=env)
+    # `report=False`: a refusal is reported just below, once, by what it was — tmux's
+    # length refusal in its own number, anything else as `report_failure` always said it.
+    proc = tmuxctl.run(started_what, start_cmd, env=env, report=False)
     if proc.returncode != 0:
+        _say_why_the_harness_did_not_start(started_what, start_cmd, proc, argv)
         return 1
     harness_pane = proc.stdout.strip()
     if not harness_pane:

--- a/charter/frame/layout.py
+++ b/charter/frame/layout.py
@@ -1284,8 +1284,10 @@ def respawn_argv(*, socket: str, harness_pane: str, env: dict[str, str],
     claude` has to run the harness where it was typed, and the panels split off this
     pane inherit its directory in turn, which is what `workspace.resolve()` reads.
     """
+    # Each harness argument through `tmuxctl.verbatim`: tmux reads one that ends in `;` as
+    # its own command separator and drops the `;` without a word (#957).
     return _tmux(socket, "respawn-pane", "-k", "-t", harness_pane, "-c", cwd,
-                 *_env_argv(env), "--", *harness_argv)
+                 *_env_argv(env), "--", *map(tmuxctl.verbatim, harness_argv))
 
 
 def session_argv(*, session: str, conf: str, socket: str, cols: int, rows: int,
@@ -1337,10 +1339,11 @@ def session_argv(*, session: str, conf: str, socket: str, cols: int, rows: int,
     with no chat to name, which is the only reason it is optional.
     """
     named = ("-n", chat) if chat else ()
+    # `tmuxctl.verbatim` per harness argument, for :func:`respawn_argv`'s reason (#957).
     return _tmux(socket, "-f", conf, "new-session", "-d", "-s", session, *named,
                 "-x", str(cols), "-y", str(rows), "-P", "-F", "#{pane_id}",
                 *_env_argv(env),
-                "--", *harness_argv)
+                "--", *map(tmuxctl.verbatim, harness_argv))
 
 
 def chat_window_argv(*, socket: str, session: str, chat: str, cwd: str,
@@ -1394,8 +1397,10 @@ def chat_window_argv(*, socket: str, session: str, chat: str, cwd: str,
     otherwise be the SESSION's, which is wherever the launcher that created the workspace
     happened to be — and the panels split off this pane inherit its directory in turn.
     """
+    # `tmuxctl.verbatim` per harness argument, for :func:`respawn_argv`'s reason (#957).
     return _tmux(socket, "new-window", "-d", "-a", "-t", session, "-n", chat, "-c", cwd,
-                 "-P", "-F", "#{pane_id}", *_env_argv(env), "--", *harness_argv)
+                 "-P", "-F", "#{pane_id}", *_env_argv(env), "--",
+                 *map(tmuxctl.verbatim, harness_argv))
 
 
 #: Every environment variable name charter will ever put on a tmux command line, and the

--- a/charter/frame/layout.py
+++ b/charter/frame/layout.py
@@ -1455,7 +1455,8 @@ def _env_argv(env: dict[str, str] | None) -> list[str]:
             f"{len(unlisted)} other name(s): {unlisted}. A `-e` is argv, and argv is "
             "world-readable; see frame/layout.CARRIABLE")
     # Each `NAME=VALUE` through `tmuxctl.verbatim`: a value ending in `;` — a plane root, a
-    # `$PATH` — otherwise ends the command at the next flag, `unknown command: --` (#957).
+    # `$PATH` — otherwise ends the command early and tmux refuses the launch. What tmux says
+    # then depends on the state; `tmuxctl.verbatim` names each measured case (#957).
     return [x for name in sorted(env or {})
             for x in ("-e", tmuxctl.verbatim(f"{name}={env[name]}"))]
 

--- a/charter/frame/layout.py
+++ b/charter/frame/layout.py
@@ -1216,8 +1216,11 @@ def window_argv(*, socket: str, session: str, window: str, cwd: str) -> list[str
 
     *cwd* is `-c`, for the same reason `respawn_argv` takes one — see its docstring.
     """
+    # The directory through `tmuxctl.verbatim`, for :func:`respawn_argv`'s reason: one that
+    # ends in `;` otherwise ends this command at `-P` (#957).
     return _tmux(socket, "new-window", "-d", "-a", "-t", session, "-n", window,
-                 "-c", cwd, "-P", "-F", "#{window_id} #{pane_id}", "--", *PLACEHOLDER)
+                 "-c", tmuxctl.verbatim(cwd), "-P", "-F", "#{window_id} #{pane_id}", "--",
+                 *PLACEHOLDER)
 
 
 def respawn_argv(*, socket: str, harness_pane: str, env: dict[str, str],
@@ -1284,9 +1287,12 @@ def respawn_argv(*, socket: str, harness_pane: str, env: dict[str, str],
     claude` has to run the harness where it was typed, and the panels split off this
     pane inherit its directory in turn, which is what `workspace.resolve()` reads.
     """
-    # Each harness argument through `tmuxctl.verbatim`: tmux reads one that ends in `;` as
-    # its own command separator and drops the `;` without a word (#957).
-    return _tmux(socket, "respawn-pane", "-k", "-t", harness_pane, "-c", cwd,
+    # Every data argument through `tmuxctl.verbatim` — the directory, each `-e` value (in
+    # `_env_argv`) and each harness argument. tmux reads ANY argument ending in `;` as its
+    # own command separator: a harness argument loses the `;`, and a directory or a value
+    # ends the command at the next flag (#957).
+    return _tmux(socket, "respawn-pane", "-k", "-t", harness_pane,
+                 "-c", tmuxctl.verbatim(cwd),
                  *_env_argv(env), "--", *map(tmuxctl.verbatim, harness_argv))
 
 
@@ -1397,8 +1403,10 @@ def chat_window_argv(*, socket: str, session: str, chat: str, cwd: str,
     otherwise be the SESSION's, which is wherever the launcher that created the workspace
     happened to be — and the panels split off this pane inherit its directory in turn.
     """
-    # `tmuxctl.verbatim` per harness argument, for :func:`respawn_argv`'s reason (#957).
-    return _tmux(socket, "new-window", "-d", "-a", "-t", session, "-n", chat, "-c", cwd,
+    # `tmuxctl.verbatim` for the directory and each harness argument, for
+    # :func:`respawn_argv`'s reason (#957).
+    return _tmux(socket, "new-window", "-d", "-a", "-t", session, "-n", chat,
+                 "-c", tmuxctl.verbatim(cwd),
                  "-P", "-F", "#{pane_id}", *_env_argv(env), "--",
                  *map(tmuxctl.verbatim, harness_argv))
 
@@ -1446,7 +1454,10 @@ def _env_argv(env: dict[str, str] | None) -> list[str]:
             f"tmux `-e` may only carry {sorted(CARRIABLE)} — refusing "
             f"{len(unlisted)} other name(s): {unlisted}. A `-e` is argv, and argv is "
             "world-readable; see frame/layout.CARRIABLE")
-    return [x for name in sorted(env or {}) for x in ("-e", f"{name}={env[name]}")]
+    # Each `NAME=VALUE` through `tmuxctl.verbatim`: a value ending in `;` — a plane root, a
+    # `$PATH` — otherwise ends the command at the next flag, `unknown command: --` (#957).
+    return [x for name in sorted(env or {})
+            for x in ("-e", tmuxctl.verbatim(f"{name}={env[name]}"))]
 
 
 def panel_command(*, slot: str, session: str) -> list[str]:

--- a/charter/frame/tmuxctl.py
+++ b/charter/frame/tmuxctl.py
@@ -465,10 +465,16 @@ def verbatim(arg: str) -> str:
 
     **Every argument is read this way, not only the harness's** (review round 1 on #959). A
     `-c` directory or an `-e NAME=VALUE` ending in `;` ends the command early instead, and
-    the flag after it is read as a command of its own — `unknown command: -P`, `-e` or `--`,
-    rc 1, measured on both versions. And a MIDDLE harness argument ending in `;` made the
-    arguments after it a tmux command run on charter's server: `["a;", "set-option", "-g",
-    "@injected", "yes"]` set `@injected` and handed the harness `["a"]`, rc 0. Only an
+    tmux refuses the launch, rc 1. What it says depends on the state — measured on both
+    versions with the identity a real launch carries — and none of it names the value:
+    `unknown command: -P` for a directory, which reaches tmux only with a session already up
+    (`frame/layout.session_argv` takes no directory); `unknown command: -e` for a
+    `$CHARTER_ROOT` while a server is running, because another identity value follows it;
+    and `error connecting to …` when no server is running yet.
+
+    And a MIDDLE harness argument ending in `;` made the arguments after it a tmux command
+    run on charter's server: `["a;", "set-option", "-g", "@injected", "yes"]` set
+    `@injected` and handed the harness `["a"]`, rc 0. Only an
     operator's own typed arguments reach a harness argv today, so that was a latent surface
     rather than a hole; it is closed all the same.
 

--- a/charter/frame/tmuxctl.py
+++ b/charter/frame/tmuxctl.py
@@ -446,6 +446,30 @@ def is_operator_socket(server: str | None, *, own: str | None = None) -> bool:
 SEPARATOR = ";"
 
 
+def verbatim(arg: str) -> str:
+    r"""*arg*, spelled so tmux's command parser hands it on exactly as it is (#957).
+
+    **tmux reads an argument that ENDS in `;` as the separator between two commands**, drops
+    the `;`, and says nothing. Measured on tmux 3.7c and at the 3.2 floor, through
+    `new-session`, `new-window` and `respawn-pane` alike, with a recorder as the harness:
+    `run the tests;` arrived as `run the tests`, `a;b c;` as `a;b c`, and a lone `;` as no
+    argument at all — every start rc 0 with an empty stderr. So `charter claude "run the
+    tests;"` started the harness on a prompt one byte shorter than the one typed.
+    :data:`SEPARATOR`'s note is not contradicted: an argument merely CONTAINING a `;` is
+    passed through whole, because the parse looks only at the end of each argument.
+
+    The same parse names its own escape — a trailing `\;` is handed on as a literal `;` —
+    and it undoes only that last pair, which is what makes one backslash exact rather than
+    approximately right: `\;` arrives as `\;`, `;;` as `;;`, ` ;` as ` ;`. Measured on both
+    versions and all three commands.
+
+    For DATA only — the harness's own arguments after `--`, which `frame/layout.py`'s
+    builders pass through here — and never for :data:`SEPARATOR` itself, which :func:`chain`
+    inserts precisely so tmux will read it as one.
+    """
+    return arg[:-1] + "\\;" if arg.endswith(";") else arg
+
+
 def chain(argvs: list[list[str]]) -> list[str] | None:
     """Several tmux commands as ONE invocation, so the SERVER runs all of them.
 
@@ -711,6 +735,33 @@ def report_failure(action: str, cmd: list[str], proc: subprocess.CompletedProces
     """
     stderr = (proc.stderr or "").strip() or "(tmux printed nothing to stderr)"
     util.err(f"charter frame: {action} failed — `{' '.join(cmd)}`: {stderr}")
+
+
+#: The most bytes tmux takes in ONE command message: the command's name and every argument
+#: after it, each followed by a NUL. The global `-L`/`-S`/`-f` in front are the client's own
+#: and are not in it. Measured on tmux 3.7c and at the 3.2 floor, identically, through
+#: `new-session`, `new-window` and `respawn-pane`: 16,364 bytes starts, one more is refused
+#: (#957). Read only to say what a refusal WAS — never to predict one, see
+#: :func:`refused_as_too_long`.
+MESSAGE_LIMIT = 16364
+
+#: tmux's two sentences for a command message past :data:`MESSAGE_LIMIT`. Two, and both are
+#: needed: measured on both versions and all three commands, 16,365 to 16,380 bytes is
+#: `failed to send command` and 16,381 up is `command too long`, each at rc 1.
+_TOO_LONG = frozenset({"failed to send command", "command too long"})
+
+
+def refused_as_too_long(stderr: str) -> bool:
+    """Did tmux refuse a command for being longer than :data:`MESSAGE_LIMIT`?
+
+    **A classification, never a prediction (ADR 0009).** Charter does not count a command's
+    bytes before sending it: the limit is tmux's to enforce, and a copy of its arithmetic
+    here would be a second answer free to drift from the first. What charter CAN do is
+    recognise tmux's own sentence once tmux has said it — so exactly that sentence and
+    nothing near it, because a stderr that merely resembles one is a different failure, and
+    naming this cause for it would be the guess ADR 0009 forbids.
+    """
+    return stderr.strip() in _TOO_LONG
 
 
 def run(action: str, argv: list[str], *, env: dict | None = None,

--- a/charter/frame/tmuxctl.py
+++ b/charter/frame/tmuxctl.py
@@ -463,9 +463,19 @@ def verbatim(arg: str) -> str:
     approximately right: `\;` arrives as `\;`, `;;` as `;;`, ` ;` as ` ;`. Measured on both
     versions and all three commands.
 
-    For DATA only — the harness's own arguments after `--`, which `frame/layout.py`'s
-    builders pass through here — and never for :data:`SEPARATOR` itself, which :func:`chain`
-    inserts precisely so tmux will read it as one.
+    **Every argument is read this way, not only the harness's** (review round 1 on #959). A
+    `-c` directory or an `-e NAME=VALUE` ending in `;` ends the command early instead, and
+    the flag after it is read as a command of its own — `unknown command: -P`, `-e` or `--`,
+    rc 1, measured on both versions. And a MIDDLE harness argument ending in `;` made the
+    arguments after it a tmux command run on charter's server: `["a;", "set-option", "-g",
+    "@injected", "yes"]` set `@injected` and handed the harness `["a"]`, rc 0. Only an
+    operator's own typed arguments reach a harness argv today, so that was a latent surface
+    rather than a hole; it is closed all the same.
+
+    For every DATA argument — the harness's arguments after `--`, the `-c` directory and
+    each `-e` value, which `frame/layout.py`'s builders pass through here — and never for
+    :data:`SEPARATOR` itself, which :func:`chain` inserts precisely so tmux will read it as
+    one.
     """
     return arg[:-1] + "\\;" if arg.endswith(";") else arg
 
@@ -751,7 +761,7 @@ MESSAGE_LIMIT = 16364
 _TOO_LONG = frozenset({"failed to send command", "command too long"})
 
 
-def refused_as_too_long(stderr: str) -> bool:
+def refused_as_too_long(stderr: str | None) -> bool:
     """Did tmux refuse a command for being longer than :data:`MESSAGE_LIMIT`?
 
     **A classification, never a prediction (ADR 0009).** Charter does not count a command's
@@ -761,7 +771,9 @@ def refused_as_too_long(stderr: str) -> bool:
     nothing near it, because a stderr that merely resembles one is a different failure, and
     naming this cause for it would be the guess ADR 0009 forbids.
     """
-    return stderr.strip() in _TOO_LONG
+    # `or ""`, the way :func:`report_failure` reads it: a `CompletedProcess` made without
+    # capturing carries `None` there, and a failure report must not raise on one.
+    return (stderr or "").strip() in _TOO_LONG
 
 
 def run(action: str, argv: list[str], *, env: dict | None = None,

--- a/docs/frame.md
+++ b/docs/frame.md
@@ -1194,13 +1194,25 @@ while two or more are looked up as a program and its arguments, with nothing in 
 expand or resolve them.
 
 **An argument that ends in `;` reaches the command with its `;`**, which tmux on its own
-would not do. tmux reads a trailing `;` as the separator between two of its own commands and
-drops it without a word: measured on tmux 3.7c and at the 3.2 floor, `charter claude "run
-the tests;"` used to start the harness on `run the tests`, and a lone `;` arrived as no
-argument at all. Charter now hands tmux every argument of the command with one backslash
-before a trailing `;` — `\;`, tmux's own spelling of a literal one — so the command gets what
-you typed, `\;`, `;;` and ` ;` included. A `;` anywhere else was never touched and still is
-not. This holds in a frame on charter's own server and inside a tmux you already had.
+would not do. tmux reads ANY argument ending in `;` as the separator between two of its own
+commands. Measured on tmux 3.7c and at the 3.2 floor, that cost three things:
+
+- `charter claude "run the tests;"` started the harness on `run the tests`, without a word,
+  and a lone `;` arrived as no argument at all.
+- A `;`-ending argument in the middle turned the arguments after it into a tmux command run
+  on charter's server: `charter claude "a;" set-option -g @x yes` set `@x` and started the
+  harness on `a`. Only arguments you type yourself reach that path, so it was a latent
+  surface rather than a hole. It is closed.
+- A directory or a `$CHARTER_ROOT` ending in `;` ended tmux's command early, so a chat
+  opened there failed with `unknown command: -P` or `unknown command: --` — sentences that
+  never name the directory.
+
+Charter now hands tmux every such argument — the command's own, the directory it starts in,
+and each identity value — with one backslash before a trailing `;`: `\;`, tmux's own
+spelling of a literal one. The command gets exactly what you typed, `;;` and ` ;` included.
+**If you had been typing `\;` to get a `;` through, you now get the backslash too** — drop
+it. A `;` anywhere but last was never touched and still is not. This holds in a frame on
+charter's own server and inside a tmux you already had.
 
 **tmux takes one command of at most 16,364 bytes, arguments and all.** Past that — a whole
 spec pasted as `charter claude "<prompt>"` is the usual way there — tmux refuses the command,

--- a/docs/frame.md
+++ b/docs/frame.md
@@ -1193,6 +1193,32 @@ So a single argument can be a whole command line — builtins, `;`, pipelines, r
 while two or more are looked up as a program and its arguments, with nothing in between to
 expand or resolve them.
 
+**An argument that ends in `;` reaches the command with its `;`**, which tmux on its own
+would not do. tmux reads a trailing `;` as the separator between two of its own commands and
+drops it without a word: measured on tmux 3.7c and at the 3.2 floor, `charter claude "run
+the tests;"` used to start the harness on `run the tests`, and a lone `;` arrived as no
+argument at all. Charter now hands tmux every argument of the command with one backslash
+before a trailing `;` — `\;`, tmux's own spelling of a literal one — so the command gets what
+you typed, `\;`, `;;` and ` ;` included. A `;` anywhere else was never touched and still is
+not. This holds in a frame on charter's own server and inside a tmux you already had.
+
+**tmux takes one command of at most 16,364 bytes, arguments and all.** Past that — a whole
+spec pasted as `charter claude "<prompt>"` is the usual way there — tmux refuses the command,
+nothing starts, and charter says so in tmux's own number instead of pasting the command back:
+
+    ✗ charter frame: tmux refused the command that starts this chat as too long — tmux takes
+      at most 16,364 bytes in one command, and this launch's harness arguments alone are
+      20,014 bytes. Nothing was started; shorten them, or put the long text in a file and
+      pass its path instead.
+
+The count is the command's own arguments. The rest of the 16,364 is the window's name,
+directory and identity, which is why a launch a few hundred bytes under the limit can still
+be refused. Charter does not predict the refusal; it recognises it. The limit is tmux's,
+measured identically on 3.7c and 3.2 through all three ways charter starts a harness —
+`failed to send command` from 16,365 bytes, `command too long` from 16,381 — and only a
+refusal in one of those two sentences is reported this way. Any other refusal is reported as
+it always was.
+
 Charter deliberately does **not** check the command against `$PATH` before starting it.
 Such a check answers the wrong question for the first form (that text is not even one
 word), and for the second it is a guess where a real answer arrives milliseconds later: a

--- a/docs/frame.md
+++ b/docs/frame.md
@@ -1203,12 +1203,12 @@ commands. Measured on tmux 3.7c and at the 3.2 floor, that cost three things:
   on charter's server: `charter claude "a;" set-option -g @x yes` set `@x` and started the
   harness on `a`. Only arguments you type yourself reach that path, so it was a latent
   surface rather than a hole. It is closed.
-- A directory or a `$CHARTER_ROOT` ending in `;` ended tmux's command at the flag after it,
-  which tmux then read as a command of its own. A second chat opened in such a directory,
-  or any chat inside a tmux you already had, failed with `unknown command: -P`; a
-  `$CHARTER_ROOT` ending in `;` failed every launch with `unknown command: -e`, because
-  charter always carries another identity value after it. Neither sentence names the
-  directory.
+- A directory or a `$CHARTER_ROOT` ending in `;` made tmux refuse the launch, because tmux
+  ended its command at the flag after it. What tmux said depended on the state, and none of
+  it named the directory: `unknown command: -P` for such a directory, on a second chat or
+  inside a tmux you already had; `unknown command: -e` for such a `$CHARTER_ROOT` when
+  charter's tmux server was already running; and `error connecting to …` when it was not
+  running yet — the first chat after a fresh install, a reboot, or the server stopping.
 
 Charter now hands tmux every such argument — the command's own, the directory it starts in,
 and each identity value — with one backslash before a trailing `;`: `\;`, tmux's own

--- a/docs/frame.md
+++ b/docs/frame.md
@@ -1203,9 +1203,12 @@ commands. Measured on tmux 3.7c and at the 3.2 floor, that cost three things:
   on charter's server: `charter claude "a;" set-option -g @x yes` set `@x` and started the
   harness on `a`. Only arguments you type yourself reach that path, so it was a latent
   surface rather than a hole. It is closed.
-- A directory or a `$CHARTER_ROOT` ending in `;` ended tmux's command early, so a chat
-  opened there failed with `unknown command: -P` or `unknown command: --` — sentences that
-  never name the directory.
+- A directory or a `$CHARTER_ROOT` ending in `;` ended tmux's command at the flag after it,
+  which tmux then read as a command of its own. A second chat opened in such a directory,
+  or any chat inside a tmux you already had, failed with `unknown command: -P`; a
+  `$CHARTER_ROOT` ending in `;` failed every launch with `unknown command: -e`, because
+  charter always carries another identity value after it. Neither sentence names the
+  directory.
 
 Charter now hands tmux every such argument — the command's own, the directory it starts in,
 and each identity value — with one backslash before a trailing `;`: `\;`, tmux's own

--- a/docs/news/unreleased-a-prompt-ending-in-a-semicolon-keeps-it.md
+++ b/docs/news/unreleased-a-prompt-ending-in-a-semicolon-keeps-it.md
@@ -6,8 +6,9 @@ headline: `charter claude "…;"` gives the harness its trailing `;`, and a laun
 tmux reads any argument that ends in `;` as its own command separator. So
 `charter claude "run the tests;"` started the harness on `run the tests`; a `;`-ending
 argument in the middle turned the arguments after it into a tmux command run on charter's
-server; and a directory or `$CHARTER_ROOT` ending in `;` failed the launch with
-`unknown command: -P` or `--`. Charter now escapes a trailing `;` as `\;` — tmux's own
+server; a second chat, or any chat inside a tmux you already had, opened in a directory
+ending in `;` failed with `unknown command: -P`; and a `$CHARTER_ROOT` ending in `;` failed
+every launch with `unknown command: -e`. Charter now escapes a trailing `;` as `\;` — tmux's own
 spelling of a literal one — in every argument, directory and identity value it hands tmux,
 on charter's own server and inside a tmux you already had.
 

--- a/docs/news/unreleased-a-prompt-ending-in-a-semicolon-keeps-it.md
+++ b/docs/news/unreleased-a-prompt-ending-in-a-semicolon-keeps-it.md
@@ -1,0 +1,13 @@
+---
+version: unreleased
+headline: `charter claude "…;"` gives the harness its trailing `;`, and a launch too long for tmux says how long
+---
+
+tmux reads an argument that ends in `;` as its own command separator and drops the `;`
+silently, so `charter claude "run the tests;"` started the harness on `run the tests`.
+Charter now escapes it as `\;`, tmux's spelling of a literal one, for every argument it
+starts a harness with — on charter's own server and inside a tmux you already had.
+
+A launch whose arguments take tmux past its 16,364-byte command limit used to print the
+whole command back beside tmux's three words. It now names the limit, how many bytes the
+launch's arguments carried, and the fix: put long text in a file and pass its path.

--- a/docs/news/unreleased-a-prompt-ending-in-a-semicolon-keeps-it.md
+++ b/docs/news/unreleased-a-prompt-ending-in-a-semicolon-keeps-it.md
@@ -3,11 +3,18 @@ version: unreleased
 headline: `charter claude "…;"` gives the harness its trailing `;`, and a launch too long for tmux says how long
 ---
 
-tmux reads an argument that ends in `;` as its own command separator and drops the `;`
-silently, so `charter claude "run the tests;"` started the harness on `run the tests`.
-Charter now escapes it as `\;`, tmux's spelling of a literal one, for every argument it
-starts a harness with — on charter's own server and inside a tmux you already had.
+tmux reads any argument that ends in `;` as its own command separator. So
+`charter claude "run the tests;"` started the harness on `run the tests`; a `;`-ending
+argument in the middle turned the arguments after it into a tmux command run on charter's
+server; and a directory or `$CHARTER_ROOT` ending in `;` failed the launch with
+`unknown command: -P` or `--`. Charter now escapes a trailing `;` as `\;` — tmux's own
+spelling of a literal one — in every argument, directory and identity value it hands tmux,
+on charter's own server and inside a tmux you already had.
+
+The middle-argument case was a latent surface, not a vulnerability: only arguments you type
+yourself reach a harness's argv today. If you had been typing `\;` to get a `;` through, you
+now get the backslash too — drop it.
 
 A launch whose arguments take tmux past its 16,364-byte command limit used to print the
-whole command back beside tmux's three words. It now names the limit, how many bytes the
+whole command back beside tmux's own refusal. It now names the limit, how many bytes the
 launch's arguments carried, and the fix: put long text in a file and pass its path.

--- a/docs/news/unreleased-a-prompt-ending-in-a-semicolon-keeps-it.md
+++ b/docs/news/unreleased-a-prompt-ending-in-a-semicolon-keeps-it.md
@@ -6,9 +6,10 @@ headline: `charter claude "…;"` gives the harness its trailing `;`, and a laun
 tmux reads any argument that ends in `;` as its own command separator. So
 `charter claude "run the tests;"` started the harness on `run the tests`; a `;`-ending
 argument in the middle turned the arguments after it into a tmux command run on charter's
-server; a second chat, or any chat inside a tmux you already had, opened in a directory
-ending in `;` failed with `unknown command: -P`; and a `$CHARTER_ROOT` ending in `;` failed
-every launch with `unknown command: -e`. Charter now escapes a trailing `;` as `\;` — tmux's own
+server; and a directory or `$CHARTER_ROOT` ending in `;` made tmux refuse the launch with
+an error that never named it — `unknown command: -P` for the directory, `unknown command: -e`
+for the root while charter's tmux server was running, and `error connecting to …` before it
+was. Charter now escapes a trailing `;` as `\;` — tmux's own
 spelling of a literal one — in every argument, directory and identity value it hands tmux,
 on charter's own server and inside a tmux you already had.
 

--- a/tests/test_a_chat_records_where_it_was_started.py
+++ b/tests/test_a_chat_records_where_it_was_started.py
@@ -101,6 +101,9 @@ class BothLaunchPathsRecordIt(PersonaIso, unittest.TestCase):
         class _Out:
             returncode = 1
             stdout = ""
+            # `tmuxctl.run` always answers with one, and a refused start now reads it to
+            # tell tmux's length refusal from any other (#957).
+            stderr = ""
 
         def _run(why, argv, **kw):
             calls.setdefault("first", why)

--- a/tests/test_a_harness_argument_ending_in_a_semicolon_arrives_whole.py
+++ b/tests/test_a_harness_argument_ending_in_a_semicolon_arrives_whole.py
@@ -112,13 +112,11 @@ class EveryBuilderEscapesEveryArgumentAfterTheSeparator(unittest.TestCase):
 class DataArgumentsEndingInASemicolonAreEscapedToo(unittest.TestCase):
     """The same tmux parse reads EVERY argument, not only the harness's (review round 1 on
     #959). A directory or an identity value ending in `;` does not vanish quietly: it ends
-    the command early and the flag after it is read as a command of its own. Measured on
-    3.7c and 3.2 with the identity a real launch carries: a directory gives `unknown
-    command: -P` from `new-window` and the guest `window_argv` (`-e` from `respawn-pane`),
-    and a `$CHARTER_ROOT` gives `unknown command: -e` on every launch, because another
-    identity value always follows it — `--` only when the value is a command's last `-e`.
-    So a chat opened from a directory named that way failed with a sentence that never
-    named the directory."""
+    the command early, and tmux refuses the launch. What tmux says depends on the state —
+    measured on 3.7c and 3.2 with the identity a real launch carries — and none of it names
+    the directory: `unknown command: -P` for a directory on `new-window` or the guest
+    `window_argv`; `unknown command: -e` for a `$CHARTER_ROOT` when a server is already
+    running on the socket; and `error connecting to …` when none is running yet."""
 
     WHERE = "/work/dir;"
 

--- a/tests/test_a_harness_argument_ending_in_a_semicolon_arrives_whole.py
+++ b/tests/test_a_harness_argument_ending_in_a_semicolon_arrives_whole.py
@@ -1,0 +1,222 @@
+r"""A harness argument that ends in `;` reaches the harness with its `;`.
+
+**tmux reads a trailing `;` as its own command separator, and says nothing about it.**
+Measured on tmux 3.7c and at the 3.2 floor, through all three builders that put a harness
+after `--` — `layout.session_argv`, `layout.chat_window_argv` and `layout.respawn_argv` —
+with a recorder standing in for the harness: `run the tests;` arrived as `run the tests`,
+`run the tests\;` as `run the tests;`, `a;b c;` as `a;b c`, and a lone `;` as no argument
+at all. Every start returned 0 with nothing on stderr. So `charter claude "run the tests;"`
+started Claude on a prompt one byte shorter than the one typed, and nothing said so.
+
+**Why `tmuxctl.SEPARATOR`'s own note did not catch it.** That note measured an argument
+merely CONTAINING a `;` and found it passed through whole, which is still true: the parse
+looks only at the END of each argument. The same parse names its own escape — a trailing
+`\;` is handed on as a literal `;` — so `tmuxctl.verbatim` puts one backslash before the
+last `;` of an argument that ends in one, and touches nothing else. Measured intact on both
+versions and all three builders for `;`, `;;`, ` ;`, `\;`, `\\;` and `a;b c;`.
+
+:class:`ARealTmuxHandsTheHarnessEveryByte` is that measurement, kept.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import time
+import unittest
+from pathlib import Path
+
+from charter.frame import layout, tmuxctl
+
+from tests import _tmuxreap, _tmuxsocket
+from tests._isolation import PersonaIso
+
+_HAS_TMUX = shutil.which("tmux") is not None
+
+#: The tmux this repo builds to measure its own floor against, named the way
+#: `test_a_planes_frame_really_reads_that_way` names it. Absent on CI, so the floor rows
+#: there are simply not run — the `tmux` on `$PATH` still is.
+_FLOOR_BIN = (Path.home() / ".local/share/charter-testing"
+              / f"tmux-{tmuxctl.FLOOR[0]}.{tmuxctl.FLOOR[1]}")
+
+#: ``(what the operator typed, what tmux has to be handed for the harness to get it)`` —
+#: the measured matrix. Each row changes by exactly one backslash, before its LAST `;`.
+_ESCAPED = (
+    (";", "\\;"),
+    (";;", ";\\;"),
+    (" ;", " \\;"),
+    ("\\;", "\\\\;"),
+    ("\\\\;", "\\\\\\;"),
+    ("a;b c;", "a;b c\\;"),
+    ("run the tests;", "run the tests\\;"),
+)
+
+#: What tmux already hands on whole, which the escape must leave byte-for-byte alone — a
+#: `;` anywhere but last, a trailing backslash with no `;`, and the text a shell or tmux's
+#: format parser would mangle if anything here were ever joined or expanded.
+_UNCHANGED = (
+    "", "plain text", "run a ; then b", "a;b", "; leading", ";\n",
+    "ends in a backslash \\", "first line\nsecond line\n\nthird",
+    "name #{session_name} here", 'say "hi"', "it's here", "run `x` now",
+    "value $(echo x) here", "a\tb c", "a\u2028b c",
+)
+
+
+class TheEscapeIsExactlyWhatTmuxUndoes(unittest.TestCase):
+    """`tmuxctl.verbatim` over the measured matrix, with no tmux running."""
+
+    def test_an_argument_ending_in_a_semicolon_gets_one_backslash_before_it(self):
+        for typed, sent in _ESCAPED:
+            with self.subTest(typed=typed):
+                self.assertEqual(tmuxctl.verbatim(typed), sent)
+
+    def test_an_argument_that_does_not_end_in_one_is_handed_on_as_it_is(self):
+        for typed in _UNCHANGED:
+            with self.subTest(typed=typed):
+                self.assertEqual(tmuxctl.verbatim(typed), typed)
+
+
+#: A harness argv with the escape's cases in every position — the program itself, a
+#: prompt, an argument it must not touch, and a lone `;` that tmux would otherwise drop.
+_TYPED = ["prog;", "run the tests;", "plain", ";"]
+_SENT = ["prog\\;", "run the tests\\;", "plain", "\\;"]
+
+
+def _after_separator(argv: list[str]) -> list[str]:
+    return argv[argv.index("--") + 1:]
+
+
+class EveryBuilderEscapesEveryArgumentAfterTheSeparator(unittest.TestCase):
+    """The three builders that hand tmux a harness, each asked on its own — a builder that
+    forgot the escape would otherwise hide behind the two that remembered it."""
+
+    def test_the_session_that_starts_a_workspace(self):
+        argv = layout.session_argv(session="w", conf="/dev/null", socket="charter",
+                                   cols=80, rows=24, harness_argv=list(_TYPED), chat="w.1")
+        self.assertEqual(_after_separator(argv), _SENT)
+
+    def test_the_window_that_adds_a_chat(self):
+        argv = layout.chat_window_argv(socket="charter", session="w", chat="w.2",
+                                       cwd="/tmp", harness_argv=list(_TYPED))
+        self.assertEqual(_after_separator(argv), _SENT)
+
+    def test_the_respawn_inside_a_tmux_you_already_had(self):
+        argv = layout.respawn_argv(socket=_tmuxsocket.OPERATOR_SOCKET, harness_pane="%7",
+                                   env={}, cwd="/tmp", harness_argv=list(_TYPED))
+        self.assertEqual(_after_separator(argv), _SENT)
+
+
+@unittest.skipUnless(_HAS_TMUX, "no tmux on this machine")
+class ARealTmuxHandsTheHarnessEveryByte(PersonaIso, unittest.TestCase):
+    """What the harness's own process receives, read back from its `sys.argv`.
+
+    The recorder is started as ``[python, recorder, text]`` rather than through a shebang:
+    three separate arguments are exec'd directly by tmux (`docs/frame.md`, *What `charter
+    frame -- <cmd>` accepts*), so no shell sits between tmux and the bytes being asked
+    about, and an interpreter path with a space in it cannot break the case.
+    """
+
+    #: The escape's own rows, and the texts that were already whole — so a change that
+    #: fixed the first by damaging the second fails here too.
+    TEXTS = tuple(typed for typed, _ in _ESCAPED) + (
+        "run a ; then b", "first line\nsecond line", "name #{session_name} here",
+        "say \"hi\", it's `x` and $(echo x)", "a\tb\u2028c",
+    )
+
+    def setUp(self) -> None:
+        super().setUp()
+        v = tmuxctl.version()
+        if v is None or v < tmuxctl.FLOOR:
+            self.skipTest(f"the frame's floor is tmux {tmuxctl.FLOOR[0]}.{tmuxctl.FLOOR[1]};"
+                          f" this machine has {v}")
+        self.recorder = self.tmp / "recorder.py"
+        self.recorder.write_text(
+            "import json, os, sys\n"
+            "p = os.path.join(os.environ['RECORD_DIR'],\n"
+            "                 os.environ['TMUX_PANE'].lstrip('%') + '.json')\n"
+            "with open(p + '.tmp', 'w') as f:\n"
+            "    json.dump(sys.argv[1:], f)\n"
+            "os.replace(p + '.tmp', p)\n")
+        #: ``(binary, socket, where its panes record)`` for every tmux this machine has.
+        #: One records directory per server, because pane ids restart at `%0` on each.
+        self.servers: list[tuple[str, str, Path]] = []
+        candidates = [("tmux", "trailing-semicolon")]
+        if _FLOOR_BIN.is_file():
+            candidates.append((str(_FLOOR_BIN), "trailing-semicolon-floor"))
+        for binary, slug in candidates:
+            socket = _tmuxreap.name(slug)
+            records = self.tmp / f"records-{slug}"
+            records.mkdir()
+            # Killed whether or not the start below worked: a server that half-started is
+            # still a server, and the reaper only sees it once this process is gone.
+            self.addCleanup(subprocess.run, [binary, "-L", socket, "kill-server"],
+                            capture_output=True, timeout=20)
+            started = subprocess.run(
+                [binary, "-L", socket, "-f", "/dev/null", "new-session", "-d", "-s",
+                 "base", "-x", "80", "-y", "24", "--", "sleep", "600"],
+                capture_output=True, text=True, timeout=20,
+                env=dict(os.environ, RECORD_DIR=str(records)))
+            self.assertEqual(started.returncode, 0, started.stderr)
+            self.servers.append((binary, socket, records))
+
+    @staticmethod
+    def _tmux(binary: str, argv: list[str]) -> subprocess.CompletedProcess:
+        """*argv* as a builder made it, run by *binary* instead of the `tmux` it names."""
+        return subprocess.run([binary, *argv[1:]], capture_output=True, text=True,
+                              timeout=20)
+
+    def _harness(self, text: str) -> list[str]:
+        return [sys.executable, str(self.recorder), text]
+
+    def _received(self, records: Path, pane: str) -> list[str]:
+        record = records / (pane.lstrip("%") + ".json")
+        deadline = time.monotonic() + 10
+        while time.monotonic() < deadline:
+            if record.is_file():
+                return json.loads(record.read_text())
+            time.sleep(0.02)
+        self.fail(f"the harness in {pane} never started")
+
+    def test_a_workspaces_first_chat_gets_every_byte(self):
+        for binary, socket, records in self.servers:
+            for i, text in enumerate(self.TEXTS):
+                with self.subTest(tmux=binary, text=text):
+                    started = self._tmux(binary, layout.session_argv(
+                        session=f"s{i}", conf="/dev/null", socket=socket, cols=80,
+                        rows=24, harness_argv=self._harness(text), chat=f"s{i}.1"))
+                    self.assertEqual(started.returncode, 0, started.stderr)
+                    self.assertEqual(self._received(records, started.stdout.strip()),
+                                     [text])
+
+    def test_a_second_chat_gets_every_byte(self):
+        for binary, socket, records in self.servers:
+            for i, text in enumerate(self.TEXTS):
+                with self.subTest(tmux=binary, text=text):
+                    started = self._tmux(binary, layout.chat_window_argv(
+                        socket=socket, session="base", chat=f"base.{i + 1}",
+                        cwd=str(self.tmp), harness_argv=self._harness(text)))
+                    self.assertEqual(started.returncode, 0, started.stderr)
+                    self.assertEqual(self._received(records, started.stdout.strip()),
+                                     [text])
+
+    def test_a_chat_respawned_into_a_placeholder_gets_every_byte(self):
+        for binary, socket, records in self.servers:
+            for text in self.TEXTS:
+                with self.subTest(tmux=binary, text=text):
+                    placeholder = self._tmux(binary, [
+                        "tmux", "-L", socket, "new-window", "-d", "-a", "-t", "base",
+                        "-P", "-F", "#{pane_id}", "--", "sleep", "600"])
+                    self.assertEqual(placeholder.returncode, 0, placeholder.stderr)
+                    pane = placeholder.stdout.strip()
+                    started = self._tmux(binary, layout.respawn_argv(
+                        socket=socket, harness_pane=pane, env={}, cwd=str(self.tmp),
+                        harness_argv=self._harness(text)))
+                    self.assertEqual(started.returncode, 0, started.stderr)
+                    self.assertEqual(self._received(records, pane), [text])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_a_harness_argument_ending_in_a_semicolon_arrives_whole.py
+++ b/tests/test_a_harness_argument_ending_in_a_semicolon_arrives_whole.py
@@ -109,6 +109,50 @@ class EveryBuilderEscapesEveryArgumentAfterTheSeparator(unittest.TestCase):
         self.assertEqual(_after_separator(argv), _SENT)
 
 
+class DataArgumentsEndingInASemicolonAreEscapedToo(unittest.TestCase):
+    """The same tmux parse reads EVERY argument, not only the harness's (review round 1 on
+    #959). A directory or an identity value ending in `;` does not vanish quietly: it ends
+    the command early and the flag after it is read as a command of its own. Measured on
+    3.7c and 3.2 — `unknown command: -P` from `new-window` and the guest `window_argv`,
+    `unknown command: -e` from `respawn-pane`, `unknown command: --` for an `-e` value — so
+    a chat opened from a directory named that way failed with a sentence that never named
+    the directory."""
+
+    WHERE = "/work/dir;"
+
+    @staticmethod
+    def _after(argv: list[str], flag: str) -> str:
+        return argv[argv.index(flag) + 1]
+
+    def test_a_directory_ending_in_a_semicolon_is_escaped(self):
+        for name, argv in (
+                ("window_argv", layout.window_argv(
+                    socket="charter", session="$1", window="w.1", cwd=self.WHERE)),
+                ("chat_window_argv", layout.chat_window_argv(
+                    socket="charter", session="w", chat="w.2", cwd=self.WHERE,
+                    harness_argv=["prog"])),
+                ("respawn_argv", layout.respawn_argv(
+                    socket=_tmuxsocket.OPERATOR_SOCKET, harness_pane="%7", env={},
+                    cwd=self.WHERE, harness_argv=["prog"]))):
+            with self.subTest(builder=name):
+                self.assertEqual(self._after(argv, "-c"), "/work/dir\\;")
+
+    def test_an_identity_value_ending_in_a_semicolon_is_escaped(self):
+        env = {"CHARTER_ROOT": "/plane;"}
+        for name, argv in (
+                ("session_argv", layout.session_argv(
+                    session="w", conf="/dev/null", socket="charter", cols=80, rows=24,
+                    harness_argv=["prog"], chat="w.1", env=env)),
+                ("chat_window_argv", layout.chat_window_argv(
+                    socket="charter", session="w", chat="w.2", cwd="/work",
+                    harness_argv=["prog"], env=env)),
+                ("respawn_argv", layout.respawn_argv(
+                    socket=_tmuxsocket.OPERATOR_SOCKET, harness_pane="%7", env=env,
+                    cwd="/work", harness_argv=["prog"]))):
+            with self.subTest(builder=name):
+                self.assertEqual(self._after(argv, "-e"), "CHARTER_ROOT=/plane\\;")
+
+
 @unittest.skipUnless(_HAS_TMUX, "no tmux on this machine")
 class ARealTmuxHandsTheHarnessEveryByte(PersonaIso, unittest.TestCase):
     """What the harness's own process receives, read back from its `sys.argv`.
@@ -138,7 +182,8 @@ class ARealTmuxHandsTheHarnessEveryByte(PersonaIso, unittest.TestCase):
             "p = os.path.join(os.environ['RECORD_DIR'],\n"
             "                 os.environ['TMUX_PANE'].lstrip('%') + '.json')\n"
             "with open(p + '.tmp', 'w') as f:\n"
-            "    json.dump(sys.argv[1:], f)\n"
+            "    json.dump({'argv': sys.argv[1:], 'cwd': os.getcwd(),\n"
+            "               'root': os.environ.get('CHARTER_ROOT')}, f)\n"
             "os.replace(p + '.tmp', p)\n")
         #: ``(binary, socket, where its panes record)`` for every tmux this machine has.
         #: One records directory per server, because pane ids restart at `%0` on each.
@@ -172,7 +217,12 @@ class ARealTmuxHandsTheHarnessEveryByte(PersonaIso, unittest.TestCase):
         return [sys.executable, str(self.recorder), text]
 
     def _received(self, binary: str, socket: str, records: Path, pane: str) -> list[str]:
-        """What the harness in *pane* was handed, read back off its own `sys.argv`.
+        """What the harness in *pane* was handed, read back off its own `sys.argv`."""
+        return self._record(binary, socket, records, pane)["argv"]
+
+    def _record(self, binary: str, socket: str, records: Path, pane: str) -> dict:
+        """What the harness in *pane* recorded: its `sys.argv`, the directory it started in,
+        and the `$CHARTER_ROOT` it was handed.
 
         **Failing fast is the half that matters when this goes red.** A harness that could
         not start leaves no record and no pane, and waiting out the deadline on every row
@@ -239,6 +289,97 @@ class ARealTmuxHandsTheHarnessEveryByte(PersonaIso, unittest.TestCase):
                         harness_argv=self._harness(text)))
                     self.assertEqual(started.returncode, 0, started.stderr)
                     self.assertEqual(self._received(binary, socket, records, pane), [text])
+
+    #: The three ways charter starts a harness, each asked on its own below.
+    BUILDERS = ("new-session", "new-window", "respawn-pane")
+
+    def _placeholder(self, binary: str, socket: str) -> str:
+        """A window running `sleep` for a respawn to replace — the guest path's own order."""
+        made = self._tmux(binary, ["tmux", "-L", socket, "new-window", "-d", "-a", "-t",
+                                   "base", "-P", "-F", "#{pane_id}", "--", "sleep", "600"])
+        self.assertEqual(made.returncode, 0, made.stderr)
+        return made.stdout.strip()
+
+    def _start(self, binary: str, socket: str, builder: str, *, tag: str,
+               harness_argv: list[str], cwd: str | None = None,
+               env: dict[str, str] | None = None) -> str:
+        """Start *harness_argv* through *builder* on this server; answer its pane."""
+        cwd = cwd or str(self.tmp)
+        pane = None
+        if builder == "new-session":
+            argv = layout.session_argv(session=tag, conf="/dev/null", socket=socket,
+                                       cols=80, rows=24, harness_argv=harness_argv,
+                                       chat=f"{tag}.1", env=env)
+        elif builder == "new-window":
+            argv = layout.chat_window_argv(socket=socket, session="base",
+                                           chat=f"base.{tag}", cwd=cwd,
+                                           harness_argv=harness_argv, env=env)
+        else:
+            pane = self._placeholder(binary, socket)
+            argv = layout.respawn_argv(socket=socket, harness_pane=pane, env=env or {},
+                                       cwd=cwd, harness_argv=harness_argv)
+        started = self._tmux(binary, argv)
+        self.assertEqual(started.returncode, 0, started.stderr)
+        return pane or started.stdout.strip()
+
+    def test_arguments_after_one_ending_in_a_semicolon_never_run_as_tmux_commands(self):
+        """**The dangerous shape the escape closes.** Before it, the arguments after a
+        harness argument ending in `;` were a tmux command of their own, run on charter's
+        server: measured on 3.7c and 3.2, `["a;", "set-option", "-g", "@injected", "yes"]`
+        set `@injected`, the harness was handed `["a"]`, and the start returned 0 with an
+        empty stderr. Only an operator's own typed arguments reach a harness argv today,
+        which makes it a latent surface rather than a hole — and that is exactly why it is
+        pinned against a real server and not only at the builder."""
+        for binary, socket, records in self.servers:
+            for builder in self.BUILDERS:
+                option = f"@injected{builder.replace('-', '')}"
+                tail = ["a;", "set-option", "-g", option, "yes"]
+                with self.subTest(tmux=binary, builder=builder):
+                    pane = self._start(binary, socket, builder, tag=f"inj{builder[4:7]}",
+                                       harness_argv=self._harness_argv(tail))
+                    self.assertEqual(self._received(binary, socket, records, pane), tail)
+                    options = self._tmux(binary, ["tmux", "-L", socket, "show-options",
+                                                  "-g"]).stdout
+                    self.assertNotIn(option, options,
+                                     "an argument of the harness ran as a tmux command")
+
+    def _harness_argv(self, arguments: list[str]) -> list[str]:
+        return [sys.executable, str(self.recorder), *arguments]
+
+    def test_a_chat_started_in_a_directory_ending_in_a_semicolon_starts_in_it(self):
+        work = self.tmp / "work;"
+        work.mkdir()
+        where = os.path.realpath(work)
+        for binary, socket, records in self.servers:
+            for builder in ("new-window", "respawn-pane"):
+                with self.subTest(tmux=binary, builder=builder):
+                    pane = self._start(binary, socket, builder, tag="cwd", cwd=str(work),
+                                       harness_argv=self._harness_argv(["x y"]))
+                    self.assertEqual(
+                        self._record(binary, socket, records, pane)["cwd"], where)
+            with self.subTest(tmux=binary, builder="the guest window_argv"):
+                started = self._tmux(binary, layout.window_argv(
+                    socket=socket, session="base", window="guest", cwd=str(work)))
+                self.assertEqual(started.returncode, 0, started.stderr)
+                pane = started.stdout.split()[1]
+                deadline, path = time.monotonic() + 5, ""
+                while time.monotonic() < deadline and path != where:
+                    path = self._tmux(binary, ["tmux", "-L", socket, "display-message",
+                                               "-p", "-t", pane,
+                                               "#{pane_current_path}"]).stdout.strip()
+                    time.sleep(0.05)
+                self.assertEqual(path, where)
+
+    def test_a_plane_root_ending_in_a_semicolon_reaches_the_harness_exactly(self):
+        root = str(self.tmp / "plane;")
+        for binary, socket, records in self.servers:
+            for builder in self.BUILDERS:
+                with self.subTest(tmux=binary, builder=builder):
+                    pane = self._start(binary, socket, builder, tag=f"root{builder[4:7]}",
+                                       env={"CHARTER_ROOT": root},
+                                       harness_argv=self._harness_argv(["x y"]))
+                    self.assertEqual(
+                        self._record(binary, socket, records, pane)["root"], root)
 
 
 if __name__ == "__main__":

--- a/tests/test_a_harness_argument_ending_in_a_semicolon_arrives_whole.py
+++ b/tests/test_a_harness_argument_ending_in_a_semicolon_arrives_whole.py
@@ -113,10 +113,12 @@ class DataArgumentsEndingInASemicolonAreEscapedToo(unittest.TestCase):
     """The same tmux parse reads EVERY argument, not only the harness's (review round 1 on
     #959). A directory or an identity value ending in `;` does not vanish quietly: it ends
     the command early and the flag after it is read as a command of its own. Measured on
-    3.7c and 3.2 — `unknown command: -P` from `new-window` and the guest `window_argv`,
-    `unknown command: -e` from `respawn-pane`, `unknown command: --` for an `-e` value — so
-    a chat opened from a directory named that way failed with a sentence that never named
-    the directory."""
+    3.7c and 3.2 with the identity a real launch carries: a directory gives `unknown
+    command: -P` from `new-window` and the guest `window_argv` (`-e` from `respawn-pane`),
+    and a `$CHARTER_ROOT` gives `unknown command: -e` on every launch, because another
+    identity value always follows it — `--` only when the value is a command's last `-e`.
+    So a chat opened from a directory named that way failed with a sentence that never
+    named the directory."""
 
     WHERE = "/work/dir;"
 
@@ -338,9 +340,11 @@ class ARealTmuxHandsTheHarnessEveryByte(PersonaIso, unittest.TestCase):
                     pane = self._start(binary, socket, builder, tag=f"inj{builder[4:7]}",
                                        harness_argv=self._harness_argv(tail))
                     self.assertEqual(self._received(binary, socket, records, pane), tail)
-                    options = self._tmux(binary, ["tmux", "-L", socket, "show-options",
-                                                  "-g"]).stdout
-                    self.assertNotIn(option, options,
+                    shown = self._tmux(binary, ["tmux", "-L", socket, "show-options", "-g"])
+                    # Asked first: a `show-options` that failed prints nothing, and an
+                    # empty listing would pass the check below for the wrong reason.
+                    self.assertEqual(shown.returncode, 0, shown.stderr)
+                    self.assertNotIn(option, shown.stdout,
                                      "an argument of the harness ran as a tmux command")
 
     def _harness_argv(self, arguments: list[str]) -> list[str]:

--- a/tests/test_a_harness_argument_ending_in_a_semicolon_arrives_whole.py
+++ b/tests/test_a_harness_argument_ending_in_a_semicolon_arrives_whole.py
@@ -171,12 +171,33 @@ class ARealTmuxHandsTheHarnessEveryByte(PersonaIso, unittest.TestCase):
     def _harness(self, text: str) -> list[str]:
         return [sys.executable, str(self.recorder), text]
 
-    def _received(self, records: Path, pane: str) -> list[str]:
+    def _received(self, binary: str, socket: str, records: Path, pane: str) -> list[str]:
+        """What the harness in *pane* was handed, read back off its own `sys.argv`.
+
+        **Failing fast is the half that matters when this goes red.** A harness that could
+        not start leaves no record and no pane, and waiting out the deadline on every row
+        turned one broken argv into a twelve-minute module — which the deletion sweep could
+        only report as a timeout with no verdict, not as the failure it was. So the wait
+        ends the moment tmux no longer knows the pane, after one last look for a record the
+        harness may have written on its way out.
+        """
         record = records / (pane.lstrip("%") + ".json")
         deadline = time.monotonic() + 10
         while time.monotonic() < deadline:
             if record.is_file():
                 return json.loads(record.read_text())
+            # `list-panes -a`, and never `display-message -t <pane>`: measured on 3.7c and
+            # at the 3.2 floor, asked about a pane whose harness failed to exec,
+            # `display-message` answers rc 0 with an empty line instead of refusing, so it
+            # cannot say "gone" at all — and this wait ran to its deadline on every row.
+            panes = subprocess.run([binary, "-L", socket, "list-panes", "-a", "-F",
+                                    "#{pane_id}"],
+                                   capture_output=True, text=True, timeout=20)
+            if pane not in panes.stdout.split():
+                if record.is_file():
+                    return json.loads(record.read_text())
+                self.fail(f"the harness in {pane} ended without recording what it was "
+                          f"handed — it never started")
             time.sleep(0.02)
         self.fail(f"the harness in {pane} never started")
 
@@ -188,7 +209,8 @@ class ARealTmuxHandsTheHarnessEveryByte(PersonaIso, unittest.TestCase):
                         session=f"s{i}", conf="/dev/null", socket=socket, cols=80,
                         rows=24, harness_argv=self._harness(text), chat=f"s{i}.1"))
                     self.assertEqual(started.returncode, 0, started.stderr)
-                    self.assertEqual(self._received(records, started.stdout.strip()),
+                    self.assertEqual(self._received(binary, socket, records,
+                                                    started.stdout.strip()),
                                      [text])
 
     def test_a_second_chat_gets_every_byte(self):
@@ -199,7 +221,8 @@ class ARealTmuxHandsTheHarnessEveryByte(PersonaIso, unittest.TestCase):
                         socket=socket, session="base", chat=f"base.{i + 1}",
                         cwd=str(self.tmp), harness_argv=self._harness(text)))
                     self.assertEqual(started.returncode, 0, started.stderr)
-                    self.assertEqual(self._received(records, started.stdout.strip()),
+                    self.assertEqual(self._received(binary, socket, records,
+                                                    started.stdout.strip()),
                                      [text])
 
     def test_a_chat_respawned_into_a_placeholder_gets_every_byte(self):
@@ -215,7 +238,7 @@ class ARealTmuxHandsTheHarnessEveryByte(PersonaIso, unittest.TestCase):
                         socket=socket, harness_pane=pane, env={}, cwd=str(self.tmp),
                         harness_argv=self._harness(text)))
                     self.assertEqual(started.returncode, 0, started.stderr)
-                    self.assertEqual(self._received(records, pane), [text])
+                    self.assertEqual(self._received(binary, socket, records, pane), [text])
 
 
 if __name__ == "__main__":

--- a/tests/test_a_launch_too_long_for_tmux_says_so.py
+++ b/tests/test_a_launch_too_long_for_tmux_says_so.py
@@ -1,0 +1,245 @@
+"""A launch tmux refuses as too long says so, with tmux's own number.
+
+**tmux takes one command message of at most 16,364 bytes, and refuses past it in one of
+two sentences.** Measured on tmux 3.7c and at the 3.2 floor, identically, through
+`new-session`, `new-window` and `respawn-pane`, counting the command's arguments from its
+name onward with a NUL after each: 16,364 bytes starts; 16,365 to 16,380 is rc 1 and
+`failed to send command`; 16,381 and up is rc 1 and `command too long`. `charter claude
+"<a pasted spec>"` reaches it.
+
+What the launcher printed for that was `tmuxctl.report_failure`'s generic line — the whole
+command, pasted text and all, then tmux's three words — so the one number that explains the
+refusal was the one thing not on screen.
+
+**Classified after the fact, never predicted.** Nothing here counts bytes before tmux is
+asked: the limit is tmux's to enforce, and a copy of its arithmetic in charter would be a
+second answer free to drift from the first. Only once tmux has refused, and only for those
+two exact sentences, does a launch say what the refusal was. Any other refusal keeps the
+report it always had.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from charter.frame import layout, tmuxctl
+
+from tests import _tmuxreap, _tmuxsocket
+from tests._isolation import PersonaIso
+from tests.test_frame_launcher import (_FakeOperatorTmux, _FakeTmux, _launch,
+                                       _launch_inside)
+
+_HAS_TMUX = shutil.which("tmux") is not None
+
+#: See `tests/test_a_harness_argument_ending_in_a_semicolon_arrives_whole.py`.
+_FLOOR_BIN = (Path.home() / ".local/share/charter-testing"
+              / f"tmux-{tmuxctl.FLOOR[0]}.{tmuxctl.FLOOR[1]}")
+
+#: tmux's two sentences for a command past its limit. Spelled by hand rather than read out
+#: of `tmuxctl`, so a reworded constant cannot follow itself into a green run.
+_TOO_LONG = ("failed to send command", "command too long")
+
+#: The limit as an operator reads it on screen, spelled by hand for the same reason.
+_LIMIT_ON_SCREEN = "16,364"
+
+#: What this launch hands the harness: long enough to be the reason, and not ending in `;`,
+#: so what tmux was sent is byte-for-byte what was typed.
+_PASTED = "fix it: " + "x" * 20000
+
+#: `_launch`'s harness is `claude`, so its arguments are that binary and the one above.
+_CARRIED = f"{len('claude') + len(_PASTED.encode()):,}"
+
+
+class TmuxsLengthRefusalIsRecognisedByItsExactWords(unittest.TestCase):
+    def test_both_of_tmuxs_sentences_are_recognised(self):
+        for said in (*_TOO_LONG, *(s + "\n" for s in _TOO_LONG)):
+            with self.subTest(stderr=said):
+                self.assertTrue(tmuxctl.refused_as_too_long(said))
+
+    def test_nothing_else_tmux_says_is_read_as_one(self):
+        """A near miss is a different sentence, and a different sentence is a different
+        failure: reading it as this one would put a byte count beside a refusal it does
+        not explain."""
+        for said in ("", f"no server running on {_tmuxsocket.socket_path('charter')}",
+                     "no space for a new pane", "create window failed: index 0 in use",
+                     "command too long: new-session", "Command too long",
+                     "failed to send command to server"):
+            with self.subTest(stderr=said):
+                self.assertFalse(tmuxctl.refused_as_too_long(said))
+
+
+class _RefusedStart(_FakeTmux):
+    """`_FakeTmux`, except that tmux refuses the command that would start the harness."""
+
+    def __init__(self, *, stderr: str, **kw):
+        super().__init__(**kw)
+        self.refusal = stderr
+
+    def _one(self, cmd, **kwargs):
+        if "new-session" in cmd or "new-window" in cmd:
+            self.calls.append(list(cmd))
+            return subprocess.CompletedProcess(cmd, 1, stdout="", stderr=self.refusal)
+        return super()._one(cmd, **kwargs)
+
+
+class ALaunchOnCharactersOwnServer(PersonaIso, unittest.TestCase):
+    """Both ways a launch on charter's own server starts a harness: the workspace's first
+    chat (`new-session`) and a chat joining its live session (`new-window`)."""
+
+    SHAPES = {"new-session": {},
+              "new-window": {"pre_existing_sessions": frozenset({"demo"})}}
+
+    def _launched(self, fake: _FakeTmux) -> tuple[int, list[str]]:
+        said: list[str] = []
+        with mock.patch("charter.util.err", side_effect=said.append):
+            rc = _launch(fake, rest=[_PASTED])
+        return rc, said
+
+    def test_a_length_refusal_says_the_limit_and_what_this_launch_carried(self):
+        for verb, shape in self.SHAPES.items():
+            for refusal in _TOO_LONG:
+                with self.subTest(verb=verb, stderr=refusal):
+                    fake = _RefusedStart(stderr=refusal + "\n", **shape)
+                    rc, said = self._launched(fake)
+                    self.assertTrue(any(verb in c for c in fake.calls),
+                                    f"this case never reached `{verb}`")
+                    self.assertEqual(rc, 1)
+                    # ONE sentence: the generic report pastes the whole command — twenty
+                    # thousand bytes of it here — and would bury this one.
+                    self.assertEqual(len(said), 1, said)
+                    self.assertIn(_LIMIT_ON_SCREEN, said[0])
+                    self.assertIn(_CARRIED, said[0])
+                    self.assertIn("in a file", said[0])
+
+    def test_any_other_refusal_keeps_the_report_it_always_had(self):
+        rc, said = self._launched(_RefusedStart(stderr="no space for a new pane\n"))
+        self.assertEqual(rc, 1)
+        self.assertTrue(any("starting the frame failed" in m
+                            and "no space for a new pane" in m for m in said), said)
+        self.assertFalse(any(_LIMIT_ON_SCREEN in m for m in said), said)
+
+
+class _RefusedRespawn(_FakeOperatorTmux):
+    """`_FakeOperatorTmux`, except that tmux refuses the respawn that starts the harness."""
+
+    def __init__(self, *, stderr: str, **kw):
+        super().__init__(**kw)
+        self.refusal = stderr
+
+    def _one(self, cmd, **kwargs):
+        if "respawn-pane" in cmd:
+            self.calls.append(list(cmd))
+            return subprocess.CompletedProcess(cmd, 1, stdout="", stderr=self.refusal)
+        return super()._one(cmd, **kwargs)
+
+
+class ALaunchInsideATmuxYouAlreadyHad(PersonaIso, unittest.TestCase):
+    """The guest path starts its harness with `respawn-pane`, and the same limit holds."""
+
+    def _launched(self, fake: _FakeOperatorTmux) -> tuple[int, list[str]]:
+        said: list[str] = []
+        with mock.patch("charter.util.err", side_effect=said.append):
+            rc = _launch_inside(fake, rest=[_PASTED])
+        return rc, said
+
+    def test_a_length_refusal_says_the_limit_and_what_this_launch_carried(self):
+        for refusal in _TOO_LONG:
+            with self.subTest(stderr=refusal):
+                rc, said = self._launched(_RefusedRespawn(stderr=refusal + "\n"))
+                self.assertEqual(rc, 1)
+                self.assertEqual(len(said), 1, said)
+                self.assertIn(_LIMIT_ON_SCREEN, said[0])
+                self.assertIn(_CARRIED, said[0])
+
+    def test_the_placeholder_window_is_still_taken_back(self):
+        """A refusal for length leaves the same window behind any refusal does, and it
+        goes the same way."""
+        fake = _RefusedRespawn(stderr="command too long\n")
+        self._launched(fake)
+        self.assertTrue(any("kill-window" in c for c in fake.calls), fake.calls)
+
+    def test_any_other_refusal_keeps_the_report_it_always_had(self):
+        rc, said = self._launched(_RefusedRespawn(stderr="no pane\n"))
+        self.assertEqual(rc, 1)
+        self.assertTrue(any("starting the harness in it failed" in m and "no pane" in m
+                            for m in said), said)
+        self.assertFalse(any(_LIMIT_ON_SCREEN in m for m in said), said)
+
+
+def _message_bytes(argv: list[str], verb: str) -> int:
+    """What tmux's client packs for *argv*: each argument from the command's name on, with
+    a NUL after each. The global `-L`/`-f` before the name are the client's own and are not
+    in it — measured: `new-session` with `-f` in front and `new-window` without it stopped
+    at the same count."""
+    return sum(len(a.encode()) + 1 for a in argv[argv.index(verb):])
+
+
+@unittest.skipUnless(_HAS_TMUX, "no tmux on this machine")
+class TmuxStillRefusesInTheWordsCharterRecognises(PersonaIso, unittest.TestCase):
+    """The limit and both sentences, asked of a real tmux — so a tmux that moves its limit
+    or rewords its refusal fails here, rather than every launch quietly quoting a number
+    that is no longer true or falling back to the generic report."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        v = tmuxctl.version()
+        if v is None or v < tmuxctl.FLOOR:
+            self.skipTest(f"the frame's floor is tmux {tmuxctl.FLOOR[0]}.{tmuxctl.FLOOR[1]};"
+                          f" this machine has {v}")
+        self.servers: list[tuple[str, str]] = []
+        candidates = [("tmux", "too-long")]
+        if _FLOOR_BIN.is_file():
+            candidates.append((str(_FLOOR_BIN), "too-long-floor"))
+        for binary, slug in candidates:
+            socket = _tmuxreap.name(slug)
+            self.addCleanup(subprocess.run, [binary, "-L", socket, "kill-server"],
+                            capture_output=True, timeout=20)
+            started = subprocess.run(
+                [binary, "-L", socket, "-f", "/dev/null", "new-session", "-d", "-s",
+                 "base", "-x", "80", "-y", "24", "--", "sleep", "600"],
+                capture_output=True, text=True, timeout=20)
+            self.assertEqual(started.returncode, 0, started.stderr)
+            self.servers.append((binary, socket))
+
+    def _window(self, socket: str, size: int) -> list[str]:
+        """A `new-window` whose command message is exactly *size* bytes."""
+        def build(text: str) -> list[str]:
+            return layout.chat_window_argv(socket=socket, session="base", chat="base.9",
+                                           cwd=str(self.tmp), harness_argv=["true", text])
+        argv = build("x" * (size - _message_bytes(build(""), "new-window")))
+        self.assertEqual(_message_bytes(argv, "new-window"), size)
+        return argv
+
+    @staticmethod
+    def _tmux(binary: str, argv: list[str]) -> subprocess.CompletedProcess:
+        return subprocess.run([binary, *argv[1:]], capture_output=True, text=True,
+                              timeout=20)
+
+    def test_a_command_exactly_at_the_limit_is_taken(self):
+        for binary, socket in self.servers:
+            with self.subTest(tmux=binary):
+                got = self._tmux(binary, self._window(socket, tmuxctl.MESSAGE_LIMIT))
+                self.assertEqual(got.returncode, 0, got.stderr)
+
+    def test_one_byte_past_it_is_refused_in_words_charter_recognises(self):
+        for binary, socket in self.servers:
+            with self.subTest(tmux=binary):
+                got = self._tmux(binary, self._window(socket, tmuxctl.MESSAGE_LIMIT + 1))
+                self.assertNotEqual(got.returncode, 0)
+                self.assertTrue(tmuxctl.refused_as_too_long(got.stderr), got.stderr)
+
+    def test_far_past_it_is_refused_in_words_charter_recognises(self):
+        for binary, socket in self.servers:
+            with self.subTest(tmux=binary):
+                got = self._tmux(binary, self._window(socket, 2 * tmuxctl.MESSAGE_LIMIT))
+                self.assertNotEqual(got.returncode, 0)
+                self.assertTrue(tmuxctl.refused_as_too_long(got.stderr), got.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_a_launch_too_long_for_tmux_says_so.py
+++ b/tests/test_a_launch_too_long_for_tmux_says_so.py
@@ -65,7 +65,8 @@ class TmuxsLengthRefusalIsRecognisedByItsExactWords(unittest.TestCase):
         """A near miss is a different sentence, and a different sentence is a different
         failure: reading it as this one would put a byte count beside a refusal it does
         not explain."""
-        for said in ("", f"no server running on {_tmuxsocket.socket_path('charter')}",
+        for said in (None, "",
+                     f"no server running on {_tmuxsocket.socket_path('charter')}",
                      "no space for a new pane", "create window failed: index 0 in use",
                      "command too long: new-session", "Command too long",
                      "failed to send command to server"):
@@ -115,6 +116,20 @@ class ALaunchOnCharactersOwnServer(PersonaIso, unittest.TestCase):
                     self.assertIn(_LIMIT_ON_SCREEN, said[0])
                     self.assertIn(_CARRIED, said[0])
                     self.assertIn("in a file", said[0])
+
+    def test_an_argument_that_is_not_utf8_is_counted_as_the_bytes_exec_was_handed(self):
+        """A byte that is not UTF-8 reaches `sys.argv` as a surrogate escape. A strict
+        `str.encode` raises on it in the middle of a failure report; `os.fsencode` counts
+        the one byte `exec` was actually handed."""
+        said: list[str] = []
+        with mock.patch("charter.util.err", side_effect=said.append):
+            rc = _launch(_RefusedStart(stderr="command too long\n"),
+                         rest=["fix \udcff " + "x" * 20000])
+        self.assertEqual(rc, 1)
+        self.assertEqual(len(said), 1, said)
+        # `claude`, then `fix `, the single byte 0xff, a space, and the padding.
+        carried = len(b"claude") + len(b"fix \xff ") + 20000
+        self.assertIn(f"{carried:,}", said[0])
 
     def test_any_other_refusal_keeps_the_report_it_always_had(self):
         rc, said = self._launched(_RefusedStart(stderr="no space for a new pane\n"))
@@ -220,25 +235,44 @@ class TmuxStillRefusesInTheWordsCharterRecognises(PersonaIso, unittest.TestCase)
         return subprocess.run([binary, *argv[1:]], capture_output=True, text=True,
                               timeout=20)
 
+    @staticmethod
+    def _which(binary: str) -> str:
+        """Which tmux answered, for a red that is about that tmux rather than charter."""
+        return f"{binary}; the tmux on $PATH reports {tmuxctl.version()}"
+
     def test_a_command_exactly_at_the_limit_is_taken(self):
         for binary, socket in self.servers:
             with self.subTest(tmux=binary):
                 got = self._tmux(binary, self._window(socket, tmuxctl.MESSAGE_LIMIT))
-                self.assertEqual(got.returncode, 0, got.stderr)
+                self.assertEqual(got.returncode, 0, f"{got.stderr} — {self._which(binary)}")
 
     def test_one_byte_past_it_is_refused_in_words_charter_recognises(self):
         for binary, socket in self.servers:
             with self.subTest(tmux=binary):
                 got = self._tmux(binary, self._window(socket, tmuxctl.MESSAGE_LIMIT + 1))
-                self.assertNotEqual(got.returncode, 0)
-                self.assertTrue(tmuxctl.refused_as_too_long(got.stderr), got.stderr)
+                self.assertNotEqual(got.returncode, 0, self._which(binary))
+                self.assertTrue(tmuxctl.refused_as_too_long(got.stderr),
+                                f"{got.stderr!r} — {self._which(binary)}")
 
     def test_far_past_it_is_refused_in_words_charter_recognises(self):
         for binary, socket in self.servers:
             with self.subTest(tmux=binary):
                 got = self._tmux(binary, self._window(socket, 2 * tmuxctl.MESSAGE_LIMIT))
-                self.assertNotEqual(got.returncode, 0)
-                self.assertTrue(tmuxctl.refused_as_too_long(got.stderr), got.stderr)
+                self.assertNotEqual(got.returncode, 0, self._which(binary))
+                self.assertTrue(tmuxctl.refused_as_too_long(got.stderr),
+                                f"{got.stderr!r} — {self._which(binary)}")
+
+    def test_the_sentence_changes_at_the_byte_the_docs_name(self):
+        """`docs/frame.md` and `tmuxctl._TOO_LONG` both say where tmux's sentence changes —
+        16,380 bytes is still `failed to send command`, 16,381 is `command too long` — so
+        that byte is asked of a real tmux rather than left standing as a claim."""
+        for binary, socket in self.servers:
+            for size, sentence in ((16380, "failed to send command"),
+                                   (16381, "command too long")):
+                with self.subTest(tmux=binary, size=size):
+                    got = self._tmux(binary, self._window(socket, size))
+                    self.assertEqual(got.stderr.strip(), sentence,
+                                     f"at {size:,} bytes — {self._which(binary)}")
 
 
 if __name__ == "__main__":

--- a/tests/test_a_launch_too_long_for_tmux_says_so.py
+++ b/tests/test_a_launch_too_long_for_tmux_says_so.py
@@ -117,18 +117,23 @@ class ALaunchOnCharactersOwnServer(PersonaIso, unittest.TestCase):
                     self.assertIn(_CARRIED, said[0])
                     self.assertIn("in a file", said[0])
 
-    def test_an_argument_that_is_not_utf8_is_counted_as_the_bytes_exec_was_handed(self):
-        """A byte that is not UTF-8 reaches `sys.argv` as a surrogate escape. A strict
-        `str.encode` raises on it in the middle of a failure report; `os.fsencode` counts
-        the one byte `exec` was actually handed."""
+    def test_arguments_are_counted_in_the_bytes_exec_was_handed_not_in_characters(self):
+        """tmux's limit is in bytes, so the count beside it is too. Two ways to get that
+        wrong, one row each: `é` and `漢` are one character and two and three bytes, so
+        counting characters comes out short (review round 2 on #959 — with ASCII and a
+        surrogate alone, `len(a)` passed every case here); and a byte that is not UTF-8
+        reaches `sys.argv` as a surrogate escape, on which a strict `str.encode` raises in
+        the middle of a failure report, where `os.fsencode` counts the one byte `exec` was
+        handed."""
         said: list[str] = []
         with mock.patch("charter.util.err", side_effect=said.append):
             rc = _launch(_RefusedStart(stderr="command too long\n"),
-                         rest=["fix \udcff " + "x" * 20000])
+                         rest=["fix é漢 \udcff " + "x" * 20000])
         self.assertEqual(rc, 1)
         self.assertEqual(len(said), 1, said)
-        # `claude`, then `fix `, the single byte 0xff, a space, and the padding.
-        carried = len(b"claude") + len(b"fix \xff ") + 20000
+        # `claude`; then `fix `, é as C3 A9, 漢 as E6 BC A2, a space, the single byte 0xff,
+        # a space; then the padding.
+        carried = len(b"claude") + len(b"fix \xc3\xa9\xe6\xbc\xa2 \xff ") + 20000
         self.assertIn(f"{carried:,}", said[0])
 
     def test_any_other_refusal_keeps_the_report_it_always_had(self):
@@ -237,8 +242,10 @@ class TmuxStillRefusesInTheWordsCharterRecognises(PersonaIso, unittest.TestCase)
 
     @staticmethod
     def _which(binary: str) -> str:
-        """Which tmux answered, for a red that is about that tmux rather than charter."""
-        return f"{binary}; the tmux on $PATH reports {tmuxctl.version()}"
+        """Which tmux answered, by that binary's own `-V` — at the floor it is not the tmux
+        on `$PATH` — for a red that is about that tmux rather than about charter."""
+        said = subprocess.run([binary, "-V"], capture_output=True, text=True, timeout=20)
+        return f"{binary} reports {said.stdout.strip()!r}"
 
     def test_a_command_exactly_at_the_limit_is_taken(self):
         for binary, socket in self.servers:

--- a/tests/test_frame_layout.py
+++ b/tests/test_frame_layout.py
@@ -947,6 +947,17 @@ class NothingUnnamedReachesACommandLine(unittest.TestCase):
         carried = {cmd[i + 1].split("=", 1)[0] for i, a in enumerate(cmd) if a == "-e"}
         self.assertEqual(carried, set(layout.CARRIABLE))
 
+    def test_every_name_travels_in_one_order_whatever_order_it_was_built_in(self):
+        """`_env_argv`'s own promise — sorted, "so the command is the same on every launch"
+        — had nothing behind it: the deletion sweep swapped `sorted` for `list` and all
+        11,972 tests stayed green (review round 1 on #959). Two frames whose identities
+        were built in different orders must put the same command line in `ps`."""
+        built = {"CHARTER_SESSION_ID": "s", "CHARTER_HARNESS": "h", "CHARTER_ROOT": "/r"}
+        cmd = layout.respawn_argv(socket="charter", harness_pane="%7", env=built, cwd="/w",
+                                  harness_argv=["claude"])
+        self.assertEqual([cmd[i + 1] for i, a in enumerate(cmd) if a == "-e"],
+                         ["CHARTER_HARNESS=h", "CHARTER_ROOT=/r", "CHARTER_SESSION_ID=s"])
+
     def test_nothing_carriable_is_a_credential_by_name(self):
         """The property that makes putting any of these on an argv acceptable at all.
         A name is not proof, but a name that ANNOUNCES a secret is proof of the


### PR DESCRIPTION
Closes #957.

Prerequisite 0c for #956 (chat handoff), ahead of Task 1 of `docs/superpowers/plans/2026-09-10-chat-handoff.md`.

## The failure

tmux reads an argument that ends in `;` as the separator between two of its own commands and drops the `;` — rc 0, nothing on stderr. Measured on tmux 3.7c and at the 3.2 floor, through every builder charter starts a harness with:

| typed | the harness received |
|---|---|
| `run the tests;` | `run the tests` |
| `run the tests\;` | `run the tests;` |
| `run the tests ;` | `run the tests ` |
| `a;b c;` | `a;b c` |
| `;` | no argument at all |

So `charter claude "run the tests;"` started the harness on a prompt one byte shorter than the one typed, and nothing said so. Task 1's background open would put every brief through the same builders.

Separately, a launch past tmux's command-size limit printed `tmuxctl.report_failure`'s generic line — the whole command, pasted text included — beside tmux's words, so the one number that explains the refusal was the one thing not on screen.

## What changed, and why

- **`tmuxctl.verbatim(arg)`**, beside `SEPARATOR`: `arg[:-1] + "\;"` when `arg` ends in `;`, otherwise `arg` untouched. tmux's parse undoes only that final pair (a trailing `\;` is its own spelling of a literal `;`), so one backslash is exact: `\;` arrives as `\;`, `;;` as `;;`. `SEPARATOR`'s existing note stays true — an argument merely *containing* `;` was always passed whole.
- **Applied to every harness argument after `--`, in all three builders that pass one through tmux:**
  - `layout.session_argv` — a workspace's first chat (`new-session`)
  - `layout.chat_window_argv` — a chat joining a live session (`new-window`)
  - `layout.respawn_argv` — the harness inside a tmux you already had (`respawn-pane`)

  Inspected under `charter/` and not covered, because none carries a harness argument: `layout.window_argv` (`PLACEHOLDER`, `cat`), `layout.panel_argvs` and the panel respawn in `commands_frame` (both `layout.panel_command`, charter's own argv), `overlay.open_argv` (the palette's argv), and the transcript pager's `new-window` (`less -R` on charter's own file). Since review round 1 (below), the `-c` directory and every `-e NAME=VALUE` element are escaped too.
- **The size limit, classified rather than predicted (ADR 0009).** `tmuxctl.MESSAGE_LIMIT = 16364` and `tmuxctl.refused_as_too_long(stderr)`, which recognises tmux's two exact sentences and nothing near them. Both launch paths now start the harness with `report=False` and report through `commands_frame._say_why_the_harness_did_not_start`: a recognised refusal says the limit, how many bytes this launch's harness arguments carried, and the fix (put long text in a file and pass its path); any other refusal goes to `report_failure` exactly as before. Nothing counts bytes before tmux is asked.

**One deviation from the ruling, measured:** the ruling named `failed to send command`. tmux says that only in a 16-byte band just past the limit; beyond it the refusal is `command too long`, so recognising only the first would miss nearly every real over-long launch. Both are recognised, and both are pinned against a real tmux.

## Measurements

tmux 3.7c (`/opt/homebrew/bin/tmux`) and 3.2 (`~/.local/share/charter-testing/tmux-3.2`), identical on both, through all three builders:

- **Escape:** `;`, `;;`, ` ;`, `\;`, `\\;`, `a;b c;` each arrive byte-for-byte as `t[:-1] + "\;"`. forge re-measured the six cases independently through `new-session` and `new-window` on both versions.
- **Already whole, and still whole:** multi-line text, a `;` mid-text, `#{session_name}`, `"`, `'`, a backtick, `$(echo x)`, a tab, U+2028.
- **Size**, counting the command's name and each argument with a NUL after it (the global `-L`/`-f` are not in the message — `new-session` with `-f` and `new-window` without it stop at the same count): up to 16,364 bytes starts; 16,365–16,380 is rc 1 `failed to send command`; 16,381 and up is rc 1 `command too long`.

## Test evidence

- `tests/test_a_harness_argument_ending_in_a_semicolon_arrives_whole.py` — the helper over the measured matrix and the texts it must leave alone; each builder asked on its own; a real tmux (the one on `$PATH`, plus the 3.2 floor binary where it exists) recording the harness's own `sys.argv` through all three builders. Against unmodified code: 45 failures and 22 errors, with real tmux handing the harness `['run the tests']`, `['a;b c']` and `[]`. The real-tmux wait ends as soon as `list-panes -a` stops listing the pane, so a harness that cannot start fails in about a second instead of waiting out its deadline. `display-message -t <gone pane>` could not be that check: measured on 3.7c and 3.2, it answers rc 0 with an empty line. Under the sweep's escape-every-argument mutation, the class fails all 72 rows in 1.2 s.
- `tests/test_a_launch_too_long_for_tmux_says_so.py` — the recogniser in both directions; `new-session`, `new-window` and `respawn-pane` refused in either sentence say the limit and the byte count, once; any other refusal keeps today's report; the guest path still takes its placeholder window back; a real tmux takes a message of exactly `MESSAGE_LIMIT` bytes and refuses one byte past it, and far past it, in words the recogniser accepts. Before the classification existed: 6 failures and 17 errors.
- Focused run (both new modules, `test_frame_launcher`, `test_frame_layout`, the news and docs checks): 569 tests, OK.
- Full suite, run once: 11,965 tests, 9 skipped, 2 red — both test-side, both now fixed. A stand-in `tmuxctl.run` answer in `test_a_chat_records_where_it_was_started` had no `stderr` (the real one always has one, and a refused start now reads it), and the two new modules spelled uid-shaped socket paths that `test_no_test_bakes_a_uid_into_a_socket_path` refuses (they now use `tests._tmuxsocket`). No production code changed after that run; the two red modules and every module the fix touches were re-run: 436 tests, OK. The sweep's own unmutated baseline then ran the full suite on the committed tree (2307214): 11,965 tests, OK.
- `python3 tools/sweep.py`: 6 mutations across the 3 charged files, **0 survivors in either run**, and every mutation measured pinned at least once — but no single run came back fully clean, so here are both:
  - On 2307214, with a green full-suite baseline: 5 pinned, and `verbatim`'s else-branch collapse unresolved. My real-tmux test was waiting out its 10 s deadline on each of 72 rows, and the 900 s budget ran out. Fixed in c34b1e8, above.
  - On c34b1e8 (`--no-baseline`; the only change since that green baseline is the test file, re-run green): 5 pinned, including that else-branch. The `TOO_LONG_FOR_TMUX` literal was unresolved: its 455-module selection timed out twice under load. The first run had pinned it with the same tests, and on c34b1e8, replacing the literal by hand turns 6 subTests of `test_a_launch_too_long_for_tmux_says_so` red in 0.3 s.

Docs: `docs/frame.md`, *What `charter frame -- <cmd>` accepts*, gains both; its example of the new sentence was checked word for word against the constant. News: `docs/news/unreleased-a-prompt-ending-in-a-semicolon-keeps-it.md`.

## Review round 1

An independent review re-measured the escape and both refusal sentences on 3.7c and 3.2. It found no double escaping (`verbatim` is called only in the builders, which receive the raw argv, and nothing stores an argv). It returned Needs fixes; these are fixed in cf6f52c.

- **The same parse broke `-c` and every `-e` value ending in `;`** (Important). A directory or a `$CHARTER_ROOT` ending in `;` ended tmux's command at the next flag: rc 1, `unknown command: -P` from `new-window` and the guest `window_argv`, `unknown command: -e` from `respawn-pane`, and `unknown command: --` for an `-e` value. So a chat opened from such a directory failed with a sentence that never names it. `layout.window_argv`, `layout.chat_window_argv` and `layout.respawn_argv` now pass their `-c` directory through `tmuxctl.verbatim`, and `layout._env_argv` — the one place charter builds a `-e` — passes each element through it. `verbatim`'s docstring now covers every data argument. Real-tmux rows on both versions: a cwd ending in `;` starts `new-window`, `respawn-pane` and the guest `window_argv` in exactly that directory, and a `$CHARTER_ROOT` ending in `;` reaches the harness exactly through all three builders.
- **A middle harness argument ending in `;` ran the arguments after it as a tmux command** (Important). Before this PR, `["a;", "set-option", "-g", "@injected", "yes"]` set `@injected` on charter's server and handed the harness `["a"]`, with rc 0. Only an operator's own typed arguments reach a harness argv today, so this was a latent surface, not a vulnerability, and the news entry is not marked `security`. A real-tmux row now asserts, through all three builders, that the harness receives the whole argv and that `show-options -g` carries no such option. With the escape removed, the row goes red: the harness gets `['a']`.
- `os.fsencode` is pinned: a too-long refusal whose arguments hold `"\udcff"` counts 20,012 bytes, where a strict `str.encode` raises.
- The byte where tmux's sentence changes is asked of a real tmux: 16,380 bytes is `failed to send command` and 16,381 is `command too long`. Every real-tmux size assertion names the tmux that answered.
- `refused_as_too_long` reads `(stderr or "").strip()`, the way `report_failure` reads it.
- The news entry and `docs/frame.md` now say plainly that the middle-argument case was latent, not a vulnerability, and that anyone who typed `\;` to get a `;` through now gets the backslash too.

Out of scope, and forge is filing it: tmux format-expands `-c`, so a directory named `x#{session_name}` silently lands the chat somewhere else.

**Covering tests.** Before the fix, the two modules showed 18 failures and 1 error: the `-c` and `-e` rows, rc 1 `unknown command: --` or `-P`, and the `None` stderr row. After the fix:

- The two modules, `test_frame_layout`, `test_frame_launcher`, `test_a_chat_records_where_it_was_started`, `test_no_test_bakes_a_uid_into_a_socket_path` and the news and docs checks: 608 tests, OK.
- The 20 other modules that exercise these builders, among them `test_frame_tmux_integration`, `test_frame_overlay`, `test_frame_overlay_escape_hatch`, `test_frame_palette_integration` and `test_harness_launch`: 729 tests, OK.

**Sweep** on cf6f52c, with a green full-suite baseline (11,972 tests): 9 mutations, 8 pinned, **1 survived**, 0 unresolved. Both of last round's timeouts got a verdict this time: `verbatim`'s else-branch and the refusal sentence's literal are both pinned. The survivor was `sorted` → `list` in `layout._env_argv`, a line older than this PR that round 1's reformat moved into the diff. Nothing pinned its documented promise that `-e` elements travel in one order on every launch. So 14e6b6b adds `test_frame_layout.NothingUnnamedReachesACommandLine.test_every_name_travels_in_one_order_whatever_order_it_was_built_in`, which fails with that mutation applied by hand; `test_frame_layout` passes, 70 tests. The sweep was not re-run for that test-only commit.

## Review round 2

The re-review marked every round-1 finding addressed. It traced every `verbatim` call and found none that can escape a value twice. On 3.7c and 3.2 it sent `semi;`, `dbl;;`, `sp ;` and `bs\;` as both a cwd and a `CHARTER_ROOT` through every builder, including `panel_argvs` and `overlay.open_argv`, which this PR had not named, and all of them arrived byte-exact. Fixed in 18c69ab, which touches docs and tests only:

- **The error text a real launch shows.** `docs/frame.md` and the news entry said a `$CHARTER_ROOT` ending in `;` used to fail with `unknown command: -P` or `--`, and round 1 above says `--` for an `-e` value. I re-measured on 3.7c and 3.2 with the identity a real launch builds (all five names from `_frame_identity_env`, plus `PATH` from `_guest_harness_env`). It is `unknown command: -e` on `new-session`, `new-window` and the guest `respawn-pane`, because another identity value always follows `CHARTER_ROOT`; `--` appears only when the value is a command's last `-e`. A `;`-ending directory fails a second chat's `new-window`, and the guest `window_argv`, with `unknown command: -P`; the guest path stops there, before its `respawn-pane`. The docs, the news entry and the test docstring now say exactly that.
- **The byte count could pass by counting characters.** The case now carries `é` (two bytes) and `漢` (three) beside the surrogate, so counting characters goes red: it reported 20,015 against 20,018.
- The injection row asserts that `show-options -g` returned 0 before trusting its listing.
- `_which` prints the `-V` of the tmux binary actually run, so the 3.2 floor rows name 3.2.

**Covering tests:** `test_a_harness_argument_ending_in_a_semicolon_arrives_whole`, `test_a_launch_too_long_for_tmux_says_so`, `test_no_test_bakes_a_uid_into_a_socket_path`, `test_news_frontmatter_is_not_yaml`, `test_news`, `test_news_gate`, `test_news_ordering`, `test_docs_claims_carry_their_residual`, `test_claims`, `test_docs_show`: 204 tests, OK.

**No sweep this round:** nothing under `charter/` changed, and the sweep mutates only `charter/`.

## Review round 3

The round-2 re-review marked items 1–4 addressed and found one sentence still false. `docs/frame.md`, the news entry and a test docstring said a `$CHARTER_ROOT` ending in `;` "failed every launch with `unknown command: -e`". I re-measured on 3.7c and 3.2 with a real launch's identity: that holds only while a tmux server is already running on the socket. On a socket with no server yet (the first chat after an install, a reboot, or the server stopping), the same pre-fix argv fails with rc 1 and `error connecting to <socket> (No such file or directory)`, and the fixed argv starts with rc 0.

Fixed in 96b924f. All three texts now say what holds in every state, that tmux refused the launch, and name each error with the state it was measured in:

- `unknown command: -P` for a directory, on a second chat or inside a tmux you already had;
- `unknown command: -e` for the root, while a server was running;
- `error connecting to …`, before one was.

They agree with the `tmuxctl.verbatim` docstring, which describes the parse rather than any single launch's error.

**Covering tests:** `test_a_harness_argument_ending_in_a_semicolon_arrives_whole`, `test_a_launch_too_long_for_tmux_says_so`, `test_news_frontmatter_is_not_yaml`, `test_news`, `test_news_gate`, `test_news_ordering`, `test_docs_claims_carry_their_residual`, `test_claims`, `test_docs_show`: 190 tests, OK. There is no sweep this round either, because nothing under `charter/` changed.

## Review round 4

The round-3 re-review confirmed the three changed texts by measurement from the pre-fix argv at ac86d7c. It also found one more site of the same false sentence: the `tmuxctl.verbatim` docstring still listed `unknown command: -P`, `-e` or `--` with no state. The searches below turned up a fourth, the `layout._env_argv` comment, which said a plane root or `$PATH` ending in `;` gave `unknown command: --`. Both are fixed in 329e19d.

- The `verbatim` docstring now says what holds in every state (tmux refuses the launch, rc 1), and names each error with the state it was measured in, matching `docs/frame.md`:
  - `unknown command: -P` for a directory, which reaches tmux only with a session already up (`session_argv` takes no directory);
  - `unknown command: -e` for a `$CHARTER_ROOT` while a server is running;
  - `error connecting to …` when no server is running yet.
- **`--` is dropped, not given a condition.** It has been measured only from a respawn handed an empty environment, or from a value that happens to be a command's last `-e`. Neither is a directory or `$CHARTER_ROOT` case this docstring describes, and I have not measured every production shape that could reach one. Naming only the measured cases keeps the docstring from claiming a failure charter may never have had.
- The `_env_argv` comment now enumerates nothing: it says tmux refuses the launch and points at the docstring.

This round changes docstring and comment text only. No code under `charter/` changes, so there is no sweep.

**Tests:** `test_frame_tmuxctl`, `test_frame_layout`, `test_a_harness_argument_ending_in_a_semicolon_arrives_whole` and `test_a_launch_too_long_for_tmux_says_so`, plus `test_docs_claims_carry_their_residual`, `test_docs_show` and `test_claims`, because they read docs and sources: 196 tests, OK.

### Every hit, and what was done with it

Run from the worktree after the fix, over `charter/`, `docs/` (which holds the news entry) and `tests/`:
`grep -rn --include='*.py' --include='*.md' -F -- '<pattern>' charter/ docs/ tests/`
That is 337 hits in all: `unknown command` 9, `error connecting` 11, `failed every` 2, `every launch` 78, `-P` 237.

**`unknown command` (9)**
- `charter/frame/tmuxctl.py:470`, `:471`: fixed (the `verbatim` docstring).
- `docs/frame.md:1208`, `:1209`: already true (round 3).
- `docs/news/unreleased-a-prompt-ending-in-a-semicolon-keeps-it.md:10`: already true (round 3).
- `tests/test_a_harness_argument_ending_in_a_semicolon_arrives_whole.py:117`, `:118`: already true (round 3).
- `docs/superpowers/specs/2026-08-26-tmux-input-findings.md:445`, `:584`: unrelated, `display-popup` on a tmux that lacks it.
- `charter/frame/layout.py:1458` was a hit before this round: fixed, and it no longer matches.

**`error connecting` (11)**
- `charter/frame/tmuxctl.py:473`: fixed.
- `docs/frame.md:1210`, `docs/news/unreleased-a-prompt-ending-in-a-semicolon-keeps-it.md:11`, `tests/test_a_harness_argument_ending_in_a_semicolon_arrives_whole.py:119`: already true.
- `docs/superpowers/specs/2026-08-26-tmux-input-findings.md:376`: unrelated, a probe of the default socket before any server existed.
- `tests/test_frame_tmux_integration.py:5222`: unrelated. `display-message` against a socket with no server, which agrees with the above.
- `tests/test_forge_github.py:107`, `:121`, `:131`: unrelated, a forge network-error fixture.
- `tests/test_frame_launcher.py:5245`, `:5256`: unrelated, a fixture for an operator socket that has gone away.

**`failed every` (2)**
- `docs/news/0.53.0-a-void-death-is-not-a-result.md:76` and `tests/test_op_readback_failure_is_not_a_missing_secret.py:244`: unrelated prose.

**`every launch` (78)**: all unrelated. They are prose about what happens on each launch (reaps, `ensure`, recording, sorting, version floors); none names a tmux error.

<details><summary>The 78 hits, by file and line</summary>

- `charter/instance.py`: 2216, 2224, 2681
- `charter/cli.py`: 761
- `charter/workspace.py`: 2010
- `charter/commands_frame.py`: 526, 1059, 1707, 2517, 2701, 4713, 5121, 5381, 5455, 5554
- `charter/frame/reopen.py`: 15
- `charter/frame/state.py`: 273, 895, 2409
- `charter/frame/layout.py`: 473, 534, 624, 1235, 1438
- `docs/frame.md`: 704, 1019, 2382, 2391
- `charter/frame/tmuxctl.py`: 159
- `charter/harness/base.py`: 267
- `docs/news/0.52.0-your-environment-off-the-tmux-command-line.md`: 12
- `docs/news/0.55.0-a-chats-harness-session-id-outlives-the-gauge-that-reads-it.md`: 8
- `docs/news/0.55.0-a-frame-on-tmux-3-2-stops-reporting-its-own-failure.md`: 3
- `docs/news/0.56.0-a-clone-gets-the-layer-and-hides-it.md`: 52
- `docs/news/0.54.0-a-guard-that-reads-prose-says-what-it-cannot-read.md`: 84
- `docs/news/0.56.0-a-restored-chat-comes-back-in-its-workspace.md`: 22
- `docs/news/0.54.0-the-repo-strip-can-have-a-height-you-chose.md`: 38
- `docs/news/0.54.0-a-claim-outlives-the-next-launchs-reap.md`: 29, 69
- `docs/news/0.54.0-switch-and-pick-a-workspace.md`: 92
- `docs/superpowers/plans/2026-08-28-phase5-workspace-and-chat-tabs.md`: 330
- `docs/superpowers/plans/2026-08-22-harness-frame.md`: 118
- `docs/superpowers/specs/2026-08-30-charter-opens-like-an-ide.md`: 331
- `tests/test_frame_density.py`: 197
- `tests/test_every_workspace_has_a_manifest.py`: 95
- `tests/test_frame_layout.py`: 951
- `tests/test_component_config.py`: 179
- `tests/test_frame_tmux_integration.py`: 4197, 5807
- `tests/test_a_quit_records_the_plane_before_it_kills.py`: 10
- `tests/test_a_chat_is_locked_to_the_workspace_it_was_launched_for.py`: 106
- `tests/test_a_workspace_tab_opens_what_it_names.py`: 498
- `tests/test_a_pinned_repo_strip_keeps_its_height.py`: 21, 99, 107
- `tests/test_a_chats_harness_session_outlives_its_gauge.py`: 127
- `tests/test_a_frame_sends_one_invocation_per_batch.py`: 67
- `tests/test_a_clone_gets_the_layer_and_hides_it.py`: 351, 880
- `tests/test_a_second_launch_focuses_instead_of_dragging.py`: 105, 280
- `tests/test_the_branch_not_taken_is_still_a_promise.py`: 631
- `tests/test_a_key_cycles_the_tab_strips_height.py`: 478
- `tests/test_frame_border_surface.py`: 416, 459
- `tests/test_a_workspace_carries_charters_layer.py`: 811
- `tests/test_charter_records_the_plane_as_it_changes.py`: 1104
- `tests/test_frame_state.py`: 344, 1108
- `tests/test_frame_launcher.py`: 413, 1955, 1969, 2776, 3280, 3782
- `tests/test_a_chat_records_where_it_was_started.py`: 278
- `tests/test_a_launch_too_long_for_tmux_says_so.py`: 205
- `tests/test_every_harness_carries_its_own_paths_into_a_clone.py`: 359

</details>

**`-P` (237)**
- `charter/frame/tmuxctl.py:470`: fixed.
- `docs/frame.md:1208`, `docs/news/unreleased-a-prompt-ending-in-a-semicolon-keeps-it.md:10`, `tests/test_a_harness_argument_ending_in_a_semicolon_arrives_whole.py:117`: already true.
- `charter/frame/layout.py:1220`: already true. `window_argv`'s comment says a directory ending in `;` "ends this command at `-P`", and in that builder `-c` is followed by `-P`.
- The other 232: unrelated. Each is tmux's `-P -F` print flag in an argv or its prose, Python's `-P` flag (#390), BSD `env -P`, or a hyphenated capitalised word such as `IN-PROCESS`, `PER-FORGE` or `Ctrl-PgUp`.

<details><summary>The 232 unrelated hits, by file and line</summary>

- `charter/update.py`: 371
- `charter/hooks.py`: 1697, 1698, 1701, 1720, 1747, 1750, 2077, 2155, 6133
- `charter/glstate.py`: 243
- `charter/util.py`: 308, 317
- `charter/commands_frame.py`: 1184, 1190, 1191, 1489, 4237, 4251, 5608
- `charter/frame/overlay.py`: 615, 898, 920
- `charter/frame/layout.py`: 12, 35, 1201, 1222, 1307, 1350, 1388, 1410, 1484, 1508, 1585
- `charter/frame/tmuxctl.py`: 241
- `docs/adr/0015-the-boundary-moves-with-the-harness.md`: 21
- `docs/news/0.50.1-relaunch-ignores-cwd.md`: 25
- `docs/news/0.57.0-the-repo-shows-you-the-frame.md`: 41
- `docs/news/0.51.0-a-dead-panel-says-why.md`: 29
- `docs/assets/README.md`: 90
- `docs/superpowers/specs/2026-08-21-harness-wrapper-design.md`: 32
- `docs/superpowers/plans/2026-08-22-harness-frame.md`: 1924
- `docs/superpowers/specs/2026-08-28-phase5-workspace-and-chat-tabs.md`: 602, 623
- `tests/test_glstate.py`: 47, 49
- `tests/test_a_harness_argument_ending_in_a_semicolon_arrives_whole.py`: 284, 299
- `tests/test_self_relaunch_shadowing.py`: 16, 25, 27, 30, 88, 130, 180
- `tests/test_hooks_need_no_async.py`: 64, 66
- `tests/test_a_real_click_on_a_real_tab_bar_switches.py`: 206, 246, 571
- `tests/test_frame_chat_switch.py`: 966
- `tests/test_frame_layout.py`: 235, 237, 238, 241, 242, 263, 267, 268, 271, 341, 346, 772
- `tests/test_frame_tmux_integration.py`: 165, 169, 170, 174, 668, 672, 1174, 1281, 1508, 1561, 1587, 1811, 1815, 1819, 1823, 1889, 1897, 1952, 1961, 2020, 2026, 2082, 2086, 2189, 2680, 2736, 3030, 3295, 3378, 3441, 4018, 4025, 4050, 4108, 4471, 4857, 4892, 5111, 5178, 5207, 5330, 5334, 5625, 5636, 5676, 6103, 6123, 6135, 6153, 6169, 6212, 6313, 6624, 6714, 6836, 6845, 6877, 6991, 7008, 7117
- `tests/test_a_workspace_tab_opens_what_it_names.py`: 1010
- `tests/test_frame_palette_integration.py`: 49, 52, 147, 614
- `tests/test_frame_surface_live.py`: 515, 518
- `tests/test_a_real_click_reaches_the_real_repo_table.py`: 175, 231
- `tests/test_a_frame_sends_one_invocation_per_batch.py`: 133, 153, 162, 283, 292, 765
- `tests/test_component_id_is_the_currency.py`: 579, 581, 583, 585
- `tests/test_frame_input_reaches_a_component.py`: 82, 278, 375, 767, 891
- `tests/test_a_panel_pane_exists_once_per_placed_component.py`: 89, 709, 720, 855
- `tests/test_frame_overlay.py`: 267
- `tests/_planeguard.py`: 1065, 1223, 1228
- `tests/test_a_real_click_opens_the_real_palette.py`: 186, 216
- `tests/test_quit_and_reopen_on_a_real_tmux.py`: 91, 94, 117, 123, 124, 178, 276, 445, 448
- `tests/test_frame_pane_style.py`: 1055, 1060
- `tests/test_self_relaunch_argv.py`: 10, 15, 86, 91, 183, 204, 205, 212
- `tests/test_a_workspace_switch_moves_the_client.py`: 645
- `tests/test_a_confirmation_is_a_drawer_not_a_window.py`: 275
- `tests/_tmuxchain.py`: 20
- `tests/test_a_real_resize_gives_a_real_strip_another_row.py`: 114, 124, 233, 241
- `tests/test_the_close_confirmation_names_the_chat_it_stops.py`: 80, 339
- `tests/test_a_planes_frame_really_reads_that_way.py`: 185, 434, 437
- `tests/test_news.py`: 6
- `tests/test_plane_spawn_guard.py`: 126, 372
- `tests/test_frame_launcher.py`: 713, 717, 769, 774, 792, 818, 878, 879, 966, 968, 971, 1732, 1947, 2913, 2917, 3045
- `tests/test_an_option_is_its_letter_not_its_position.py`: 45, 84, 316
- `tests/test_names_from_files_are_contained.py`: 169, 575, 642, 644, 763, 766
- `tests/test_frame_overlay_escape_hatch.py`: 123, 130, 340
- `tests/test_frame_appearance.py`: 616, 619
- `tests/test_frame_panel.py`: 396

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
