### PR TITLE
`charter claude` runs the command you launch Claude Code with, from `.charter/local.toml`

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,10 @@ session, after `init` and `--fix` alike, so restart any session that was already
 **The recording stops before `charter claude`**, because the frame is a full-screen tmux
 client and `capture-demo.sh` records a line transcript; the picture at the top of this page
 is what that step opens. `charter claude` needs `claude` on your `PATH`: without it no frame
-is drawn, and charter says the binary is not installed and exits 127. The frame also needs
+is drawn, and charter says the binary is not installed and exits 127. If you reach Claude
+Code through something else — `ccs work`, a binary off `PATH` — `.charter/local.toml` names
+it, per developer and never committed
+([docs/control-plane.md](docs/control-plane.md#harnessnamecommand--your-own-launcher-in-charterlocaltoml)). The frame also needs
 tmux, and of tmux only its absence stops a launch — below 3.2, the version charter checks
 its requirements against, the frame still starts. `charter opencode` and `charter codex`
 need their own binaries the same way, and `charter claude --probe` says whether a frame can

--- a/charter/commands_frame.py
+++ b/charter/commands_frame.py
@@ -2553,8 +2553,9 @@ def _guest_harness_env(env: dict[str, str]) -> dict[str, str]:
     servers is in that one extra name. On charter's own private server the base the `-e`
     overlays is a server SOME charter launcher started, so its `$PATH` is a charter
     launcher's. On the operator's it is a server THEY started, possibly weeks ago, in
-    another shell — and `cmd_launch` has already resolved the harness binary
-    (`shutil.which(h.binary)`) against charter's OWN `$PATH`. Handing the pane a
+    another shell — and `cmd_launch` has already resolved the harness's first word
+    (`shutil.which(argv[0])` — its binary, or the operator's own `[harness.<name>]
+    command`) against charter's OWN `$PATH`. Handing the pane a
     different one would make that check a promise charter cannot keep: the frame comes
     up, the exec fails, and the operator gets `_UNKNOWN_DEATH_CODE` for a binary charter
     said it had found.
@@ -4542,7 +4543,8 @@ def early_death_message(argv: list[str], code: int, last_words: list[str]) -> st
 
     **The design call #384 left open, and the argument for taking it this way.** `charter
     <harness>` can refuse a missing binary before tmux (see `cmd_launch`'s `if h and not
-    shutil.which(h.binary)`), because charter chose that name itself. `charter frame --
+    shutil.which(argv[0])`), because that word is either a name charter chose itself or one
+    the operator wrote into their own `.charter/local.toml` as an executable. `charter frame --
     <cmd>` cannot be closed the same way without changing what it ACCEPTS, and what it
     accepts is tmux's rule, not charter's — verified against tmux 3.7c:
 
@@ -5062,7 +5064,15 @@ def _launch(args) -> int:
     # is the separator that told argparse to stop parsing, not part of the command.
     if rest and rest[0] == "--":
         rest = rest[1:]
-    argv = h.launch_argv(rest) if h else rest
+    # The operator's own way of reaching this harness — `[harness.<name>] command` in the
+    # plane's per-developer `.charter/local.toml` (`instance.harness_local_of`), `None` on
+    # every plane that wrote none, which is every plane until somebody does. Read HERE and
+    # handed to `launch_argv` rather than read by the harness: `harness/base.py` knows what
+    # a harness is, and which account one operator bills a chat to is not that. A plain
+    # subscript: `harness_local_of` returns the ``command`` key on every path, and a
+    # fallback here would be a guard no test can reach.
+    command = config.HARNESS_LOCAL["command"].get(h.cli_name) if h else None
+    argv = h.launch_argv(rest, command=command) if h else rest
     if not argv:
         util.err("charter frame: nothing to run — `charter frame -- <command>`")
         return 2
@@ -5096,19 +5106,26 @@ def _launch(args) -> int:
     # output, exit 127, no alternate-screen switch. `charter claude` before installing
     # `claude` returned instantly with no explanation of any kind.
     #
-    # Scoped to `if h` deliberately, and this is the whole reason the check sits here
-    # rather than over `argv[0]`. A registered harness's binary comes from charter's own
-    # registry (`harness.base.binary`), so `shutil.which` is asking about a name charter
-    # chose. `charter frame -- <cmd>` is the opposite: `argv[0]` is the operator's own
-    # verbatim word, and it is allowed to be a shell builtin, a relative path, or
-    # anything else tmux's own resolution accepts — a `which` check over THAT would
-    # narrow what the escape hatch accepts, which is a design change and not this fix.
+    # Scoped to `if h` deliberately, and that scope is the whole reason the check sits
+    # here. For a REGISTERED harness `argv[0]` is one of two things, both meant to be an
+    # executable: charter's own `harness.base.binary`, or the first word of the
+    # `[harness.<name>] command` the operator wrote into their `.charter/local.toml` —
+    # and it is `argv[0]` that is asked about rather than `h.binary`, because with a
+    # command in force the binary is not what is about to be exec'd, so `claude` being
+    # installed would answer the wrong question and `ccs` missing would die inside tmux
+    # with nothing drawn, the exact silence this check exists to end. `shutil.which`
+    # takes a path with a separator in it as well as a `$PATH` word, so `["./bin/claude"]`
+    # is answered honestly too. `charter frame -- <cmd>` is the opposite: `argv[0]` is
+    # the operator's own verbatim word, and it is allowed to be a shell builtin, a
+    # relative path, or anything else tmux's own resolution accepts — a `which` check
+    # over THAT would narrow what the escape hatch accepts, which is a design change and
+    # not this fix, and `h is None` there keeps it out of this branch.
     #
     # The escape hatch's ACCEPTANCE is still exactly that: nothing is refused for it, and
     # #384 deliberately did not change that either (see the module docstring, and
     # `early_death_message`'s own). Its SILENCE is what changed — the same death is now
     # legible from the other end, once tmux has already answered.
-    if h and not shutil.which(h.binary):
+    if h and not shutil.which(argv[0]):
         return bypass(argv)
 
     # ONE call (correction 5): asking `tmux -V` twice on a path that branches on the

--- a/charter/commands_harness.py
+++ b/charter/commands_harness.py
@@ -9,16 +9,27 @@ consent), and nothing here is ever done as a side effect of something else.
 
 from __future__ import annotations
 
-from . import util
+from . import config, contain, util
 from .harness import codex, registry
 
 
 def cmd_harness_list(args) -> int:
     """Every registered harness, its ceilings, and which one this session is in."""
     live = registry.current()
+    commands = config.HARNESS_LOCAL["command"]
     for h in registry.all():
         mark = "*" if h.name == live else " "
         util.info(f"{mark} {h.name}")
+        # The operator's own launcher for this harness, when their `.charter/local.toml`
+        # names one (`instance.harness_local_of`). Besides `doctor` this is the one place
+        # that says what `charter <cli_name>` will actually run, and the reader asking
+        # "what does charter know about this harness" is the one who needs to hear it —
+        # a refused table is `doctor`'s to name, not this listing's, which reports what IS
+        # in force. `contain.readable`: the words are the operator's own, and one row is
+        # one row.
+        words = commands.get(h.cli_name)
+        if words:
+            util.info(f"      → runs: {contain.readable(' '.join(words))}")
         for d in h.deficits:
             util.info(f"      ↳ {d.key}: {d.detail}")
             if d.remedy:

--- a/charter/config.py
+++ b/charter/config.py
@@ -752,6 +752,29 @@ def derive(root: Path, start: Path | None = None) -> dict:
     state = _migrate_state_dir(root)
     d["STATE_DIR"] = state
 
+    #: The per-developer half of the plane's configuration — `instance.LOCAL_FILE`, beside
+    #: the vault registry, so it is gitignored and one account's like everything in here.
+    #: A derived path rather than a literal in `doctor`, because the row that names this
+    #: file has to name the one that was READ, and ``$CHARTER_HOME`` moves it.
+    d["LOCAL_CONFIG"] = state / _instance.LOCAL_FILE
+
+    #: Parsed once, and degraded the way `charter.toml` is above: this module is imported
+    #: by every command, and a typo in a file one operator wrote must not take `charter
+    #: --version` down. No `PLANE_REFUSAL` half here — the file declares no plane format,
+    #: so nothing in it can be unplaceable, only unreadable. `doctor` names it.
+    try:
+        local = _instance.load_local(state)
+        d["LOCAL_CONFIG_ERROR"] = None
+    except Exception as e:            # malformed TOML, unreadable file
+        local, d["LOCAL_CONFIG_ERROR"] = {}, str(e)
+
+    #: How `charter <harness>` reaches each harness on THIS machine — ``{"command": {},
+    #: "refused": []}`` unless the operator wrote a ``[harness.<name>] command`` into
+    #: `LOCAL_CONFIG`. ``command`` is keyed by the word after ``charter``; ``refused``
+    #: names every table that is declared and not in force. Read from the state dir and
+    #: never from `charter.toml` — `instance.harness_local_of` has the argument.
+    d["HARNESS_LOCAL"] = _instance.harness_local_of(local)
+
     #: Registry of configured vaults (name -> provider + config + persona).
     d["VAULTS_REGISTRY"] = state / "vaults.json"
 

--- a/charter/doctor.py
+++ b/charter/doctor.py
@@ -378,6 +378,60 @@ def check_control_plane_config() -> Result:
     return Result("charter.toml", OK, detail=f"parsed cleanly ({_config.ROOT})")
 
 
+def check_local_config() -> Result:
+    """``.charter/local.toml`` — the per-developer half of the plane's configuration, and
+    whether what it declares is in force.
+
+    The `charter.toml` row's reason, one file over. A ``[harness.<name>] command`` charter
+    cannot honour degrades to launching the harness's own binary
+    (`instance.harness_local_of`), which is byte-identical to what a plane with no such
+    file does — so `charter claude` on a machine with a typo in this file behaves as though
+    the file were absent, and the launch itself deliberately prints nothing before tmux
+    takes the screen (`commands_frame.frame_ready`'s docstring measures why). This row and
+    `charter harness list` are the whole surface, which is why the row also says what IS
+    in force: an override that reads green and names `ccs work` is the one an operator can
+    check against what they meant.
+
+    WARN and never FAIL, for the malformed file and the refused table alike. Charter
+    carries on with the binary, which is a working plane; the operator is just not getting
+    what they wrote, and that is what the row says. `_first_line` on the parse error for
+    the `charter.toml` row's reason — the message names the file and the position, and a
+    second line would break the table.
+    """
+    from . import config as _config, contain, instance as _instance
+
+    where = _config.LOCAL_CONFIG
+    if _config.LOCAL_CONFIG_ERROR is not None:
+        return Result(
+            "local.toml",
+            WARN,
+            detail=_first_line(_config.LOCAL_CONFIG_ERROR),
+            hint=f"Fix or remove {where}. Until it parses, every `charter <harness>` runs "
+                 f"the harness's own binary, exactly as a plane with no local.toml does.",
+        )
+    refused = _config.HARNESS_LOCAL["refused"]
+    if refused:
+        shown = "; ".join(refused[:3]) + (" …" if len(refused) > 3 else "")
+        return Result(
+            "local.toml",
+            WARN,
+            detail=f"{len(refused)} [harness.*] override(s) in {where} are not in force",
+            hint=f"{shown}. A `[harness.<name>]` table names one of: "
+                 f"{', '.join(_instance.launchable_harnesses())}, and its `command` is a "
+                 f"list of words — `command = [\"ccs\", \"work\"]`. Until fixed, "
+                 f"`charter <harness>` runs the harness's own binary, exactly as a plane "
+                 f"with no local.toml does.",
+        )
+    commands = _config.HARNESS_LOCAL["command"]
+    if commands:
+        # The words are the operator's own, out of a file they wrote — but this line is
+        # charter's report format, and one row is one row.
+        shown = ", ".join(f"{name} → {contain.readable(' '.join(words))}"
+                          for name, words in commands.items())
+        return Result("local.toml", OK, detail=shown)
+    return Result("local.toml", OK, detail="no per-developer overrides")
+
+
 def check_control_plane_schema() -> Result:
     """Structural drift, from ``charter.instance.drift``: baseline top-level directories
     (personas/, inventory/, workspaces/) a control plane is expected to have. This is
@@ -3196,7 +3250,8 @@ def _checks():
     for forge in declared_or_default_forges():
         results.append(check_forge_cli(forge))
         results.append(check_forge_auth(forge))
-    results += [check_ssh(), check_control_plane_config(), check_control_plane_schema(),
+    results += [check_ssh(), check_control_plane_config(), check_local_config(),
+                check_control_plane_schema(),
                 check_plane_root(), check_index_lock(),
                 check_session_root(), check_session_layer(),
                 check_harness(), check_frame(), check_guard_wired(), check_guard_seen(), check_nested_plane(),
@@ -3239,7 +3294,7 @@ def _checks():
 _FIXED_CHECK_NAMES = (
     "python3", "git", "git identity",
     # ← the forge cli/auth pair is spliced in here, see `check_names`
-    "git auth", "charter.toml", "schema", "plane root", "index lock",
+    "git auth", "charter.toml", "local.toml", "schema", "plane root", "index lock",
     "session root", "session layer",
     "harness", "frame",
     "plane-root guard", "guard seen", "nested plane", "workspace clones",

--- a/charter/harness/base.py
+++ b/charter/harness/base.py
@@ -258,15 +258,27 @@ class Harness:
     #: one attribute would make each of those a change to the other's meaning.
     binary: str = ""
 
-    def launch_argv(self, extra: list[str]) -> list[str]:
+    def launch_argv(self, extra: list[str], command: list[str] | None = None) -> list[str]:
         """Argv for starting this harness, with the operator's arguments appended.
+
+        *command* is the operator's own way of reaching this harness — ``["ccs", "work"]``
+        for a wrapper that picks which account a chat is billed to, a path for a binary
+        kept off ``$PATH`` — read out of the plane's per-developer ``.charter/local.toml``
+        (`instance.harness_local_of`) and handed in by the launcher rather than read here:
+        this module knows what a harness IS, and how one operator reaches it on one
+        machine is not that. It stands where :attr:`binary` stood and *extra* still
+        follows it, so ``--resume <id>`` on a reopen reaches whatever the wrapper forwards
+        to. ``None`` — every plane that wrote no such file — is the binary, exactly as
+        before. It is never read out of a COMMITTED file: README's containment rule, and
+        `instance.harness_of` refusing a ``default`` it cannot match, are why the setting
+        lives where it does.
 
         A **list**, never a joined string, and that is a security property rather than a
         style preference: tmux does not shell-interpret separate arguments and does
         interpret a joined one (pinned against 3.7c). Returning a string here would put
         command injection back into every launch.
         """
-        return [self.binary, *extra]
+        return [*(command or [self.binary]), *extra]
 
     def detect(self) -> bool:
         """Is this harness live, judged by its own native evidence?

--- a/charter/instance.py
+++ b/charter/instance.py
@@ -3009,3 +3009,95 @@ def harness_of(cfg: dict) -> dict:
     # function exists to empty.
     out["refused"] = contain.readable(value)
     return out
+
+
+#: The per-developer half of the plane's configuration — ``<state dir>/local.toml``,
+#: beside the vault registry in ``.charter/``, read by :func:`load_local`. One table
+#: today, ``[harness.<name>]``, and it lives here and not in `charter.toml` for a reason
+#: the README states as a rule: **a name charter reads out of a committed file cannot
+#: choose what it runs.** A harness's ``command`` is exactly that choice. `charter.toml`
+#: arrives from somebody else's machine; this file is written by the operator whose
+#: machine it runs on, gitignored on every plane `init` has written, and one account's
+#: (`config.STATE_FILE_MODE`) like everything beside it. It is also the right scope on
+#: the merits — which account a chat is billed to is one operator's business, and a
+#: teammate on the same plane may run plain `claude`.
+LOCAL_FILE = "local.toml"
+
+
+def load_local(state_dir: Path) -> dict:
+    """Parse ``<state dir>/local.toml``. Returns ``{}`` when there is no such file.
+
+    :func:`load` without the schema check: this file declares no plane format, because it
+    describes no plane — only how one operator reaches a harness on one machine, so there
+    is nothing in it a newer charter could have laid out differently. Malformed TOML
+    raises, as `load` does, and `config.derive` catches it into ``LOCAL_CONFIG_ERROR`` for
+    `doctor` to name, so a typo here never takes ``charter --version`` down with it.
+    """
+    p = Path(state_dir) / LOCAL_FILE
+    try:
+        raw = p.read_bytes()
+    except OSError:
+        return {}
+    try:
+        return tomllib.loads(raw.decode("utf-8"))
+    except (tomllib.TOMLDecodeError, UnicodeDecodeError) as e:
+        raise ValueError(f"{p} is not valid TOML: {e}") from None
+
+
+def harness_local_of(cfg: dict) -> dict:
+    """The ``[harness.<name>]`` tables of `local.toml`, as ``{"command": …, "refused": …}``.
+
+    ``command`` maps a launchable harness's :attr:`~charter.harness.base.Harness.cli_name`
+    — ``claude``, the word after ``charter``, never ``claude-code``, :func:`harness_of`'s
+    own rule — to the argv that starts it in the binary's place: ``["ccs", "work"]``. The
+    words are the operator's own and pass through as written, which is the one place this
+    differs from :func:`harness_of`, and it differs because the FILE does: `charter.toml`
+    is committed and its values are only ever compared against charter's registry; this
+    file is one machine's, and choosing what runs on that machine is what it is for.
+
+    What is checked is the SHAPE, and every failure of it is refused and named rather than
+    degraded: a table for a harness charter cannot launch; a ``command`` that is not a
+    non-empty list of non-empty strings — ``"ccs work"`` is one word naming no program,
+    and splitting it would be a shell's job when there is deliberately no shell between
+    here and `execvp` (`harness.base.launch_argv`); a harness key holding a value where a
+    table should be, which is the shape of ``[harness] default = "claude"`` copied across
+    from `charter.toml`. Each becomes one line of ``refused``, and `doctor` prints them,
+    because a refused override degrades to launching the binary — byte-identical to what
+    a plane with no `local.toml` does, which is #535's shape: a declared thing silently
+    not in force. Rendered through :func:`contain.readable`, since a value out of this
+    file is about to be told to somebody as the thing to fix, and a newline in it would
+    forge a second row of charter's own report.
+
+    ``refused`` is a list on every path, `frame_of`'s rule for ``components``: a key
+    present on one path and absent on another is two shapes for one answer.
+    """
+    out: dict = {"command": {}, "refused": []}
+    section = cfg.get("harness")
+    if not isinstance(section, dict):
+        return out
+    known = launchable_harnesses()
+    for name, table in section.items():
+        shown = contain.readable(name)
+        if not isinstance(table, dict):
+            out["refused"].append(
+                f"[harness] {shown} = {contain.readable(table)} is not a "
+                f"[harness.<name>] table")
+            continue
+        if name not in known:
+            out["refused"].append(
+                f"[harness.{shown}] is not a harness charter can launch")
+            continue
+        if "command" not in table:
+            continue
+        words = table["command"]
+        # `bool` is an `int` and `tomllib` yields both; neither is a word. A list is what
+        # `execvp` and tmux take, and every element has to be a word that names something
+        # — `[""]` resolves to nothing and would die inside tmux with nothing drawn.
+        if (not isinstance(words, list) or not words
+                or not all(isinstance(w, str) and w for w in words)):
+            out["refused"].append(
+                f"[harness.{shown}] command = {contain.readable(words)} is not a list "
+                f"of words")
+            continue
+        out["command"][name] = words
+    return out

--- a/docs/control-plane.md
+++ b/docs/control-plane.md
@@ -95,6 +95,10 @@ default = "claude"               # "claude" | "opencode" | "codex" — the word 
                                   # have typed after `charter`. No default: charter does
                                   # not pick one for you. A name it does not know is
                                   # REPORTED, not ignored — see "Bare `charter`" below.
+                                  # HOW `charter claude` reaches Claude Code on your
+                                  # machine (`ccs work`, a binary off $PATH) is not here:
+                                  # it is `[harness.claude] command` in .charter/local.toml,
+                                  # yours and never committed — see that section below.
 
 # Which charter this plane tracks. Opt-in; absent, you track published releases.
 [update]
@@ -498,6 +502,57 @@ is a terminal. Piped or redirected, it prints the usage message and exits 2, whi
 it did before this key existed — so a script that runs `charter 2>&1 | head` to find out
 whether charter is installed gets an answer instead of an agent session. `charter claude`
 into a pipe is unaffected: it runs the harness bare, as it always did.
+
+## `[harness.<name>].command` — your own launcher, in `.charter/local.toml`
+
+**Opt-in, and per developer.** `charter claude` execs `claude`, by that name, off your
+`$PATH`. If you reach Claude Code some other way — a wrapper that picks which account a
+chat is billed to (`ccs work`, `ccs personal`), a script that sets the environment first,
+a binary you keep off `$PATH` — name it in the plane's `.charter/local.toml`:
+
+```toml
+[harness.claude]
+command = ["ccs", "work"]
+```
+
+With it, `charter claude` runs `ccs work` where it ran `claude`, and everything else is
+unchanged: the frame, the workspace picker, `--no-frame`, `--resume` on a `charter reopen`.
+Your arguments follow the command, so `charter claude -p hi` is `ccs work -p hi`. It is
+still the Claude Code harness charter is launching — `$CHARTER_HARNESS` set in the pane,
+the workspace layer written, the chat resumable — which is what `charter frame -- ccs work`
+cannot give you: the escape hatch runs the words and forgets the harness.
+
+The table is named by the word you type after `charter` — `claude`, `opencode`, `codex`,
+whatever `charter harness list` shows — and `command` is a **list of words**, one argv
+element each. `"ccs work"` is refused, not split: there is deliberately no shell between
+charter and the harness ([frame.md](frame.md#what-charter-frame----cmd-accepts)), so
+splitting it would be inventing one. A path works where a word does
+(`["/opt/claude/bin/claude"]`). Each harness has its own table; one file can carry a
+`[harness.claude]` and a `[harness.codex]`.
+
+**Not in `charter.toml`, and that is a rule rather than a limitation.** `charter.toml` is
+committed and arrives from somebody else's machine, and the containment rule says a name
+charter reads out of a committed file cannot choose what it runs — it is why
+`[harness] default` above is only ever *compared* against charter's own registry. A
+`command` is exactly that choice, so it lives in `.charter/`, which `init` gitignores on
+every plane, whose files are yours alone (mode 0600), and which already holds your half of
+the vault registry over the committed one. It is also the right scope: which account you
+bill a chat to is your business, and a teammate on the same plane may run plain `claude`.
+`$CHARTER_HOME` moves this file with the rest of `.charter/`.
+
+**A table charter cannot honour is reported, not ignored.** A misspelt harness name, a
+`command` that is not a list of words, or a `[harness] claude = "…"` where a table should
+be, each degrade to the binary — exactly what a plane with no `local.toml` gets, so from
+the launch alone you could not tell a typo from a file you never wrote. `charter doctor`
+has a `local.toml` row that names each one, and prints `claude → ccs work` when the
+override is in force; `charter harness list` prints `→ runs: ccs work` under the harness.
+The launch itself prints nothing: a warning before tmux takes the screen is lost with it
+([frame.md](frame.md)). A file that does not parse is reported the same way, and charter
+carries on with the binary until it does.
+
+`charter claude` still checks that what it is about to run is installed before drawing
+anything — the command's first word now, rather than `claude` — and exits 127 naming it
+when it is not.
 
 ## `[update].channel` — the dev channel
 

--- a/docs/frame.md
+++ b/docs/frame.md
@@ -26,6 +26,20 @@ below applies to it unchanged. A plane that names no default keeps the usage lis
 does `charter` with its output piped or redirected — a script asking whether charter is
 installed must not get a harness session instead of an answer.
 
+`charter claude` execs `claude` by that name, off your `$PATH`. If you reach Claude Code
+through something else — `ccs work`, which picks the account a chat is billed to; a binary
+you keep off `$PATH` — name it in the plane's `.charter/local.toml` and `charter claude`
+runs that in the binary's place, your arguments after it, with the harness still known to
+charter: `$CHARTER_HARNESS` in the pane, the workspace layer, `charter reopen`. Per
+developer and never committed, for the reason
+[control-plane.md](control-plane.md#harnessnamecommand--your-own-launcher-in-charterlocaltoml)
+gives. `charter frame -- ccs work` is not that: it runs the words and forgets the harness.
+
+```toml
+[harness.claude]
+command = ["ccs", "work"]
+```
+
 `claude`, `codex` and `opencode` are top-level commands (`charter claude`), never nested
 under `frame` (`charter frame claude`) — `charter frame` is its own, separate escape hatch
 for a command charter has no launcher for at all. That is not just naming: once `charter

--- a/docs/news/unreleased-charter-claude-runs-the-command-you-launch-claude-code-with.md
+++ b/docs/news/unreleased-charter-claude-runs-the-command-you-launch-claude-code-with.md
@@ -1,0 +1,23 @@
+---
+version: unreleased
+headline: `charter claude` runs the command you launch Claude Code with
+---
+
+`charter claude` used to exec `claude` by name, and there was no way to tell it otherwise
+short of `charter frame -- ccs work`, which runs the words and forgets the harness: no
+`$CHARTER_HARNESS` in the pane, no workspace layer, nothing `charter reopen` can resume.
+
+Now a per-developer file names your launcher, one table per harness:
+
+```toml
+# .charter/local.toml — yours, never committed
+[harness.claude]
+command = ["ccs", "work"]
+```
+
+`charter claude` runs `ccs work` in `claude`'s place, your arguments follow it, and it is
+still the Claude Code harness charter is launching. `.charter/` is already gitignored on
+every plane, and that is the point rather than a convenience: the containment rule keeps a
+committed `charter.toml` from choosing what runs on a teammate's machine, and which account
+you bill a chat to is yours to decide. `charter doctor` has a `local.toml` row that names a
+table charter cannot honour, and `charter harness list` shows the command in force.

--- a/tests/test_a_harness_runs_through_the_command_you_name.py
+++ b/tests/test_a_harness_runs_through_the_command_you_name.py
@@ -321,6 +321,19 @@ class DoctorNamesAnOverrideNotInForce(PersonaIso):
         self.assertIn("clyde", result.detail + result.hint)
         for name in instance.launchable_harnesses():
             self.assertIn(name, result.hint)
+        self.assertNotIn("…", result.hint,
+                         "one refusal, shown whole, must not claim there are more")
+
+    def test_exactly_three_refusals_are_all_shown_and_nothing_is_clipped(self):
+        """The boundary itself. The sweep found `> 3` indistinguishable from `>= 3` with
+        only one and four refusals to look at; three is the case that tells them apart,
+        and it is the case an operator with three typos actually sees."""
+        result = self._declare("".join(f'[harness.wrong{i}]\ncommand = ["x"]\n'
+                                       for i in range(3)))
+        self.assertEqual(result.status, doctor.WARN)
+        for i in range(3):
+            self.assertIn(f"wrong{i}", result.hint)
+        self.assertNotIn("…", result.hint)
 
     def test_more_than_three_refusals_are_clipped_rather_than_printed_whole(self):
         """One row is one row. The `[[forge]]` branch of the `charter.toml` row clips at

--- a/tests/test_a_harness_runs_through_the_command_you_name.py
+++ b/tests/test_a_harness_runs_through_the_command_you_name.py
@@ -1,0 +1,388 @@
+"""`charter claude` runs the command YOU launch Claude Code with — `.charter/local.toml`.
+
+An operator who reaches Claude Code through a wrapper — `ccs work`, which picks the
+subscription a chat is billed to; a script that pins a binary off `$PATH` — had two doors,
+both wrong. `charter frame -- ccs work` runs the words but forgets the harness: no
+`$CHARTER_HARNESS` in the pane, no workspace layer, nothing `charter reopen` can resume. A
+shell alias is invisible to charter, which execs `claude` by name. `[harness.<name>]
+command` in the plane's `.charter/local.toml` is the third door: the REGISTERED harness,
+launched through the operator's own words, with everything the registration carries.
+
+**Per developer, never committed — and that is the design rather than a limitation.**
+The containment rule (README) says a name charter reads out of a committed file cannot
+choose what it runs; `instance.harness_of` refuses ``[harness] default = "clyde"`` on
+exactly those grounds, and a ``command`` in `charter.toml` would hand a cloned plane
+``argv[0]`` of what runs on a teammate's machine. It is also the right scope on the
+merits: which account a chat is billed to is the operator's business, and a teammate on
+the same plane may well run plain `claude`. `.charter/` is gitignored on every plane
+`init` ever wrote, its files are one account's (`config.STATE_FILE_MODE`), and it already
+holds the per-developer half of the vault registry over the committed one — the precedent
+this follows.
+
+Three things are new and each is tested here rather than described:
+
+* a second TOML file, ``<state dir>/local.toml``, parsed by `instance.load_local` and
+  degraded — never raised — by `config.derive`, the way `charter.toml` is;
+* a refusal at the CONFIG boundary for a table charter cannot honour, carried out to the
+  two readers that can say so (`doctor`, `charter harness list`) rather than degrading into
+  silence — the #535 shape, a declared thing that is not in force;
+* the launcher handing the command to tmux in the binary's place, and asking `$PATH` about
+  the command's first word rather than about a binary it is no longer going to run.
+"""
+
+from __future__ import annotations
+
+import io
+import os
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from types import SimpleNamespace
+from unittest import mock
+
+from charter import commands_frame, commands_harness, config, doctor, instance
+from tests._isolation import PersonaIso
+# Imported at MODULE level, deliberately: `test_frame_launcher` captures the real
+# `config.STATE_DIR` at import so `_refuse_the_real_plane` can compare against it. Imported
+# inside a `PersonaIso` case it would capture the case's tmp instead, and then refuse that
+# very case as "the real plane".
+from tests.test_frame_launcher import _FakeTmux, _launch
+
+_NONE = {"command": {}, "refused": []}
+
+
+def _run_capturing(fn, args) -> tuple[int, str]:
+    out, err = io.StringIO(), io.StringIO()
+    with redirect_stdout(out), redirect_stderr(err):
+        rc = fn(args)
+    return rc, out.getvalue() + err.getvalue()
+
+
+class TheOverrideIsReadAtTheConfigBoundary(unittest.TestCase):
+    """`instance.harness_local_of` — pure, no plane, no filesystem."""
+
+    def test_a_file_that_declares_nothing_overrides_nothing(self):
+        self.assertEqual(instance.harness_local_of({}), _NONE)
+
+    def test_a_declared_command_is_stored_for_the_harness_it_names(self):
+        got = instance.harness_local_of({"harness": {"claude": {"command": ["ccs", "work"]}}})
+        self.assertEqual(got, {"command": {"claude": ["ccs", "work"]}, "refused": []})
+
+    def test_every_registered_harness_can_carry_one(self):
+        for name in instance.launchable_harnesses():
+            with self.subTest(harness=name):
+                got = instance.harness_local_of({"harness": {name: {"command": ["run-it"]}}})
+                self.assertEqual(got["command"], {name: ["run-it"]})
+                self.assertEqual(got["refused"], [])
+
+    def test_two_harnesses_can_each_carry_their_own(self):
+        got = instance.harness_local_of({"harness": {
+            "claude": {"command": ["ccs", "work"]},
+            "codex": {"command": ["/opt/codex/bin/codex"]},
+        }})
+        self.assertEqual(got["command"], {"claude": ["ccs", "work"],
+                                          "codex": ["/opt/codex/bin/codex"]})
+
+    def test_a_command_for_a_harness_charter_cannot_launch_is_refused_and_named(self):
+        """The refusal asserts the REASON: a `command` dict that came back empty proves
+        nothing on its own, because that is also what a file declaring nothing gets."""
+        got = instance.harness_local_of({"harness": {"clyde": {"command": ["x"]}}})
+        self.assertEqual(got["command"], {})
+        self.assertEqual(len(got["refused"]), 1)
+        self.assertIn("clyde", got["refused"][0])
+
+    def test_the_tables_are_named_by_the_words_an_operator_types(self):
+        """`claude`, not `claude-code`: the same rule `[harness] default` follows, because
+        it is the same word — the one after `charter` on the command line."""
+        got = instance.harness_local_of({"harness": {"claude-code": {"command": ["x"]}}})
+        self.assertEqual(got["command"], {})
+        self.assertIn("claude-code", got["refused"][0])
+
+    def test_a_command_that_is_not_a_list_of_words_is_refused_and_named(self):
+        """tmux and `execvp` take a LIST; `"ccs work"` is one word that names no program.
+        Refused rather than split, because splitting is a shell's job and there is no
+        shell here on purpose (`harness.base.launch_argv`). The other shapes are
+        `tomllib` handing over something declared and unusable — as declared, and as not
+        in force, as the string."""
+        for value in ("ccs work", ["ccs", 1], [], [""], 7, True, {"words": ["ccs"]}):
+            with self.subTest(value=value):
+                got = instance.harness_local_of({"harness": {"claude": {"command": value}}})
+                self.assertEqual(got["command"], {})
+                self.assertEqual(len(got["refused"]), 1, got)
+                self.assertIn("claude", got["refused"][0])
+
+    def test_a_harness_entry_that_is_not_a_table_is_refused_and_named(self):
+        """``[harness] claude = "ccs work"`` — the shape of a likely typo, and a declared
+        thing. Silently reading it as no table would be the #535 failure."""
+        got = instance.harness_local_of({"harness": {"claude": "ccs work"}})
+        self.assertEqual(got["command"], {})
+        self.assertIn("claude", got["refused"][0])
+
+    def test_a_table_with_no_command_key_is_not_a_refusal(self):
+        got = instance.harness_local_of({"harness": {"claude": {"nothing": "here"}}})
+        self.assertEqual(got, _NONE)
+
+    def test_a_section_that_is_not_a_section_degrades_rather_than_raising(self):
+        for section in ("claude", 3, None, ["claude"]):
+            with self.subTest(section=section):
+                self.assertEqual(instance.harness_local_of({"harness": section}), _NONE)
+
+    def test_a_refused_value_cannot_forge_a_second_report_line(self):
+        """The refusal is a sentence `doctor` prints; the value in it comes off a file."""
+        got = instance.harness_local_of(
+            {"harness": {"claude": {"command": "ccs\n✓ charter: pwned"}}})
+        self.assertEqual(len(got["refused"]), 1)
+        self.assertNotIn("\n", got["refused"][0])
+
+    def test_a_refused_name_cannot_forge_a_second_report_line_either(self):
+        """TOML quotes a key, so a harness NAME can carry a newline as readily as a value
+        — and so can the value sitting where a table should be."""
+        got = instance.harness_local_of({"harness": {
+            "cly\nde": {"command": ["x"]},
+            "claude": "ccs\n✓ charter: pwned",
+        }})
+        self.assertEqual(len(got["refused"]), 2)
+        for line in got["refused"]:
+            self.assertNotIn("\n", line)
+
+    def test_refused_is_a_list_on_every_path(self):
+        """`frame_of`'s rule for `components`: a key present on one path and absent on
+        another is two shapes for one answer."""
+        for cfg in ({}, {"harness": None}, {"harness": {}},
+                    {"harness": {"claude": {"command": ["ccs"]}}}):
+            with self.subTest(cfg=cfg):
+                self.assertIsInstance(instance.harness_local_of(cfg)["refused"], list)
+
+
+class TheFileIsReadFromTheStateDir(PersonaIso):
+    """`config.HARNESS_LOCAL` derives from ``<state dir>/local.toml``, like `config.HARNESS`
+    derives from `charter.toml` — and from the STATE dir, not the plane root, because that
+    is the per-developer directory, gitignored on every plane and redirected as one by
+    ``$CHARTER_HOME``."""
+
+    def _declare(self, text: str) -> None:
+        config.STATE_DIR.mkdir(parents=True, exist_ok=True)
+        (config.STATE_DIR / "local.toml").write_text(text)
+        config.use(self.tmp)
+
+    def test_a_local_file_that_declares_a_command_reaches_config(self):
+        self._declare('[harness.claude]\ncommand = ["ccs", "work"]\n')
+        self.assertEqual(config.HARNESS_LOCAL,
+                         {"command": {"claude": ["ccs", "work"]}, "refused": []})
+        self.assertIsNone(config.LOCAL_CONFIG_ERROR)
+
+    def test_a_plane_with_no_local_file_derives_no_override(self):
+        self.assertFalse((config.STATE_DIR / "local.toml").exists())
+        self.assertEqual(config.HARNESS_LOCAL, _NONE)
+        self.assertIsNone(config.LOCAL_CONFIG_ERROR)
+
+    def test_the_path_is_a_derived_setting_so_reports_can_name_it(self):
+        self.assertEqual(config.LOCAL_CONFIG, config.STATE_DIR / "local.toml")
+
+    def test_a_malformed_local_file_is_recorded_and_still_derives_a_usable_shape(self):
+        """`config` is imported by every command including `charter --version`; a typo in
+        a per-developer file must not take the CLI down, and every setting must still
+        have a shape a caller can read without a `KeyError`."""
+        self._declare("this is not = valid = toml\n")
+        self.assertIsNotNone(config.LOCAL_CONFIG_ERROR)
+        self.assertEqual(config.HARNESS_LOCAL, _NONE)
+
+    def test_a_refused_declaration_reaches_config_as_a_refusal(self):
+        self._declare('[harness.clyde]\ncommand = ["x"]\n')
+        self.assertEqual(config.HARNESS_LOCAL["command"], {})
+        self.assertIn("clyde", config.HARNESS_LOCAL["refused"][0])
+
+    def test_the_settings_are_ones_the_test_harness_isolates(self):
+        """`config.DERIVED` is what `config.use` swaps. A setting absent from it is one no
+        test can isolate — and this one is read off the developer's own machine."""
+        for name in ("HARNESS_LOCAL", "LOCAL_CONFIG_ERROR", "LOCAL_CONFIG"):
+            self.assertIn(name, config.DERIVED)
+
+    def test_bytes_that_are_not_utf8_are_refused_as_not_toml(self):
+        """`load_local`'s contract is `load`'s: one exception class for "cannot read this
+        as TOML", so `config.derive` has one thing to catch and `doctor` one thing to
+        print. A raw `UnicodeDecodeError` would be a second."""
+        config.STATE_DIR.mkdir(parents=True, exist_ok=True)
+        (config.STATE_DIR / "local.toml").write_bytes(b"\xff\xfe[harness]")
+        with self.assertRaises(ValueError):
+            instance.load_local(config.STATE_DIR)
+
+    def test_a_state_dir_that_does_not_exist_yet_is_an_empty_file(self):
+        """A fresh clone has no `.charter/` at all until something writes one."""
+        self.assertEqual(instance.load_local(self.tmp / "never-made"), {})
+
+    def test_the_file_follows_the_state_dir_when_charter_home_moves_it(self):
+        """``$CHARTER_HOME`` is documented as the way to share one `.charter/` across
+        clones; a per-developer override travels with it."""
+        home = self.tmp / "elsewhere"
+        home.mkdir()
+        (home / "local.toml").write_text('[harness.claude]\ncommand = ["ccs", "personal"]\n')
+        with mock.patch.dict(os.environ, {"CHARTER_HOME": str(home)}):
+            config.use(self.tmp)
+            self.assertEqual(config.HARNESS_LOCAL["command"], {"claude": ["ccs", "personal"]})
+
+
+class TheLaunchRunsTheCommand(PersonaIso):
+    """`commands_frame.cmd_launch`, on both of its paths."""
+
+    def _declare(self, text: str) -> None:
+        config.STATE_DIR.mkdir(parents=True, exist_ok=True)
+        (config.STATE_DIR / "local.toml").write_text(text)
+        config.use(self.tmp)
+
+    def test_a_bare_launch_execs_the_command_with_the_operators_arguments_after_it(self):
+        self._declare('[harness.claude]\ncommand = ["ccs", "work"]\n')
+        args = SimpleNamespace(harness="claude", rest=["-p", "hi"], no_frame=True)
+        with mock.patch("os.execvp") as execvp:
+            commands_frame.cmd_launch(args)
+        execvp.assert_called_once_with("ccs", ["ccs", "work", "-p", "hi"])
+
+    def test_a_plane_with_no_override_execs_the_binary_as_before(self):
+        args = SimpleNamespace(harness="claude", rest=["-p", "hi"], no_frame=True)
+        with mock.patch("os.execvp") as execvp:
+            commands_frame.cmd_launch(args)
+        execvp.assert_called_once_with("claude", ["claude", "-p", "hi"])
+
+    def test_the_framed_launch_hands_tmux_the_command(self):
+        """The `new-session` that starts the chat carries the command's words where the
+        binary used to be — verbatim, one argv element each, never joined."""
+        self._declare('[harness.claude]\ncommand = ["ccs", "work"]\n')
+        fake = _FakeTmux(exit_code=0)
+        with mock.patch("os.execvp", side_effect=AssertionError("bypassed the frame")):
+            rc = _launch(fake, harness="claude", rest=["--resume", "abc"])
+        self.assertEqual(rc, 0)
+        starts = [c for c in fake.calls if "new-session" in c]
+        self.assertTrue(starts, fake.calls)
+        words = starts[0]
+        at = words.index("ccs")
+        self.assertEqual(words[at:at + 4], ["ccs", "work", "--resume", "abc"])
+        self.assertNotIn("claude", words[at:])
+
+    def test_the_pre_tmux_check_asks_about_the_command_not_the_binary(self):
+        """`cmd_launch` refuses to reach tmux for a registered harness whose binary is not
+        on `$PATH`, because a `new-session` whose exec fails draws nothing at all. With a
+        command in force the binary is not what is about to be exec'd, so `claude` being
+        installed answers the wrong question: `ccs` missing has to be what is refused,
+        before tmux, and named."""
+        self._declare('[harness.claude]\ncommand = ["ccs", "work"]\n')
+        fake = _FakeTmux(exit_code=0)
+        buf = []
+        with mock.patch("os.execvp", side_effect=FileNotFoundError(2, "No such file")), \
+             mock.patch("charter.util.err", side_effect=lambda m: buf.append(m)):
+            rc = _launch(fake, harness="claude",
+                         which=lambda name, *a, **k: None if name == "ccs"
+                         else f"/usr/bin/{name}")
+        self.assertEqual(rc, 127)
+        self.assertTrue(any("ccs" in m for m in buf), buf)
+        self.assertFalse([c for c in fake.calls if "new-session" in c],
+                         "refused AFTER tmux — the operator was left with nothing drawn")
+
+    def test_a_binary_off_the_path_does_not_stop_a_command_that_is_on_it(self):
+        """The other direction: the wrapper is what runs, so the wrapper is what has to
+        be findable — a `claude` that `$PATH` cannot see is the wrapper's problem to
+        solve, not charter's to refuse."""
+        self._declare('[harness.claude]\ncommand = ["ccs", "work"]\n')
+        fake = _FakeTmux(exit_code=0)
+        with mock.patch("os.execvp", side_effect=AssertionError("bypassed the frame")):
+            rc = _launch(fake, harness="claude",
+                         which=lambda name, *a, **k: None if name == "claude"
+                         else f"/usr/bin/{name}")
+        self.assertEqual(rc, 0)
+        self.assertTrue([c for c in fake.calls if "new-session" in c])
+
+
+class DoctorNamesAnOverrideNotInForce(PersonaIso):
+    """The reader for the operator who runs `doctor`. A value refused inside `derive` has
+    nobody to tell — `charter claude` deliberately prints nothing before tmux takes the
+    screen (`commands_frame.frame_ready`) — so this row asks the same question of the file
+    and names it, the way the `charter.toml` row names a refused `[harness] default`."""
+
+    def _declare(self, text: str):
+        config.STATE_DIR.mkdir(parents=True, exist_ok=True)
+        (config.STATE_DIR / "local.toml").write_text(text)
+        config.use(self.tmp)
+        return doctor.check_local_config()
+
+    def test_the_row_is_named_for_the_file(self):
+        self.assertEqual(doctor.check_local_config().name, "local.toml")
+
+    def test_no_file_is_not_a_problem_and_says_there_is_nothing_in_force(self):
+        result = doctor.check_local_config()
+        self.assertEqual(result.status, doctor.OK)
+        self.assertIn("no per-developer overrides", result.detail)
+
+    def test_a_command_in_force_is_green_and_says_what_runs(self):
+        result = self._declare('[harness.claude]\ncommand = ["ccs", "work"]\n')
+        self.assertEqual(result.status, doctor.OK)
+        self.assertIn("ccs work", result.detail)
+
+    def test_a_refused_table_is_a_warning_that_names_it(self):
+        result = self._declare('[harness.clyde]\ncommand = ["x"]\n')
+        self.assertEqual(result.status, doctor.WARN)
+        self.assertIn("clyde", result.detail + result.hint)
+        for name in instance.launchable_harnesses():
+            self.assertIn(name, result.hint)
+
+    def test_more_than_three_refusals_are_clipped_rather_than_printed_whole(self):
+        """One row is one row. The `[[forge]]` branch of the `charter.toml` row clips at
+        three for the same reason, and the fourth name is what proves the clip happened."""
+        result = self._declare("".join(f'[harness.wrong{i}]\ncommand = ["x"]\n'
+                                       for i in range(4)))
+        self.assertEqual(result.status, doctor.WARN)
+        self.assertIn("wrong2", result.hint)
+        self.assertNotIn("wrong3", result.hint)
+        self.assertIn("…", result.hint)
+
+    def test_a_word_of_the_command_cannot_forge_a_second_row(self):
+        """A list of non-empty strings is a VALID command — the operator's own words, out
+        of their own file — and one of them can still hold a newline. This is charter's
+        report format, and a newline in a detail is a second row."""
+        result = self._declare('[harness.claude]\ncommand = ["ccs", "work\\n✓ pwned"]\n')
+        self.assertEqual(result.status, doctor.OK)
+        self.assertNotIn("\n", result.detail)
+
+    def test_a_malformed_file_is_a_warning_that_names_the_parse_error(self):
+        """A warning and not a failure: charter carries on with no override, which is a
+        working plane — the operator just is not getting what they wrote."""
+        result = self._declare("this is not = valid = toml\n")
+        self.assertEqual(result.status, doctor.WARN)
+        self.assertIn("TOML", result.detail + result.hint)
+
+    def test_the_row_is_in_the_preflight_and_its_name_is_pinned(self):
+        """`_FIXED_CHECK_NAMES` sizes the table before a single check runs; a row added to
+        `_checks` and not to it fails the width pin. Beside `charter.toml`, which is the
+        row it is the per-developer half of."""
+        names = doctor.check_names()
+        self.assertIn("local.toml", names)
+        self.assertEqual(names.index("local.toml"), names.index("charter.toml") + 1)
+
+
+class HarnessListSaysWhatRuns(PersonaIso):
+    """The second reader, for an operator asking charter what it knows about a harness."""
+
+    def _declare(self, text: str) -> None:
+        config.STATE_DIR.mkdir(parents=True, exist_ok=True)
+        (config.STATE_DIR / "local.toml").write_text(text)
+        config.use(self.tmp)
+
+    def test_a_harness_with_a_command_in_force_shows_it(self):
+        self._declare('[harness.claude]\ncommand = ["ccs", "work"]\n')
+        _rc, text = _run_capturing(commands_harness.cmd_harness_list, SimpleNamespace())
+        self.assertIn("ccs work", text)
+        self.assertLess(text.index("claude-code"), text.index("ccs work"))
+        self.assertLess(text.index("ccs work"), text.index("opencode"),
+                        "the command belongs under the harness it launches")
+
+    def test_a_word_of_the_command_cannot_forge_a_second_row(self):
+        self._declare('[harness.claude]\ncommand = ["ccs", "work\\n* opencode"]\n')
+        _rc, text = _run_capturing(commands_harness.cmd_harness_list, SimpleNamespace())
+        self.assertNotIn("\n* opencode", text,
+                         "a word out of the operator's file drew a second harness row")
+        self.assertIn("ccs work", text)
+
+    def test_a_harness_without_one_shows_nothing_new(self):
+        _rc, text = _run_capturing(commands_harness.cmd_harness_list, SimpleNamespace())
+        self.assertNotIn("runs", text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_frame_launcher.py
+++ b/tests/test_frame_launcher.py
@@ -201,12 +201,13 @@ class MissingHarnessBinary(PersonaIso, unittest.TestCase):
         """`charter frame -- <cmd>` must behave exactly as it did. `argv[0]` there is the
         operator's own verbatim word and is allowed to be a shell builtin, a relative
         path, or anything else tmux's own resolution accepts — so the check is scoped to
-        `if h`, a REGISTERED harness whose binary charter itself chose
-        (`harness.base.binary`), and never to `argv[0]`.
+        `if h`, a REGISTERED harness, whose `argv[0]` is either the binary charter itself
+        chose (`harness.base.binary`) or the first word of the `[harness.<name>] command`
+        the operator wrote into their own `.charter/local.toml` as an executable.
 
-        This is what fails if anyone "simplifies" the guard to `not
-        shutil.which(argv[0])`: a command charter has never met, provably not on `$PATH`,
-        must still reach `new-session`."""
+        This is what fails if anyone "simplifies" the guard by dropping the `if h`: a
+        command charter has never met, provably not on `$PATH`, must still reach
+        `new-session`."""
         fake = _FakeTmux(exit_code=0)
         self.assertIsNone(shutil.which("charter-definitely-not-a-real-binary-xyz"))
         # NOTHING resolves on `$PATH` for the duration — the strongest form of the

--- a/tests/test_harness_launch.py
+++ b/tests/test_harness_launch.py
@@ -27,6 +27,20 @@ class HarnessLaunchIdentity(unittest.TestCase):
         self.assertEqual(h.launch_argv(["--resume", "a;b"]),
                          ["claude", "--resume", "a;b"])
 
+    def test_launch_argv_runs_the_operators_own_command_in_the_binarys_place(self):
+        """`.charter/local.toml`'s `[harness.claude] command` — the operator reaches Claude
+        Code through `ccs work`, and the registered harness has to be launched through
+        those words rather than through `charter frame -- ccs work`, which forgets which
+        harness it is. The command REPLACES the binary and the operator's arguments still
+        follow it, so `--resume <id>` on a reopen lands where the wrapper forwards it."""
+        h = harness.get(harness.CLAUDE_CODE)
+        self.assertEqual(h.launch_argv(["--resume", "a;b"], command=["ccs", "work"]),
+                         ["ccs", "work", "--resume", "a;b"])
+
+    def test_no_command_means_the_binary_exactly_as_before(self):
+        h = harness.get(harness.CLAUDE_CODE)
+        self.assertEqual(h.launch_argv(["-p", "hi"], command=None), ["claude", "-p", "hi"])
+
     def test_launch_argv_returns_a_list_never_a_string(self):
         """Pinned against tmux 3.7c: separate argv is not shell-interpreted, a joined
         string is. A harness returning a string would put the injection back."""


### PR DESCRIPTION
## What

`charter claude` execs `claude` by name. If you reach Claude Code through something else — `ccs work`, a wrapper that picks which account a chat is billed to; a binary you keep off `$PATH` — you had two doors, both wrong: `charter frame -- ccs work` runs the words and forgets the harness (no `$CHARTER_HARNESS` in the pane, no workspace layer, nothing `charter reopen` can resume), and a shell alias is invisible to an `execvp`.

This adds a **per-developer** file that names the launcher, one table per harness:

```toml
# .charter/local.toml — yours, never committed
[harness.claude]
command = ["ccs", "work"]
```

`charter claude` then runs `ccs work` in `claude`'s place, your arguments follow it (`charter claude -p hi` → `ccs work -p hi`, `--resume <id>` on a reopen), and it is still the Claude Code harness charter is launching.

## Why `.charter/local.toml` and not `charter.toml`

The README's containment rule: *a name charter reads out of a committed file cannot choose what it runs*. That is why `instance.harness_of` only ever *compares* `[harness] default` against the registry and refuses `"clyde"`. A `command` is exactly that choice, so it cannot live in a committed file. `.charter/` is gitignored on every plane `init` wrote, its files are one account's (`STATE_FILE_MODE`), and it already holds the per-developer half of the vault registry over the committed one — the precedent this follows. It is also the right scope on the merits: which account a chat is billed to is one operator's business, and a teammate on the same plane may run plain `claude`. `$CHARTER_HOME` moves the file with the rest of `.charter/`.

## How

- `harness/base.py` — `Harness.launch_argv(extra, command=None)` returns `[*(command or [binary]), *extra]`; still a list, never a joined string.
- `instance.py` — `LOCAL_FILE`, `load_local(state_dir)` (`load` without the schema check), `harness_local_of(cfg)` → `{"command": {cli_name: [words]}, "refused": [sentences]}`. Tables are keyed by the word after `charter` (`claude`, not `claude-code`), `harness_of`'s rule. A table for a harness charter cannot launch, a `command` that is not a non-empty list of non-empty strings (`"ccs work"` is refused, not split — there is deliberately no shell), or a value where a table should be, is **refused and named** through `contain.readable`.
- `config.py` — derives `LOCAL_CONFIG`, `LOCAL_CONFIG_ERROR` (a malformed file degrades, the way `charter.toml`'s does) and `HARNESS_LOCAL`.
- `commands_frame._launch` — passes the override into `launch_argv`; the pre-tmux `shutil.which` check now asks about `argv[0]` rather than `h.binary`, still scoped to `if h` so `charter frame -- <cmd>` is not narrowed (its test's docstring updated to say so).
- `doctor.py` — a `local.toml` row beside `charter.toml`: WARN naming each refused table or the parse error (charter carries on with the binary, which is a working plane), OK with `claude → ccs work` when in force, OK `no per-developer overrides` otherwise. Added to `_FIXED_CHECK_NAMES`.
- `commands_harness.py` — `charter harness list` prints `→ runs: ccs work` under a harness whose command is in force.

## Tests

`tests/test_a_harness_runs_through_the_command_you_name.py` (new) plus two cases in `tests/test_harness_launch.py`, written first and watched fail:

- the parser: every registered harness, unknown names, `claude-code` vs `claude`, every wrong shape of `command`, a value where a table should be, `refused` is a list on every path, newlines in names and values cannot forge a report line;
- `config`: the file reaches `HARNESS_LOCAL`, absent/malformed/non-UTF-8 degrade, the settings are in `DERIVED`, `$CHARTER_HOME` moves the file;
- the launcher: `--no-frame` execs `["ccs", "work", "-p", "hi"]`, the framed path hands `new-session` the command's words verbatim, the pre-tmux check refuses a missing `ccs` before tmux and names it, and a `claude` off `$PATH` does not stop a `ccs` that is on it;
- `doctor`: row name pinned beside `charter.toml`, each status, hint clipping past three refusals, a newline in a command word cannot forge a second row;
- `harness list`: shows the command, and only for the harness it launches.

Full suite locally: `python3 -m unittest discover -s tests` → 12,024 tests, OK (20 skipped), Python 3.13.

Deletion sweep locally (`tools/sweep.py --gate --base main`): 44 mutations, **39 pinned, 2 survivors, 3 unresolved**. The two survivors were both on the `local.toml` row's hint-clipping line (`> 3` vs `>= 3`, and an unconditional ellipsis); the second commit pins them with a one-refusal case asserting no ellipsis and an exactly-three case on the boundary, each watched turn red under its mutation first. The three unresolved are mutations that kill the runner rather than a test (`if h: return bypass(argv)` execs a real `claude` over the test process on a machine that has one; dropping the parser's `isinstance(section, dict)` guard raises inside `config.derive` at import), so zero tests ran and the sweep declines to count that as evidence. Each is pinned by a direct test in an ordinary run; CI's runner has no `claude`, so the first should resolve there.

## Scope, and a possible follow-up

The override is per **plane** and per developer: every workspace in a plane launches the same way, and a work/personal split is two planes with two `local.toml`s. A per-**workspace** override would need a second per-developer location (`.charter/workspaces/<ws>/local.toml`, say) and a lookup in the launcher once it knows the workspace; it is left out of this PR deliberately, and is a small follow-up if anyone wants it. `charter init`, `doctor --fix` and `charter update` still shell out to plain `claude` for plugin installation — the override is about launching a chat, not about which `claude` administers plugins — and the docs say so implicitly by scoping the setting to `charter <harness>`.

## Docs

- `docs/control-plane.md` — new section *`[harness.<name>].command` — your own launcher, in `.charter/local.toml`*, plus a pointer in the annotated `[harness]` sample.
- `docs/frame.md` — a paragraph under the launch commands.
- `README.md` — one sentence after "`charter claude` needs `claude` on your `PATH`".
- `docs/news/unreleased-charter-claude-runs-the-command-you-launch-claude-code-with.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
