### PR TITLE
A directory with `#` in its name is where the chat starts

### DIFF
--- a/charter/frame/layout.py
+++ b/charter/frame/layout.py
@@ -1216,11 +1216,12 @@ def window_argv(*, socket: str, session: str, window: str, cwd: str) -> list[str
 
     *cwd* is `-c`, for the same reason `respawn_argv` takes one — see its docstring.
     """
-    # The directory through `tmuxctl.verbatim`, for :func:`respawn_argv`'s reason: one that
-    # ends in `;` otherwise ends this command at `-P` (#957).
+    # The directory through `tmuxctl.start_directory`, for :func:`respawn_argv`'s reason:
+    # tmux reads it as a format (#961), and one that ends in `;` otherwise ends this command
+    # at `-P` (#957).
     return _tmux(socket, "new-window", "-d", "-a", "-t", session, "-n", window,
-                 "-c", tmuxctl.verbatim(cwd), "-P", "-F", "#{window_id} #{pane_id}", "--",
-                 *PLACEHOLDER)
+                 "-c", tmuxctl.start_directory(cwd), "-P", "-F", "#{window_id} #{pane_id}",
+                 "--", *PLACEHOLDER)
 
 
 def respawn_argv(*, socket: str, harness_pane: str, env: dict[str, str],
@@ -1290,9 +1291,10 @@ def respawn_argv(*, socket: str, harness_pane: str, env: dict[str, str],
     # Every data argument through `tmuxctl.verbatim` — the directory, each `-e` value (in
     # `_env_argv`) and each harness argument. tmux reads ANY argument ending in `;` as its
     # own command separator: a harness argument loses the `;`, and a directory or a value
-    # ends the command at the next flag (#957).
+    # ends the command at the next flag (#957). The directory's is `tmuxctl.start_directory`,
+    # which also doubles each `#` tmux would read as a format (#961).
     return _tmux(socket, "respawn-pane", "-k", "-t", harness_pane,
-                 "-c", tmuxctl.verbatim(cwd),
+                 "-c", tmuxctl.start_directory(cwd),
                  *_env_argv(env), "--", *map(tmuxctl.verbatim, harness_argv))
 
 
@@ -1403,10 +1405,10 @@ def chat_window_argv(*, socket: str, session: str, chat: str, cwd: str,
     otherwise be the SESSION's, which is wherever the launcher that created the workspace
     happened to be — and the panels split off this pane inherit its directory in turn.
     """
-    # `tmuxctl.verbatim` for the directory and each harness argument, for
-    # :func:`respawn_argv`'s reason (#957).
+    # `tmuxctl.start_directory` for the directory and `tmuxctl.verbatim` for each harness
+    # argument, for :func:`respawn_argv`'s reason (#957, #961).
     return _tmux(socket, "new-window", "-d", "-a", "-t", session, "-n", chat,
-                 "-c", tmuxctl.verbatim(cwd),
+                 "-c", tmuxctl.start_directory(cwd),
                  "-P", "-F", "#{pane_id}", *_env_argv(env), "--",
                  *map(tmuxctl.verbatim, harness_argv))
 

--- a/charter/frame/tmuxctl.py
+++ b/charter/frame/tmuxctl.py
@@ -486,6 +486,58 @@ def verbatim(arg: str) -> str:
     return arg[:-1] + "\\;" if arg.endswith(";") else arg
 
 
+#: A run of `#` that tmux's format expander reads as the start of a format: every run except
+#: one that `[` directly follows. See :func:`start_directory` for what was measured.
+_FORMAT_HASHES = re.compile(r"#+(?![#\[])")
+
+
+def _literal_hashes(text: str) -> str:
+    """*text* with each `#` tmux would expand spelled `##`, and a run of `#` directly before
+    `[` left as it is — :func:`start_directory`'s first half, kept apart so the suite can pin
+    that its two halves give one string in either order."""
+    return _FORMAT_HASHES.sub(lambda run: run.group(0) * 2, text)
+
+
+def start_directory(path: str) -> str:
+    r"""*path*, spelled so tmux starts a pane in exactly that directory (#961).
+
+    **tmux reads a `-c <start-directory>` as a FORMAT before it looks for the directory**,
+    and says nothing when the answer is somewhere else. Measured on tmux 3.7c and at the 3.2
+    floor through `new-window -c` and `respawn-pane -c`, every start rc 0 with an empty
+    stderr: `x#{session_name}` started in `xbase` when a directory by that name sat beside
+    it, and in `$HOME` when none did; `a#S`, `a#,b` and `a##b` went to `$HOME` too; and on
+    3.7c, not on 3.2, a trailing `#` was dropped, so a directory named `#` started in its
+    parent. `y#(touch job-ran)` went to `$HOME` as well, and its command RAN in 5 of 5
+    starts per command whose client a chained `run-shell` held connected. Sent as one
+    command, the way charter sends each of these, it ran in 0 of 30 per command.
+
+    `##` is tmux's own literal `#`, and doubling each `#` brought every one of those names
+    to the directory asked for — **except a run of `#` directly before `[`**, which tmux
+    already hands on as it is: `a#[b`, `a##[b`, `a###[b`, `a####[b` and `a#[fg=red]b` each
+    started in place unescaped and, doubled, each went to `$HOME`, on both versions. So that
+    run alone is left as it is. A `#` after the `[` is still doubled: `a#[#{session_name}`
+    goes to tmux as `a#[##{session_name}`, and lands.
+
+    Then :func:`verbatim`, because a directory ending in `;` still ends tmux's command
+    (#957). The order of the two halves cannot change the string — `verbatim` adds only a
+    `\` before a final `;`, and neither character decides whether a run of `#` is doubled —
+    and both orders were measured to start the pane in the same place for every name above.
+
+    **Not :func:`inert_format`.** That is for text tmux draws: it doubles every `#`, and
+    adds a space before a leading `-` and after a trailing `#`. In a start directory a
+    doubled `#[` sent each name above to `$HOME`, and a space is a character the
+    directory's name does not have.
+
+    For `-c` only. An `-e NAME=VALUE` is not read as a format — measured through
+    `new-session`, `new-window` and `respawn-pane` on both versions, values carrying
+    `#{session_name}`, `##`, `#S`, `#[` and `#(…)` each arrived exactly — so an identity
+    value goes through :func:`verbatim` alone. And `new-session` is handed no directory:
+    from a working directory named `x#{session_name}` it started exactly there, on both
+    versions, with a server already running and without one.
+    """
+    return verbatim(_literal_hashes(path))
+
+
 def chain(argvs: list[list[str]]) -> list[str] | None:
     """Several tmux commands as ONE invocation, so the SERVER runs all of them.
 
@@ -552,12 +604,16 @@ def inert_format(text: str) -> str:
     name by `state.workspace_prefix`'s alphabet, a hotkey by `instance._HOTKEY_RE`, a
     chrome or background value by a lookup table that answers `()` for anything it does not
     know. charter sets no `status-left`, `status-right`, `pane-border-format` or
-    `window-status-format`, and has no `display-menu` or `display-popup` at all, so there
-    is no format today whose text is not a module constant.
+    `window-status-format`, and has no `display-menu` or `display-popup` at all. This
+    paragraph used to end "so there is no format today whose text is not a module
+    constant", and #961 is why it no longer does: a `-c` start directory is a format too,
+    and its text is the name of the directory a chat was launched from. :func:`start_directory`
+    closes that one, and it is not a second spelling of this function — its docstring
+    names the run of `#` tmux reads differently there.
 
     It is kept rather than deleted because the measurements above are the reason those
-    guards are shaped the way they are, and because the next surface that hands tmux a
-    string built from a name will need exactly this. **A caller that appears must use it
+    guards are shaped the way they are, and because the next surface that hands tmux text
+    to draw, built from a name, will need exactly this. **A caller that appears must use it
     rather than re-spell it** — a second copy would be a second answer to "what may reach
     tmux's parser", which is #547's shape and which this repo has already paid for once.
     If no such surface arrives, this and its tests are a clean deletion.

--- a/docs/frame.md
+++ b/docs/frame.md
@@ -1217,6 +1217,30 @@ spelling of a literal one. The command gets exactly what you typed, `;;` and ` ;
 it. A `;` anywhere but last was never touched and still is not. This holds in a frame on
 charter's own server and inside a tmux you already had.
 
+**A directory with `#` in its name is where the chat starts.** tmux reads the directory it
+starts a chat in as a *format* — the language of `#{session_name}` — before it looks for the
+directory, and says nothing when the answer is somewhere else. Measured on tmux 3.7c and at
+the 3.2 floor, for a second chat in a workspace and for a chat inside a tmux you already
+had, with tmux reporting success and printing nothing:
+
+- A chat launched from `x#{session_name}` started in `xbase` when a directory by that name
+  sat beside it, and in `$HOME` when none did. `a#S` and `a##b` went to `$HOME` too.
+- `y#(touch job-ran)` went to `$HOME`. Sent the way charter sends a launch — one tmux
+  command, after which the client disconnects — its command did not run in 30 launches per
+  command. With the tmux client held connected, it ran in 5 launches out of 5.
+- On 3.7c, and not on 3.2, a trailing `#` was dropped: a directory named `#` started the
+  chat in its parent.
+
+A workspace's first chat was not affected: tmux is handed no directory for it, and launched
+from `x#{session_name}` it started exactly there on both versions.
+
+Charter now doubles each `#` in the directory — `##` is tmux's own spelling of a literal
+one — except a run of `#` directly before `[`, which tmux already hands on as it is:
+doubled, `a#[b` went to `$HOME`. The trailing-`;` escape above still applies on top. The
+identity values charter passes beside the directory are not read as formats — measured the
+same way, values carrying `#{session_name}`, `##`, `#S`, `#[` and `#(…)` each arrived
+exactly — so they are passed as before.
+
 **tmux takes one command of at most 16,364 bytes, arguments and all.** Past that — a whole
 spec pasted as `charter claude "<prompt>"` is the usual way there — tmux refuses the command,
 nothing starts, and charter says so in tmux's own number instead of pasting the command back:

--- a/docs/news/unreleased-a-directory-with-a-hash-in-its-name-is-where-the-chat-starts.md
+++ b/docs/news/unreleased-a-directory-with-a-hash-in-its-name-is-where-the-chat-starts.md
@@ -1,0 +1,20 @@
+---
+version: unreleased
+headline: A chat launched from a directory with `#` in its name starts in that directory
+---
+
+tmux reads the directory a chat starts in as a format, so a name with `#` in it could start
+the chat somewhere else without a word. Measured on tmux 3.7c and 3.2, for a second chat in
+a workspace and for a chat inside a tmux you already had: `x#{session_name}` started in
+`xbase` when a directory by that name sat beside it and in `$HOME` when none did, `a#S` and
+`a##b` went to `$HOME`, and on 3.7c a trailing `#` was dropped. A workspace's first chat is
+handed to tmux with no directory and was not affected.
+
+Charter now escapes the `#` tmux would read, as `##` — tmux's own spelling of a literal one
+— and every name measured, `x#{session_name}`, `a#S`, `a##b`, `a#[b` and `#` among them,
+now starts the chat in exactly that directory.
+
+A directory named like a tmux shell job, `y#(…)`, went to `$HOME` too. Launched the way
+charter launches — one tmux command, after which the client disconnects — its command did
+not run in 30 launches per command; with the tmux client held connected, it ran in 5 out of
+5. Escaped, it ran in none of 5 held launches, and the chat started in it.

--- a/tests/test_a_directory_with_a_hash_in_its_name_is_where_the_chat_starts.py
+++ b/tests/test_a_directory_with_a_hash_in_its_name_is_where_the_chat_starts.py
@@ -1,0 +1,372 @@
+r"""A chat starts in the directory it was launched from, whatever `#` that name carries (#961).
+
+**tmux reads a `-c <start-directory>` as a FORMAT before it looks for the directory**, and
+says nothing when the answer is somewhere else. Measured on tmux 3.7c and at the 3.2 floor
+through `new-window -c` and `respawn-pane -c` — the two commands `frame/layout.py` hands a
+directory to — with every start returning 0 and an empty stderr:
+
+* `x#{session_name}` started in `xbase` when a directory by that name sat beside it, and in
+  `$HOME` when none did. `a#S`, `a#,b`, `a#}b`, `a#{b` and `a##b` went to `$HOME` too.
+* `y#(touch job-ran)` went to `$HOME`. Sent as ONE command, after which the client
+  disconnects, its command ran in 0 of 30 starts per command. With the client held
+  connected by a chained `run-shell 'sleep 1'`, it ran in 5 of 5.
+* On 3.7c and not on 3.2, a trailing `#` was dropped: `trail#` went to `$HOME`, and a
+  directory named `#` started in its parent.
+* A run of `#` directly before `[` arrived exactly as it was — `a#[b`, `a##[b`, `a###[b`,
+  `a####[b`, `a#[fg=red]b` — and each of those, DOUBLED, went to `$HOME`.
+
+`tmuxctl.start_directory` is the escape those measurements describe. `new-session` — a
+workspace's first chat — is handed no directory, and from a working directory named
+`x#{session_name}` it started exactly there on both versions, with and without a server
+already running.
+
+`-e NAME=VALUE` is not read as a format: through `new-session`, `new-window` and
+`respawn-pane` on both versions, values carrying `#{session_name}`, `##`, `#S`, `#[` and
+`#(…)` each arrived exactly. So identity values keep #959's escape and no other, and
+:meth:`ARealTmuxStartsTheChatInThatDirectory.test_an_identity_value_carrying_a_format_reaches_the_harness_exactly`
+keeps that measurement.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import time
+import unittest
+from pathlib import Path
+
+from charter.frame import layout, tmuxctl
+
+from tests import _tmuxreap, _tmuxsocket
+from tests._isolation import PersonaIso
+
+_HAS_TMUX = shutil.which("tmux") is not None
+
+#: The tmux this repo builds to measure its own floor against, named the way
+#: `test_a_harness_argument_ending_in_a_semicolon_arrives_whole` names it. Absent on CI, so
+#: the floor rows there are simply not run — the `tmux` on `$PATH` still is.
+_FLOOR_BIN = (Path.home() / ".local/share/charter-testing"
+              / f"tmux-{tmuxctl.FLOOR[0]}.{tmuxctl.FLOOR[1]}")
+
+#: ``(directory, what tmux has to be handed for the chat to start in it)``.
+_ESCAPED = (
+    # A format, a shell job, a short alias, and the characters tmux reads after a `#`.
+    ("/w/x#{session_name}", "/w/x##{session_name}"),
+    ("/w/y#(touch job-ran)", "/w/y##(touch job-ran)"),
+    ("/w/a#S", "/w/a##S"),
+    ("/w/a#,b", "/w/a##,b"),
+    ("/w/a#}b", "/w/a##}b"),
+    ("/w/a#{b", "/w/a##{b"),
+    ("/w/a#1", "/w/a##1"),
+    # A trailing `#`, which 3.7c drops.
+    ("/w/trail#", "/w/trail##"),
+    ("/w/#", "/w/##"),
+    # `##` in a NAME is two literal `#`, so it is doubled like any other pair.
+    ("/w/a##b", "/w/a####b"),
+    ("/w/a##{session_name}", "/w/a####{session_name}"),
+    ("/w/a\\#{b", "/w/a\\##{b"),
+    # A `[` keeps only the run directly in front of it.
+    ("/w/a#[#{session_name}", "/w/a#[##{session_name}"),
+    ("/w/a#[##b", "/w/a#[####b"),
+    ("/w/a#[b]#S", "/w/a#[b]##S"),
+    # And #957's trailing `;`, with a `#` and without one.
+    ("/w/z#{session_name};", "/w/z##{session_name}\\;"),
+    ("/w/a#;", "/w/a##\\;"),
+    ("/w/a#[;", "/w/a#[\\;"),
+    ("/w/dir;", "/w/dir\\;"),
+)
+
+#: What tmux already hands on exactly, which the escape must leave byte-for-byte alone.
+_UNCHANGED = (
+    "", "/", "/w/plain dir", "/w/a;b",
+    "/w/a#[b", "/w/a##[b", "/w/a###[b", "/w/a####[b", "/w/a#[fg=red]b",
+    "/w/#[x", "/w/a#[b#[c", "/w/a #[ b", "/w/a#[",
+)
+
+
+class TheEscapeIsExactlyWhatTmuxUndoes(unittest.TestCase):
+    """`tmuxctl.start_directory` over the measured names, with no tmux running."""
+
+    def test_every_hash_tmux_reads_as_a_format_is_doubled(self):
+        for where, sent in _ESCAPED:
+            with self.subTest(where=where):
+                self.assertEqual(tmuxctl.start_directory(where), sent)
+
+    def test_hashes_already_doubled_in_a_name_are_doubled_again(self):
+        """A directory named `a##b` has two `#` in it. tmux reads `##` as one, so it has to
+        be handed `####` for the chat to start in `a##b`."""
+        self.assertEqual(tmuxctl.start_directory("/w/a##b"), "/w/a####b")
+
+    def test_what_tmux_already_hands_on_whole_is_left_alone(self):
+        for where in _UNCHANGED:
+            with self.subTest(where=where):
+                self.assertEqual(tmuxctl.start_directory(where), where)
+
+    def test_the_two_escapes_give_one_string_in_either_order(self):
+        """`verbatim` puts a `\\` before a final `;` and nothing else. The `#` half never
+        makes or unmakes a final `;`, and neither `\\` nor `;` is a character that decides
+        whether a run of `#` is doubled — so the order cannot change the string. Pinned
+        here, so a change to either half that makes the order matter is caught, and on
+        tmux 3.7c and 3.2 both orders were measured to start the chat in the same place for
+        every name in this module."""
+        for where in tuple(w for w, _ in _ESCAPED) + _UNCHANGED:
+            with self.subTest(where=where):
+                hashes_first = tmuxctl.verbatim(tmuxctl._literal_hashes(where))
+                semicolon_first = tmuxctl._literal_hashes(tmuxctl.verbatim(where))
+                self.assertEqual(hashes_first, semicolon_first)
+                self.assertEqual(tmuxctl.start_directory(where), hashes_first)
+
+
+class EveryBuilderThatTakesADirectoryEscapesIt(unittest.TestCase):
+    """The three builders that pass `-c`, each asked on its own — a builder that forgot the
+    escape would otherwise hide behind the two that remembered it."""
+
+    WHERE = "/work/x#{session_name};"
+    SENT = "/work/x##{session_name}\\;"
+
+    @staticmethod
+    def _after(argv: list[str], flag: str) -> str:
+        return argv[argv.index(flag) + 1]
+
+    def test_the_directory_is_handed_to_tmux_escaped(self):
+        for name, argv in (
+                ("window_argv", layout.window_argv(
+                    socket=_tmuxsocket.OPERATOR_SOCKET, session="$1", window="w.1",
+                    cwd=self.WHERE)),
+                ("chat_window_argv", layout.chat_window_argv(
+                    socket="charter", session="w", chat="w.2", cwd=self.WHERE,
+                    harness_argv=["prog"])),
+                ("respawn_argv", layout.respawn_argv(
+                    socket=_tmuxsocket.OPERATOR_SOCKET, harness_pane="%7", env={},
+                    cwd=self.WHERE, harness_argv=["prog"]))):
+            with self.subTest(builder=name):
+                self.assertEqual(self._after(argv, "-c"), self.SENT)
+
+    def test_an_identity_value_is_not_escaped_as_a_format(self):
+        """`-e` is not read as a format (module docstring), so a `#` doubled here would
+        reach the harness doubled."""
+        env = {"CHARTER_ROOT": "/plane/x#{session_name}"}
+        for name, argv in (
+                ("session_argv", layout.session_argv(
+                    session="w", conf="/dev/null", socket="charter", cols=80, rows=24,
+                    harness_argv=["prog"], chat="w.1", env=env)),
+                ("chat_window_argv", layout.chat_window_argv(
+                    socket="charter", session="w", chat="w.2", cwd="/work",
+                    harness_argv=["prog"], env=env)),
+                ("respawn_argv", layout.respawn_argv(
+                    socket=_tmuxsocket.OPERATOR_SOCKET, harness_pane="%7", env=env,
+                    cwd="/work", harness_argv=["prog"]))):
+            with self.subTest(builder=name):
+                self.assertEqual(self._after(argv, "-e"),
+                                 "CHARTER_ROOT=/plane/x#{session_name}")
+
+
+@unittest.skipUnless(_HAS_TMUX, "no tmux on this machine")
+class ARealTmuxStartsTheChatInThatDirectory(PersonaIso, unittest.TestCase):
+    """Where a real tmux started the pane, read back as its `pane_current_path`.
+
+    Every tmux client here runs from `client/` and every server's `$HOME` is `home/`, both
+    inside the test's own tree: a fallback lands somewhere the assertion can name, and a
+    `#(…)` job that did run could only write in here.
+    """
+
+    #: The three ways a directory reaches tmux, each asked on its own below.
+    BUILDERS = ("new-window", "respawn-pane", "guest window")
+
+    def setUp(self) -> None:
+        super().setUp()
+        v = tmuxctl.version()
+        if v is None or v < tmuxctl.FLOOR:
+            self.skipTest(f"the frame's floor is tmux {tmuxctl.FLOOR[0]}.{tmuxctl.FLOOR[1]};"
+                          f" this machine has {v}")
+        self.home = self.tmp / "home"
+        self.client = self.tmp / "client"
+        self.home.mkdir()
+        self.client.mkdir()
+        self.env = dict(os.environ, HOME=str(self.home))
+        self.recorder = self.tmp / "recorder.py"
+        self.recorder.write_text(
+            "import json, os, sys\n"
+            "with open(sys.argv[1] + '.tmp', 'w') as f:\n"
+            "    json.dump({'root': os.environ.get('CHARTER_ROOT')}, f)\n"
+            "os.replace(sys.argv[1] + '.tmp', sys.argv[1])\n")
+        #: ``(binary, socket)`` for every tmux this machine has.
+        self.servers: list[tuple[str, str]] = []
+        candidates = [("tmux", "hash-cwd")]
+        if _FLOOR_BIN.is_file():
+            candidates.append((str(_FLOOR_BIN), "hash-cwd-floor"))
+        for binary, slug in candidates:
+            socket = _tmuxreap.name(slug)
+            # Killed whether or not the start below worked: a server that half-started is
+            # still a server, and the reaper only sees it once this process is gone.
+            self.addCleanup(subprocess.run, [binary, "-L", socket, "kill-server"],
+                            capture_output=True, timeout=20)
+            started = self._tmux(binary, ["tmux", "-L", socket, "-f", "/dev/null",
+                                          "new-session", "-d", "-s", "base", "-x", "80",
+                                          "-y", "24", "--", "sleep", "600"])
+            self.assertEqual(started.returncode, 0, started.stderr)
+            self.servers.append((binary, socket))
+
+    def _tmux(self, binary: str, argv: list[str], *then: str) -> subprocess.CompletedProcess:
+        """*argv* as a builder made it, run by *binary* instead of the `tmux` it names, with
+        *then* chained after it in the same invocation."""
+        return subprocess.run([binary, *argv[1:], *then], capture_output=True, text=True,
+                              timeout=20, env=self.env, cwd=str(self.client))
+
+    def _start(self, binary: str, socket: str, builder: str, where: str,
+               *then: str) -> tuple[str, str]:
+        """Start a pane in *where* through *builder*; answer its id and the program in it."""
+        if builder == "new-window":
+            started = self._tmux(binary, layout.chat_window_argv(
+                socket=socket, session="base", chat="base.2", cwd=where,
+                harness_argv=["sleep", "600"]), *then)
+            self.assertEqual(started.returncode, 0, started.stderr)
+            return started.stdout.split()[0], "sleep"
+        if builder == "respawn-pane":
+            made = self._tmux(binary, ["tmux", "-L", socket, "new-window", "-d", "-a", "-t",
+                                       "base", "-P", "-F", "#{pane_id}", "--",
+                                       *layout.PLACEHOLDER])
+            self.assertEqual(made.returncode, 0, made.stderr)
+            pane = made.stdout.strip()
+            started = self._tmux(binary, layout.respawn_argv(
+                socket=socket, harness_pane=pane, env={}, cwd=where,
+                harness_argv=["sleep", "600"]), *then)
+            self.assertEqual(started.returncode, 0, started.stderr)
+            return pane, "sleep"
+        started = self._tmux(binary, layout.window_argv(
+            socket=socket, session="base", window="guest", cwd=where), *then)
+        self.assertEqual(started.returncode, 0, started.stderr)
+        return started.stdout.split()[1], layout.PLACEHOLDER[0]
+
+    def _path(self, binary: str, socket: str, pane: str, program: str) -> str:
+        """*pane*'s `pane_current_path`, read once `pane_current_command` names *program*.
+
+        Waiting on the command rather than on the path is what makes a wrong directory fail
+        at once: a wait for the RIGHT path would sit out its deadline on every row that is
+        wrong, and a red run is made of exactly those rows. The respawn's placeholder runs a
+        different program from the harness it is replaced by, so the reading cannot be the
+        placeholder's.
+        """
+        deadline = time.monotonic() + 10
+        while time.monotonic() < deadline:
+            running = self._tmux(binary, ["tmux", "-L", socket, "display-message", "-p",
+                                          "-t", pane, "#{pane_current_command}"])
+            if running.stdout.strip() == program:
+                return self._tmux(binary, ["tmux", "-L", socket, "display-message", "-p",
+                                           "-t", pane, "#{pane_current_path}"]
+                                  ).stdout.rstrip("\n")
+            time.sleep(0.02)
+        self.fail(f"{program} never ran in {pane}")
+
+    def _starts_in(self, name: str, *, sibling: str | None = None) -> None:
+        """Through every builder on every tmux: a pane started in a directory called *name*
+        is in exactly that directory. *sibling* is made beside it — the directory tmux's
+        expansion of *name* would otherwise reach."""
+        for binary, socket in self.servers:
+            for builder in self.BUILDERS:
+                parent = self.tmp / "dirs" / f"{len(list(self.tmp.glob('dirs/*')))}"
+                (parent / name).mkdir(parents=True)
+                if sibling:
+                    (parent / sibling).mkdir()
+                where = os.path.realpath(parent / name)
+                with self.subTest(tmux=binary, builder=builder, name=name, sibling=sibling):
+                    pane, program = self._start(binary, socket, builder, str(parent / name))
+                    self.assertEqual(self._path(binary, socket, pane, program), where)
+                    self._tmux(binary, ["tmux", "-L", socket, "kill-window", "-t", pane])
+
+    def test_a_directory_tmux_would_read_as_a_format_is_where_the_chat_starts(self):
+        """Every row here started somewhere else before the escape, on both versions."""
+        self._starts_in("x#{session_name}", sibling="xbase")
+        self._starts_in("x#{session_name}")
+        self._starts_in("a#S")
+        self._starts_in("a##b")
+        self._starts_in("z#{session_name};")
+
+    def test_a_trailing_hash_stays_in_the_name(self):
+        """3.7c dropped a trailing `#` — `trail#` went to `$HOME` and `#` to its parent —
+        and 3.2 kept it, so on the floor binary these rows pass with or without the
+        escape."""
+        self._starts_in("trail#")
+        self._starts_in("#")
+
+    def test_a_run_of_hashes_before_a_bracket_is_not_doubled(self):
+        """A guard on the escape's one exception rather than on the defect: the first three
+        names started in the right place before the escape and pass without it. Doubled
+        like every other `#`, each went to `$HOME` on both versions. The fourth moved
+        before the escape, and only the `#` after the `[` may be doubled for it to land."""
+        self._starts_in("a#[b")
+        self._starts_in("a##[b")
+        self._starts_in("a#[fg=red]b")
+        self._starts_in("a#[#{session_name}")
+
+    def _took(self, name: str) -> list[str]:
+        """Every file called *name* under this test's tree, removed once found — so one
+        builder's job cannot be counted against the next."""
+        found = sorted(self.tmp.rglob(name))
+        for path in found:
+            path.unlink()
+        return [str(path.relative_to(self.tmp)) for path in found]
+
+    def test_a_directory_named_like_a_shell_job_starts_the_chat_there_and_runs_nothing(self):
+        """**Held connected, or this could not go red.** Measured on 3.7c and 3.2, a
+        `#(…)` in `-c` ran its command in 5 of 5 starts whose client a chained
+        `run-shell 'sleep 1'` kept connected, and in 0 of 30 sent as one command. So each
+        start here is held the same way, and a control — a `#(…)` through `display-message`,
+        held identically — first shows that a job CAN write its marker from here."""
+        hold = (";", "run-shell", "sleep 1")
+        for binary, socket in self.servers:
+            with self.subTest(tmux=binary, control="display-message"):
+                shown = self._tmux(binary, ["tmux", "-L", socket, "display-message", "-p",
+                                            "-t", "base", "control#(touch control-ran)"],
+                                   *hold)
+                self.assertEqual(shown.returncode, 0, shown.stderr)
+                self.assertNotEqual(self._took("control-ran"), [],
+                                    "a #(…) job held connected wrote no marker, so the "
+                                    "check below could not tell a job from none")
+            for builder in self.BUILDERS:
+                parent = self.tmp / "jobs" / f"{len(list(self.tmp.glob('jobs/*')))}"
+                (parent / "y#(touch job-ran)").mkdir(parents=True)
+                where = parent / "y#(touch job-ran)"
+                with self.subTest(tmux=binary, builder=builder):
+                    pane, program = self._start(binary, socket, builder, str(where), *hold)
+                    self.assertEqual(self._took("job-ran"), [],
+                                     "the directory's name ran as a shell command")
+                    self.assertEqual(self._path(binary, socket, pane, program),
+                                     os.path.realpath(where))
+                    self._tmux(binary, ["tmux", "-L", socket, "kill-window", "-t", pane])
+
+    def test_an_identity_value_carrying_a_format_reaches_the_harness_exactly(self):
+        """The `-e` half of the measurement, kept: it passes before and after the escape,
+        and goes red if identity values are ever doubled as though tmux expanded them."""
+        root = str(self.tmp / "plane" / "x#{session_name}")
+        for n, (binary, socket) in enumerate(self.servers):
+            for builder in ("new-session", "new-window", "respawn-pane"):
+                record = self.tmp / f"root-{n}-{builder}.json"
+                harness = [sys.executable, str(self.recorder), str(record)]
+                env = {"CHARTER_ROOT": root}
+                with self.subTest(tmux=binary, builder=builder):
+                    if builder == "new-session":
+                        argv = layout.session_argv(session="r", conf="/dev/null",
+                                                   socket=socket, cols=80, rows=24,
+                                                   harness_argv=harness, chat="r.1", env=env)
+                    elif builder == "new-window":
+                        argv = layout.chat_window_argv(socket=socket, session="base",
+                                                       chat="base.r", cwd=str(self.tmp),
+                                                       harness_argv=harness, env=env)
+                    else:
+                        pane, _ = self._start(binary, socket, "respawn-pane", str(self.tmp))
+                        argv = layout.respawn_argv(socket=socket, harness_pane=pane, env=env,
+                                                   cwd=str(self.tmp), harness_argv=harness)
+                    started = self._tmux(binary, argv)
+                    self.assertEqual(started.returncode, 0, started.stderr)
+                    deadline = time.monotonic() + 10
+                    while not record.is_file() and time.monotonic() < deadline:
+                        time.sleep(0.02)
+                    self.assertEqual(json.loads(record.read_text())["root"], root)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_a_directory_with_a_hash_in_its_name_is_where_the_chat_starts.py
+++ b/tests/test_a_directory_with_a_hash_in_its_name_is_where_the_chat_starts.py
@@ -295,8 +295,9 @@ class ARealTmuxStartsTheChatInThatDirectory(PersonaIso, unittest.TestCase):
     def test_a_run_of_hashes_before_a_bracket_is_not_doubled(self):
         """A guard on the escape's one exception rather than on the defect: the first three
         names started in the right place before the escape and pass without it. Doubled
-        like every other `#`, each went to `$HOME` on both versions. The fourth moved
-        before the escape, and only the `#` after the `[` may be doubled for it to land."""
+        like every other `#`, each went to `$HOME` on both versions. The fourth went to
+        `$HOME` before the escape and doubled whole, and lands with the `#` after the `[`
+        doubled and the one before it left as it is."""
         self._starts_in("a#[b")
         self._starts_in("a##[b")
         self._starts_in("a#[fg=red]b")


### PR DESCRIPTION
Closes #961.

## The failure

tmux reads a `-c <start-directory>` as a **format** before it looks for the directory. Measured on tmux 3.7c (`/opt/homebrew/bin/tmux`) and 3.2 (`~/.local/share/charter-testing/tmux-3.2`), through `new-window -c` and `respawn-pane -c` — the two commands `frame/layout.py` hands a directory to — each start rc 0 with an empty stderr:

| directory | where the pane started, unescaped |
|---|---|
| `x#{session_name}`, with `xbase` beside it | `xbase`, both versions |
| `x#{session_name}`, nothing beside it | `$HOME`, both versions |
| `a#S`, `a#,b`, `a#}b`, `a#{b`, `a##b` | `$HOME`, both versions |
| `y#(touch job-ran)` | `$HOME`, both versions |
| `trail#` | `$HOME` on 3.7c, and `trail` when that sat beside it; exactly there on 3.2 |
| `#` | its parent on 3.7c; exactly there on 3.2 |
| `a#[b`, `a##[b`, `a###[b`, `a####[b`, `a#[fg=red]b` | exactly there, both versions |

`charter/frame/state.record_cwd` stores the launch's own `os.getcwd()`, not a path read back from tmux, so the record is right. A reopen that starts the chat through `chat_window_argv` hands tmux the same name again.

A workspace's first chat is not affected: `session_argv` passes no `-c`, and `new-session` run from a working directory named `x#{session_name}` started exactly there on both versions, with a server already running and without one.

### The issue's "no job runs" holds only while the client disconnects at once

The issue measured `y#(touch <marker>)` and saw no marker. I re-measured with a control, and the result depends on the client:

- Sent as one command, the way charter sends each `-c` builder (`tmuxctl.run`, never chained — the one chained batch, `layout.panel_argvs`, is `split-window` with no `-c`): the job ran in **0 of 30** starts per command, on each version.
- With the client held connected by a chained `run-shell 'sleep 1'`: it ran in **5 of 5** per command, on each version, and wrote its marker.
- The control, `display-message -p 'ctl#(touch …)'`: no marker when its client exited at once, and a marker 3 times out of 3 when held the same way.

So tmux reads the directory's name as a shell command, and the one difference measured between the command running and not running was whether the client stayed connected. This PR does not mark the news entry `security:`; see *Concerns*.

## What changed, and why

- **`tmuxctl.start_directory(path)`**, beside `verbatim`: `verbatim(_literal_hashes(path))`. `_literal_hashes` doubles every run of `#` **except a run directly before `[`**, because tmux already hands that run on as it is: plain doubling sent `a#[b`, `a##[b`, `a###[b` and `a#[fg=red]b` to `$HOME` on both versions. A `#` after the `[` is still doubled (`a#[#{session_name}` → `a#[##{session_name}`, which lands).
- **The order, measured rather than assumed.** `verbatim(_literal_hashes(p))` and `_literal_hashes(verbatim(p))` produce the same string for every name here: `verbatim` adds only a `\` before a final `;`, and neither character decides whether a run of `#` is doubled. Both orders, spelled by the committed helper, were run against real tmux for all 30 directory names in the test module, through `new-window -c` and `respawn-pane -c`: 120 starts per version. On 3.7c and 3.2 every start was rc 0 with an empty stderr and landed exactly in its directory. The test pins that the two orders agree.
- **Used at every `-c` in `charter/`**: `layout.window_argv`, `layout.respawn_argv`, `layout.chat_window_argv`. `grep -rn '"-c"' charter/` finds those three and `switch-client -c <client>` (a client, not a directory); `'-c'` finds nothing. The other window- and pane-creating commands (`session_argv`, `panel_argvs`, `overlay.open_argv`, the panel respawn, the transcript pager) pass no start directory.
- **`-e` is left as #959 left it, by measurement.** `new-session -e`, `new-window -e` and `respawn-pane -e`, on both versions, with values `a#{session_name}`, `a##b`, `a#(touch …)`, `a#S` and `a#[b`: all 30 arrived byte-for-byte. An `-e` value carrying `#(touch …)`, sent through `new-window` with the client held connected, ran its command in 0 of 3.
- **`inert_format`'s docstring corrected.** It said "there is no format today whose text is not a module constant". The `-c` directory was one all along. It now names `start_directory`, and says why that is not a second spelling of `inert_format`: that function doubles every `#` and adds spaces for text tmux draws, and in a path a doubled `#[` lands in `$HOME`.

## Test evidence

`tests/test_a_directory_with_a_hash_in_its_name_is_where_the_chat_starts.py`, 11 tests:

- The helper over the measured matrix. `##` in a name becomes `####`. What tmux already hands on whole is left alone. Both orders give one string.
- Each of the three builders asked on its own for `-c`, and `-e` shown not escaped.
- A real tmux (the one on `$PATH`, plus the 3.2 floor binary where it exists), read back as `pane_current_path` through `chat_window_argv`, `respawn_argv` and the guest `window_argv`. The cases: `x#{session_name}` with and without `xbase`, `a#S`, `a##b`, `z#{session_name};`, `trail#`, `#`, the `[` guard rows, and `y#(touch job-ran)` held connected with its control, asserting no marker. Plus `-e` carrying `#{session_name}` through all three harness builders.

**Against unmodified code (cda535e): 51 failures, 65 errors.** The `x#{…}` rows landed in `xbase` or `$HOME`. The held job wrote `client/job-ran` through all three builders on both versions, while its control passed. The trailing-`#` rows failed on 3.7c only. In the `[` guard, only `a#[#{session_name}` failed. The three pure `#[` rows and the `-e` row pass on main by design, as guards.

**Hand mutations on the fix:**
- Plain doubling (`#+`): 33 failures, all `[` guard rows on both versions plus 9 unit rows.
- `start_directory` without `verbatim`: 10 failures, the `z#{session_name};` rows plus 4 unit rows.

- New module: 11 tests, OK.
- `test_frame_tmuxctl`, `test_frame_layout`, `test_a_harness_argument_ending_in_a_semicolon_arrives_whole`, `test_a_launch_too_long_for_tmux_says_so`, `test_a_chat_records_where_it_was_started`, `test_frame_launcher`: 486 tests, OK.
- News and docs checks (`test_news_frontmatter_is_not_yaml`, `test_news`, `test_news_gate`, `test_news_ordering`, `test_docs_claims_carry_their_residual`, `test_claims`, `test_docs_show`): 165 tests, OK.
- Full suite, run once on 0e66851 (ce3c292 after it changes one test docstring only): 11,984 tests, OK (9 skipped), 632 s.

`python3 tools/sweep.py` on ce3c292 against cda535e: 2 charged files, 71 added lines, **0 mutations applied** — "no operator finds a mutation in what they add". The sweep says that is not evidence the diff is tested, and it is not: the new code has no `if` to delete. The evidence is the two hand mutations above and the red run.

Docs: `docs/frame.md`, *What `charter frame -- <cmd>` accepts*, beside #959's trailing-`;` paragraph. News: `docs/news/unreleased-a-directory-with-a-hash-in-its-name-is-where-the-chat-starts.md`.

## Concerns

- **The job can run.** A `#(…)` in a directory's name ran as a shell command in every held start measured: 5 of 5 per command on each version, plus all six held rows of the red run. It ran 0 times in 30 per command for charter's single-command launch. Nothing I measured makes that 0 a guarantee. This PR escapes it either way. Whether the entry should carry `security: true` is a call for the owner: I did not mark it, because I measured no charter launch that ran it.
- **CI's tmux is not one I measured.** `ubuntu-latest` ships its own tmux, whose version I did not read, and every claim here is from 3.7c and 3.2. The branch's CI passed on 0e66851 (run 34551170047) and ce3c292 (run 34551356733), on Python 3.11–3.14. In 34551170047's log, all five real-tmux tests in the new module report `ok`, not skipped, on every Python job. So that tmux agreed with every assertion here, including the held job's control. That is not a measurement of its behaviour beyond these rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
