### PR TITLE
A chat can open in any workspace without moving your terminal, already told its first message (chat handoff, task 1)

### DIFF
--- a/charter/commands_frame.py
+++ b/charter/commands_frame.py
@@ -10664,12 +10664,17 @@ def background_refusal(ws: str, *, caller: str, first_message: str) -> str:
        :func:`_open_workspace`'s guard and :data:`NO_SESSION_HERE` said once. A session this
        plane can prove is its own is joined, and a name no session holds is started.
     """
-    if not first_message.strip():
+    # Split once, on whitespace: no words is an empty message, and one word is a single word.
+    # `split()` and never `strip()`, which the deletion sweep settled: `not text.strip()` and
+    # `not text.lstrip()` answer alike for every string, so the strip was a line nothing
+    # could pin, and the word it named could keep a trailing newline.
+    words = first_message.split()
+    if not words:
         return EMPTY_FIRST_MESSAGE
     if first_message.startswith("-"):
         return FLAG_FIRST_MESSAGE
-    if len(first_message.split()) == 1:
-        return WORD_FIRST_MESSAGE.format(word=contain.one_line(first_message.strip()))
+    if len(words) == 1:
+        return WORD_FIRST_MESSAGE.format(word=contain.one_line(words[0]))
     if "\x00" in first_message:
         return NUL_FIRST_MESSAGE
     size = len(os.fsencode(first_message))
@@ -10756,7 +10761,11 @@ def open_in_background(ws: str, *, caller: str, first_message: str,
             os.chdir(here_dir)
         except OSError:
             pass
-    if rc == 0 and opening.fid and state.harness_pane(opening.fid) is not None:
+    # Both halves are needed, and nothing more. An id the launcher never claimed is `""`,
+    # whose harness pane is `None` (`state.frame_dir("")` refuses), so the pane record alone
+    # stands for "a chat was started". The return code is still asked: a harness that died in
+    # its first moments leaves that record behind while `_launch` returns its exit code.
+    if rc == 0 and state.harness_pane(opening.fid) is not None:
         return Opened(True, opening.fid, "")
     return Opened(False, "", f"could not open a chat in '{ws}' — the launcher returned {rc} "
                              "and no chat came back")

--- a/charter/commands_frame.py
+++ b/charter/commands_frame.py
@@ -146,6 +146,7 @@ import shutil
 import subprocess
 import sys
 import time
+from typing import NamedTuple
 
 from . import config, contain, harness, inflight, instance, tui, util, workspace
 from .frame import (actions as frame_actions, builtin_actions, chats, choose, component,
@@ -4849,6 +4850,47 @@ def _reopening(args) -> "Reopening | None":
     return got if isinstance(got, Reopening) else None
 
 
+class Opening:
+    """One chat on its way into a workspace nobody is attached to, and the id it came up as.
+
+    **`Reopening`'s seam, for a chat with no record to restore** (chat-handoff plan, Task
+    1). It rides the `args` namespace :func:`open_in_background` builds and is read with
+    `getattr`, for `Reopening`'s reasons: no CLI surface, and every other caller of
+    `cmd_launch` constructs an `args` without it. It is a second seam rather than a
+    `Reopening` holding an invented record, because a reopen also moves a captured
+    transcript and restores a recorded persona (:func:`_restore_recorded_chat`), and a new
+    chat has neither.
+
+    **Mutable, for `Reopening.fid`'s reason**: `cmd_launch` allocates the id and the driver
+    needs it back. :attr:`fid` stays ``""`` for a launch that never got as far as claiming
+    one, which is what lets "no chat came back" be reported rather than inferred.
+    """
+
+    def __init__(self, first_message: str, persona: str = "") -> None:
+        #: The whole first message. It reaches the harness through the launch's `rest`
+        #: (`harness.base.first_message_argv`); it is carried here so the driver's record of
+        #: what it opened says what the chat was started on.
+        self.first_message = first_message
+        #: The persona to point the new chat at before its harness starts, or ``""`` for
+        #: whichever one a new chat in that workspace gets when nothing is pinned.
+        self.persona = persona
+        #: The chat id the launcher allocated, or ``""`` if it never got one.
+        self.fid = ""
+
+
+def _opening(args) -> "Opening | None":
+    """The background open this launch is, or ``None`` for any other launch.
+
+    Two things in :func:`cmd_launch` turn on it: the persona pointer written under the new
+    id before the harness starts, and the `select-window`/`_drop_panels` pair, which an
+    opening skips — the chat it builds is not the one anybody is looking at, and the chat
+    the operator IS looking at keeps its panels. The rest already follows from
+    `attach=False`: no non-tty `bypass`, no recorder, no attach and no detach sentence.
+    """
+    got = getattr(args, "opening", None)
+    return got if isinstance(got, Opening) else None
+
+
 def _wants_attach(args) -> bool:
     """Whether this launch should become the operator's terminal.
 
@@ -5373,6 +5415,16 @@ def _launch(args) -> int:
     if restoring is not None:
         restoring.fid = fid
         _restore_recorded_chat(restoring.chat, fid)
+    # **And a background open learns its id here, for the same two reasons**: the id did not
+    # exist a line earlier, and a persona pointer written after the harness starts is read
+    # one turn late. The session's pointer and nothing else (`terminal_id=""`, the call
+    # `_restore_recorded_chat` makes), so no terminal the operator is typing in is repointed.
+    opening = _opening(args)
+    if opening is not None:
+        opening.fid = fid
+        if opening.persona:
+            from . import persona as persona_mod
+            persona_mod.set_active(opening.persona, session_id=fid, terminal_id="")
     state.clear_respawn(fid)
     state.bump(fid)
     # And the record this process keeps now knows which chat it is standing in (#845) —
@@ -5725,7 +5777,10 @@ def _launch(args) -> int:
             # window it was looking at, because nobody is looking yet — the one
             # `select-window` a reopen wants is the one `cmd_reopen` issues at the end, at
             # the chat the manifest says was active.
-            if _reopening(args) is None:
+            #
+            # **Nor does a background open** (`_opening`): the chat it builds is not the one
+            # anybody is looking at, and the chat the operator IS looking at keeps its panels.
+            if _reopening(args) is None and _opening(args) is None:
                 leaving = _chat_being_left(SOCKET, beside=fid)
                 selected = tmuxctl.run(
                     "selecting the chat",
@@ -5750,6 +5805,11 @@ def _launch(args) -> int:
             # `layout.panel_argvs`'s own split ordering, not something this diff
             # introduced, but leaving the frame in a state the operator can actually type
             # into is this launcher's job.
+            #
+            # **A background open runs it too, and no window moves.** Measured through a
+            # whole `open_in_background` on tmux 3.7c and at the 3.2 floor, this `select-pane`
+            # included: the target session's current window is the same before and after
+            # (`tests/test_a_background_chat_really_starts_on_its_brief.py`).
             tmuxctl.run("focusing the harness pane",
                         tmuxctl.server_argv(SOCKET, "select-pane", "-t", harness_pane),
                         env=env)
@@ -10517,3 +10577,186 @@ def cmd_new_chat(args) -> int:
         # command exists to answer, arriving through the door built to answer it.
         _say_on_screen(fid, f"could not open another chat — the launcher returned {rc}")
     return 0
+
+
+#: The most bytes a first message may carry into :func:`open_in_background`, counted the way
+#: `exec` is handed them.
+#:
+#: **Charter's own bound: a policy, not a prediction of tmux's limit** (ADR 0009). tmux
+#: refuses a command message past 16,364 bytes — measured on 3.7c and at the 3.2 floor,
+#: `tmuxctl.MESSAGE_LIMIT` (#959) — and the message that starts a chat carries its names, its
+#: directory and the identity overlay beside the first message. 12,288 leaves about 4 KiB for
+#: those; `tests/test_a_background_chat_really_starts_on_its_brief.py` starts a chat on a
+#: first message exactly this long through a real tmux. Anything tmux still refuses is
+#: reported in tmux's own words by `_say_why_the_harness_did_not_start`. The cost, stated: a
+#: brief between 12,288 and about 15,800 bytes is refused here although tmux would take it.
+FIRST_MESSAGE_MAX_BYTES = 12288
+
+#: What :func:`background_refusal` says. Every one is said before anything starts, so every
+#: one says the rule worked and names the fix in the same breath (CONTEXT.md, *A refusal is
+#: the rule working*).
+EMPTY_FIRST_MESSAGE = ("cannot open a chat with an empty first message — a chat nobody has "
+                       "told anything sits at its prompt, and one opened in the background "
+                       "is then silence by construction. Nothing was opened.")
+FLAG_FIRST_MESSAGE = ("cannot open a chat whose first message starts with `-` — the harness "
+                      "would read it as one of its own flags, not as a message. Nothing was "
+                      "opened; start the message with a word.")
+WORD_FIRST_MESSAGE = ("cannot open a chat whose first message is the single word '{word}' — "
+                      "the harness may read it as one of its own subcommands (`codex login`). "
+                      "Nothing was opened; say it as a sentence.")
+NUL_FIRST_MESSAGE = ("cannot open a chat whose first message contains a NUL byte — a "
+                     "command-line argument cannot carry one. Nothing was opened.")
+LONG_FIRST_MESSAGE = ("cannot open a chat with a {n}-byte first message — charter refuses one "
+                      "past {max} bytes, its own bound, set under tmux's 16,364-byte command "
+                      "limit so the chat's names, directory and identity still fit beside it. "
+                      "Nothing was opened; shorten it, and name long material by its path "
+                      "instead of pasting it.")
+NO_BACKGROUND_CHAT_HERE = ("this chat is a window in a tmux you already had, where charter's "
+                           "launcher stays awake for the life of the harness it starts — so "
+                           "it cannot open a chat in the background from here. Nothing was "
+                           "opened.")
+UNMEASURED_FIRST_MESSAGE = ("cannot open a chat in '{ws}': charter has not measured how "
+                            "{harness} takes a first message, so it will not guess at an "
+                            "argument. Nothing was opened.")
+NOT_THIS_PLANES_SESSION = ("cannot open a chat in '{ws}': a session of that name is running on "
+                           "this machine and this plane cannot prove it is its own — it is "
+                           "probably another plane's. Nothing was opened; attach to it by hand "
+                           "if it is yours: tmux -L {socket} attach -t {prefix}")
+
+
+class Opened(NamedTuple):
+    """What :func:`open_in_background` did: the chat it opened, or why it opened none."""
+
+    #: Whether a chat exists now that did not before.
+    ok: bool
+    #: The new chat's id, or ``""`` when none was opened.
+    chat: str
+    #: The refusal or the failure as one sentence, or ``""`` when *ok*.
+    message: str
+
+
+def background_refusal(ws: str, *, caller: str, first_message: str) -> str:
+    """Every reason :func:`open_in_background` would refuse, or ``""`` when it may open.
+
+    **Asked before anything starts, and it writes nothing**, so `charter handoff` (Task 2)
+    can ask it before any write of its own. :func:`open_in_background` asks it again because
+    the plane may have moved in between — a race answered by refusing late, which is still a
+    refusal and never a half-open chat.
+
+    Cheapest first, and the one tmux question last:
+
+    1. an empty first message: a chat told nothing sits at its prompt, silence by
+       construction;
+    2. one starting with `-`, which the harness would read as its own flag;
+    3. a single word, which a CLI with subcommands may match against them (`codex login`).
+       A handoff's stamp makes a real first message several words, so only a direct caller
+       of this seam gets here;
+    4. a NUL byte, which no command-line argument can carry;
+    5. more than :data:`FIRST_MESSAGE_MAX_BYTES`, counted with `os.fsencode` — the bytes
+       `exec` is handed. A byte that is not UTF-8 reaches a `str` as a surrogate escape,
+       and a strict `str.encode` raises on it;
+    6. a caller that is a window in the operator's own tmux, where the launcher stays awake
+       for the life of the harness (`_launch_in_operator_tmux`) and a Bash tool call would
+       hang on it;
+    7. no harness the caller's chat records and no `[harness] default` (:data:`NO_HARNESS`);
+    8. a harness charter has not measured the first message of;
+    9. a session of *ws*'s name that this plane cannot prove is its own —
+       :func:`_open_workspace`'s guard and :data:`NO_SESSION_HERE` said once. A session this
+       plane can prove is its own is joined, and a name no session holds is started.
+    """
+    if not first_message.strip():
+        return EMPTY_FIRST_MESSAGE
+    if first_message.startswith("-"):
+        return FLAG_FIRST_MESSAGE
+    if len(first_message.split()) == 1:
+        return WORD_FIRST_MESSAGE.format(word=contain.one_line(first_message.strip()))
+    if "\x00" in first_message:
+        return NUL_FIRST_MESSAGE
+    size = len(os.fsencode(first_message))
+    if size > FIRST_MESSAGE_MAX_BYTES:
+        return LONG_FIRST_MESSAGE.format(n=size, max=FIRST_MESSAGE_MAX_BYTES)
+    socket = state.frame_server(caller) or SOCKET
+    if tmuxctl.is_operator_socket(socket, own=SOCKET):
+        return NO_BACKGROUND_CHAT_HERE
+    h = _same_harness_as(caller)
+    if h is None:
+        return f"cannot open a chat in '{ws}': {NO_HARNESS}"
+    if h.first_message_argv("x y") is None:
+        return UNMEASURED_FIRST_MESSAGE.format(ws=ws, harness=h.name)
+    prefix = state.workspace_prefix(ws)
+    if _plane_session(socket, ws=ws) is None and prefix in _live_sessions(socket):
+        return NOT_THIS_PLANES_SESSION.format(ws=ws, socket=socket, prefix=prefix)
+    return ""
+
+
+def open_in_background(ws: str, *, caller: str, first_message: str,
+                       persona: str = "") -> Opened:
+    """Open a chat in workspace *ws*, started on *first_message*, and move nobody.
+
+    **The seam `charter handoff` drives** (chat-handoff plan, Task 1): `cmd_launch` run for
+    the caller, on :func:`_open_workspace`'s and :func:`cmd_new_chat`'s precedent.
+    `attach=False` means no client moves and nothing blocks; the :class:`Opening` means the
+    new window is not selected and the chat the operator is on keeps its panels. The new
+    window still gets its panel processes before anyone looks, as every chat a reopen
+    builds does. The harness is the caller's own (:func:`_same_harness_as`), started on its
+    own spelling of a first message (`harness.base.first_message_argv`).
+
+    **Where, and how big.** *ws*'s own directory (:func:`_launch_root`), laid out for the
+    window *caller* is on: its own pane, else the pane :func:`_plane_session` proves is live
+    in *ws*, else nothing — which `_launch_size` reads as "measure your own terminal".
+    `cmd_new_chat`'s pair of readings, and its reason for never aiming an empty `-t`.
+
+    **The calling chat's pins stay behind.** `_frame_env` is ``dict(os.environ, …)`` and
+    `_frame_identity_env` carries `$CHARTER_WORKSPACE` and `$CHARTER_PERSONA` onto the new
+    window, so a pin the CALLER carries would become the new chat's: `state.own_workspace`'s
+    first rung would file it under the caller's workspace, which #936's launch-recorded lock
+    holds only for an unpinned launcher, and `switch.to_persona` would refuse to move it. So
+    both are emptied for the length of the launch and put back exactly, "was absent"
+    included. This is the one caller whose environment is another chat's —
+    `_open_workspace` and `cmd_new_chat` run as children of charter's own server — which is
+    why `_frame_env` itself is not changed.
+
+    **Success is a chat id with a harness pane, never a return code**: a launcher that
+    answered 0 and handed back no id has proved nothing exists.
+    """
+    refusal = background_refusal(ws, caller=caller, first_message=first_message)
+    if refusal:
+        return Opened(False, "", refusal)
+    h = _same_harness_as(caller)
+    socket = state.frame_server(caller) or SOCKET
+    pane = chats.pane_of(caller)
+    if pane is None:
+        seat = _plane_session(socket, ws=ws)
+        pane = chats.pane_of(seat[1]) if seat else None
+    size = _window_size(socket, pane) if pane else None
+    here_dir = os.getcwd()
+    try:
+        os.chdir(_launch_root(ws))
+    except OSError:
+        return Opened(False, "", f"cannot open a chat in '{ws}': charter cannot enter its "
+                                 "directory. Nothing was opened.")
+    from types import SimpleNamespace
+    opening = Opening(first_message, persona)
+    pins = {name: os.environ.get(name) for name in ("CHARTER_WORKSPACE", "CHARTER_PERSONA")}
+    try:
+        for name in pins:
+            os.environ[name] = ""
+        # Every field named, `_reopen_args`' rule. A non-empty `rest` also keeps §4k's
+        # open-or-focus shortcut out, which could never answer "run this".
+        rc = cmd_launch(SimpleNamespace(
+            harness=h.cli_name, rest=h.first_message_argv(first_message), no_frame=False,
+            workspace=ws, pick=False, attach=False, size=size, opening=opening))
+    finally:
+        for name, was in pins.items():
+            if was is None:
+                os.environ.pop(name)
+            else:
+                os.environ[name] = was
+        try:
+            os.chdir(here_dir)
+        except OSError:
+            pass
+    if rc == 0 and opening.fid and state.harness_pane(opening.fid) is not None:
+        return Opened(True, opening.fid, "")
+    return Opened(False, "", f"could not open a chat in '{ws}' — the launcher returned {rc} "
+                             "and no chat came back")

--- a/charter/harness/base.py
+++ b/charter/harness/base.py
@@ -268,6 +268,25 @@ class Harness:
         """
         return [self.binary, *extra]
 
+    def first_message_argv(self, text: str) -> list[str] | None:
+        """The arguments that start this harness's own interactive session on *text*, or
+        ``None`` when charter has not measured how this harness takes a first message.
+
+        **An argument, never keystrokes.** Typing *text* into the harness pane would be
+        drawing in it (ADR 0018), and it would race the harness's own start. So the message
+        rides the argv :meth:`launch_argv` builds, as the arguments this returns.
+
+        **A member, not the launcher's pass-through.** The spelling differs by harness —
+        opencode takes `--prompt <text>` where the others take a positional — so no single
+        `extra` is right for every harness. A harness nobody has measured answers ``None``,
+        and the caller refuses rather than handing it a guess.
+
+        *text* is always ONE element and never split. tmux execs a multi-element argv
+        directly, and `frame/tmuxctl.verbatim` (#959) is what carries an element ending in
+        `;` through whole — so nothing here escapes it a second time.
+        """
+        return None
+
     def detect(self) -> bool:
         """Is this harness live, judged by its own native evidence?
 

--- a/charter/harness/claude_code.py
+++ b/charter/harness/claude_code.py
@@ -132,6 +132,17 @@ class ClaudeCodeHarness(Harness):
     cli_name = "claude"
     binary = "claude"
 
+    def first_message_argv(self, text: str) -> list[str] | None:
+        """`claude "<text>"`: the positional prompt starts the interactive session on it.
+
+        Measured with `claude --help` on Claude Code 2.1.268: `Usage: claude [options]
+        [command] [prompt]`, and it "starts an interactive session by default, use
+        -p/--print for non-interactive output" — so this is the session's first message,
+        not print mode. The `[command]` ahead of the prompt is why a single-word first
+        message is refused before it gets here (`commands_frame.WORD_FIRST_MESSAGE`).
+        """
+        return [text]
+
     def detect(self) -> bool:
         """``$CLAUDE_PLUGIN_ROOT`` is set for the plugin's own processes.
 

--- a/charter/harness/codex.py
+++ b/charter/harness/codex.py
@@ -208,6 +208,16 @@ class CodexHarness(Harness):
     cli_name = "codex"
     binary = "codex"
 
+    def first_message_argv(self, text: str) -> list[str] | None:
+        """`codex "<text>"`: the positional prompt starts the session on it.
+
+        Measured with `codex --help` on codex-cli 0.147.0: `Usage: codex [OPTIONS]
+        [PROMPT]`, where `[PROMPT]` is "Optional user prompt to start the session". Codex
+        also has subcommands (`codex login`), which is why a single-word first message is
+        refused before it gets here (`commands_frame.WORD_FIRST_MESSAGE`).
+        """
+        return [text]
+
     def upgrade(self, root: Path) -> tuple[str, str]:
         """Codex's own config block never needs moving; its PLUGIN does.
 

--- a/charter/harness/opencode.py
+++ b/charter/harness/opencode.py
@@ -781,6 +781,14 @@ class OpenCodeHarness(Harness):
     cli_name = "opencode"
     binary = "opencode"
 
+    def first_message_argv(self, text: str) -> list[str] | None:
+        """`opencode --prompt "<text>"`, because opencode's positional is not a prompt.
+
+        Measured with `opencode --help` on opencode 1.18.23: the positional is `[project]`
+        ("start opencode tui"), and the prompt is `--prompt` ("prompt to use").
+        """
+        return ["--prompt", text]
+
     def stale_wiring(self) -> str:
         """What the installed plugin REALM is, when charter cannot vouch for all of it.
 

--- a/docs/frame.md
+++ b/docs/frame.md
@@ -642,6 +642,55 @@ one — so on a machine running several frames a refusal about one could be draw
 another. A panel reads its own frame's state, and every client attached to that frame sees
 it.
 
+### A chat opened for you in the background
+
+**A chat that hands work to a new chat has to start that chat without taking your screen.**
+`charter handoff` — the next piece of the chat-handoff plan, not shipped yet — opens a chat in
+a workspace you name and starts it on a first message you approved. The opening underneath
+it exists now, and it is built so nothing you are looking at changes:
+
+- **No client moves.** The chat is a new window in the target workspace's session, created
+  detached. It is not selected, nothing attaches, and the chat you are on keeps its panels.
+  Measured with a real session on tmux 3.7c and at the 3.2 floor: the session's current
+  window is the same one before and after the open. The new window still gets its panels
+  before anyone looks at it, as every chat a reopen builds does.
+- **The first message is the harness's own first prompt**, passed as one command-line
+  argument in that harness's spelling, and never typed into its pane:
+
+      claude "<message>"              Claude Code 2.1.268: claude [options] [command] [prompt]
+      codex "<message>"               codex-cli 0.147.0:   codex [OPTIONS] [PROMPT]
+      opencode --prompt "<message>"   opencode 1.18.23:    its positional is [project]
+
+  A harness charter has not measured is refused rather than handed a guess. The message
+  arrives whole — blank lines, quotes, `$(…)`, `#{…}` and a trailing `;` included — measured
+  through a real tmux on both versions. **Because it is an argument, any process on this
+  machine that can list processes can read it while the harness starts**, so a first message
+  is never the place for a secret.
+- **At most 12,288 bytes, and that bound is charter's own, not tmux's.** tmux refuses a
+  command past 16,364 bytes, and the command that starts a chat carries the chat's names,
+  its directory and its identity beside the message. A first message exactly 12,288 bytes
+  long starts, on 3.7c and at the 3.2 floor. The cost: one between 12,288 and about 15,800
+  bytes is refused although tmux would take it — name long material by its path instead.
+  Anything tmux still refuses is reported in tmux's own words (*What `charter frame --
+  <cmd>` accepts*, below).
+- **The new chat does not inherit the pins of the chat that opened it.** `$CHARTER_WORKSPACE`
+  and `$CHARTER_PERSONA` are emptied for the length of the launch, so a pinned chat cannot
+  file the new one under its own workspace or persona. The new chat gets the persona a new
+  chat in that workspace gets when nothing is pinned, unless one is named for it.
+
+Before starting anything, it refuses a first message that is empty, starts with `-`, is a
+single word (which a harness may read as a subcommand), carries a NUL byte, or is past the
+bound. It also refuses from a chat that is a window in a tmux you already had, where
+charter's launcher stays awake for the harness's whole life; from a chat that records no
+harness charter can launch; and into a workspace whose session name is running on this
+machine but cannot be proved this plane's. Each refusal says which rule it was, and that
+nothing was opened.
+
+Whether the new chat is locked to its workspace (#936) depends on the harness keeping the
+chat id charter starts it with. Two harnesses are named as not doing that yet: opencode's
+plugin overwrites `$CHARTER_SESSION_ID` (#946), and Codex gets no session id outside a frame
+(#954).
+
 ### The two bars, and why they are off unless you ask
 
 `chats` and `workspaces` are tab strips: the chat bar names every chat in this workspace

--- a/docs/superpowers/plans/2026-09-10-chat-handoff.md
+++ b/docs/superpowers/plans/2026-09-10-chat-handoff.md
@@ -199,11 +199,18 @@ def open_in_background(ws: str, *, caller: str, first_message: str,
   `` `x` ``, `$(echo x)`, a tab, U+2028. `tmuxctl.SEPARATOR`'s note (tmuxctl.py:440-446)
   measured an argument *containing* `;`; a *trailing* `;` is the unmeasured case. If any
   string does not arrive intact, stop and report — the seam's contract changes.
-- **M2 — the size limit.** Find the largest `text` (bytes, with the identity `-e` overlay
-  `_frame_identity_env` adds) that `new-window` and `new-session` accept. Hypothesis to
-  confirm or refute: the tmux client refuses a command message over its fixed message size
-  ("command too long"). Set `FIRST_MESSAGE_MAX_BYTES` below the smaller measured value with
-  the margin written beside it.
+  **Done by #959** (controller ruling on resume): it measured the trailing-`;` loss, and
+  every harness argument after `--`, every `-c` value and every `-e` value now goes through
+  `tmuxctl.verbatim`, so a first message ending in `;` arrives whole. Task 1 does not escape
+  again — #959's review traced every route to exactly one escape, and a second is a defect.
+- **M2 — the size limit.** Measured by #959 on 3.7c and 3.2: tmux refuses a command message
+  past 16,364 bytes (`tmuxctl.MESSAGE_LIMIT`), in one of two sentences, and #959 reports that
+  refusal in tmux's own words. **`FIRST_MESSAGE_MAX_BYTES = 12288` is `charter handoff`'s own
+  documented policy bound, not a prediction of tmux's limit** (ADR 0009 rejects predicting;
+  controller ruling on resume). It leaves about 4 KiB for the names, cwd and `CHARTER_ROOT`
+  the start command also carries, and it is checked before any side effect — before a
+  workspace is created and before the todo is written. Cost if wrong: a brief between 12,288
+  and about 15,800 bytes is refused although tmux would take it.
 - **M3 — nothing moves.** A session whose current window is A; open a background chat into
   it through the real `_launch`; `display-message -p -t <session id> '#{window_id}'` is A
   before and after. `_launch` still runs `select-pane -t <harness pane>` (5712) — the
@@ -231,7 +238,7 @@ the one tmux question last); each is a module constant with `{}` fields filled i
 4. `"\x00" in first_message` → `NUL_FIRST_MESSAGE`:
    `"cannot open a chat whose first message contains a NUL byte — a command-line argument cannot carry one. Nothing was opened."`
 5. `len(first_message.encode()) > FIRST_MESSAGE_MAX_BYTES` → `LONG_FIRST_MESSAGE`:
-   `"cannot open a chat with a {n}-byte first message — it travels to the harness as one tmux argument, and tmux refuses a command past {max} bytes (measured). Nothing was opened; shorten it, and name long material by its path instead of pasting it."`
+   `"cannot open a chat with a {n}-byte first message — charter refuses one past {max} bytes, its own bound, set under tmux's 16,364-byte command limit so the chat's names, directory and identity still fit beside it. Nothing was opened; shorten it, and name long material by its path instead of pasting it."` (Reworded on resume: the bound is charter's policy, not a measured tmux limit. Counted with `os.fsencode`, the bytes `exec` is handed, because a strict `str.encode` raises on a surrogate escape — #959's finding.)
 6. `tmuxctl.is_operator_socket(state.frame_server(caller) or SOCKET, own=SOCKET)` →
    `NO_BACKGROUND_CHAT_HERE`:
    `"this chat is a window in a tmux you already had, where charter's launcher stays awake for the life of the harness it starts — so it cannot open a chat in the background from here. Nothing was opened."`
@@ -306,6 +313,7 @@ seat, `display-message` answers `132:43`, `list-sessions` answers the names in
 - `test_the_launch_names_the_workspace_and_never_attaches` — `launched[0].workspace == "beta"`, `.attach is False`, `.pick is False`, `.no_frame is False`.
 - `test_the_first_message_rides_the_harnesses_own_argv` — subTest per harness recorded on `alpha.1`: `claude-code` → `rest == ["fix the widget please"]`; `opencode` → `["--prompt", "fix the widget please"]`; `codex` → `["fix the widget please"]`.
 - `test_the_opening_carries_the_new_chat_id_back` — `_open() == Opened(True, "beta.1", "")`.
+- `test_the_opening_carries_the_message_and_the_persona_it_was_given` — `launched[0].opening` is an `Opening` whose `first_message` and `persona` are what `_open` was given. (Added on resume, so dropping `persona` on the way to the launcher is caught here and not only by the `_launch` class.)
 - `test_it_is_sized_for_the_window_the_calling_chat_is_on` — `launched[0].size == (132, 43)`.
 - `test_the_launch_runs_in_the_target_workspaces_own_directory` — cwd read inside the fake `== str(workspace.workspace_dir("beta").resolve())` (compare `os.path.realpath`); after return `os.getcwd()` is what it was.
 - `test_a_pin_the_calling_chat_carries_does_not_reach_the_new_chat` — `os.environ` holds `CHARTER_WORKSPACE=alpha`, `CHARTER_PERSONA=forge`; inside the fake both read `""`; after return both read `alpha`/`forge` again.
@@ -314,10 +322,11 @@ seat, `display-message` answers `132:43`, `list-sessions` answers the names in
 - `test_a_first_message_starting_with_a_dash_is_refused` — `"--dangerously-skip-permissions now"` → `"starts with `-`" in message`, `launched == []`.
 - `test_a_single_word_first_message_is_refused` — `"login"` → `"single word 'login'" in message`.
 - `test_a_nul_byte_is_refused` — `"fix\x00 it"` → `"NUL byte" in message`.
-- `test_a_first_message_past_the_measured_limit_is_refused` — `"x " * (FIRST_MESSAGE_MAX_BYTES // 2 + 1)` → `"past" in message and str(FIRST_MESSAGE_MAX_BYTES) in message`.
-- `test_a_first_message_exactly_at_the_limit_is_taken` — a text whose `len(.encode()) == FIRST_MESSAGE_MAX_BYTES` with a space in it → `ok is True`, one launch. (Pins `>` against `>=`.)
+- `test_a_first_message_past_the_bound_is_refused` — `"x " * (FIRST_MESSAGE_MAX_BYTES // 2 + 1)` → `"past" in message and str(FIRST_MESSAGE_MAX_BYTES) in message`. (Renamed on resume: the bound is charter's policy, not a measured limit.)
+- `test_a_first_message_exactly_at_the_bound_is_taken` — a text whose `len(.encode()) == FIRST_MESSAGE_MAX_BYTES` with a space in it → `ok is True`, one launch. (Pins `>` against `>=`.)
 - `test_a_first_message_is_measured_in_bytes_not_characters` — `"é " * (FIRST_MESSAGE_MAX_BYTES // 3 + 1)` (fewer characters than the limit, more bytes) → refused.
-- `test_a_chat_in_a_tmux_you_already_had_is_refused` — `state.record_server("alpha.1", "/tmp/tmux-501/default")` → `"a tmux you already had" in message`, `launched == []`.
+- `test_a_byte_that_is_not_utf8_is_counted_not_crashed_on` — `"fix \udcff it"` → `background_refusal` answers `""`. (Added on resume: the count is `os.fsencode`, which a strict `str.encode` would turn into an exception.)
+- `test_a_chat_in_a_tmux_you_already_had_is_refused` — `state.record_server("alpha.1", _tmuxsocket.OPERATOR_SOCKET)` → `"a tmux you already had" in message`, `launched == []`. (A literal `/tmp/tmux-<uid>/…` path is refused by `test_no_test_bakes_a_uid_into_a_socket_path`.)
 - `test_a_chat_with_no_launchable_harness_is_refused` — identity harness `""`, `mock.patch.object(config, "HARNESS", None)` → `NO_HARNESS in message`.
 - `test_a_harness_charter_has_not_measured_is_refused` — patch `ClaudeCodeHarness.first_message_argv` to return `None` → `"has not measured how claude-code" in message`.
 - `test_a_session_this_plane_cannot_prove_is_its_own_is_refused` — `self.sessions = {"beta"}` with no beta seat in `list-panes` → `"probably another plane's" in message`, `launched == []`.
@@ -348,14 +357,16 @@ exist with `self.make_persona("forge")`.
 - `test_an_opening_writes_the_persona_it_was_given_under_the_new_chat` — `persona.for_session("beta.1") == "forge"`.
 - `test_an_opening_with_no_persona_writes_no_pointer` — `persona.for_session("beta.1") is None`.
 - `test_an_ordinary_launch_still_selects_its_window` — same patches, no `opening`, `attach` left absent: an argv containing `"select-window"` was recorded (the gate is `and`, not a replacement).
+- `test_an_opening_still_gets_its_panels_before_anyone_looks` — `_draw_panels` is called once for an opening. (Added on resume: Open question 15 as ruled, pinned so a later gate cannot quietly skip the panels too.)
 
 `tests/test_a_background_chat_really_starts_on_its_brief.py` — skipped when
 `shutil.which("tmux") is None`. Socket `_tmuxreap.name("handoff-argv")`, killed in
-`addCleanup`. A recorder script in `self.tmp` (`#!<sys.executable>` writing `json.dumps(sys.argv[1:])` to a path from its env).
+`addCleanup`. A recorder script in `self.tmp` (`#!<sys.executable>` writing `json.dumps(sys.argv[1:])` to a path from its env, then staying alive so the launch reaches `select-pane`). Every open stands in `_spawn_gather`: a launch forks a detached `charter frame-gather` with `start_new_session=True`, which `tests/_planeguard.py` refuses — shown failing without the stand-in (controller ruling on resume).
 
-- `test_hostile_text_reaches_the_harness_argv_byte_for_byte` — subTest per M1 string, through `tmuxctl.run(layout.chat_window_argv(...))` into a session made with `layout.session_argv(...)`: the recorded JSON `== ["<text>"]`.
-- `test_a_first_message_at_the_limit_starts_and_one_past_it_is_the_measured_refusal` — at `FIRST_MESSAGE_MAX_BYTES` plus the identity overlay the window starts; the documented over-limit size reproduces the measured failure.
-- `test_opening_a_background_chat_leaves_the_sessions_current_window_where_it_was` — M3 through `open_in_background` with `commands_frame.SOCKET` patched to the reaped name (the `mock.patch.object(commands_frame, "SOCKET", …)` shape of tests/test_frame_tmux_integration.py:6628), the harness's `binary` patched to the recorder, and a caller window sized so `commands_frame._drawable_slots(cols, rows) == []` (assert that in `setUp`) so no panel process starts.
+- `test_opening_a_background_chat_leaves_the_sessions_current_window_where_it_was` — M3 through `open_in_background` with `commands_frame.SOCKET` patched to the reaped name (the `mock.patch.object(commands_frame, "SOCKET", …)` shape of tests/test_frame_tmux_integration.py:6628), the harness's `binary` patched to the recorder, and a caller window sized so `commands_frame._drawable_slots(cols, rows) == []` (assert that in `setUp`) so no panel process starts. The recorded argv is exactly the brief, for one carrying a trailing `;`, a blank line, quotes, `$(…)` and `#{…}` — M1 through Task 1's own path.
+- `test_a_first_message_at_charters_bound_still_fits_under_tmuxs_limit` — a first message exactly `FIRST_MESSAGE_MAX_BYTES` long starts, and arrives whole.
+
+Both pass on tmux 3.7c and at the 3.2 floor. On resume, the byte-for-byte matrix and tmux's own limit are #959's tests (`test_a_harness_argument_ending_in_a_semicolon_arrives_whole`, `test_a_launch_too_long_for_tmux_says_so`), so they are not repeated here. And because the bound is a policy, "one past it is the measured refusal" no longer describes anything tmux does.
 
 **Implementation notes**
 

--- a/tests/test_a_background_chat_really_starts_on_its_brief.py
+++ b/tests/test_a_background_chat_really_starts_on_its_brief.py
@@ -92,9 +92,13 @@ class _TwoChatsOnARealServer(PersonaIso):
             self.skipTest(f"the frame's floor is tmux {tmuxctl.FLOOR[0]}.{tmuxctl.FLOOR[1]};"
                           f" this machine has {v}")
         make_plane(self)
+        #: The tmux binary this case measures, resolved once. Every command the case sends
+        #: itself, and the client it attaches, runs this file; `tmuxctl`'s own calls resolve
+        #: the same `$PATH`, which is how a run is pointed at the 3.2 floor binary.
+        self.tmux = shutil.which("tmux")
         self.socket = _tmuxreap.name(f"{self.SLUG}-{next(_SERVERS)}")
         self.enterContext(mock.patch.object(commands_frame, "SOCKET", self.socket))
-        self.addCleanup(subprocess.run, ["tmux", "-L", self.socket, "kill-server"],
+        self.addCleanup(subprocess.run, [self.tmux, "-L", self.socket, "kill-server"],
                         capture_output=True, timeout=20)
         #: Where the server this case starts writes its `-v` log, read only on a failure.
         self.tmux_logs = self.tmp / "tmux-logs"
@@ -132,7 +136,7 @@ class _TwoChatsOnARealServer(PersonaIso):
             self.panes[ws] = pane
 
     def _tmux(self, *args: str, env=None) -> subprocess.CompletedProcess:
-        return subprocess.run(["tmux", "-L", self.socket, *args], capture_output=True,
+        return subprocess.run([self.tmux, "-L", self.socket, *args], capture_output=True,
                               text=True, timeout=20, env=env)
 
     def _session(self, name: str, env: dict) -> str:
@@ -140,7 +144,7 @@ class _TwoChatsOnARealServer(PersonaIso):
 
         `-v` so the server this starts keeps a log, run from :attr:`tmux_logs` because that
         is where tmux writes it; read only when something went wrong."""
-        argv = ["tmux", "-v", "-L", self.socket, "-f", "/dev/null", "new-session", "-d",
+        argv = [self.tmux, "-v", "-L", self.socket, "-f", "/dev/null", "new-session", "-d",
                 "-s", name, "-x", str(self.COLS), "-y", str(self.ROWS),
                 "-P", "-F", "#{pane_id}", "--", "sleep", "600"]
         existed = os.path.exists(_tmuxsocket.socket_path(self.socket))
@@ -155,7 +159,8 @@ class _TwoChatsOnARealServer(PersonaIso):
         """Everything a failed session start on a runner nobody can log into needs to say."""
         named = {k: env.get(k) for k in ("TERM", "SHELL", "HOME", "TMUX_TMPDIR", "LANG",
                                          "LC_ALL", "PATH")}
-        version = subprocess.run(["tmux", "-V"], capture_output=True, text=True).stdout.strip()
+        version = subprocess.run([self.tmux, "-V"], capture_output=True,
+                                 text=True).stdout.strip()
         logs = []
         for log in sorted(self.tmux_logs.glob("tmux-*.log")):
             lines = log.read_text(errors="replace").splitlines()
@@ -294,16 +299,22 @@ class ABackgroundChatWithItsPanelsMovesNoAttachedClient(_TwoChatsOnARealServer,
         """A real client on *session*, on a pty sized to the window, and its tmux name — or
         ``None`` where no terminal type would attach.
 
+        **The client is :attr:`tmux`, the binary this case measures, by its absolute path**:
+        a bare `tmux` resolved again here could be a different binary from the server the case
+        is asking about.
+
         Started through `subprocess.Popen` with the pty as its three streams, and not as a
-        `pty.fork` child that `os.execvp`s: `tests/test_plane_spawn_guard.py` watches `Popen`
-        and requires every exec-family call in the tree to be one it has written down. The
-        client needs no controlling terminal — tmux's server opens the client's tty by name —
-        measured attaching this way on tmux 3.7c and 3.2 on macOS and 3.4 on Linux."""
+        `pty.fork` child that `os.execvp`s, because `tests/test_plane_spawn_guard.py` requires
+        every exec-family call in the tree to be one it has written down. That static guard is
+        the whole of what covers this call: the runtime `_planeguard` does not resolve a bare,
+        non-interpreter program through `$PATH`, so it would not refuse a charter posing as
+        tmux. The client needs no controlling terminal — tmux's server opens the client's tty
+        by name — measured attaching this way on tmux 3.7c and 3.2 on macOS and 3.4 on Linux."""
         for term in _TERM_CANDIDATES:
             master, slave = os.openpty()
             fcntl.ioctl(slave, termios.TIOCSWINSZ,
                         struct.pack("HHHH", self.ROWS, self.COLS, 0, 0))
-            client = subprocess.Popen(["tmux", "-L", self.socket, "attach", "-t", session],
+            client = subprocess.Popen([self.tmux, "-L", self.socket, "attach", "-t", session],
                                       stdin=slave, stdout=slave, stderr=slave,
                                       env=dict(os.environ, TERM=term),
                                       start_new_session=True)

--- a/tests/test_a_background_chat_really_starts_on_its_brief.py
+++ b/tests/test_a_background_chat_really_starts_on_its_brief.py
@@ -1,0 +1,164 @@
+"""A chat opened in the background really starts on its whole first message, and nobody's
+window moves.
+
+Real tmux on a private socket (`tests._tmuxreap`), driven through `open_in_background` and
+the real `_launch`, with only the harness binary swapped for a recorder that writes the argv
+it was started with and then stays alive — so the launch goes all the way through
+`select-pane` rather than stopping at an early death.
+
+**Why `_spawn_gather` is stood in.** A launch fills the new chat's gather cache in a detached
+`charter frame-gather` child (`util.detach_self`, `start_new_session=True`), and
+`tests/_planeguard.py` refuses exactly that child in the suite: it would outlive the test and
+spend a gather on whatever plane its copied environment resolves. What is asked here is what
+tmux does, not what the gather writes.
+
+**What the #959 tests already hold, and what this adds.** `tests/test_a_harness_argument_ending_
+in_a_semicolon_arrives_whole.py` measures the builders byte for byte and
+`tests/test_a_launch_too_long_for_tmux_says_so.py` tmux's command limit. This file sends a
+brief through Task 1's own path — `first_message_argv`, the `Opening`, the launcher — and
+checks that it arrives whole, that the session's current window stays where it was (M3), and
+that a first message at charter's own bound still fits under tmux's limit with the identity a
+real launch carries.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import time
+import unittest
+from unittest import mock
+
+from charter import commands_frame, config
+from charter.frame import state, tmuxctl
+from charter.harness import claude_code
+
+from tests import _tmuxreap
+from tests._isolation import PersonaIso, make_plane
+
+_HAS_TMUX = shutil.which("tmux") is not None
+
+
+@unittest.skipUnless(_HAS_TMUX, "no tmux on this machine")
+class ABackgroundChatReallyStartsOnItsBrief(PersonaIso, unittest.TestCase):
+
+    #: A brief that tmux's own parser and a shell would each mangle if charter joined, split
+    #: or failed to escape it: a trailing `;` (#957, carried through by #959's
+    #: `tmuxctl.verbatim`), a blank line, quotes, command substitution and a tmux format.
+    BRIEF = 'fix the widget;\n\nit says "$(echo boom)" and `x` at #{session_name};'
+
+    #: The calling chat's window — small enough that no panel is drawable, so no panel
+    #: process starts (asserted in `setUp` rather than assumed).
+    COLS, ROWS = 20, 6
+
+    def setUp(self):
+        super().setUp()
+        v = tmuxctl.version()
+        if v is None or v < tmuxctl.FLOOR:
+            self.skipTest(f"the frame's floor is tmux {tmuxctl.FLOOR[0]}.{tmuxctl.FLOOR[1]};"
+                          f" this machine has {v}")
+        make_plane(self)
+        self.socket = _tmuxreap.name("handoff-argv")
+        self.enterContext(mock.patch.object(commands_frame, "SOCKET", self.socket))
+        self.addCleanup(subprocess.run, ["tmux", "-L", self.socket, "kill-server"],
+                        capture_output=True, timeout=20)
+        self.records = self.tmp / "records"
+        self.records.mkdir()
+        self.recorder = self.tmp / "claude-recorder"
+        self.recorder.write_text(
+            f"#!{sys.executable}\n"
+            "import json, os, sys, time\n"
+            "p = os.path.join(os.environ['RECORD_DIR'],\n"
+            "                 os.environ['TMUX_PANE'].lstrip('%') + '.json')\n"
+            "with open(p + '.tmp', 'w') as f:\n"
+            "    json.dump(sys.argv[1:], f)\n"
+            "os.replace(p + '.tmp', p)\n"
+            "time.sleep(120)\n")
+        self.recorder.chmod(0o755)
+        server_env = dict(os.environ, RECORD_DIR=str(self.records),
+                          CHARTER_ROOT=str(config.ROOT))
+        self.caller_pane = self._session("alpha", server_env)
+        self.target_pane = self._session("beta", server_env)
+        for fid, ws, pane in (("alpha.1", "alpha", self.caller_pane),
+                              ("beta.1", "beta", self.target_pane)):
+            (config.WORKSPACES_DIR / ws).mkdir(parents=True, exist_ok=True)
+            state.frame_dir(fid, create=True)
+            state.record_workspace(fid, ws)
+            state.record_server(fid, self.socket)
+            state.record_identity(fid, {"CHARTER_HARNESS": "claude-code"})
+            state.record_harness_pane(fid, pane)
+            # What a launcher writes on the window, and what `reap` keeps a chat alive by.
+            named = self._tmux("set-option", "-w", "-t", pane, commands_frame._CHAT_OPTION,
+                               fid)
+            self.assertEqual(named.returncode, 0, named.stderr)
+        self.assertEqual(commands_frame._window_size(self.socket, self.caller_pane),
+                         (self.COLS, self.ROWS))
+        self.assertEqual(commands_frame._drawable_slots(self.COLS, self.ROWS), [])
+
+    def _tmux(self, *args: str, env=None) -> subprocess.CompletedProcess:
+        return subprocess.run(["tmux", "-L", self.socket, *args], capture_output=True,
+                              text=True, timeout=20, env=env)
+
+    def _session(self, name: str, env: dict) -> str:
+        started = self._tmux("-f", "/dev/null", "new-session", "-d", "-s", name,
+                             "-x", str(self.COLS), "-y", str(self.ROWS),
+                             "-P", "-F", "#{pane_id}", "--", "sleep", "600", env=env)
+        self.assertEqual(started.returncode, 0, started.stderr)
+        return started.stdout.strip()
+
+    def _open(self, text: str):
+        with mock.patch.object(claude_code.ClaudeCodeHarness, "binary", str(self.recorder)), \
+                mock.patch.object(commands_frame, "_spawn_gather"), \
+                mock.patch("sys.stdout.isatty", return_value=True), \
+                mock.patch("sys.stdin.isatty", return_value=False):
+            return commands_frame.open_in_background("beta", caller="alpha.1",
+                                                     first_message=text)
+
+    def _received(self, pane: str) -> list[str]:
+        """The recorder's argv — failing as soon as tmux no longer lists the pane, because
+        `display-message` on a pane that has gone answers rc 0 with an empty line (#959)."""
+        record = self.records / (pane.lstrip("%") + ".json")
+        deadline = time.monotonic() + 15
+        while time.monotonic() < deadline:
+            if record.is_file():
+                return json.loads(record.read_text())
+            listed = self._tmux("list-panes", "-a", "-F", "#{pane_id}")
+            if pane not in listed.stdout.split():
+                if record.is_file():
+                    return json.loads(record.read_text())
+                self.fail(f"the harness in {pane} ended without recording its argv")
+            time.sleep(0.05)
+        self.fail(f"the harness in {pane} never recorded its argv")
+
+    def test_opening_a_background_chat_leaves_the_sessions_current_window_where_it_was(self):
+        session = self._tmux("display-message", "-p", "-t", self.target_pane,
+                             "#{session_id}").stdout.strip()
+        before = self._tmux("display-message", "-p", "-t", session, "#{window_id}")
+        self.assertEqual(before.returncode, 0, before.stderr)
+        opened = self._open(self.BRIEF)
+        self.assertTrue(opened.ok, opened.message)
+        pane = state.harness_pane(opened.chat)
+        self.assertEqual(self._received(pane), [self.BRIEF])
+        after = self._tmux("display-message", "-p", "-t", session, "#{window_id}")
+        self.assertEqual(after.stdout.strip(), before.stdout.strip(),
+                         "opening a chat in the background moved the session's window")
+        windows = self._tmux("list-windows", "-t", session, "-F", "#{window_id}")
+        self.assertEqual(len(windows.stdout.split()), 2,
+                         "the chat was not opened as a window in the target's session")
+
+    def test_a_first_message_at_charters_bound_still_fits_under_tmuxs_limit(self):
+        """`FIRST_MESSAGE_MAX_BYTES` is charter's own bound, not a prediction of tmux's
+        limit (ADR 0009). What this asks is that the bound leaves room: a first message
+        exactly at it, with the names, directory and identity a real launch carries beside
+        it, still starts and still arrives whole."""
+        text = "x" * (commands_frame.FIRST_MESSAGE_MAX_BYTES - 2) + " y"
+        opened = self._open(text)
+        self.assertTrue(opened.ok, opened.message)
+        self.assertEqual(self._received(state.harness_pane(opened.chat)), [text])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_a_background_chat_really_starts_on_its_brief.py
+++ b/tests/test_a_background_chat_really_starts_on_its_brief.py
@@ -16,9 +16,10 @@ tmux does, not what the gather writes.
 in_a_semicolon_arrives_whole.py` measures the builders byte for byte and
 `tests/test_a_launch_too_long_for_tmux_says_so.py` tmux's command limit. This file sends a
 brief through Task 1's own path — `first_message_argv`, the `Opening`, the launcher — and
-checks that it arrives whole, that the session's current window stays where it was (M3), and
-that a first message at charter's own bound still fits under tmux's limit with the identity a
-real launch carries.
+checks that it arrives whole, that a first message at charter's own bound still fits under
+tmux's limit with the identity a real launch carries, and that no window moves: once in a
+window too small for panels (M3), and once with the panels really split and real clients
+attached (:class:`ABackgroundChatWithItsPanelsMovesNoAttachedClient`).
 """
 
 from __future__ import annotations
@@ -30,29 +31,30 @@ import subprocess
 import sys
 import time
 import unittest
+from contextlib import ExitStack
 from unittest import mock
 
 from charter import commands_frame, config
-from charter.frame import state, tmuxctl
+from charter.frame import layout, state, tmuxctl
 from charter.harness import claude_code
 
 from tests import _tmuxreap
-from tests._isolation import PersonaIso, make_plane
+from tests._isolation import PersonaIso, make_plane, no_update_check_in
+from tests.test_a_real_click_on_a_real_tab_bar_switches import (_TERM_CANDIDATES, _await,
+                                                                 _fork_pty)
 
 _HAS_TMUX = shutil.which("tmux") is not None
 
 
-@unittest.skipUnless(_HAS_TMUX, "no tmux on this machine")
-class ABackgroundChatReallyStartsOnItsBrief(PersonaIso, unittest.TestCase):
+class _TwoChatsOnARealServer(PersonaIso):
+    """`alpha.1` and `beta.1`, each the first window of a real session on a private socket,
+    recorded on disk the way a launcher records them, and a recorder standing in for the
+    harness a background open starts."""
 
-    #: A brief that tmux's own parser and a shell would each mangle if charter joined, split
-    #: or failed to escape it: a trailing `;` (#957, carried through by #959's
-    #: `tmuxctl.verbatim`), a blank line, quotes, command substitution and a tmux format.
-    BRIEF = 'fix the widget;\n\nit says "$(echo boom)" and `x` at #{session_name};'
-
-    #: The calling chat's window — small enough that no panel is drawable, so no panel
-    #: process starts (asserted in `setUp` rather than assumed).
-    COLS, ROWS = 20, 6
+    #: The size each session starts at.
+    COLS, ROWS = 80, 24
+    #: This class's `tests._tmuxreap` slug.
+    SLUG = "handoff"
 
     def setUp(self):
         super().setUp()
@@ -61,7 +63,7 @@ class ABackgroundChatReallyStartsOnItsBrief(PersonaIso, unittest.TestCase):
             self.skipTest(f"the frame's floor is tmux {tmuxctl.FLOOR[0]}.{tmuxctl.FLOOR[1]};"
                           f" this machine has {v}")
         make_plane(self)
-        self.socket = _tmuxreap.name("handoff-argv")
+        self.socket = _tmuxreap.name(self.SLUG)
         self.enterContext(mock.patch.object(commands_frame, "SOCKET", self.socket))
         self.addCleanup(subprocess.run, ["tmux", "-L", self.socket, "kill-server"],
                         capture_output=True, timeout=20)
@@ -80,10 +82,11 @@ class ABackgroundChatReallyStartsOnItsBrief(PersonaIso, unittest.TestCase):
         self.recorder.chmod(0o755)
         server_env = dict(os.environ, RECORD_DIR=str(self.records),
                           CHARTER_ROOT=str(config.ROOT))
-        self.caller_pane = self._session("alpha", server_env)
-        self.target_pane = self._session("beta", server_env)
-        for fid, ws, pane in (("alpha.1", "alpha", self.caller_pane),
-                              ("beta.1", "beta", self.target_pane)):
+        #: Each workspace's recorded chat pane.
+        self.panes: dict[str, str] = {}
+        for ws in ("alpha", "beta"):
+            fid = f"{ws}.1"
+            pane = self._session(ws, server_env)
             (config.WORKSPACES_DIR / ws).mkdir(parents=True, exist_ok=True)
             state.frame_dir(fid, create=True)
             state.record_workspace(fid, ws)
@@ -94,9 +97,7 @@ class ABackgroundChatReallyStartsOnItsBrief(PersonaIso, unittest.TestCase):
             named = self._tmux("set-option", "-w", "-t", pane, commands_frame._CHAT_OPTION,
                                fid)
             self.assertEqual(named.returncode, 0, named.stderr)
-        self.assertEqual(commands_frame._window_size(self.socket, self.caller_pane),
-                         (self.COLS, self.ROWS))
-        self.assertEqual(commands_frame._drawable_slots(self.COLS, self.ROWS), [])
+            self.panes[ws] = pane
 
     def _tmux(self, *args: str, env=None) -> subprocess.CompletedProcess:
         return subprocess.run(["tmux", "-L", self.socket, *args], capture_output=True,
@@ -109,12 +110,18 @@ class ABackgroundChatReallyStartsOnItsBrief(PersonaIso, unittest.TestCase):
         self.assertEqual(started.returncode, 0, started.stderr)
         return started.stdout.strip()
 
-    def _open(self, text: str):
-        with mock.patch.object(claude_code.ClaudeCodeHarness, "binary", str(self.recorder)), \
-                mock.patch.object(commands_frame, "_spawn_gather"), \
-                mock.patch("sys.stdout.isatty", return_value=True), \
-                mock.patch("sys.stdin.isatty", return_value=False):
-            return commands_frame.open_in_background("beta", caller="alpha.1",
+    def _stand_ins(self) -> list:
+        """Everything an open runs with here beyond the real launcher and the real tmux."""
+        return [mock.patch.object(claude_code.ClaudeCodeHarness, "binary", str(self.recorder)),
+                mock.patch.object(commands_frame, "_spawn_gather"),
+                mock.patch("sys.stdout.isatty", return_value=True),
+                mock.patch("sys.stdin.isatty", return_value=False)]
+
+    def _open(self, text: str, *, ws: str = "beta"):
+        with ExitStack() as stack:
+            for stand_in in self._stand_ins():
+                stack.enter_context(stand_in)
+            return commands_frame.open_in_background(ws, caller="alpha.1",
                                                      first_message=text)
 
     def _received(self, pane: str) -> list[str]:
@@ -133,8 +140,28 @@ class ABackgroundChatReallyStartsOnItsBrief(PersonaIso, unittest.TestCase):
             time.sleep(0.05)
         self.fail(f"the harness in {pane} never recorded its argv")
 
+
+@unittest.skipUnless(_HAS_TMUX, "no tmux on this machine")
+class ABackgroundChatReallyStartsOnItsBrief(_TwoChatsOnARealServer, unittest.TestCase):
+
+    #: A brief that tmux's own parser and a shell would each mangle if charter joined, split
+    #: or failed to escape it: a trailing `;` (#957, carried through by #959's
+    #: `tmuxctl.verbatim`), a blank line, quotes, command substitution and a tmux format.
+    BRIEF = 'fix the widget;\n\nit says "$(echo boom)" and `x` at #{session_name};'
+
+    #: Small enough that no panel is drawable, so no panel process starts (asserted below
+    #: rather than assumed). The class after this one draws them.
+    COLS, ROWS = 20, 6
+    SLUG = "handoff-argv"
+
+    def setUp(self):
+        super().setUp()
+        self.assertEqual(commands_frame._window_size(self.socket, self.panes["alpha"]),
+                         (self.COLS, self.ROWS))
+        self.assertEqual(commands_frame._drawable_slots(self.COLS, self.ROWS), [])
+
     def test_opening_a_background_chat_leaves_the_sessions_current_window_where_it_was(self):
-        session = self._tmux("display-message", "-p", "-t", self.target_pane,
+        session = self._tmux("display-message", "-p", "-t", self.panes["beta"],
                              "#{session_id}").stdout.strip()
         before = self._tmux("display-message", "-p", "-t", session, "#{window_id}")
         self.assertEqual(before.returncode, 0, before.stderr)
@@ -158,6 +185,109 @@ class ABackgroundChatReallyStartsOnItsBrief(PersonaIso, unittest.TestCase):
         opened = self._open(text)
         self.assertTrue(opened.ok, opened.message)
         self.assertEqual(self._received(state.harness_pane(opened.chat)), [text])
+
+
+@unittest.skipUnless(_HAS_TMUX, "no tmux on this machine")
+class ABackgroundChatWithItsPanelsMovesNoAttachedClient(_TwoChatsOnARealServer,
+                                                        unittest.TestCase):
+    """Real panels and real attached clients: a background open moves nobody.
+
+    `docs/frame.md` promises both that no client moves and that the new window gets its
+    panels, and the panels are `split-window`s with no `-d` (`layout.panel_argvs`) — so a
+    window too small to draw any, as above, never asked the question. This one is big
+    enough that `_draw_panels` really splits, and one client is attached to each
+    workspace's session. Every client says where it is before and after an open into a
+    workspace somebody is looking at, and an open into the caller's own.
+
+    `layout.panel_command` is stood in with `sleep`: the splits are real, but no pane runs
+    `charter panel`, which would be a child charter this test cannot see, spending a version
+    check and a gather against whatever plane it resolves. Where no client will attach —
+    a runner with no usable terminal type — the class skips and says so.
+    """
+
+    COLS, ROWS = 120, 40
+    SLUG = "handoff-panels"
+
+    def setUp(self):
+        super().setUp()
+        no_update_check_in(config.ROOT)
+        #: The client attached to each workspace's session.
+        self.clients = {ws: self._attach(ws) for ws in ("alpha", "beta")}
+        size = commands_frame._window_size(self.socket, self.panes["alpha"])
+        self.slots = commands_frame._drawable_slots(*size)
+        self.assertTrue(self.slots, f"nothing is drawable at {size}, so no panel is split")
+
+    def _stand_ins(self) -> list:
+        return [*super()._stand_ins(),
+                mock.patch.object(layout, "panel_command", return_value=["sleep", "600"])]
+
+    def _attach(self, session: str) -> str:
+        """A real client on *session*, on a pty sized to the window, and its tmux name."""
+        refused = []
+        for term in _TERM_CANDIDATES:
+            pid, fd = _fork_pty(rows=self.ROWS, cols=self.COLS)
+            if pid == 0:
+                try:
+                    os.environ["TERM"] = term
+                    os.execvp("tmux", ["tmux", "-L", self.socket, "attach", "-t", session])
+                finally:
+                    os._exit(127)
+            self.addCleanup(self._reap, pid, fd)
+
+            def names():
+                return self._tmux("list-clients", "-t", session, "-F",
+                                  "#{client_name}").stdout.split()
+
+            if _await(lambda: bool(names()), timeout=10.0):
+                return names()[0]
+            refused.append(term)
+        self.skipTest("no tmux client will attach on this machine — tried TERM="
+                      + ", ".join(refused))
+
+    @staticmethod
+    def _reap(pid: int, fd: int) -> None:
+        """The client this case forked, and only that pid."""
+        for step in (lambda: os.kill(pid, 9), lambda: os.waitpid(pid, 0),
+                     lambda: os.close(fd)):
+            try:
+                step()
+            except OSError:
+                pass
+
+    def _views(self) -> dict[str, list[str]]:
+        """Each attached client's ``[session, current window, active pane]``, by client name.
+
+        Asked of `list-clients`, never `display-message -c <client>`. Measured with two real
+        clients: on tmux 3.7c `display-message -c` answers the server's current session for
+        every client alike, and at the 3.2 floor it fails with rc 1 — neither says where one
+        client is looking. `list-clients` reports each client's own, on both, and follows a
+        `select-window` that moves it."""
+        listed = self._tmux("list-clients", "-F",
+                            "#{client_name}\t#{session_name}\t#{window_id}\t#{pane_id}")
+        rows = [row.split("\t") for row in listed.stdout.splitlines() if row]
+        return {row[0]: row[1:] for row in rows}
+
+    def _open_moves_no_client(self, ws: str) -> None:
+        before = self._views()
+        for name, client in self.clients.items():
+            view = before.get(client, [])
+            self.assertEqual([view[0], view[2]] if len(view) == 3 else view,
+                             [name, self.panes[name]],
+                             f"the client on {name!r} is not on its own chat: {view!r}")
+        opened = self._open("look at the widget please", ws=ws)
+        self.assertTrue(opened.ok, opened.message)
+        drawn = self._tmux("list-panes", "-t", state.harness_pane(opened.chat), "-F",
+                           "#{pane_id}").stdout.split()
+        self.assertEqual(len(drawn), 1 + len(self.slots),
+                         f"the new chat's panels were not split, so this measured nothing "
+                         f"about them: {drawn}")
+        self.assertEqual(self._views(), before, "a background open moved an attached client")
+
+    def test_an_open_into_a_workspace_somebody_is_looking_at_moves_no_client(self):
+        self._open_moves_no_client("beta")
+
+    def test_an_open_into_the_callers_own_workspace_moves_no_client(self):
+        self._open_moves_no_client("alpha")
 
 
 if __name__ == "__main__":

--- a/tests/test_a_background_chat_really_starts_on_its_brief.py
+++ b/tests/test_a_background_chat_really_starts_on_its_brief.py
@@ -12,6 +12,14 @@ it was started with and then stays alive — so the launch goes all the way thro
 spend a gather on whatever plane its copied environment resolves. What is asked here is what
 tmux does, not what the gather writes.
 
+**One tmux server per case, never one per class.** Both cases of a class used to share a
+socket name, and on CI (pull_request run 34559973556, tmux 3.4) the second case's first
+`new-session` came 7 ms after the first case's `kill-server` and failed with `server exited
+unexpectedly`: the old server, already told to exit, was still accepting on that socket. The
+other real-tmux modules draw a fresh name per case from a counter for the same reason. And a
+session that tmux will not start fails with tmux's own account of why (:meth:`_diagnosis`),
+so a flake on a runner nobody can log into names its cause instead of just its symptom.
+
 **What the #959 tests already hold, and what this adds.** `tests/test_a_harness_argument_ending_
 in_a_semicolon_arrives_whole.py` measures the builders byte for byte and
 `tests/test_a_launch_too_long_for_tmux_says_so.py` tmux's command limit. This file sends a
@@ -24,11 +32,15 @@ attached (:class:`ABackgroundChatWithItsPanelsMovesNoAttachedClient`).
 
 from __future__ import annotations
 
+import fcntl
+import itertools
 import json
 import os
 import shutil
+import struct
 import subprocess
 import sys
+import termios
 import time
 import unittest
 from contextlib import ExitStack
@@ -38,12 +50,29 @@ from charter import commands_frame, config
 from charter.frame import layout, state, tmuxctl
 from charter.harness import claude_code
 
-from tests import _tmuxreap
+from tests import _tmuxreap, _tmuxsocket
 from tests._isolation import PersonaIso, make_plane, no_update_check_in
-from tests.test_a_real_click_on_a_real_tab_bar_switches import (_TERM_CANDIDATES, _await,
-                                                                 _fork_pty)
 
 _HAS_TMUX = shutil.which("tmux") is not None
+
+#: A fresh number for every case's socket name — see the module docstring for the CI run that
+#: showed why a name must not outlive its case.
+_SERVERS = itertools.count()
+
+#: Terminal types to hand an attached client, the list
+#: `tests/test_a_real_click_on_a_real_tab_bar_switches.py` keeps.
+_TERM_CANDIDATES = tuple(dict.fromkeys(
+    ([os.environ["TERM"]] if os.environ.get("TERM", "dumb") != "dumb" else [])
+    + ["xterm-256color", "screen", "vt100"]))
+
+
+def _await(predicate, timeout: float) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(0.05)
+    return predicate()
 
 
 class _TwoChatsOnARealServer(PersonaIso):
@@ -53,7 +82,7 @@ class _TwoChatsOnARealServer(PersonaIso):
 
     #: The size each session starts at.
     COLS, ROWS = 80, 24
-    #: This class's `tests._tmuxreap` slug.
+    #: This class's `tests._tmuxreap` slug, numbered per case.
     SLUG = "handoff"
 
     def setUp(self):
@@ -63,10 +92,13 @@ class _TwoChatsOnARealServer(PersonaIso):
             self.skipTest(f"the frame's floor is tmux {tmuxctl.FLOOR[0]}.{tmuxctl.FLOOR[1]};"
                           f" this machine has {v}")
         make_plane(self)
-        self.socket = _tmuxreap.name(self.SLUG)
+        self.socket = _tmuxreap.name(f"{self.SLUG}-{next(_SERVERS)}")
         self.enterContext(mock.patch.object(commands_frame, "SOCKET", self.socket))
         self.addCleanup(subprocess.run, ["tmux", "-L", self.socket, "kill-server"],
                         capture_output=True, timeout=20)
+        #: Where the server this case starts writes its `-v` log, read only on a failure.
+        self.tmux_logs = self.tmp / "tmux-logs"
+        self.tmux_logs.mkdir()
         self.records = self.tmp / "records"
         self.records.mkdir()
         self.recorder = self.tmp / "claude-recorder"
@@ -104,11 +136,35 @@ class _TwoChatsOnARealServer(PersonaIso):
                               text=True, timeout=20, env=env)
 
     def _session(self, name: str, env: dict) -> str:
-        started = self._tmux("-f", "/dev/null", "new-session", "-d", "-s", name,
-                             "-x", str(self.COLS), "-y", str(self.ROWS),
-                             "-P", "-F", "#{pane_id}", "--", "sleep", "600", env=env)
-        self.assertEqual(started.returncode, 0, started.stderr)
+        """A session running `sleep`, its first pane's id — or a failure naming tmux's cause.
+
+        `-v` so the server this starts keeps a log, run from :attr:`tmux_logs` because that
+        is where tmux writes it; read only when something went wrong."""
+        argv = ["tmux", "-v", "-L", self.socket, "-f", "/dev/null", "new-session", "-d",
+                "-s", name, "-x", str(self.COLS), "-y", str(self.ROWS),
+                "-P", "-F", "#{pane_id}", "--", "sleep", "600"]
+        existed = os.path.exists(_tmuxsocket.socket_path(self.socket))
+        started = subprocess.run(argv, capture_output=True, text=True, timeout=20, env=env,
+                                 cwd=self.tmux_logs)
+        if started.returncode != 0:
+            self.fail(self._diagnosis(started, argv, env, socket_existed=existed))
         return started.stdout.strip()
+
+    def _diagnosis(self, done: subprocess.CompletedProcess, argv: list[str], env: dict,
+                   *, socket_existed: bool) -> str:
+        """Everything a failed session start on a runner nobody can log into needs to say."""
+        named = {k: env.get(k) for k in ("TERM", "SHELL", "HOME", "TMUX_TMPDIR", "LANG",
+                                         "LC_ALL", "PATH")}
+        version = subprocess.run(["tmux", "-V"], capture_output=True, text=True).stdout.strip()
+        logs = []
+        for log in sorted(self.tmux_logs.glob("tmux-*.log")):
+            lines = log.read_text(errors="replace").splitlines()
+            logs.append(f"--- {log.name}, last 40 of {len(lines)} lines\n"
+                        + "\n".join(lines[-40:]))
+        return (f"tmux would not start a session: rc {done.returncode}, stderr "
+                f"{done.stderr.strip()!r}\n{version}\nargv: {argv}\n"
+                f"socket {_tmuxsocket.socket_path(self.socket)} existed before the call: "
+                f"{socket_existed}\nenv: {named}\n" + ("\n".join(logs) or "no tmux log"))
 
     def _stand_ins(self) -> list:
         """Everything an open runs with here beyond the real launcher and the real tmux."""
@@ -195,14 +251,18 @@ class ABackgroundChatWithItsPanelsMovesNoAttachedClient(_TwoChatsOnARealServer,
     `docs/frame.md` promises both that no client moves and that the new window gets its
     panels, and the panels are `split-window`s with no `-d` (`layout.panel_argvs`) — so a
     window too small to draw any, as above, never asked the question. This one is big
-    enough that `_draw_panels` really splits, and one client is attached to each
-    workspace's session. Every client says where it is before and after an open into a
-    workspace somebody is looking at, and an open into the caller's own.
+    enough that `_draw_panels` really splits.
+
+    Two views are compared before and after an open into a workspace somebody is looking
+    at, and an open into the caller's own. **Every session's current window and that
+    window's active pane**, which is what any client of the session is shown and which needs
+    no client to ask. **Every attached client's own view**, from a real client on each
+    workspace's session; where no client will attach on a machine, that half is a skipped
+    subtest naming the terminal types tried, and the first half has still run.
 
     `layout.panel_command` is stood in with `sleep`: the splits are real, but no pane runs
     `charter panel`, which would be a child charter this test cannot see, spending a version
-    check and a gather against whatever plane it resolves. Where no client will attach —
-    a runner with no usable terminal type — the class skips and says so.
+    check and a gather against whatever plane it resolves.
     """
 
     COLS, ROWS = 120, 40
@@ -211,8 +271,14 @@ class ABackgroundChatWithItsPanelsMovesNoAttachedClient(_TwoChatsOnARealServer,
     def setUp(self):
         super().setUp()
         no_update_check_in(config.ROOT)
-        #: The client attached to each workspace's session.
-        self.clients = {ws: self._attach(ws) for ws in ("alpha", "beta")}
+        #: The terminal types a client would not attach with, for the skip that says so.
+        self.unattached: list[str] = []
+        #: The client attached to each workspace's session, where one would attach.
+        self.clients: dict[str, str] = {}
+        for ws in ("alpha", "beta"):
+            client = self._attach(ws)
+            if client is not None:
+                self.clients[ws] = client
         size = commands_frame._window_size(self.socket, self.panes["alpha"])
         self.slots = commands_frame._drawable_slots(*size)
         self.assertTrue(self.slots, f"nothing is drawable at {size}, so no panel is split")
@@ -221,38 +287,54 @@ class ABackgroundChatWithItsPanelsMovesNoAttachedClient(_TwoChatsOnARealServer,
         return [*super()._stand_ins(),
                 mock.patch.object(layout, "panel_command", return_value=["sleep", "600"])]
 
-    def _attach(self, session: str) -> str:
-        """A real client on *session*, on a pty sized to the window, and its tmux name."""
-        refused = []
+    def _client_names(self, session: str) -> list[str]:
+        return self._tmux("list-clients", "-t", session, "-F", "#{client_name}").stdout.split()
+
+    def _attach(self, session: str) -> str | None:
+        """A real client on *session*, on a pty sized to the window, and its tmux name — or
+        ``None`` where no terminal type would attach.
+
+        Started through `subprocess.Popen` with the pty as its three streams, and not as a
+        `pty.fork` child that `os.execvp`s: `tests/test_plane_spawn_guard.py` watches `Popen`
+        and requires every exec-family call in the tree to be one it has written down. The
+        client needs no controlling terminal — tmux's server opens the client's tty by name —
+        measured attaching this way on tmux 3.7c and 3.2 on macOS and 3.4 on Linux."""
         for term in _TERM_CANDIDATES:
-            pid, fd = _fork_pty(rows=self.ROWS, cols=self.COLS)
-            if pid == 0:
-                try:
-                    os.environ["TERM"] = term
-                    os.execvp("tmux", ["tmux", "-L", self.socket, "attach", "-t", session])
-                finally:
-                    os._exit(127)
-            self.addCleanup(self._reap, pid, fd)
-
-            def names():
-                return self._tmux("list-clients", "-t", session, "-F",
-                                  "#{client_name}").stdout.split()
-
-            if _await(lambda: bool(names()), timeout=10.0):
-                return names()[0]
-            refused.append(term)
-        self.skipTest("no tmux client will attach on this machine — tried TERM="
-                      + ", ".join(refused))
+            master, slave = os.openpty()
+            fcntl.ioctl(slave, termios.TIOCSWINSZ,
+                        struct.pack("HHHH", self.ROWS, self.COLS, 0, 0))
+            client = subprocess.Popen(["tmux", "-L", self.socket, "attach", "-t", session],
+                                      stdin=slave, stdout=slave, stderr=slave,
+                                      env=dict(os.environ, TERM=term),
+                                      start_new_session=True)
+            os.close(slave)
+            self.addCleanup(self._reap, client, master)
+            if _await(lambda: bool(self._client_names(session)), timeout=10.0):
+                return self._client_names(session)[0]
+            self.unattached.append(term)
+        return None
 
     @staticmethod
-    def _reap(pid: int, fd: int) -> None:
-        """The client this case forked, and only that pid."""
-        for step in (lambda: os.kill(pid, 9), lambda: os.waitpid(pid, 0),
-                     lambda: os.close(fd)):
+    def _reap(client: subprocess.Popen, master: int) -> None:
+        """The client this case started, by the handle that started it."""
+        for step in (client.kill, lambda: client.wait(timeout=10), lambda: os.close(master)):
             try:
                 step()
-            except OSError:
+            except (OSError, subprocess.TimeoutExpired):
                 pass
+
+    def _current(self) -> dict[str, list[str]]:
+        """Each session's ``[current window, its active pane]`` — what any client of it is
+        shown, attached or not."""
+        listed = self._tmux("list-panes", "-a", "-F",
+                            "#{session_name}\t#{window_active}\t#{pane_active}\t"
+                            "#{window_id}\t#{pane_id}")
+        current = {}
+        for row in listed.stdout.splitlines():
+            session, window_active, pane_active, window, pane = row.split("\t")
+            if window_active == "1" and pane_active == "1":
+                current[session] = [window, pane]
+        return current
 
     def _views(self) -> dict[str, list[str]]:
         """Each attached client's ``[session, current window, active pane]``, by client name.
@@ -268,12 +350,10 @@ class ABackgroundChatWithItsPanelsMovesNoAttachedClient(_TwoChatsOnARealServer,
         return {row[0]: row[1:] for row in rows}
 
     def _open_moves_no_client(self, ws: str) -> None:
-        before = self._views()
-        for name, client in self.clients.items():
-            view = before.get(client, [])
-            self.assertEqual([view[0], view[2]] if len(view) == 3 else view,
-                             [name, self.panes[name]],
-                             f"the client on {name!r} is not on its own chat: {view!r}")
+        sessions_before = self._current()
+        self.assertEqual({name: view[1] for name, view in sessions_before.items()},
+                         self.panes, f"a session is not on its own chat: {sessions_before}")
+        clients_before = self._views()
         opened = self._open("look at the widget please", ws=ws)
         self.assertTrue(opened.ok, opened.message)
         drawn = self._tmux("list-panes", "-t", state.harness_pane(opened.chat), "-F",
@@ -281,7 +361,20 @@ class ABackgroundChatWithItsPanelsMovesNoAttachedClient(_TwoChatsOnARealServer,
         self.assertEqual(len(drawn), 1 + len(self.slots),
                          f"the new chat's panels were not split, so this measured nothing "
                          f"about them: {drawn}")
-        self.assertEqual(self._views(), before, "a background open moved an attached client")
+        self.assertEqual(self._current(), sessions_before,
+                         "a background open moved a session's current window or pane")
+        with self.subTest(view="attached clients"):
+            if sorted(self.clients) != ["alpha", "beta"]:
+                self.skipTest(f"no real client would attach on this machine with TERM "
+                              f"{self.unattached}; each session's current window and pane "
+                              f"were still compared above")
+            for name, client in self.clients.items():
+                view = clients_before.get(client, [])
+                self.assertEqual([view[0], view[2]] if len(view) == 3 else view,
+                                 [name, self.panes[name]],
+                                 f"the client on {name!r} is not on its own chat: {view!r}")
+            self.assertEqual(self._views(), clients_before,
+                             "a background open moved an attached client")
 
     def test_an_open_into_a_workspace_somebody_is_looking_at_moves_no_client(self):
         self._open_moves_no_client("beta")

--- a/tests/test_a_chat_opens_in_the_background_with_its_first_message.py
+++ b/tests/test_a_chat_opens_in_the_background_with_its_first_message.py
@@ -73,8 +73,11 @@ class _AChatInAlpha(PersonaIso, unittest.TestCase):
         self.records_pane = True
         self.launched: list = []
         self.seen: list[dict] = []
+        #: Every tmux command the open asked, in order.
+        self.calls: list[list[str]] = []
 
     def _tmux(self, cmd, **kw):
+        self.calls.append(list(cmd))
         if "display-message" in cmd:
             if "window_width" in cmd[-1]:
                 return _completed(cmd, 0, "132:43")
@@ -146,6 +149,46 @@ class TheOpenRunsTheLauncherForTheNamedWorkspace(_AChatInAlpha):
         self._open()
         self.assertEqual(self.launched[0].size, (132, 43))
 
+    def test_a_caller_with_no_recorded_pane_is_sized_off_the_target_workspaces_live_chat(self):
+        """`cmd_new_chat`'s second reading: with the calling chat's own pane not on record,
+        the window is measured off the pane `_plane_session` proves is live in the target."""
+        (state.frame_dir(self.CALLER) / "harness").unlink()
+        self.beta_seat = "%5"
+        _a_chat("beta.2", ws="beta", pane="%5")
+        self.sessions = {"beta"}
+        self._open()
+        self.assertEqual(self.launched[0].size, (132, 43))
+        self.assertEqual([c[c.index("-t") + 1] for c in self.calls if "display-message" in c],
+                         ["%5"])
+
+    def test_with_no_pane_to_measure_it_aims_no_target_and_hands_no_size(self):
+        """Neither pane is on record, so no `-t` is aimed at all — an empty target resolves
+        to the tmux server's CURRENT window, very likely another plane's — and the launcher
+        is handed ``None``, which `_launch_size` reads as "measure your own terminal"."""
+        (state.frame_dir(self.CALLER) / "harness").unlink()
+        self._open()
+        self.assertIsNone(self.launched[0].size)
+        self.assertEqual([c for c in self.calls if "display-message" in c], [])
+
+    def test_a_directory_it_cannot_return_to_does_not_lose_the_chat_it_opened(self):
+        """The launch ran in the target's directory, and this process could not change back
+        (the directory it started in was removed meanwhile, say). The chat is open, and
+        reporting that it is not would be the one wrong answer left — `cmd_new_chat`'s own
+        arrangement."""
+        was = os.getcwd()
+        self.addCleanup(os.chdir, was)
+        real = os.chdir
+        target = os.path.realpath(workspace.workspace_dir("beta"))
+
+        def chdir(path):
+            if os.path.realpath(path) != target:
+                raise OSError("the directory it started in is gone")
+            return real(path)
+
+        with mock.patch("charter.commands_frame.os.chdir", side_effect=chdir):
+            got = self._open()
+        self.assertEqual(got, commands_frame.Opened(True, "beta.1", ""))
+
     def test_the_launch_runs_in_the_target_workspaces_own_directory(self):
         was = os.getcwd()
         self._open()
@@ -188,6 +231,16 @@ class EveryRefusalComesBeforeAnythingStarts(_AChatInAlpha):
         self.assertIn("single word 'login'", got.message)
         self.assertEqual(self.launched, [])
 
+    def test_a_single_word_is_named_without_the_whitespace_around_it(self):
+        self.assertIn("single word 'login'", self._refusal(text="  login\n"))
+
+    def test_the_word_it_names_cannot_forge_a_line_or_a_colour(self):
+        """The word is the caller's own text, echoed into a sentence an operator reads, so
+        an escape sequence in it arrives escaped (`contain.one_line`)."""
+        said = self._refusal(text="log\x1b[31min")
+        self.assertNotIn("\x1b", said)
+        self.assertIn("log\\x1b[31min", said)
+
     def test_a_nul_byte_is_refused(self):
         got = self._open(text="fix\x00 it")
         self.assertIn("NUL byte", got.message)
@@ -208,6 +261,15 @@ class EveryRefusalComesBeforeAnythingStarts(_AChatInAlpha):
         got = self._open(text=text)
         self.assertIs(got.ok, True, got.message)
         self.assertEqual(len(self.launched), 1)
+
+    def test_the_bound_is_the_ruled_twelve_thousand_two_hundred_and_eighty_eight_bytes(self):
+        """The ruled number, spelled by hand rather than read off the constant. Every other
+        case here reads `FIRST_MESSAGE_MAX_BYTES` and follows whatever value it holds — the
+        deletion sweep retuned it and they all stayed green — while `docs/frame.md` and the
+        refusal promise 12,288."""
+        taken = self._open(text="x" * 12286 + " y")
+        self.assertIs(taken.ok, True, taken.message)
+        self.assertIn("12289-byte", self._refusal(text="x" * 12287 + " y"))
 
     def test_a_first_message_is_measured_in_bytes_not_characters(self):
         bound = commands_frame.FIRST_MESSAGE_MAX_BYTES
@@ -280,6 +342,16 @@ class EveryRefusalComesBeforeAnythingStarts(_AChatInAlpha):
         """The chat id is the only proof a chat exists; a 0 without one proves nothing."""
         self.gives_back = ""
         self.assertIs(self._open().ok, False)
+
+    def test_a_chat_whose_harness_died_on_start_is_not_success(self):
+        """`_launch` records the harness pane the moment tmux reports one; a harness that
+        then dies in its first moments leaves that record behind while the launcher returns
+        its exit code (the early-death path). A recorded pane proves a chat was started, not
+        that it is running, so the return code is asked as well."""
+        self.rc = 1
+        got = self._open()
+        self.assertIs(got.ok, False)
+        self.assertIn("returned 1", got.message)
 
     def test_a_chat_id_with_no_harness_pane_is_not_success(self):
         self.records_pane = False

--- a/tests/test_a_chat_opens_in_the_background_with_its_first_message.py
+++ b/tests/test_a_chat_opens_in_the_background_with_its_first_message.py
@@ -1,0 +1,417 @@
+"""A chat opens in a named workspace in the background, already told its first message.
+
+This is the seam `charter handoff` (chat-handoff plan, Task 2) drives: `open_in_background`
+runs the ordinary launcher — `cmd_launch` with `attach=False`, the `_open_workspace` and
+`cmd_new_chat` precedent — carrying an `Opening`, `Reopening`'s sibling for a chat nobody
+attaches to. Three promises, each pinned here:
+
+* **Everything it refuses, it refuses before it starts anything** (`background_refusal`), so
+  Task 2 can ask the same question before any write of its own.
+* **Nobody moves.** The new window is not selected and the chat the operator is on keeps its
+  panels; nothing attaches.
+* **A pin the CALLING chat carries does not reach the new one.** #936 made a framed chat's
+  launch record its workspace lock, but only for an unpinned launcher: a non-empty
+  `$CHARTER_WORKSPACE` in the launching process wins that rung instead. The calling chat is
+  another chat, so its pins are emptied for the length of the launch and put back exactly.
+
+Real tmux — that the window really does not move, and that the whole message arrives — is
+`tests/test_a_background_chat_really_starts_on_its_brief.py`.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import unittest
+from types import SimpleNamespace
+from unittest import mock
+
+from charter import commands_frame, config, persona, workspace
+from charter.frame import state
+from charter.harness import claude_code
+
+from tests import _tmuxsocket
+from tests._isolation import PersonaIso
+
+
+def _completed(cmd, rc=0, out=""):
+    return subprocess.CompletedProcess(list(cmd), rc, out, "")
+
+
+def _a_chat(fid: str, *, ws: str, pane: str | None = "%1", harness: str = "claude-code",
+            socket: str | None = None) -> None:
+    """A chat directory on THIS plane, in the shape a launcher leaves one — the same helper
+    `tests/test_the_chat_bars_plus_makes_a_chat.py` keeps, for the same reason."""
+    state.frame_dir(fid, create=True)
+    state.record_workspace(fid, ws)
+    state.record_server(fid, socket or commands_frame.SOCKET)
+    state.record_identity(fid, {"CHARTER_HARNESS": harness})
+    if pane is not None:
+        state.record_harness_pane(fid, pane)
+
+
+class _AChatInAlpha(PersonaIso, unittest.TestCase):
+    """`alpha.1` on charter's own server, a `beta` workspace on disk, a stand-in tmux and a
+    stand-in launcher that records how it was called and what it could see."""
+
+    CALLER = "alpha.1"
+
+    def setUp(self):
+        super().setUp()
+        self.enterContext(mock.patch.dict(os.environ, {}, clear=True))
+        for ws in ("alpha", "beta"):
+            (config.WORKSPACES_DIR / ws).mkdir(parents=True, exist_ok=True)
+        _a_chat(self.CALLER, ws="alpha")
+        #: Session names `list-sessions` reports.
+        self.sessions: set[str] = set()
+        #: A live `beta` harness pane `list-panes` reports as this plane's, or ``None``.
+        self.beta_seat: str | None = None
+        #: What the stand-in launcher returns, which chat it says it made, and whether that
+        #: chat recorded a harness pane.
+        self.rc = 0
+        self.gives_back = "beta.1"
+        self.records_pane = True
+        self.launched: list = []
+        self.seen: list[dict] = []
+
+    def _tmux(self, cmd, **kw):
+        if "display-message" in cmd:
+            if "window_width" in cmd[-1]:
+                return _completed(cmd, 0, "132:43")
+            return _completed(cmd, 0, "$1\t@1")
+        if "list-panes" in cmd:
+            rows = [f"$1\t%1\t{config.STATE_DIR}"]
+            if self.beta_seat:
+                rows.append(f"$2\t{self.beta_seat}\t{config.STATE_DIR}")
+            return _completed(cmd, 0, "".join(r + "\n" for r in rows))
+        if "list-sessions" in cmd:
+            return _completed(cmd, 0, "".join(s + "\n" for s in sorted(self.sessions)))
+        return _completed(cmd, 0)
+
+    def _fake_launch(self, args):
+        self.launched.append(args)
+        self.seen.append({"cwd": os.getcwd(),
+                          "CHARTER_WORKSPACE": os.environ.get("CHARTER_WORKSPACE"),
+                          "CHARTER_PERSONA": os.environ.get("CHARTER_PERSONA")})
+        if self.gives_back:
+            _a_chat(self.gives_back, ws="beta", pane="%9" if self.records_pane else None)
+            args.opening.fid = self.gives_back
+        return self.rc
+
+    def _open(self, ws="beta", text="fix the widget please", persona=""):
+        with mock.patch("charter.commands_frame.subprocess.run", side_effect=self._tmux), \
+                mock.patch("charter.commands_frame.cmd_launch",
+                           side_effect=self._fake_launch):
+            return commands_frame.open_in_background(ws, caller=self.CALLER,
+                                                     first_message=text, persona=persona)
+
+    def _refusal(self, ws="beta", text="fix the widget please"):
+        with mock.patch("charter.commands_frame.subprocess.run", side_effect=self._tmux):
+            return commands_frame.background_refusal(ws, caller=self.CALLER,
+                                                     first_message=text)
+
+
+class TheOpenRunsTheLauncherForTheNamedWorkspace(_AChatInAlpha):
+
+    def test_the_launch_names_the_workspace_and_never_attaches(self):
+        self._open()
+        self.assertEqual(len(self.launched), 1)
+        launched = self.launched[0]
+        self.assertEqual(launched.workspace, "beta")
+        self.assertIs(launched.attach, False)
+        self.assertIs(launched.pick, False)
+        self.assertIs(launched.no_frame, False)
+
+    def test_the_first_message_rides_the_harnesses_own_argv(self):
+        for name, rest in (("claude-code", ["fix the widget please"]),
+                           ("opencode", ["--prompt", "fix the widget please"]),
+                           ("codex", ["fix the widget please"])):
+            with self.subTest(harness=name):
+                self.launched.clear()
+                state.record_identity(self.CALLER, {"CHARTER_HARNESS": name})
+                self._open()
+                self.assertEqual(self.launched[0].rest, rest)
+
+    def test_the_opening_carries_the_new_chat_id_back(self):
+        self.assertEqual(self._open(), commands_frame.Opened(True, "beta.1", ""))
+
+    def test_the_opening_carries_the_message_and_the_persona_it_was_given(self):
+        self._open(text="fix the widget please", persona="forge")
+        opening = self.launched[0].opening
+        self.assertIsInstance(opening, commands_frame.Opening)
+        self.assertEqual(opening.first_message, "fix the widget please")
+        self.assertEqual(opening.persona, "forge")
+
+    def test_it_is_sized_for_the_window_the_calling_chat_is_on(self):
+        self._open()
+        self.assertEqual(self.launched[0].size, (132, 43))
+
+    def test_the_launch_runs_in_the_target_workspaces_own_directory(self):
+        was = os.getcwd()
+        self._open()
+        self.assertEqual(os.path.realpath(self.seen[0]["cwd"]),
+                         os.path.realpath(workspace.workspace_dir("beta")))
+        self.assertEqual(os.getcwd(), was)
+
+    def test_a_pin_the_calling_chat_carries_does_not_reach_the_new_chat(self):
+        with mock.patch.dict(os.environ, {"CHARTER_WORKSPACE": "alpha",
+                                          "CHARTER_PERSONA": "forge"}):
+            self._open()
+            self.assertEqual(self.seen[0]["CHARTER_WORKSPACE"], "")
+            self.assertEqual(self.seen[0]["CHARTER_PERSONA"], "")
+            self.assertEqual(os.environ["CHARTER_WORKSPACE"], "alpha")
+            self.assertEqual(os.environ["CHARTER_PERSONA"], "forge")
+
+    def test_a_name_the_calling_chat_did_not_have_is_absent_again_afterwards(self):
+        self._open()
+        self.assertEqual(self.seen[0]["CHARTER_WORKSPACE"], "")
+        self.assertEqual(self.seen[0]["CHARTER_PERSONA"], "")
+        self.assertNotIn("CHARTER_WORKSPACE", os.environ)
+        self.assertNotIn("CHARTER_PERSONA", os.environ)
+
+
+class EveryRefusalComesBeforeAnythingStarts(_AChatInAlpha):
+
+    def test_an_empty_first_message_is_refused(self):
+        got = self._open(text="  \n")
+        self.assertIs(got.ok, False)
+        self.assertIn("empty first message", got.message)
+        self.assertEqual(self.launched, [])
+
+    def test_a_first_message_starting_with_a_dash_is_refused(self):
+        got = self._open(text="--dangerously-skip-permissions now")
+        self.assertIn("starts with `-`", got.message)
+        self.assertEqual(self.launched, [])
+
+    def test_a_single_word_first_message_is_refused(self):
+        got = self._open(text="login")
+        self.assertIn("single word 'login'", got.message)
+        self.assertEqual(self.launched, [])
+
+    def test_a_nul_byte_is_refused(self):
+        got = self._open(text="fix\x00 it")
+        self.assertIn("NUL byte", got.message)
+        self.assertEqual(self.launched, [])
+
+    def test_a_first_message_past_the_bound_is_refused(self):
+        bound = commands_frame.FIRST_MESSAGE_MAX_BYTES
+        got = self._open(text="x " * (bound // 2 + 1))
+        self.assertIn("past", got.message)
+        self.assertIn(str(bound), got.message)
+        self.assertEqual(self.launched, [])
+
+    def test_a_first_message_exactly_at_the_bound_is_taken(self):
+        """Pins `>` against `>=`."""
+        bound = commands_frame.FIRST_MESSAGE_MAX_BYTES
+        text = "x" * (bound - 2) + " y"
+        self.assertEqual(len(text.encode()), bound)
+        got = self._open(text=text)
+        self.assertIs(got.ok, True, got.message)
+        self.assertEqual(len(self.launched), 1)
+
+    def test_a_first_message_is_measured_in_bytes_not_characters(self):
+        bound = commands_frame.FIRST_MESSAGE_MAX_BYTES
+        text = "é " * (bound // 3 + 1)
+        self.assertLess(len(text), bound)
+        got = self._open(text=text)
+        self.assertIs(got.ok, False)
+        self.assertEqual(self.launched, [])
+
+    def test_a_byte_that_is_not_utf8_is_counted_not_crashed_on(self):
+        """A first message can carry a surrogate escape (a byte that is not UTF-8, as
+        `sys.argv` or a surrogateescape stdin hands it over). The bound counts the bytes
+        `exec` is handed; a strict `str.encode` would raise instead of answering (#959)."""
+        self.assertEqual(self._refusal(text="fix \udcff it"), "")
+
+    def test_a_chat_in_a_tmux_you_already_had_is_refused(self):
+        state.record_server(self.CALLER, _tmuxsocket.OPERATOR_SOCKET)
+        got = self._open()
+        self.assertIn("a tmux you already had", got.message)
+        self.assertEqual(self.launched, [])
+
+    def test_a_chat_with_no_launchable_harness_is_refused(self):
+        state.record_identity(self.CALLER, {"CHARTER_HARNESS": ""})
+        with mock.patch.object(config, "HARNESS", None):
+            got = self._open()
+        self.assertIn(commands_frame.NO_HARNESS, got.message)
+        self.assertEqual(self.launched, [])
+
+    def test_a_harness_charter_has_not_measured_is_refused(self):
+        with mock.patch.object(claude_code.ClaudeCodeHarness, "first_message_argv",
+                               return_value=None):
+            got = self._open()
+        self.assertIn("has not measured how claude-code", got.message)
+        self.assertEqual(self.launched, [])
+
+    def test_a_session_this_plane_cannot_prove_is_its_own_is_refused(self):
+        self.sessions = {"beta"}
+        got = self._open()
+        self.assertIn("probably another plane's", got.message)
+        self.assertEqual(self.launched, [])
+
+    def test_a_session_this_plane_can_prove_is_its_own_is_joined(self):
+        self.beta_seat = "%5"
+        _a_chat("beta.2", ws="beta", pane="%5")
+        self.sessions = {"beta"}
+        got = self._open()
+        self.assertIs(got.ok, True, got.message)
+
+    def test_a_workspace_directory_charter_cannot_enter_is_refused(self):
+        real = os.chdir
+        target = os.path.realpath(workspace.workspace_dir("beta"))
+
+        def chdir(path):
+            if os.path.realpath(path) == target:
+                raise OSError("permission denied")
+            return real(path)
+
+        with mock.patch("charter.commands_frame.os.chdir", side_effect=chdir):
+            got = self._open()
+        self.assertIn("cannot enter its directory", got.message)
+        self.assertEqual(self.launched, [])
+
+    def test_a_launcher_that_fails_is_said(self):
+        self.rc, self.gives_back = 1, ""
+        got = self._open()
+        self.assertIs(got.ok, False)
+        self.assertIn("returned 1", got.message)
+
+    def test_a_launcher_that_answers_zero_with_no_chat_is_not_success(self):
+        """The chat id is the only proof a chat exists; a 0 without one proves nothing."""
+        self.gives_back = ""
+        self.assertIs(self._open().ok, False)
+
+    def test_a_chat_id_with_no_harness_pane_is_not_success(self):
+        self.records_pane = False
+        self.assertIs(self._open().ok, False)
+
+    def test_the_refusal_check_writes_nothing(self):
+        """Task 2 asks this before any write of its own, so it must make none itself."""
+        self.sessions = {"beta"}
+
+        def listings():
+            return (sorted(os.listdir(state._root())),
+                    {ws: sorted(os.listdir(config.WORKSPACES_DIR / ws))
+                     for ws in sorted(os.listdir(config.WORKSPACES_DIR))})
+
+        before = listings()
+        self.assertIn("probably another plane's", self._refusal())
+        self.assertEqual(listings(), before)
+
+    def test_each_refusal_says_a_different_thing(self):
+        bound = commands_frame.FIRST_MESSAGE_MAX_BYTES
+        said = [self._refusal(text=t) for t in (
+            "  \n", "--dangerously-skip-permissions now", "login", "fix\x00 it",
+            "x " * (bound // 2 + 1))]
+        state.record_server(self.CALLER, _tmuxsocket.OPERATOR_SOCKET)
+        said.append(self._refusal())
+        state.record_server(self.CALLER, commands_frame.SOCKET)
+        state.record_identity(self.CALLER, {"CHARTER_HARNESS": ""})
+        with mock.patch.object(config, "HARNESS", None):
+            said.append(self._refusal())
+        state.record_identity(self.CALLER, {"CHARTER_HARNESS": "claude-code"})
+        with mock.patch.object(claude_code.ClaudeCodeHarness, "first_message_argv",
+                               return_value=None):
+            said.append(self._refusal())
+        self.sessions = {"beta"}
+        said.append(self._refusal())
+        self.assertTrue(all(said), said)
+        self.assertEqual(len(set(said)), 9, said)
+
+
+class TheLaunchOpensWithoutMovingAnyone(PersonaIso, unittest.TestCase):
+    """The real `_launch`, with tmux and everything that would start a process stood in."""
+
+    def setUp(self):
+        super().setUp()
+        self.enterContext(mock.patch.dict(os.environ, {}, clear=True))
+        self.make_persona("forge")
+        self.argvs: list[list[str]] = []
+
+    def _launch(self, *, opening=None, attach=False):
+        args = SimpleNamespace(harness="claude", rest=["fix it please"], no_frame=False,
+                               workspace="beta", pick=False, size=(120, 40))
+        if attach is False:
+            args.attach = False
+        if opening is not None:
+            args.opening = opening
+
+        def run(action, argv, **kw):
+            self.argvs.append(list(argv))
+            return subprocess.CompletedProcess(
+                argv, 0, "%9\n" if "new-window" in argv else "", "")
+
+        def write_all(joint, writes, **kw):
+            return [subprocess.CompletedProcess(w.argv, 0, "", "") for w in writes]
+
+        with mock.patch("charter.commands_frame.shutil.which",
+                        return_value="/nowhere/claude"), \
+                mock.patch("sys.stdout.isatty", return_value=True), \
+                mock.patch("sys.stdin.isatty", return_value=False), \
+                mock.patch.object(commands_frame.tmuxctl, "version", return_value=(3, 7)), \
+                mock.patch.object(commands_frame.tmuxctl, "operator_server",
+                                  return_value=None), \
+                mock.patch.object(commands_frame, "_live_sessions", return_value={"beta"}), \
+                mock.patch.object(commands_frame, "_live_chats", return_value=set()), \
+                mock.patch.object(commands_frame.tmuxctl, "run", side_effect=run), \
+                mock.patch.object(commands_frame.tmuxctl, "write_all",
+                                  side_effect=write_all), \
+                mock.patch.object(commands_frame.tmuxctl, "interact",
+                                  return_value=subprocess.CompletedProcess([], 0)) as interact, \
+                mock.patch.object(commands_frame, "_query_pane_dead_status",
+                                  return_value=None), \
+                mock.patch.object(commands_frame, "_draw_panels", return_value={}) as panels, \
+                mock.patch.object(commands_frame, "_arm_panel_respawn"), \
+                mock.patch.object(commands_frame, "_spawn_gather"), \
+                mock.patch.object(commands_frame, "_chat_being_left",
+                                  return_value="beta.0") as left, \
+                mock.patch.object(commands_frame, "_drop_panels") as drop, \
+                mock.patch.object(commands_frame.state, "reap"):
+            rc = commands_frame._launch(args)
+        self.interact, self.left, self.drop, self.panels = interact, left, drop, panels
+        return rc
+
+    def test_an_opening_selects_no_window(self):
+        self._launch(opening=commands_frame.Opening("fix it please"))
+        self.assertFalse([a for a in self.argvs if "select-window" in a], self.argvs)
+
+    def test_an_opening_drops_no_one_elses_panels(self):
+        self._launch(opening=commands_frame.Opening("fix it please"))
+        self.drop.assert_not_called()
+        self.left.assert_not_called()
+
+    def test_an_opening_never_attaches(self):
+        self._launch(opening=commands_frame.Opening("fix it please"))
+        self.interact.assert_not_called()
+
+    def test_an_opening_still_gets_its_panels_before_anyone_looks(self):
+        """Open question 15, as ruled: the new window gets its panel processes the way every
+        chat a reopen builds does. Only the select and the teardown are skipped, so a later
+        gate that also skipped the panels would leave a chat nobody has looked at yet with
+        none."""
+        self._launch(opening=commands_frame.Opening("fix it please"))
+        self.panels.assert_called_once()
+
+    def test_an_opening_learns_the_chat_id_the_launcher_allocated(self):
+        opening = commands_frame.Opening("fix it please")
+        self._launch(opening=opening)
+        self.assertEqual(opening.fid, "beta.1")
+        self.assertTrue((config.STATE_DIR / "frame" / "beta.1").is_dir())
+
+    def test_an_opening_writes_the_persona_it_was_given_under_the_new_chat(self):
+        self._launch(opening=commands_frame.Opening("fix it please", persona="forge"))
+        self.assertEqual(persona.for_session("beta.1"), "forge")
+
+    def test_an_opening_with_no_persona_writes_no_pointer(self):
+        self._launch(opening=commands_frame.Opening("fix it please"))
+        self.assertIsNone(persona.for_session("beta.1"))
+
+    def test_an_ordinary_launch_still_selects_its_window(self):
+        """The gate is an `and`, not a replacement: a launch with no opening, whose `attach`
+        is left absent, is still the operator's terminal and still lands on its chat."""
+        self._launch(attach=None)
+        self.assertTrue([a for a in self.argvs if "select-window" in a], self.argvs)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_a_chat_opens_in_the_background_with_its_first_message.py
+++ b/tests/test_a_chat_opens_in_the_background_with_its_first_message.py
@@ -319,6 +319,23 @@ class EveryRefusalComesBeforeAnythingStarts(_AChatInAlpha):
         self.assertEqual(len(set(said)), 9, said)
 
 
+class OnlyAnOpeningIsReadAsOne(unittest.TestCase):
+    """`_opening`'s `isinstance`, for `_reopening`'s reason. `args` is whatever namespace a
+    caller built: one that happens to carry an unrelated `opening` attribute, or a `Mock`
+    that answers every attribute, must not be read as a background open — whose "persona"
+    would then be handed to `persona.set_active`."""
+
+    def test_an_unrelated_opening_attribute_is_not_an_opening(self):
+        self.assertIsNone(commands_frame._opening(SimpleNamespace(opening="beta")))
+
+    def test_a_mock_that_answers_every_attribute_is_not_an_opening(self):
+        self.assertIsNone(commands_frame._opening(mock.Mock()))
+
+    def test_an_opening_is_read_as_itself(self):
+        opening = commands_frame.Opening("fix it please")
+        self.assertIs(commands_frame._opening(SimpleNamespace(opening=opening)), opening)
+
+
 class TheLaunchOpensWithoutMovingAnyone(PersonaIso, unittest.TestCase):
     """The real `_launch`, with tmux and everything that would start a process stood in."""
 
@@ -328,13 +345,15 @@ class TheLaunchOpensWithoutMovingAnyone(PersonaIso, unittest.TestCase):
         self.make_persona("forge")
         self.argvs: list[list[str]] = []
 
-    def _launch(self, *, opening=None, attach=False):
+    def _launch(self, *, opening=None, attach=False, reopening=None):
         args = SimpleNamespace(harness="claude", rest=["fix it please"], no_frame=False,
                                workspace="beta", pick=False, size=(120, 40))
         if attach is False:
             args.attach = False
         if opening is not None:
             args.opening = opening
+        if reopening is not None:
+            args.reopening = reopening
 
         def run(action, argv, **kw):
             self.argvs.append(list(argv))
@@ -411,6 +430,16 @@ class TheLaunchOpensWithoutMovingAnyone(PersonaIso, unittest.TestCase):
         is left absent, is still the operator's terminal and still lands on its chat."""
         self._launch(attach=None)
         self.assertTrue([a for a in self.argvs if "select-window" in a], self.argvs)
+
+    def test_a_reopen_still_selects_no_window_and_drops_no_panels(self):
+        """The `_reopening` half of the gate this change re-spelled — the deletion sweep
+        showed nothing pinned it. A reopen builds several chats with nobody attached: a
+        select would move a client that does not exist yet, and a teardown would strip the
+        panels off the sibling the same reopen had just drawn (`_reopening`)."""
+        recorded = SimpleNamespace(chat="beta.9", persona="")
+        self._launch(reopening=commands_frame.Reopening(recorded), attach=None)
+        self.assertFalse([a for a in self.argvs if "select-window" in a], self.argvs)
+        self.drop.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/tests/test_a_harness_takes_its_first_message_on_its_own_argv.py
+++ b/tests/test_a_harness_takes_its_first_message_on_its_own_argv.py
@@ -1,0 +1,49 @@
+"""A harness is told its first message on its own command line, in its own spelling.
+
+`charter handoff` (chat-handoff plan, Task 2) opens a chat whose first message is a brief the
+operator approved. Charter never types it into the harness pane — typing there is drawing in
+it (ADR 0018), and it races the harness's own start — so the message rides the argv the
+harness is started with. The spelling differs by harness: `claude "<text>"` and
+`codex "<text>"` take it as their positional prompt, and opencode takes it as
+`--prompt "<text>"`. That difference is why this is a member of the harness rather than the
+launcher's `extra` pass-through. A harness charter has not measured answers `None`, and the
+seam that asks refuses rather than guessing at an argument.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from charter.harness import base, registry
+
+
+class AHarnessTakesItsFirstMessageOnItsOwnArgv(unittest.TestCase):
+    def test_claude_code_takes_it_as_its_positional_prompt(self):
+        self.assertEqual(registry.get("claude-code").first_message_argv("fix the widget"),
+                         ["fix the widget"])
+
+    def test_codex_takes_it_as_its_positional_prompt(self):
+        self.assertEqual(registry.get("codex").first_message_argv("fix the widget"),
+                         ["fix the widget"])
+
+    def test_opencode_takes_it_as_its_prompt_flag(self):
+        self.assertEqual(registry.get("opencode").first_message_argv("fix the widget"),
+                         ["--prompt", "fix the widget"])
+
+    def test_a_harness_charter_has_not_measured_says_none(self):
+        self.assertIsNone(base.Harness().first_message_argv("x y"))
+
+    def test_a_multi_line_text_stays_one_argument(self):
+        """The whole message is ONE element, never split on whitespace or lines: tmux execs
+        a multi-element argv directly, so each element reaches the harness as one argument,
+        and #959's `tmuxctl.verbatim` is what carries a trailing `;` through whole."""
+        text = "a\n\nb c"
+        for h in registry.all():
+            with self.subTest(harness=h.name):
+                got = h.first_message_argv(text)
+                self.assertEqual(got[-1], text)
+                self.assertEqual(got.count(text), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Part of #956 — Task 1 of 6 in `docs/superpowers/plans/2026-09-10-chat-handoff.md`.

## The failure this removes

Nothing could open a chat from inside one. `charter frame-new-chat` opens only in the presser's own workspace, sends nothing, and moves the view; `charter claude …` run from an agent's Bash tool has no terminal, so it runs a bare harness inside that tool call. `charter handoff` (Task 2) therefore had no way to start a chat in a named workspace, in the background, already working on the brief the operator approved.

## What changed, and why

- **`Harness.first_message_argv(text)`**: the arguments that start a harness's own interactive session on `text`, or `None` for a harness charter has not measured. Claude Code and Codex take it as their positional prompt, and opencode as `--prompt`. It is a member rather than the launcher's `extra` pass-through because the spelling differs. It is an argument rather than keystrokes because typing into the harness pane is drawing in it (ADR 0018) and races its start. The text is one element and is not escaped again: #959's `tmuxctl.verbatim` already carries it whole.
- **`commands_frame.Opening` and `_opening`**: `Reopening`'s sibling for a chat nobody attaches to. In `_launch`, the opening learns the allocated chat id, and a named persona is written under that id before the harness starts (`terminal_id=""`). The `select-window`/`_drop_panels` pair is skipped (`_reopening(args) is None and _opening(args) is None`). Panels are still drawn, as a reopen draws them (Q15).
- **`background_refusal(ws, *, caller, first_message)`**: every refusal comes before anything starts, and the check writes nothing. The order is the brief's: empty; starts with `-`; a single word; a NUL byte; past `FIRST_MESSAGE_MAX_BYTES`; a caller in the operator's own tmux; no launchable harness; an unmeasured harness; a session of that name this plane cannot prove is its own.
- **`open_in_background(ws, *, caller, first_message, persona="")` → `Opened(ok, chat, message)`**: it refuses first, sizes the chat for the caller's window, and runs `cmd_launch` in the target workspace's directory with `attach=False` and the `Opening`. `$CHARTER_WORKSPACE` and `$CHARTER_PERSONA` are emptied for the length of the launch and restored exactly (Q21). A pin the calling chat carries would otherwise become the new chat's, and #936's lock holds only for an unpinned launcher. Success is a chat id with a harness pane, never a return code.
- **`FIRST_MESSAGE_MAX_BYTES = 12288`**: charter's own policy bound, not a prediction of tmux's limit (ruling on resume). It is counted with `os.fsencode`, because a surrogate escape makes a strict `str.encode` raise (#959's finding).
- **Docs**: `docs/frame.md` gains *A chat opened for you in the background*. The plan's M1, M2 and refusal-5 text and its Task 1 test list now match what shipped. A comment at `_launch`'s `select-pane` records the M3 measurement. There is no news entry: nothing an operator can run yet, and Task 2's entry covers it.

## Measurements

- **Harness first messages**, from each binary's own `--help`, 2026-09-11:
  - Claude Code 2.1.268: `claude [options] [command] [prompt]`, which "starts an interactive session by default, use -p/--print for non-interactive output".
  - codex-cli 0.147.0: `codex [OPTIONS] [PROMPT]`, "Optional user prompt to start the session".
  - opencode 1.18.23: `opencode [project]`, with `--prompt` ("prompt to use").
- **M1** belongs to #959, which puts every harness argument, `-c` value and `-e` value through `tmuxctl.verbatim`. Through Task 1's own path, a brief carrying a trailing `;`, a blank line, quotes, `$(…)` and `#{…}` reaches the harness's `sys.argv` exactly, on tmux 3.7c and at the 3.2 floor.
- **M2**: tmux refuses a command past 16,364 bytes (#959). A first message exactly 12,288 bytes long starts and arrives whole through a real launch, on 3.7c and at the 3.2 floor.
- **M3**: through a whole `open_in_background` (the real `_launch`, `select-pane` included), the target session's current window is the same before and after, on 3.7c and at the 3.2 floor.

## Test evidence

- `tests/test_a_harness_takes_its_first_message_on_its_own_argv.py`: 5 tests, red before the change (`first_message_argv` missing).
- `tests/test_a_chat_opens_in_the_background_with_its_first_message.py`: the seam, every refusal, the pins and the `_launch` gate. Red before the change, on the missing symbols. `test_an_ordinary_launch_still_selects_its_window` was already green, which shows the fixture drives a whole launch.
- `tests/test_a_background_chat_really_starts_on_its_brief.py`: real tmux on a `_tmuxreap` socket. It passes on 3.7c, and at the 3.2 floor with `tmux` on `$PATH` pointed at the floor binary. With the `_spawn_gather` stand-in removed, the M3 test errors on `_planeguard`'s `BackgroundCharterChild` refusal of the detached `frame-gather`.
- Focused run after the survivor fixes, 634 tests OK: the three modules plus `test_frame_launcher`, `test_the_chat_bars_plus_makes_a_chat`, `test_a_workspace_tab_opens_what_it_names`, `test_harness_registry`, `test_frame_layout`, `test_frame_tmuxctl`, the uid guard, and the docs and claims checks.
- Full suite: 12,015 tests, OK (9 skipped), run before the first commit. On the final tree (6b74ff8), after the survivor fixes and the rebase onto #965: 12,037 tests, OK (9 skipped).
- Rebased onto `3286a4f` (#965, `tmuxctl.start_directory` at the three `-c` sites) with no conflict; Task 1 puts no start directory of its own on a tmux argv. After the rebase, the real-tmux module passes on 3.7c and at the 3.2 floor (2 tests each).
- `python3 tools/sweep.py` on 6541752, before the rebase, with a green full-suite baseline of 12,015 tests: 43 mutations, 31 pinned, **12 survived**, 0 unresolved. Every survivor is now closed: ten by pins that fail with the survivor re-applied by hand, and two removed by construction.
  - [4] `_opening`'s `isinstance` and [5] the reopen half of the `_launch` gate: pinned in 67e5b4e. An unrelated `opening` attribute, or a `Mock`, is not an opening, and a reopen selects no window and drops no panels.
  - [7] `FIRST_MESSAGE_MAX_BYTES`'s value: pinned by hand, with 12,288 bytes taken and 12,289 refused.
  - [29] `contain.one_line` on the named word: pinned with an escape sequence.
  - [38], [39] and [40], the size fallbacks: pinned. A caller with no recorded pane is sized off the target workspace's live chat; with neither, no `-t` is aimed and no size is handed.
  - [41] the `OSError` swallowed on the way back to the original directory: pinned, and the opened chat is still reported.
  - [43] `rc == 0`: pinned by a harness that died on start, which leaves a harness-pane record behind.
  - [27] `not first_message.strip()` → `lstrip` in refusal 1: removed. `not text.strip()` and `not text.lstrip()` answer alike for every string, so no test could pin it. Refusal 1 now asks `split()` for words, and the sweep leaves the no-argument `split` alone.
  - [30] `first_message.strip()` → `lstrip` in the word refusal 3 names: this one was observable, because `"login\n"` would have kept its newline in the refusal. It is closed by naming `words[0]` and pinned by `test_a_single_word_is_named_without_the_whitespace_around_it`, which fails with `lstrip` re-applied by hand.
  - [42] the `opening.fid` conjunct: removed as redundant, because `state.harness_pane("")` is `None`.

  The sweep was not re-run on the final commit. The by-hand re-application is the evidence for the pins, and a CI sweep will run on this PR.

## Rulings

Taken under the dispatch's "smallest reading consistent with the spec":

- The brief's real-tmux M1 matrix is not repeated here, because it is #959's (`test_a_harness_argument_ending_in_a_semicolon_arrives_whole`). M1 is checked through Task 1's own path instead.
- The brief's "one past the bound is the measured refusal" test is replaced by "at the bound it starts": under the ruling the bound is a policy, so nothing tmux does happens one byte past it.
- Refusal 5's sentence no longer says "tmux refuses a command past {max} bytes (measured)". It names charter's own bound, set under tmux's measured 16,364-byte limit. The tests say "bound" rather than "limit".
- Three pins beyond the brief's list:
  - a surrogate escape is counted, not raised on;
  - the `Opening` carries the message and persona it was given;
  - an opening still gets its panels (Q15).
- `open_in_background` asks `_plane_session` for a seat only when the caller's own pane is unrecorded, which saves a tmux round trip in the ordinary case.
- No news entry: the brief says Task 1 alone is not user-visible.

## Known limits (stated, not fixed)

- Whether the new chat is locked to its workspace (#936) depends on the harness keeping the chat id charter starts it with. opencode's plugin overwrites `$CHARTER_SESSION_ID` (#946), and Codex gets no session id outside a frame (#954). This PR claims no lock for either.
- The first message is a command-line argument, so any process on the machine that can list processes can read it while the harness starts.
- A first message between 12,288 and about 15,800 bytes is refused although tmux would take it.

## Review round 1

The task review passed Spec and Quality and asked for two Minor fixes. Both are in f749d22, which changes one test file and this body.

- **"No client moves" is now pinned with the panels really drawn.** The M3 case uses a 20x6 window, so it never split a panel, while `docs/frame.md` claims both that no client moves and that panels are drawn — and the panel splits carry no `-d`.
  - `ABackgroundChatWithItsPanelsMovesNoAttachedClient` opens into a 120x40 window, where `_draw_panels` really splits four panels; the new window is asserted to have five panes. A real pty client is attached to each workspace's session.
  - For an open into a workspace somebody is looking at (`beta`), and one into the caller's own (`alpha`), every client's session, current window and active pane are the same before and after, on tmux 3.7c and at the 3.2 floor.
  - `layout.panel_command` is stood in with `sleep`, so the splits are real but no pane runs a `charter panel` child.
  - **It goes red under a hand mutation:** a `select-window -t <new chat's harness pane>` inserted into `_draw_panels` before `_split_panels` fails both cases with "a background open moved an attached client".
  - Found on the way, and recorded in the test: `display-message -p -c <client>` cannot say where one client is looking. On 3.7c it answered the server's current session for both clients, and at the 3.2 floor it failed with rc 1. So clients are read with `list-clients -F '#{client_name} #{session_name} #{window_id} #{pane_id}'`, which on both versions reports each client's own view and follows a `select-window`.
- **The [27]/[30] sentence is corrected** in the sweep section above. [27] was an equivalent mutant and is removed. [30] was observable (`"login\n"` would have kept its newline) and is pinned by `test_a_single_word_is_named_without_the_whitespace_around_it`, which fails with `lstrip` re-applied by hand. The count is now ten pinned and two removed.

**Focused tests, 538 OK:** `test_a_harness_takes_its_first_message_on_its_own_argv`, `test_a_chat_opens_in_the_background_with_its_first_message`, `test_a_background_chat_really_starts_on_its_brief`, `test_a_real_click_on_a_real_tab_bar_switches` (whose pty helpers the new class imports), `test_frame_launcher`, `test_the_chat_bars_plus_makes_a_chat`, `test_a_workspace_tab_opens_what_it_names`, `test_no_test_bakes_a_uid_into_a_socket_path`, `test_docs_claims_carry_their_residual`, `test_docs_show` and `test_claims`. `test_a_background_chat_really_starts_on_its_brief` alone passes 4 tests on 3.7c and 4 at the 3.2 floor.

**No sweep:** f749d22 changes only a test file, and the sweep mutates only `charter/`.

## Review round 2

CI on f749d22 failed twice on Linux (tmux 3.4): the static exec guard, and one panels case that failed only some of the time. Both are fixed in aeca22e, which again changes one test file.

- **The exec guard.** Round 1's `_attach` started its client as a `pty.fork` child that ran `os.execvp("tmux", …)`, and `test_plane_spawn_guard.NoCharterEscapesThroughTheExecFamily` found a call it does not know. The guard's own message names two ways through: list the site in `KNOWN` with the reason it cannot become charter, or go through `subprocess` instead. This takes the second. The client is started with `subprocess.Popen` on an `os.openpty()` pair, with its size set before it starts. `KNOWN` is unchanged, and the guard passes. *Corrected in round 3:* that static guard — no exec of charter anywhere in the tree — is the whole of what covers this call. The runtime `_planeguard` does not resolve a bare, non-interpreter program through `$PATH`, so a `tmux` on `$PATH` that was really charter would not be refused.
- **Why the panels case failed some of the time.** Both cases of each class started their tmux server on one socket name (`_tmuxreap.name(self.SLUG)`). That predates round 1: the M3 class did it from the start, and round 1 moved it unchanged into `_TwoChatsOnARealServer` while adding the panels class. The panels class is where it showed: on Linux its second case's first `new-session` sometimes reached the first case's server, which had been told to exit but was still accepting connections on the socket. I did not measure the M3 class under the same load, so this does not say why the panels class tripped it and M3 did not; the fix covers both. In CI the first case is logged `ok` at 03:50:55.638, and the second fails at .645 with `server exited unexpectedly`.
  - **Reproduced and isolated on Linux** (tmux 3.4 in Docker, `--cpus 2`, two busy loops):
    - f749d22 as committed: 28 of 50 runs failed, every one that case with that message;
    - only the socket name made per-case: 0 of 50;
    - the full fix: 0 of 50, with no skipped subtest;
    - the full fix with the shared name put back: 14 of 20 failed, now carrying the diagnosis. One such run reports `socket /tmp/tmux-0/charter-handoff-panels-11 existed before the call: True`, and tmux's own client log shows it sending the command to a peer already listening, starting no server, and seeing `client loop exit` 0.44 ms later.
  - **On macOS the race never showed:** before the fix, 50 of 50 passed unloaded and 50 of 50 with all 14 CPUs busy; after it, 50 of 50 unloaded and 50 of 50 with all 14 busy.
  - **The fix:** a fresh socket name for every case, from a module counter (`_tmuxreap.name(f"{SLUG}-{next(_SERVERS)}")`), which is what the other real-tmux modules already do. It is in the base class, so the older M3 cases get it too.
- **Diagnostics stay.** Every session start runs `tmux -v` from a directory kept for that case. A start tmux refuses fails with the return code, stderr, `tmux -V`, the argv, whether the socket file already existed, the relevant environment, and the tail of each tmux log — so a later flake names its cause.
- **No silent skip on Linux.** Each panels case now also compares every session's current window and active pane before and after the open. That is what any client of the session is shown, and it needs no client, so it runs on every platform. The attached-client comparison is a subtest that skips visibly, naming the terminal types it tried, only where no client will attach. Across the 50 Linux runs of the fix, it never skipped.

**Tests:** both panels cases, 5 runs each, pass on tmux 3.7c and 5 each at the 3.2 floor. The exec guard passes. Full suite: 12,039 tests, OK (9 skipped, the same nine as before).

**No sweep:** aeca22e changes only a test file, and the sweep mutates only `charter/`.

## Review round 3

The round-2 re-review confirmed the root cause and the fix in an ubuntu-24.04 container with tmux 3.4: f749d22 failed 26 of 50 runs, and aeca22e passed 50 of 50. CI is green, including all eight sweep shards. It found one claim in this body false, measured live. 94ddc29 fixes it and changes one test file.

- **Corrected: what covers `_attach`'s `Popen`.** Round 2 said `_planeguard.RealPlaneSpawn` would catch a `tmux` on `$PATH` that was really charter. It would not. `_cmd_launches_charter` resolves a bare program name through `$PATH` only when the arguments reach an interpreter (`-c`, `-m` or a `.py` argument). `attach -t` never does, so the name stays `tmux`. The reviewer ran this exact argv and environment against a `tmux` shim that imports charter, on a guarded throwaway plane, and it was not refused. The static exec-family guard alone covers the call. The round-2 bullet above and the test's docstring now say so. aeca22e's commit message makes the same overstatement; it is pushed and stays as it is. The `_planeguard` gap predates this PR and is not changed here; forge is filing it.
- **The client is the binary under test.** `_TwoChatsOnARealServer` now resolves `tmux` once, in `setUp`. The sessions, the queries, `kill-server`, the diagnosis and the attached client all run that absolute path, so the client cannot be a different binary from the server the case measures. This does not close the `_planeguard` gap.

**Tests:** the panels class, 5 runs each, passes on tmux 3.7c and at the 3.2 floor. Full suite: 12,039 tests, OK (9 skipped).

**No sweep:** 94ddc29 changes only a test file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
