### PR TITLE
`doctor` answers for the Claude config folder in use (#969)

### DIFF
--- a/charter/commands.py
+++ b/charter/commands.py
@@ -1146,6 +1146,14 @@ def _plugin_dispatches_guard(root: Path) -> str | None:
 
     Shared with `doctor.check_guard_wired` on purpose. A writer and a checker answering
     "is this wired?" from different evidence is how the guard came to be declared twice.
+
+    **So it follows `$CLAUDE_CONFIG_DIR` with doctor (#969)**, which means it answers for the
+    Claude Code config folder of the shell `charter reinit` runs in. That is a real
+    consequence, not an accident: in a second-account shell whose folder has no plugin, this
+    writes the hook into a settings file every folder shares. The alternative was worse. Kept
+    on `~/.claude`, `doctor` in that shell says the guard is not wired and points at
+    `charter reinit`, and `reinit` answers that nothing needs doing — a remedy followed,
+    believed, and changing nothing.
     """
     from . import doctor
 

--- a/charter/commands.py
+++ b/charter/commands.py
@@ -1147,17 +1147,19 @@ def _plugin_dispatches_guard(root: Path) -> str | None:
     Shared with `doctor.check_guard_wired` on purpose. A writer and a checker answering
     "is this wired?" from different evidence is how the guard came to be declared twice.
 
-    **So it follows `$CLAUDE_CONFIG_DIR` with doctor (#969)**, which means it answers for the
-    Claude Code config folder of the shell `charter reinit` runs in. That is a real
-    consequence, not an accident: in a second-account shell whose folder has no plugin, this
-    writes the hook into a settings file every folder shares. The alternative was worse. Kept
-    on `~/.claude`, `doctor` in that shell says the guard is not wired and points at
-    `charter reinit`, and `reinit` answers that nothing needs doing — a remedy followed,
-    believed, and changing nothing.
+    **But not the config folder doctor answers for (#969).** `doctor` follows
+    `$CLAUDE_CONFIG_DIR`, because a row reports on the session in front of it. This decides a
+    write into the plane's COMMITTED `.claude/settings.json`, which the sessions of every
+    config folder read, and a committed file must not change with one person's shell: followed
+    here, a second-account shell with no plugin wrote the hook into it, and every `~/.claude`
+    session that has the plugin then ran the guard twice. So it names ``~/.claude`` — the
+    evidence it used before #969 — whatever the shell says. Per-profile wiring is designed in
+    harness-profiles task 4; until then the writer keeps its old answer and `doctor` reports
+    the divergence.
     """
     from . import doctor
 
-    return doctor._plugin_declaring_guard(root)
+    return doctor._plugin_declaring_guard(root, folder=Path.home() / ".claude")
 
 
 def _ensure_guard_hook(root: Path) -> tuple[str, Path | None]:

--- a/charter/doctor.py
+++ b/charter/doctor.py
@@ -1622,9 +1622,9 @@ def check_guard_seen() -> Result:
         # An age under another Claude Code config folder is not an age of anything in this
         # one (#969). Green here sat under the guard row's warning and told the reader the
         # guard had just run for them. `guardseen.folder_standing` decides it, for this row
-        # and for `plane-root guard` alike: a sighting from a NAMED harness other than Claude
-        # Code has no folder to be wrong about and passes through, and one that names no
-        # harness at all is unknown and says so.
+        # and for `plane-root guard` alike: a sighting from a registered harness other than
+        # Claude Code has no folder to be wrong about and passes through, and one that names no
+        # harness, or a name charter has no record of, is unknown and says so.
         if standing.doubt is not None:
             detail = f"last ran {at} ago under {where}, but {standing.doubt}"
             # A settings declaration in the folder the sighting DID run under is still there.

--- a/charter/doctor.py
+++ b/charter/doctor.py
@@ -839,11 +839,18 @@ def _settings_files(root: Path | None = None) -> list[Path]:
     this session names its own root: `commands._ensure_guard_hook` is about to write the
     PLANE's `settings.json` and must read the plane's `enabledPlugins`, whatever directory
     the operator happened to be standing in when they typed `charter reinit`.
+
+    **The user half is the config folder Claude Code is using, not ``~/.claude``** (#969).
+    `$CLAUDE_CONFIG_DIR` moves it — a second account is the usual reason — and a session
+    under that folder never opens ``~/.claude/settings.json``. Reading it anyway credited
+    the session with a guard hook and an `enabledPlugins` entry it did not have.
     """
+    from .harness import claude_code as _cc
+
     here = Path(root) if root is not None else session_root()
     return [here / ".claude" / "settings.json",
             here / ".claude" / "settings.local.json",
-            Path.home() / ".claude" / "settings.json"]
+            _cc.config_home() / "settings.json"]
 
 
 def _settings_docs(root: Path | None = None) -> list[dict]:
@@ -913,10 +920,17 @@ def _plugin_declaring_guard(root: Path | None = None) -> str | None:
     ``settings.json`` is not enabled for a chat rooted at ``workspaces/<ws>/`` (#851). A
     caller writing a specific file names that file's directory instead.
     """
+    from .harness import claude_code as _cc
+
     enabled = _enabled_plugin_ids(root)
     if not enabled:
         return None
-    manifest = Path.home() / ".claude" / "plugins" / "installed_plugins.json"
+    # The manifest of the config folder Claude Code is USING (#969). This read
+    # `~/.claude/plugins/installed_plugins.json` while `plugin install` asked `claude plugin
+    # list`, which follows `$CLAUDE_CONFIG_DIR` — so one report said the plugin was not
+    # installed for this plane and, rows earlier, that the guard it carries was wired. Under
+    # that folder no charter hook ran at all: installed somewhere else read as installed here.
+    manifest = _cc.config_home() / "plugins" / "installed_plugins.json"
     try:
         doc = json.loads(manifest.read_text())
     except (OSError, ValueError):
@@ -1041,14 +1055,20 @@ def check_session_root() -> Result:
         return Result(name, OK, detail=f"{here} — no control plane found")
     if session_is_the_plane():
         return Result(name, OK, detail=f"{here} — the plane")
+    from .harness import claude_code as _cc
+
     cwd_only, walking = _discovery_rules()
     lines = [f"{here} — not the plane ({_config.ROOT})"]
+    # The folder the rows below actually read, not a spelling of the default one (#969):
+    # under `$CLAUDE_CONFIG_DIR` they read that folder, and naming `~/.claude/` here would
+    # send the operator to check a file no row consulted.
+    user = f"{util.short_path(_cc.config_home())}/"
     if cwd_only:
         lines.append(f"the host reads {_named(cwd_only)} from the session's own directory "
                      f"and does not walk up, so the plane's .claude/ is not in force for "
-                     f"them — the rows below read {here}/.claude/ and ~/.claude/")
+                     f"them — the rows below read {here}/.claude/ and {user}")
     else:
-        lines.append(f"the rows below read {here}/.claude/ and ~/.claude/, not the "
+        lines.append(f"the rows below read {here}/.claude/ and {user}, not the "
                      f"plane's")
     if walking:
         # Said here, in the row that would otherwise be read as "none of it reaches",
@@ -1244,9 +1264,10 @@ def check_guard_wired() -> Result:
 
     Reachable means ANY of: running under the plugin, or `charter hook pretooluse` declared
     in the plane's ``.claude/settings.json``, its ``.claude/settings.local.json``, or the
-    user's ``~/.claude/settings.json``. All four, because a plane that IS wired and gets
-    warned every session teaches people to ignore the row — the failure
-    `check_memory_indexes` already records.
+    user settings of the config folder Claude Code is using — ``$CLAUDE_CONFIG_DIR/
+    settings.json`` when that is set, ``~/.claude/settings.json`` otherwise (#969). All
+    four, because a plane that IS wired and gets warned every session teaches people to
+    ignore the row — the failure `check_memory_indexes` already records.
 
     It asserts that specific handler rather than "some hook exists": a plane wiring only
     `sessionstart` is unprotected while looking configured, which is this issue again one
@@ -1299,14 +1320,29 @@ def check_guard_wired() -> Result:
         # Reaching the handler is the only proof available, which is what `guardseen`
         # exists to record; a sighting from THIS plugin is that proof.
         from . import guardseen as _seen
-        if _seen.last_source() == _seen.PLUGIN:
+        from .harness import claude_code as _cc
+
+        # ...and only for the config folder it ran under (#969). `$CLAUDE_CONFIG_DIR` moves
+        # the manifest and settings this row just read, so a guard that fired yesterday under
+        # `~/.claude` says nothing about a session under a second account's folder — where
+        # the plugin can be installed and not yet loaded, which is #261's window reached from
+        # a new direction. A sighting that predates the recorded folder cannot say which one
+        # it ran under, so it vouches for none; the next guarded Bash call replaces it.
+        # Absolute on both sides, as `guardseen` records it: a relative `$CLAUDE_CONFIG_DIR`
+        # is a different folder in every directory it is read from.
+        folder = _cc.config_home()
+        if (_seen.last_source() == _seen.PLUGIN
+                and _seen.last_claude_config_dir() == os.path.abspath(folder)):
             return Result(name, OK,
                           detail=f"wired (enabled plugin {plugin}) — and it has fired here")
+        # The folder is named because `guard seen`, one row down, can truthfully say a
+        # guard ran minutes ago. Under another folder both rows are right, and without the
+        # folder they read as a contradiction — which is how #969 was reported.
         return Result(
             name, WARN,
-            detail=f"enabled plugin {plugin} declares it, but nothing has fired here yet — "
-                   f"a plugin's hooks load at session start, so this is wired for the NEXT "
-                   f"session and THIS one may be unguarded",
+            detail=f"enabled plugin {plugin} declares it, but nothing has fired here under "
+                   f"{util.short_path(folder)} yet — a plugin's hooks load at session start, "
+                   f"so this is wired for the NEXT session and THIS one may be unguarded",
             hint="Restart the session (or run a Bash command through it and re-check). If "
                  "you just removed a duplicate `hooks` block on this check's advice, that "
                  "was right — but it was the declaration this session actually had.")
@@ -1319,8 +1355,13 @@ def check_guard_wired() -> Result:
     # remedy that looks like a fix and is not.
     if not session_is_the_plane():
         from . import config as _config
+        from .harness import claude_code as _cc
 
         here = session_root()
+        # The user settings file of the folder in use (#969). Under `$CLAUDE_CONFIG_DIR`
+        # a declaration in `~/.claude/settings.json` reaches no session at all, so naming
+        # that file would be a remedy that is followed, believed, and changes nothing.
+        user = util.short_path(_cc.config_home() / "settings.json")
         return Result(
             name, WARN,
             detail=f"pretooluse is not wired — branch moves in the plane root are NOT "
@@ -1329,8 +1370,8 @@ def check_guard_wired() -> Result:
                   f"the host does not walk up — so the plane's .claude/settings.json never "
                   f"reaches here, wired or not. `charter reinit` writes THAT file, so it "
                   f"would not change this session. Declare `charter hook pretooluse` under "
-                  f"hooks.PreToolUse in {here}/.claude/settings.json, or in "
-                  f"~/.claude/settings.json which every session reads — or install the "
+                  f"hooks.PreToolUse in {here}/.claude/settings.json, or in {user}, which "
+                  f"every session on that Claude config folder reads — or install the "
                   f"Claude Code plugin."))
     return Result(name, WARN,
                   detail="pretooluse is not wired — branch moves in the plane root are "
@@ -2952,8 +2993,15 @@ _REMOVED_SHIMS = ("edm", "charter")
 
 def _claude_json() -> Path:
     """Claude Code's user-level config — where `mcpServers` registrations live, both the
-    user-scoped ones and the per-project ones under `projects`."""
-    return Path.home() / ".claude.json"
+    user-scoped ones and the per-project ones under `projects`.
+
+    The file of the config folder Claude Code is using, not ``~/.claude.json`` (#969):
+    measured on 2.1.268, with `$CLAUDE_CONFIG_DIR` set Claude Code writes `.claude.json`
+    inside that folder, so the servers a second account registers are there and the home
+    file's are not launched at all. `claude_code.global_config_file` owns the rule."""
+    from .harness import claude_code as _cc
+
+    return _cc.global_config_file()
 
 
 def _vault_in_args(args) -> str | None:
@@ -3112,10 +3160,13 @@ def check_mcp_launchers() -> Result:
         # A machine that never registered an MCP server is healthy, not unknown.
         return Result("mcp", OK, detail="no MCP servers registered")
     except (OSError, ValueError, UnicodeDecodeError) as exc:
-        return Result("mcp", WARN, detail=f"~/.claude.json unreadable ({_first_line(str(exc))})",
+        # Named by the path actually read (#969): the file moves with `$CLAUDE_CONFIG_DIR`,
+        # and a row that always says `~/.claude.json` sends the reader to the wrong file.
+        return Result("mcp", WARN,
+                      detail=f"{util.short_path(path)} unreadable ({_first_line(str(exc))})",
                       hint=_NOT_CHECKED_HINT)
     if not isinstance(doc, dict):
-        return Result("mcp", WARN, detail="~/.claude.json is not an object",
+        return Result("mcp", WARN, detail=f"{util.short_path(path)} is not an object",
                       hint=_NOT_CHECKED_HINT)
 
     registered = _registered_launchers(doc)

--- a/charter/doctor.py
+++ b/charter/doctor.py
@@ -828,7 +828,7 @@ def session_is_the_plane() -> bool:
     return session_root() == _canonical(Path(_config.ROOT))
 
 
-def _settings_files(root: Path | None = None) -> list[Path]:
+def _settings_files(root: Path | None = None, folder: Path | None = None) -> list[Path]:
     """The settings the HOST actually resolves, in the order it reads them.
 
     One list, used both for a directly-declared hook and for `enabledPlugins`, so the two
@@ -843,17 +843,30 @@ def _settings_files(root: Path | None = None) -> list[Path]:
     **The user half is the config folder Claude Code is using, not ``~/.claude``** (#969).
     `$CLAUDE_CONFIG_DIR` moves it — a second account is the usual reason — and a session
     under that folder never opens ``~/.claude/settings.json``. Reading it anyway credited
-    the session with a guard hook and an `enabledPlugins` entry it did not have.
+    the session with a guard hook and an `enabledPlugins` entry it did not have. *folder*
+    names another folder for the one caller that must not follow the shell — see
+    :func:`_claude_folder`.
     """
-    from .harness import claude_code as _cc
-
     here = Path(root) if root is not None else session_root()
     return [here / ".claude" / "settings.json",
             here / ".claude" / "settings.local.json",
-            _cc.config_home() / "settings.json"]
+            _claude_folder(folder) / "settings.json"]
 
 
-def _settings_docs(root: Path | None = None) -> list[dict]:
+def _claude_folder(folder: Path | None) -> Path:
+    """*folder*, or the Claude Code config folder in use when none is named (#969).
+
+    Every `doctor` row asks about the folder in use. `commands._plugin_dispatches_guard`
+    names ``~/.claude`` instead, because `charter reinit` writes the plane's committed
+    `.claude/settings.json` — read by the sessions of every config folder — and a committed
+    file must not change with one person's shell.
+    """
+    from .harness import claude_code as _claude_code
+
+    return Path(folder) if folder is not None else _claude_code.config_home()
+
+
+def _settings_docs(root: Path | None = None, folder: Path | None = None) -> list[dict]:
     """Every settings document the host resolves from *root*, parsed, unreadable ones dropped.
 
     One reader for :func:`_settings_files`, because two of them drifted once already: the
@@ -867,7 +880,7 @@ def _settings_docs(root: Path | None = None) -> list[dict]:
     not there.
     """
     out: list[dict] = []
-    for p in _settings_files(root):
+    for p in _settings_files(root, folder):
         try:
             doc = json.loads(p.read_text())
         except (OSError, ValueError, UnicodeDecodeError):
@@ -877,17 +890,18 @@ def _settings_docs(root: Path | None = None) -> list[dict]:
     return out
 
 
-def _enabled_plugin_ids(root: Path | None = None) -> set[str]:
+def _enabled_plugin_ids(root: Path | None = None, folder: Path | None = None) -> set[str]:
     """Plugin ids the host has ENABLED. Installed is not enabled (#177)."""
     out: set[str] = set()
-    for doc in _settings_docs(root):
+    for doc in _settings_docs(root, folder):
         for pid, on in (doc.get("enabledPlugins") or {}).items():
             if on:
                 out.add(pid)
     return out
 
 
-def _plugin_declaring_guard(root: Path | None = None) -> str | None:
+def _plugin_declaring_guard(root: Path | None = None,
+                            folder: Path | None = None) -> str | None:
     """An ENABLED Claude Code plugin whose own ``hooks.json`` dispatches the guard.
 
     ``CLAUDE_PLUGIN_ROOT`` is set only for the plugin's OWN processes, so a `charter doctor`
@@ -919,10 +933,12 @@ def _plugin_declaring_guard(root: Path | None = None) -> str | None:
     scoped to the directory the host read it from — a plugin enabled in the plane's
     ``settings.json`` is not enabled for a chat rooted at ``workspaces/<ws>/`` (#851). A
     caller writing a specific file names that file's directory instead.
-    """
-    from .harness import claude_code as _cc
 
-    enabled = _enabled_plugin_ids(root)
+    *folder* is the Claude Code config folder whose plugins and user settings to believe,
+    defaulting to the one in use (#969); see :func:`_claude_folder` for the caller that names
+    ``~/.claude`` instead.
+    """
+    enabled = _enabled_plugin_ids(root, folder)
     if not enabled:
         return None
     # The manifest of the config folder Claude Code is USING (#969). This read
@@ -930,7 +946,7 @@ def _plugin_declaring_guard(root: Path | None = None) -> str | None:
     # list`, which follows `$CLAUDE_CONFIG_DIR` — so one report said the plugin was not
     # installed for this plane and, rows earlier, that the guard it carries was wired. Under
     # that folder no charter hook ran at all: installed somewhere else read as installed here.
-    manifest = _cc.config_home() / "plugins" / "installed_plugins.json"
+    manifest = _claude_folder(folder) / "plugins" / "installed_plugins.json"
     try:
         doc = json.loads(manifest.read_text())
     except (OSError, ValueError):
@@ -1044,8 +1060,9 @@ def check_session_root() -> Result:
     directory answers yes to the first and no to the second. That belongs to
     `check_guard_seen`, which already answers dispatch from evidence (a guard that ran)
     rather than from configuration, and which says in its own docstring why no amount of
-    reading configuration can see it. Naming a directory as trusted by reading
-    ``~/.claude.json`` would be one more proxy in the family this row is fixing.
+    reading configuration can see it. Naming a directory as trusted by reading Claude Code's
+    ``.claude.json`` — which is not even ``~/.claude.json`` once `$CLAUDE_CONFIG_DIR` moves it
+    (#969) — would be one more proxy in the family this row is fixing.
     """
     from . import config as _config
 
@@ -1055,20 +1072,20 @@ def check_session_root() -> Result:
         return Result(name, OK, detail=f"{here} — no control plane found")
     if session_is_the_plane():
         return Result(name, OK, detail=f"{here} — the plane")
-    from .harness import claude_code as _cc
+    from .harness import claude_code as _claude_code
 
     cwd_only, walking = _discovery_rules()
     lines = [f"{here} — not the plane ({_config.ROOT})"]
     # The folder the rows below actually read, not a spelling of the default one (#969):
     # under `$CLAUDE_CONFIG_DIR` they read that folder, and naming `~/.claude/` here would
     # send the operator to check a file no row consulted.
-    user = f"{util.short_path(_cc.config_home())}/"
+    user_folder = f"{util.short_path(_claude_code.config_home())}/"
     if cwd_only:
         lines.append(f"the host reads {_named(cwd_only)} from the session's own directory "
                      f"and does not walk up, so the plane's .claude/ is not in force for "
-                     f"them — the rows below read {here}/.claude/ and {user}")
+                     f"them — the rows below read {here}/.claude/ and {user_folder}")
     else:
-        lines.append(f"the rows below read {here}/.claude/ and {user}, not the "
+        lines.append(f"the rows below read {here}/.claude/ and {user_folder}, not the "
                      f"plane's")
     if walking:
         # Said here, in the row that would otherwise be read as "none of it reaches",
@@ -1161,7 +1178,7 @@ def check_session_layer() -> Result:
     untrusted directory answers yes to the first and no to the second. Charter asks the
     question it **owns**: trust is inherited up to the git root, so a directory with a git
     root of its own needs its own acceptance. That comes from `git rev-parse
-    --show-toplevel` and no host-private state. ``~/.claude.json`` is deliberately not
+    --show-toplevel` and no host-private state. Claude Code's ``.claude.json`` is deliberately not
     read — a missing project entry there means *never opened* just as readily as
     *refused*, and reading absence as refusal would warn at planes that are fine, which is
     the failure two other checks in this file already record. Weaker than a verdict on
@@ -1320,29 +1337,34 @@ def check_guard_wired() -> Result:
         # Reaching the handler is the only proof available, which is what `guardseen`
         # exists to record; a sighting from THIS plugin is that proof.
         from . import guardseen as _seen
-        from .harness import claude_code as _cc
 
-        # ...and only for the config folder it ran under (#969). `$CLAUDE_CONFIG_DIR` moves
-        # the manifest and settings this row just read, so a guard that fired yesterday under
-        # `~/.claude` says nothing about a session under a second account's folder — where
-        # the plugin can be installed and not yet loaded, which is #261's window reached from
-        # a new direction. A sighting that predates the recorded folder cannot say which one
-        # it ran under, so it vouches for none; the next guarded Bash call replaces it.
-        # Absolute on both sides, as `guardseen` records it: a relative `$CLAUDE_CONFIG_DIR`
-        # is a different folder in every directory it is read from.
-        folder = _cc.config_home()
-        if (_seen.last_source() == _seen.PLUGIN
-                and _seen.last_claude_config_dir() == os.path.abspath(folder)):
-            return Result(name, OK,
-                          detail=f"wired (enabled plugin {plugin}) — and it has fired here")
-        # The folder is named because `guard seen`, one row down, can truthfully say a
-        # guard ran minutes ago. Under another folder both rows are right, and without the
-        # folder they read as a contradiction — which is how #969 was reported.
+        if _seen.last_source() == _seen.PLUGIN:
+            # ...and only for the Claude Code config folder it ran under (#969).
+            # `$CLAUDE_CONFIG_DIR` moves the manifest and settings this row just read, so a
+            # guard that fired yesterday under `~/.claude` says nothing about a session under a
+            # second account's folder — where the plugin can be installed and not yet loaded,
+            # #261's window reached from a new direction. `guardseen.folder_standing` is the
+            # one place that decides it, for this row and for `guard seen` alike.
+            standing = _seen.folder_standing()
+            if standing.doubt is None:
+                return Result(name, OK,
+                              detail=f"wired (enabled plugin {plugin}) — and it has fired here")
+            # Something DID fire from the plugin, so "nothing has fired here yet" would be
+            # false beside `guard seen`; and it cannot vouch for this folder, so a tick would
+            # be false too. Neither a pass nor a claim that nothing fired (ADR 0009): the row
+            # says which of the two it cannot tell, in `guardseen`'s words.
+            return Result(
+                name, WARN,
+                detail=f"enabled plugin {plugin} declares it and a guard has fired from it, "
+                       f"but {standing.doubt} — so nothing shows it is loaded for the folder "
+                       f"in use",
+                hint="Run a Bash command in a Claude Code session on this config folder and "
+                     "re-check: a sighting made there is what vouches for it.")
         return Result(
             name, WARN,
-            detail=f"enabled plugin {plugin} declares it, but nothing has fired here under "
-                   f"{util.short_path(folder)} yet — a plugin's hooks load at session start, "
-                   f"so this is wired for the NEXT session and THIS one may be unguarded",
+            detail=f"enabled plugin {plugin} declares it, but nothing has fired here yet — "
+                   f"a plugin's hooks load at session start, so this is wired for the NEXT "
+                   f"session and THIS one may be unguarded",
             hint="Restart the session (or run a Bash command through it and re-check). If "
                  "you just removed a duplicate `hooks` block on this check's advice, that "
                  "was right — but it was the declaration this session actually had.")
@@ -1355,13 +1377,13 @@ def check_guard_wired() -> Result:
     # remedy that looks like a fix and is not.
     if not session_is_the_plane():
         from . import config as _config
-        from .harness import claude_code as _cc
+        from .harness import claude_code as _claude_code
 
         here = session_root()
         # The user settings file of the folder in use (#969). Under `$CLAUDE_CONFIG_DIR`
         # a declaration in `~/.claude/settings.json` reaches no session at all, so naming
         # that file would be a remedy that is followed, believed, and changes nothing.
-        user = util.short_path(_cc.config_home() / "settings.json")
+        user_settings = util.short_path(_claude_code.config_home() / "settings.json")
         return Result(
             name, WARN,
             detail=f"pretooluse is not wired — branch moves in the plane root are NOT "
@@ -1370,15 +1392,27 @@ def check_guard_wired() -> Result:
                   f"the host does not walk up — so the plane's .claude/settings.json never "
                   f"reaches here, wired or not. `charter reinit` writes THAT file, so it "
                   f"would not change this session. Declare `charter hook pretooluse` under "
-                  f"hooks.PreToolUse in {here}/.claude/settings.json, or in {user}, which "
+                  f"hooks.PreToolUse in {here}/.claude/settings.json, or in {user_settings}, which "
                   f"every session on that Claude config folder reads — or install the "
                   f"Claude Code plugin."))
+    hint = ("The 0.30.0 guard only fires through `charter hook pretooluse`.  "
+            "→ charter reinit  (wires it into .claude/settings.json), or "
+            "install the Claude Code plugin.")
+    folder = _claude_folder(None)
+    if folder != Path.home() / ".claude":
+        # `charter reinit` decides from `~/.claude` whatever the shell says, because it writes
+        # a committed file every folder's sessions read (#969, `commands.
+        # _plugin_dispatches_guard`). So under another folder the first remedy above writes
+        # nothing whenever `~/.claude` already has the plugin — followed, believed, and
+        # changing nothing (#851). Said here, and the remedy that does act on this folder named.
+        hint += (f" This session uses the Claude Code config folder "
+                 f"{util.short_path(folder)}, and `charter reinit` still decides from "
+                 f"~/.claude: it writes nothing if the plugin is installed there. `charter "
+                 f"doctor --fix` run from this shell installs the plugin for this folder.")
     return Result(name, WARN,
                   detail="pretooluse is not wired — branch moves in the plane root are "
                          "NOT refused",
-                  hint=("The 0.30.0 guard only fires through `charter hook pretooluse`.  "
-                        "→ charter reinit  (wires it into .claude/settings.json), or "
-                        "install the Claude Code plugin."))
+                  hint=hint)
 
 
 def check_harness() -> Result:
@@ -1568,6 +1602,28 @@ def check_guard_seen() -> Result:
     if rec:
         at = _seen_age(rec.get("ts"))
         where = rec.get("harness") or "an unnamed harness"
+        # An age under another Claude Code config folder is not an age of anything in this
+        # one (#969). Green here sat under the guard row's warning and told the reader the
+        # guard had just run for them. `guardseen.folder_standing` decides it, for this row
+        # and for `plane-root guard` alike; a Codex or opencode sighting has no folder to be
+        # wrong about and passes straight through.
+        standing = _seen.folder_standing()
+        if standing.doubt is not None:
+            detail = f"last ran {at} ago under {where}, but {standing.doubt}"
+            # A settings declaration in the folder the sighting DID run under is still there.
+            # It is in a file this folder's sessions never open, and saying it is gone — the
+            # branch below — would send the reader looking for an edit nobody made. Said only
+            # where it is true: the sighting came from settings, and that file declares it.
+            if (_seen.last_source() == _seen.SETTINGS and standing.elsewhere
+                    and "charter hook pretooluse" in _read_text(
+                        Path(standing.elsewhere) / "settings.json")):
+                detail += (f"; its declaration is still in "
+                           f"{util.short_path(Path(standing.elsewhere) / 'settings.json')}, a "
+                           f"file sessions on the folder in use never read")
+            return Result(name, WARN, detail=detail,
+                          hint="That sighting says nothing about the Claude Code config folder "
+                               "in use. Run a Bash command in a Claude Code session on this "
+                               "folder and re-check.")
         # A sighting is evidence for the declaration that PRODUCED it and for no other. The
         # settings block that fired minutes ago can have been deleted since — on this
         # command's own duplicate-guard advice — and "last ran 0m ago" then invites the
@@ -2999,9 +3055,9 @@ def _claude_json() -> Path:
     measured on 2.1.268, with `$CLAUDE_CONFIG_DIR` set Claude Code writes `.claude.json`
     inside that folder, so the servers a second account registers are there and the home
     file's are not launched at all. `claude_code.global_config_file` owns the rule."""
-    from .harness import claude_code as _cc
+    from .harness import claude_code as _claude_code
 
-    return _cc.global_config_file()
+    return _claude_code.global_config_file()
 
 
 def _vault_in_args(args) -> str | None:
@@ -3026,7 +3082,7 @@ def _registered_launchers(doc: dict) -> list[tuple[str, str, list]]:
 
     Both scopes, because checking only the top level would miss most real registrations —
     project-scoped servers are the common case. Every container is type-checked on the way
-    down: `~/.claude.json` is a large harness-owned file (124KB of caches and counters on the
+    down: `.claude.json` is a large harness-owned file (124KB of caches and counters on the
     machine that reported #197) whose shape charter does not control, and one odd value
     must not take the whole preflight down.
     """
@@ -3199,7 +3255,7 @@ def check_mcp_launchers() -> Result:
                 # The half of the advice that was missing. The old command was an absolute
                 # path into a particular umbrella; a bare `charter` resolves its plane from
                 # the LAUNCHING directory, and an `mcpServers` entry at the top level of
-                # `~/.claude.json` is user-scope — it launches for every project, most of
+                # the config folder's `.claude.json` is user-scope — it launches for every project, most of
                 # which are not that plane. The server then starts, fails to find the vault,
                 # and the tools are missing again, silently, exactly as before.
                 fix += (f". It opens vault `{vault}`, so also set CHARTER_ROOT in this "

--- a/charter/doctor.py
+++ b/charter/doctor.py
@@ -1296,6 +1296,18 @@ def check_guard_wired() -> Result:
     if not _config.HAS_CONTROL_PLANE:
         return Result(name, OK, detail="no control plane found")
 
+    from . import guardseen as _seen
+
+    # A Claude Code config folder that cannot be compared — empty, relative, or with no home to
+    # resolve it from — turns every answer below into a guess: the plugin list and the user
+    # settings this row reads resolve against doctor's working directory, not Claude Code's,
+    # and no sighting can vouch for that folder. So it is said first, whatever the sightings,
+    # with the one remedy that changes it (the #970 re-review: this row read "nothing has fired
+    # here yet" there, and its "run a Bash command" hint could never clear it).
+    standing = _seen.folder_standing()
+    if standing.folder_in_doubt:
+        return Result(name, WARN, detail=f"not checked — {standing.doubt}", hint=standing.hint)
+
     # `commands._ensure_guard_hook` asks the SAME question through the same function.
     # Reading different evidence is how a writer and a checker disagreed about "wired"
     # and left the guard declared twice — and enabled is not dispatched (#177).
@@ -1336,16 +1348,13 @@ def check_guard_wired() -> Result:
         #
         # Reaching the handler is the only proof available, which is what `guardseen`
         # exists to record; a sighting from THIS plugin is that proof.
-        from . import guardseen as _seen
-
         if _seen.last_source() == _seen.PLUGIN:
             # ...and only for the Claude Code config folder it ran under (#969).
             # `$CLAUDE_CONFIG_DIR` moves the manifest and settings this row just read, so a
             # guard that fired yesterday under `~/.claude` says nothing about a session under a
             # second account's folder — where the plugin can be installed and not yet loaded,
-            # #261's window reached from a new direction. `guardseen.folder_standing` is the
-            # one place that decides it, for this row and for `guard seen` alike.
-            standing = _seen.folder_standing()
+            # #261's window reached from a new direction. `guardseen.folder_standing`, read at
+            # the top of this row, is the one place that decides it, for `guard seen` too.
             if standing.doubt is None:
                 return Result(name, OK,
                               detail=f"wired (enabled plugin {plugin}) — and it has fired here")
@@ -1356,10 +1365,9 @@ def check_guard_wired() -> Result:
             return Result(
                 name, WARN,
                 detail=f"enabled plugin {plugin} declares it and a guard has fired from it, "
-                       f"but {standing.doubt} — so nothing shows it is loaded for the folder "
-                       f"in use",
-                hint="Run a Bash command in a Claude Code session on this config folder and "
-                     "re-check: a sighting made there is what vouches for it.")
+                       f"but {standing.doubt}. Until a guard fires under the folder in use, "
+                       f"nothing shows the plugin is loaded there",
+                hint=standing.hint)
         return Result(
             name, WARN,
             detail=f"enabled plugin {plugin} declares it, but nothing has fired here yet — "
@@ -1599,15 +1607,24 @@ def check_guard_seen() -> Result:
 
     name = "guard seen"
     rec = _seen.last()
+    standing = _seen.folder_standing()
+    if standing.folder_in_doubt:
+        # Whatever the sightings — none, a plane nobody has worked in, another harness's —
+        # because the remedy is the folder, and every other branch of this row ends in "run a
+        # Bash command", which records one more sighting nothing can be compared with (the
+        # #970 re-review). The age is kept when there is one: it is still true.
+        seen = (f"last ran {_seen_age(rec.get('ts'))} ago under "
+                f"{rec.get('harness') or 'an unnamed harness'}, but " if rec else "")
+        return Result(name, WARN, detail=f"{seen}{standing.doubt}", hint=standing.hint)
     if rec:
         at = _seen_age(rec.get("ts"))
         where = rec.get("harness") or "an unnamed harness"
         # An age under another Claude Code config folder is not an age of anything in this
         # one (#969). Green here sat under the guard row's warning and told the reader the
         # guard had just run for them. `guardseen.folder_standing` decides it, for this row
-        # and for `plane-root guard` alike; a Codex or opencode sighting has no folder to be
-        # wrong about and passes straight through.
-        standing = _seen.folder_standing()
+        # and for `plane-root guard` alike: a sighting from a NAMED harness other than Claude
+        # Code has no folder to be wrong about and passes through, and one that names no
+        # harness at all is unknown and says so.
         if standing.doubt is not None:
             detail = f"last ran {at} ago under {where}, but {standing.doubt}"
             # A settings declaration in the folder the sighting DID run under is still there.
@@ -1620,10 +1637,7 @@ def check_guard_seen() -> Result:
                 detail += (f"; its declaration is still in "
                            f"{util.short_path(Path(standing.elsewhere) / 'settings.json')}, a "
                            f"file sessions on the folder in use never read")
-            return Result(name, WARN, detail=detail,
-                          hint="That sighting says nothing about the Claude Code config folder "
-                               "in use. Run a Bash command in a Claude Code session on this "
-                               "folder and re-check.")
+            return Result(name, WARN, detail=detail, hint=standing.hint)
         # A sighting is evidence for the declaration that PRODUCED it and for no other. The
         # settings block that fired minutes ago can have been deleted since — on this
         # command's own duplicate-guard advice — and "last ran 0m ago" then invites the

--- a/charter/guardseen.py
+++ b/charter/guardseen.py
@@ -53,6 +53,31 @@ def _source() -> str:
     return PLUGIN if os.environ.get("CLAUDE_PLUGIN_ROOT") else SETTINGS
 
 
+def _claude_config_dir() -> str | None:
+    """The Claude Code config folder this process would use, made absolute — or ``None``
+    when it cannot be resolved.
+
+    **Absolute, because a folder is compared across processes that stand in different
+    directories.** `$CLAUDE_CONFIG_DIR=cfg` (or an empty value) is relative to wherever it is
+    read, so recorded as spelled, a sighting made in the plane root compared equal to a
+    `doctor` run from a workspace, where ``cfg`` names another folder — a false green by
+    string equality, the #969 defect one step removed.
+
+    `Path.home()` raises with no `$HOME` and no passwd entry, and making a relative folder
+    absolute asks for a working directory that may have been deleted. `mark` runs inside the
+    guard, which must never fail a turn over bookkeeping, so the sighting is still recorded;
+    one with no folder simply vouches for none.
+    """
+    import os
+
+    from .harness import claude_code
+
+    try:
+        return os.path.abspath(claude_code.config_home())
+    except (RuntimeError, OSError):
+        return None
+
+
 def mark(harness: str | None = None, when: datetime | None = None,
          source: str | None = None) -> Path | None:
     """Record that a guard just ran. Best-effort — never raises, never blocks a turn.
@@ -77,11 +102,17 @@ def mark(harness: str | None = None, when: datetime | None = None,
     # plugin replacing it was live — while the running session held no declaration at all
     # (#261). A sighting belongs to the thing that made it.
     src = source or _source()
+    # And under WHICH Claude Code config folder (#969), for the same reason one field over:
+    # `$CLAUDE_CONFIG_DIR` moves the plugin manifest and the settings a declaration lives in,
+    # so a sighting made under `~/.claude` read as proof for a session under a second
+    # account's folder — where no charter hook ran at all.
+    folder = _claude_config_dir()
     p = path()
     try:
         config.private_mkdir(p.parent)
         config.write_for(p, json.dumps({"ts": when.isoformat(timespec="seconds"),
-                                       "harness": harness, "source": src},
+                                       "harness": harness, "source": src,
+                                       "claude_config_dir": folder},
                                       sort_keys=True) + "\n")
         return p
     except OSError:
@@ -97,6 +128,17 @@ def last_source() -> str | None:
         return None
     val = rec.get("source")
     return str(val) if val else None
+
+
+def last_claude_config_dir() -> str | None:
+    """The Claude Code config folder the latest sighting ran under (#969) — or ``None``: no
+    sighting, one from before the field, or one whose folder could not be resolved.
+
+    ``None`` vouches for nothing, the reading `check_guard_wired` already gives a sighting
+    with no `source`. It is not reported as a fault either; the next guarded call replaces it.
+    """
+    rec = last()
+    return rec.get("claude_config_dir") if rec else None
 
 
 def last() -> dict | None:

--- a/charter/guardseen.py
+++ b/charter/guardseen.py
@@ -26,10 +26,12 @@ would be unbounded for a question nobody asks. Same shape as `pieces.seen`, deli
 from __future__ import annotations
 
 import json
+import os
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import NamedTuple
 
-from . import config
+from . import config, util
 
 #: One file per plane, under the state dir — gitignored, machine-local, and about this
 #: machine's harnesses. Committing it would describe one laptop's wiring to everybody.
@@ -53,29 +55,51 @@ def _source() -> str:
     return PLUGIN if os.environ.get("CLAUDE_PLUGIN_ROOT") else SETTINGS
 
 
-def _claude_config_dir() -> str | None:
-    """The Claude Code config folder this process would use, made absolute — or ``None``
-    when it cannot be resolved.
+#: The field a Claude Code sighting records its config folder in (#969). **Only Claude
+#: Code's.** The folder is Claude Code's alone, so a Codex or opencode sighting carries no such
+#: field and is never judged by one; a per-harness "config folder in use" belongs to the
+#: harness-profiles work, not to this record.
+CLAUDE_CONFIG_DIR = "claude_config_dir"
 
-    **Absolute, because a folder is compared across processes that stand in different
-    directories.** `$CLAUDE_CONFIG_DIR=cfg` (or an empty value) is relative to wherever it is
-    read, so recorded as spelled, a sighting made in the plane root compared equal to a
-    `doctor` run from a workspace, where ``cfg`` names another folder — a false green by
-    string equality, the #969 defect one step removed.
 
-    `Path.home()` raises with no `$HOME` and no passwd entry, and making a relative folder
-    absolute asks for a working directory that may have been deleted. `mark` runs inside the
-    guard, which must never fail a turn over bookkeeping, so the sighting is still recorded;
-    one with no folder simply vouches for none.
+def _is_claude_code(harness: str | None, source: str | None) -> bool:
+    """Is this a Claude Code sighting? Named so, or launched by a plugin: `$CLAUDE_PLUGIN_ROOT`
+    is Claude Code's own variable, so a plugin-launched guard is one whatever the registry
+    managed to name."""
+    from .harness import claude_code
+
+    return harness == claude_code.NAME or source == PLUGIN
+
+
+def _folder_in_use() -> tuple[str | None, str | None]:
+    """The Claude Code config folder this process would use, as ``(folder, None)`` — or
+    ``(None, why)`` when there is no absolute folder to record or to compare with.
+
+    **One exception policy for both ends of the comparison** — `mark`, which records, and
+    :func:`folder_standing`, which compares — so the two can never disagree about what counts
+    as a folder (#969). `doctor` used to resolve its own end, without this handling.
+
+    **Absolute only.** A relative `$CLAUDE_CONFIG_DIR`, an empty one included, stays relative
+    inside Claude Code, resolved against that process's own directory; a hook would resolve it
+    against its directory and `doctor` against the one it was run from, and nobody has
+    measured that those are the same. Recorded as spelled, `cfg` from the plane root compared
+    equal to `cfg` from a workspace. So a relative folder is recorded as none and compared with
+    nothing, and the row that cannot compare says so.
+
+    Only `RuntimeError`: `Path.home()` raises it with no `$HOME` and no passwd entry, and the
+    resolver does no I/O that could raise anything else.
     """
-    import os
-
     from .harness import claude_code
 
     try:
-        return os.path.abspath(claude_code.config_home())
-    except (RuntimeError, OSError):
-        return None
+        folder = str(claude_code.config_home())
+    except RuntimeError:
+        return None, ("the Claude Code config folder in use cannot be resolved (there is no "
+                      "home folder)")
+    if not os.path.isabs(folder):
+        return None, (f"the Claude Code config folder in use, {folder!r}, is a relative path — "
+                      f"a different folder in every directory it is read from")
+    return folder, None
 
 
 def mark(harness: str | None = None, when: datetime | None = None,
@@ -102,18 +126,19 @@ def mark(harness: str | None = None, when: datetime | None = None,
     # plugin replacing it was live — while the running session held no declaration at all
     # (#261). A sighting belongs to the thing that made it.
     src = source or _source()
+    rec = {"ts": when.isoformat(timespec="seconds"), "harness": harness, "source": src}
     # And under WHICH Claude Code config folder (#969), for the same reason one field over:
     # `$CLAUDE_CONFIG_DIR` moves the plugin manifest and the settings a declaration lives in,
     # so a sighting made under `~/.claude` read as proof for a session under a second
-    # account's folder — where no charter hook ran at all.
-    folder = _claude_config_dir()
+    # account's folder — where no charter hook ran at all. Recorded even when there is no
+    # absolute folder to record: a present-but-empty field is "this process had none", which
+    # is not the same fact as a record written before the field existed.
+    if _is_claude_code(harness, src):
+        rec[CLAUDE_CONFIG_DIR] = _folder_in_use()[0]
     p = path()
     try:
         config.private_mkdir(p.parent)
-        config.write_for(p, json.dumps({"ts": when.isoformat(timespec="seconds"),
-                                       "harness": harness, "source": src,
-                                       "claude_config_dir": folder},
-                                      sort_keys=True) + "\n")
+        config.write_for(p, json.dumps(rec, sort_keys=True) + "\n")
         return p
     except OSError:
         return None
@@ -130,15 +155,54 @@ def last_source() -> str | None:
     return str(val) if val else None
 
 
-def last_claude_config_dir() -> str | None:
-    """The Claude Code config folder the latest sighting ran under (#969) — or ``None``: no
-    sighting, one from before the field, or one whose folder could not be resolved.
+class FolderStanding(NamedTuple):
+    """Whether the latest sighting counts for the Claude Code config folder in use (#969).
 
-    ``None`` vouches for nothing, the reading `check_guard_wired` already gives a sighting
-    with no `source`. It is not reported as a fault either; the next guarded call replaces it.
+    ``doubt`` is ``None`` when it does — or when there is nothing for a folder to be wrong
+    about: no sighting, or another harness's. Otherwise it is the clause a `doctor` row prints
+    to say why the sighting cannot vouch. ``elsewhere`` is the other absolute folder the
+    sighting provably ran under, and nothing else: a sighting charter cannot place names none.
+    """
+
+    doubt: str | None
+    elsewhere: str | None
+
+
+def folder_standing() -> FolderStanding:
+    """**The one place that decides whether a sighting counts for the folder in use** (#969).
+
+    `check_guard_wired` needs this to go green and `check_guard_seen` to stay green. The rule
+    used to live in both modules, held together by a comment, and `doctor` resolved its end
+    without `mark`'s exception handling; two readers of one rule is how a writer and a checker
+    once disagreed about "wired" (#177). Each way a sighting fails to count is a different
+    thing for the reader to do, so each says so in its own words:
+
+    * the folder in use cannot be compared at all — relative, or unresolvable — so nothing
+      can vouch for it, the next sighting included;
+    * the sighting predates folder recording — something fired, under a folder charter cannot
+      name. Neither a pass nor "nothing fired" (ADR 0009); the next guarded call replaces it;
+    * the sighting recorded no folder — the same, from a process that had none to record;
+    * it ran under another folder — named, because that is the incident.
     """
     rec = last()
-    return rec.get("claude_config_dir") if rec else None
+    if not rec or not _is_claude_code(rec.get("harness"), rec.get("source")):
+        return FolderStanding(None, None)
+    in_use, why = _folder_in_use()
+    if in_use is None:
+        return FolderStanding(f"{why}, so no guard sighting can be compared with it", None)
+    if CLAUDE_CONFIG_DIR not in rec:
+        return FolderStanding("that sighting predates charter recording which Claude Code "
+                              "config folder a guard ran under, so charter cannot tell which "
+                              "folder it came from", None)
+    recorded = rec[CLAUDE_CONFIG_DIR]
+    if not isinstance(recorded, str):
+        return FolderStanding("that sighting recorded no absolute Claude Code config folder, "
+                              "so charter cannot tell which folder it came from", None)
+    if recorded != in_use:
+        return FolderStanding(f"that sighting ran under Claude Code config folder "
+                              f"{util.short_path(recorded)}, not {util.short_path(in_use)}, "
+                              f"the one in use", recorded)
+    return FolderStanding(None, None)
 
 
 def last() -> dict | None:

--- a/charter/guardseen.py
+++ b/charter/guardseen.py
@@ -82,6 +82,19 @@ _FIRE_HERE = ("Run a Bash command in a Claude Code session on this config folder
               "a guard that fires there records the folder it ran under.")
 
 
+def _name_the_harness() -> str:
+    """The remedy for a sighting charter cannot attribute to a harness it knows. The known names
+    are asked of the registry, so the sentence cannot fall behind the day one is registered."""
+    from .harness import registry as _registry
+
+    known = ", ".join(_registry.KINDS)
+    return (f"A sighting names its harness from $CHARTER_HARNESS, exactly as spelled, or from "
+            f"charter's plugin. Set $CHARTER_HARNESS to a harness charter knows ({known}) — "
+            f"`charter reinit` writes it into .claude/settings.json — or register a new one in "
+            f"charter/harness/registry.py (KINDS). Then run a Bash command in a session started "
+            f"that way and re-check.")
+
+
 def _folder_in_use() -> tuple[str | None, str | None, str | None]:
     """The Claude Code config folder this process would use, as ``(folder, None, None)`` — or
     ``(None, why, fix)`` when there is no absolute folder to record or to compare with.
@@ -112,7 +125,7 @@ def _folder_in_use() -> tuple[str | None, str | None, str | None]:
     from .harness import claude_code
 
     if os.environ.get("CLAUDE_CONFIG_DIR") == "":
-        return None, ("$CLAUDE_CONFIG_DIR is set but empty, so Claude Code uses its own working "
+        return None, ("$CLAUDE_CONFIG_DIR is empty, which makes Claude Code use its own working "
                       "directory as the config folder, and charter cannot see that "
                       "directory"), _ABSOLUTE_FOLDER
     try:
@@ -185,7 +198,7 @@ class FolderStanding(NamedTuple):
     """Whether the latest sighting counts for the Claude Code config folder in use (#969).
 
     ``doubt`` is ``None`` when it does — or when there is nothing to be wrong about: no
-    sighting, or one from a NAMED harness other than Claude Code. Otherwise it is the clause a
+    sighting, or one from a registered harness other than Claude Code. Otherwise it is the clause a
     `doctor` row prints, and ``hint`` is the one remedy that can change that row, never a step
     that would leave it as it is. ``elsewhere`` is the other absolute folder the sighting
     provably ran under, and nothing else. ``folder_in_doubt`` says the doubt is about the folder
@@ -211,14 +224,17 @@ def folder_standing() -> FolderStanding:
     * the folder in use cannot be compared at all — empty, relative, or unresolvable — so
       nothing can vouch for it, whatever the sightings; the remedy is the folder, not a command
       (the #970 re-review: "run a Bash command" there was followed and changed nothing);
-    * the sighting names no harness and no plugin launched it — charter cannot tell whose it
-      is, or which folder it ran under. Unknown, never green (the #970 re-review: it used to
-      pass straight through as another harness's);
+    * the sighting names no harness, or a name charter has no record of (ADR 0015), and no
+      plugin launched it — charter cannot tell whose it is, or which folder it ran under.
+      Unknown, never green (the #970 re-review and its verification: both used to pass
+      straight through as another harness's);
     * the sighting predates folder recording — something fired, under a folder charter cannot
       name. Neither a pass nor "nothing fired" (ADR 0009); the next guarded call replaces it;
     * the sighting recorded no folder — the same, from a process that had none to record;
     * it ran under another folder — named, because that is the incident.
     """
+    from .harness import registry as _registry
+
     folder, why, fix = _folder_in_use()
     if folder is None:
         return FolderStanding(f"{why}, so no guard sighting can be compared with it", fix,
@@ -230,11 +246,18 @@ def folder_standing() -> FolderStanding:
     if not harness and source != PLUGIN:
         return FolderStanding(
             "that sighting names no harness, so charter cannot tell which harness recorded it "
-            "or under which Claude Code config folder",
-            "A sighting names its harness when $CHARTER_HARNESS is set in the session "
-            "(`charter reinit` writes it into .claude/settings.json) or charter's plugin "
-            "launched the guard. Run a Bash command in a session started that way, then "
-            "re-check.", None, False)
+            "or under which Claude Code config folder", _name_the_harness(), None, False)
+    if source != PLUGIN and _registry.get(harness) is None:
+        # A name charter has no record of is not a harness it can vouch for: ADR 0015 already
+        # has `check_harness` warn on an unregistered `$CHARTER_HARNESS`. The variable is
+        # recorded exactly as spelled, so one typo — `claude` for `claude-code` — read as
+        # another harness's sighting and passed straight through under any folder (the
+        # verification review of 3624287). A plugin-launched guard is Claude Code's whatever it
+        # was named, which is why the plugin source is exempt.
+        return FolderStanding(
+            f"that sighting names {harness!r}, a harness charter has no record of, so charter "
+            f"cannot tell which harness recorded it or under which Claude Code config folder",
+            _name_the_harness(), None, False)
     if not _is_claude_code(harness, source):
         return FolderStanding(None, None, None, False)
     if CLAUDE_CONFIG_DIR not in rec:

--- a/charter/guardseen.py
+++ b/charter/guardseen.py
@@ -71,9 +71,20 @@ def _is_claude_code(harness: str | None, source: str | None) -> bool:
     return harness == claude_code.NAME or source == PLUGIN
 
 
-def _folder_in_use() -> tuple[str | None, str | None]:
-    """The Claude Code config folder this process would use, as ``(folder, None)`` — or
-    ``(None, why)`` when there is no absolute folder to record or to compare with.
+#: The one remedy for a folder in use that cannot be compared (empty or relative). Said once,
+#: because both guard rows print it.
+_ABSOLUTE_FOLDER = ("Set CLAUDE_CONFIG_DIR to an absolute path in the shell you start Claude Code "
+                    "from, then re-check.")
+
+#: The remedy for a sighting that cannot vouch for a folder that CAN be compared. It works: a
+#: guard firing in such a session records that very folder, and the row changes.
+_FIRE_HERE = ("Run a Bash command in a Claude Code session on this config folder, then re-check: "
+              "a guard that fires there records the folder it ran under.")
+
+
+def _folder_in_use() -> tuple[str | None, str | None, str | None]:
+    """The Claude Code config folder this process would use, as ``(folder, None, None)`` — or
+    ``(None, why, fix)`` when there is no absolute folder to record or to compare with.
 
     **One exception policy for both ends of the comparison** — `mark`, which records, and
     :func:`folder_standing`, which compares — so the two can never disagree about what counts
@@ -86,20 +97,35 @@ def _folder_in_use() -> tuple[str | None, str | None]:
     equal to `cfg` from a workspace. So a relative folder is recorded as none and compared with
     nothing, and the row that cannot compare says so.
 
+    **An empty value is named as empty** (the #970 re-review). The binary spells the folder
+    ``CLAUDE_CONFIG_DIR ?? join(homedir(), ".claude")``, and `??` keeps an empty string, so
+    Claude Code uses its own working directory; "'.' is a relative path" named nothing the
+    operator had typed. No path is printed for a relative folder either: the one charter could
+    print is resolved against its OWN directory, which is exactly the answer it cannot vouch for.
+
     Only `RuntimeError`: `Path.home()` raises it with no `$HOME` and no passwd entry, and the
     resolver does no I/O that could raise anything else.
+
+    The third element is the one remedy that changes a row in that state — never "run a Bash
+    command", which records one more sighting that nothing can be compared with.
     """
     from .harness import claude_code
 
+    if os.environ.get("CLAUDE_CONFIG_DIR") == "":
+        return None, ("$CLAUDE_CONFIG_DIR is set but empty, so Claude Code uses its own working "
+                      "directory as the config folder, and charter cannot see that "
+                      "directory"), _ABSOLUTE_FOLDER
     try:
-        folder = str(claude_code.config_home())
+        folder = claude_code.config_home()
     except RuntimeError:
-        return None, ("the Claude Code config folder in use cannot be resolved (there is no "
-                      "home folder)")
+        return None, ("the Claude Code config folder in use cannot be resolved: there is no "
+                      "home folder"), ("Set HOME, or set CLAUDE_CONFIG_DIR to an absolute path, "
+                                       "in the shell you start Claude Code from, then re-check.")
     if not os.path.isabs(folder):
-        return None, (f"the Claude Code config folder in use, {folder!r}, is a relative path — "
-                      f"a different folder in every directory it is read from")
-    return folder, None
+        return None, ("the Claude Code config folder in use is a relative path, which Claude Code "
+                      "resolves against its own working directory, and charter cannot see that "
+                      "directory"), _ABSOLUTE_FOLDER
+    return str(folder), None, None
 
 
 def mark(harness: str | None = None, when: datetime | None = None,
@@ -158,14 +184,19 @@ def last_source() -> str | None:
 class FolderStanding(NamedTuple):
     """Whether the latest sighting counts for the Claude Code config folder in use (#969).
 
-    ``doubt`` is ``None`` when it does — or when there is nothing for a folder to be wrong
-    about: no sighting, or another harness's. Otherwise it is the clause a `doctor` row prints
-    to say why the sighting cannot vouch. ``elsewhere`` is the other absolute folder the
-    sighting provably ran under, and nothing else: a sighting charter cannot place names none.
+    ``doubt`` is ``None`` when it does — or when there is nothing to be wrong about: no
+    sighting, or one from a NAMED harness other than Claude Code. Otherwise it is the clause a
+    `doctor` row prints, and ``hint`` is the one remedy that can change that row, never a step
+    that would leave it as it is. ``elsewhere`` is the other absolute folder the sighting
+    provably ran under, and nothing else. ``folder_in_doubt`` says the doubt is about the folder
+    in use itself: it holds whatever the sightings are, so a row reports it before anything it
+    would otherwise have read from that folder.
     """
 
     doubt: str | None
+    hint: str | None
     elsewhere: str | None
+    folder_in_doubt: bool
 
 
 def folder_standing() -> FolderStanding:
@@ -177,32 +208,49 @@ def folder_standing() -> FolderStanding:
     once disagreed about "wired" (#177). Each way a sighting fails to count is a different
     thing for the reader to do, so each says so in its own words:
 
-    * the folder in use cannot be compared at all — relative, or unresolvable — so nothing
-      can vouch for it, the next sighting included;
+    * the folder in use cannot be compared at all — empty, relative, or unresolvable — so
+      nothing can vouch for it, whatever the sightings; the remedy is the folder, not a command
+      (the #970 re-review: "run a Bash command" there was followed and changed nothing);
+    * the sighting names no harness and no plugin launched it — charter cannot tell whose it
+      is, or which folder it ran under. Unknown, never green (the #970 re-review: it used to
+      pass straight through as another harness's);
     * the sighting predates folder recording — something fired, under a folder charter cannot
       name. Neither a pass nor "nothing fired" (ADR 0009); the next guarded call replaces it;
     * the sighting recorded no folder — the same, from a process that had none to record;
     * it ran under another folder — named, because that is the incident.
     """
+    folder, why, fix = _folder_in_use()
+    if folder is None:
+        return FolderStanding(f"{why}, so no guard sighting can be compared with it", fix,
+                              None, True)
     rec = last()
-    if not rec or not _is_claude_code(rec.get("harness"), rec.get("source")):
-        return FolderStanding(None, None)
-    in_use, why = _folder_in_use()
-    if in_use is None:
-        return FolderStanding(f"{why}, so no guard sighting can be compared with it", None)
+    if not rec:
+        return FolderStanding(None, None, None, False)
+    harness, source = rec.get("harness"), rec.get("source")
+    if not harness and source != PLUGIN:
+        return FolderStanding(
+            "that sighting names no harness, so charter cannot tell which harness recorded it "
+            "or under which Claude Code config folder",
+            "A sighting names its harness when $CHARTER_HARNESS is set in the session "
+            "(`charter reinit` writes it into .claude/settings.json) or charter's plugin "
+            "launched the guard. Run a Bash command in a session started that way, then "
+            "re-check.", None, False)
+    if not _is_claude_code(harness, source):
+        return FolderStanding(None, None, None, False)
     if CLAUDE_CONFIG_DIR not in rec:
         return FolderStanding("that sighting predates charter recording which Claude Code "
                               "config folder a guard ran under, so charter cannot tell which "
-                              "folder it came from", None)
+                              "folder it came from", _FIRE_HERE, None, False)
     recorded = rec[CLAUDE_CONFIG_DIR]
     if not isinstance(recorded, str):
         return FolderStanding("that sighting recorded no absolute Claude Code config folder, "
-                              "so charter cannot tell which folder it came from", None)
-    if recorded != in_use:
+                              "so charter cannot tell which folder it came from", _FIRE_HERE,
+                              None, False)
+    if recorded != folder:
         return FolderStanding(f"that sighting ran under Claude Code config folder "
-                              f"{util.short_path(recorded)}, not {util.short_path(in_use)}, "
-                              f"the one in use", recorded)
-    return FolderStanding(None, None)
+                              f"{util.short_path(recorded)}, not {util.short_path(folder)}, "
+                              f"the one in use", _FIRE_HERE, recorded, False)
+    return FolderStanding(None, None, None, False)
 
 
 def last() -> dict | None:

--- a/charter/harness/claude_code.py
+++ b/charter/harness/claude_code.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import json
 import os
+import unicodedata
 from pathlib import Path
 
 from .base import Harness, LayerPart
@@ -100,6 +101,57 @@ LAYER = (
 #: plane and there is no gap here for a mirror to close. What a mirror would add is the
 #: plane's instructions inside somebody else's repository, read there as that repository's.
 WALKUP_DIRS = (".claude/agents", ".claude/skills")
+
+
+def config_home() -> Path:
+    """The folder Claude Code keeps its user-level state in — ``settings.json`` and the
+    ``plugins/`` manifest among it — resolved the way the binary resolves it (#969).
+
+    Not ``~/.claude`` by assumption. `$CLAUDE_CONFIG_DIR` moves it, most often for a second
+    account, and 2.1.268 moves that account's login with it (the Keychain item's name gains
+    a hash of the folder) — so a session set up that way never reads the default folder's
+    plugins or settings, and a checker reading them answers for a session that is not
+    running.
+
+    Read off the 2.1.268 binary: ``(CLAUDE_CONFIG_DIR ?? join(homedir(), ".claude"))
+    .normalize("NFC")``. Two details follow from that spelling, and both are pinned:
+
+    * `??`, not `||` — an EMPTY value is kept, and names the working directory. Measured:
+      ``CLAUDE_CONFIG_DIR= claude plugin list --json`` listed the plugins recorded in
+      ``./plugins/installed_plugins.json``. Reading empty as unset would be a kinder rule
+      about a different folder from the one Claude Code reads.
+    * NFC — on a filesystem that keeps normalisation forms apart, a decomposed name is a
+      different directory, and the binary reads the composed one.
+
+    **Not followed yet**, each a narrower knob than this one: `$CLAUDE_CODE_PLUGIN_CACHE_DIR`
+    moves the plugin manifest out of this folder, and the cowork switch
+    (`$CLAUDE_CODE_USE_COWORK_PLUGINS`) renames ``plugins/`` and ``settings.json`` inside it.
+    """
+    named = os.environ.get("CLAUDE_CONFIG_DIR")
+    raw = os.path.join(Path.home(), ".claude") if named is None else named
+    return Path(unicodedata.normalize("NFC", raw))
+
+
+def global_config_file() -> Path:
+    """Claude Code's ``.claude.json`` for the folder in use — where `mcpServers` live (#969).
+
+    Its own rule, not :func:`config_home`'s, read off the same binary: a legacy
+    ``.config.json`` inside the config home wins while it exists; otherwise the file is
+    ``join(CLAUDE_CONFIG_DIR || homedir(), ".claude.json")``. So `||` here where the folder
+    has `??` — an empty value falls back to home for this one file — and the raw value
+    rather than the NFC one. Measured: with `$CLAUDE_CONFIG_DIR` set, Claude Code writes
+    ``.claude.json`` inside that folder.
+
+    ``os.path.exists`` because the binary asks `existsSync`, and both answer False rather
+    than raise for a path they cannot stat: a raise here would take the `mcp` row down over
+    a file Claude Code itself passes over.
+
+    Not followed: `$CLAUDE_CODE_CUSTOM_OAUTH_URL` renames the file ``.claude-custom-oauth.json``.
+    """
+    legacy = config_home() / ".config.json"
+    if os.path.exists(legacy):
+        return legacy
+    return Path(os.environ.get("CLAUDE_CONFIG_DIR") or Path.home()) / ".claude.json"
 
 
 class ClaudeCodeHarness(Harness):

--- a/charter/util.py
+++ b/charter/util.py
@@ -63,8 +63,19 @@ def short_path(p) -> str:
 
     ``~`` rather than the full path because these render on one line beside other things,
     and the home prefix is the longest part carrying the least information.
+
+    **Never for a path with a literal ``~`` segment** (#969). Nothing expands a ``~`` that
+    arrives inside a value — `CLAUDE_CONFIG_DIR='~/acct2'` is read as ``<cwd>/~/acct2`` — so
+    abbreviating that path, or printing it as spelled, renders ``~/acct2/…``: the home folder,
+    which the code never read. Such a path is shown absolute instead, or with ``./`` in front
+    when there is no working directory left to make it absolute against.
     """
     p = Path(p)
+    if any(part.startswith("~") for part in p.parts):
+        try:
+            return os.path.abspath(p)
+        except OSError:
+            return f"./{p}"
     try:
         return f"~/{p.relative_to(Path.home())}"
     except (ValueError, RuntimeError, OSError):

--- a/charter/util.py
+++ b/charter/util.py
@@ -64,7 +64,8 @@ def short_path(p) -> str:
     ``~`` rather than the full path because these render on one line beside other things,
     and the home prefix is the longest part carrying the least information.
 
-    **Never for a path with a literal ``~`` segment** (#969). Nothing expands a ``~`` that
+    **Never for a path with a segment that starts with ``~``** — ``~`` itself, or a ``~name`` a
+    shell would read as somebody's home (#969). Nothing expands a ``~`` that
     arrives inside a value — `CLAUDE_CONFIG_DIR='~/acct2'` is read as ``<cwd>/~/acct2`` — so
     abbreviating that path, or printing it as spelled, renders ``~/acct2/…``: the home folder,
     which the code never read. Such a path is shown absolute instead, or with ``./`` in front

--- a/docs/install.md
+++ b/docs/install.md
@@ -115,10 +115,11 @@ start Claude Code from, so it sees the same variable.
   writes the guard hook is decided by `~/.claude` whatever your shell says.
 - **A guard sighting counts only for the folder it ran under.** `plane-root guard` and `guard
   seen` stay yellow for a sighting from another folder, one recorded before charter kept the
-  folder, or one that names no harness (`$CHARTER_HARNESS` unset and no plugin), and each says
-  which case it is. A Bash command in a Claude Code session on the folder you use clears the
-  first two; for the third, `charter reinit` writes `$CHARTER_HARNESS` into
-  `.claude/settings.json`, and a session started after that names its harness.
+  folder, or one that names no harness charter knows (`$CHARTER_HARNESS` unset or misspelled,
+  and no plugin), and each says which case it is. A Bash command in a Claude Code session on
+  the folder you use clears the first two. For the third, set `$CHARTER_HARNESS` to
+  `claude-code`, `codex` or `opencode` — `charter reinit` writes it into
+  `.claude/settings.json` — and a session started after that names its harness.
 - **An empty or relative `$CLAUDE_CONFIG_DIR` is reported on both guard rows**, whatever the
   sightings. Claude Code resolves it against its own working directory, which charter cannot
   see, so nothing can be compared with it. Set it to an absolute path; running a command

--- a/docs/install.md
+++ b/docs/install.md
@@ -101,6 +101,18 @@ plugin loads nothing until it is enabled. charter will not enable it for you —
 plugin enable charter@charter --scope project` is yours to run, since turning a plugin off
 is a choice and charter does not revert a deliberate edit.
 
+**These rows answer for the Claude Code config folder in use.** `plugin install`, `plugin
+files`, `plane-root guard`, `guard seen`, `session root` and `mcp` read the folder Claude Code
+itself reads: `$CLAUDE_CONFIG_DIR` when it is set — the usual way to run a second account —
+and `~/.claude` with `~/.claude.json` when it is not. With the variable set, Claude Code keeps
+that folder's own plugins, settings and `.claude.json`, so a plugin installed under
+`~/.claude` does not count there, and `plane-root guard` warns rather than staying green. A
+guard that fired under one folder vouches for that folder only. `charter reinit` asks the
+same question before it writes the guard hook, so it too answers for the shell it runs in.
+Run both from the shell you start Claude Code from, so they see the same variable. One row
+does not follow the variable yet: `personas` still looks for a persona's skills under
+`~/.claude`.
+
 By hand, if you would rather, or if `charter doctor --fix` could not (an old `claude`, no
 network):
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -101,17 +101,30 @@ plugin loads nothing until it is enabled. charter will not enable it for you —
 plugin enable charter@charter --scope project` is yours to run, since turning a plugin off
 is a choice and charter does not revert a deliberate edit.
 
-**These rows answer for the Claude Code config folder in use.** `plugin install`, `plugin
-files`, `plane-root guard`, `guard seen`, `session root` and `mcp` read the folder Claude Code
-itself reads: `$CLAUDE_CONFIG_DIR` when it is set — the usual way to run a second account —
-and `~/.claude` with `~/.claude.json` when it is not. With the variable set, Claude Code keeps
-that folder's own plugins, settings and `.claude.json`, so a plugin installed under
-`~/.claude` does not count there, and `plane-root guard` warns rather than staying green. A
-guard that fired under one folder vouches for that folder only. `charter reinit` asks the
-same question before it writes the guard hook, so it too answers for the shell it runs in.
-Run both from the shell you start Claude Code from, so they see the same variable. One row
-does not follow the variable yet: `personas` still looks for a persona's skills under
-`~/.claude`.
+**Which Claude Code config folder these rows answer for.** `$CLAUDE_CONFIG_DIR` points Claude
+Code at another folder — the usual way to run a second account — and Claude Code then keeps
+that folder's own plugins, settings and `.claude.json`. Run `charter doctor` from the shell you
+start Claude Code from, so it sees the same variable.
+
+- **Follow `$CLAUDE_CONFIG_DIR`:** `plugin install` and `plugin files` (they ask `claude
+  plugin list`), `plane-root guard`, `guard seen`, `session root` and `mcp`. With the variable
+  unset they read `~/.claude` and `~/.claude.json`.
+- **Do not follow it:** `personas`, which still looks for a persona's skills under
+  `~/.claude/plugins` and `~/.claude/skills`. And `charter reinit`, deliberately: it writes the
+  plane's committed `.claude/settings.json`, which every folder's sessions read, so whether it
+  writes the guard hook is decided by `~/.claude` whatever your shell says.
+- **A guard sighting counts only for the folder it ran under.** `plane-root guard` and `guard
+  seen` both stay yellow for a sighting from another folder, one recorded before charter kept
+  the folder, or any sighting under a relative `$CLAUDE_CONFIG_DIR`, and each says which case it
+  is. One Bash command in a Claude Code session on the folder you use clears the first two.
+- **Three narrower Claude Code settings are not followed**, so with any of them set these rows
+  read the wrong file:
+  - `$CLAUDE_CODE_PLUGIN_CACHE_DIR` moves the installed-plugin list out of the config folder.
+    `plane-root guard` and `guard seen` still read `<config folder>/plugins/installed_plugins.json`.
+  - `$CLAUDE_CODE_USE_COWORK_PLUGINS` renames `plugins/` to `cowork_plugins/` and
+    `settings.json` to `cowork_settings.json`. The guard rows still read the ordinary names.
+  - `$CLAUDE_CODE_CUSTOM_OAUTH_URL` renames `.claude.json` to `.claude-custom-oauth.json`.
+    `mcp` still reads `.claude.json`.
 
 By hand, if you would rather, or if `charter doctor --fix` could not (an old `claude`, no
 network):

--- a/docs/install.md
+++ b/docs/install.md
@@ -114,9 +114,15 @@ start Claude Code from, so it sees the same variable.
   plane's committed `.claude/settings.json`, which every folder's sessions read, so whether it
   writes the guard hook is decided by `~/.claude` whatever your shell says.
 - **A guard sighting counts only for the folder it ran under.** `plane-root guard` and `guard
-  seen` both stay yellow for a sighting from another folder, one recorded before charter kept
-  the folder, or any sighting under a relative `$CLAUDE_CONFIG_DIR`, and each says which case it
-  is. One Bash command in a Claude Code session on the folder you use clears the first two.
+  seen` stay yellow for a sighting from another folder, one recorded before charter kept the
+  folder, or one that names no harness (`$CHARTER_HARNESS` unset and no plugin), and each says
+  which case it is. A Bash command in a Claude Code session on the folder you use clears the
+  first two; for the third, `charter reinit` writes `$CHARTER_HARNESS` into
+  `.claude/settings.json`, and a session started after that names its harness.
+- **An empty or relative `$CLAUDE_CONFIG_DIR` is reported on both guard rows**, whatever the
+  sightings. Claude Code resolves it against its own working directory, which charter cannot
+  see, so nothing can be compared with it. Set it to an absolute path; running a command
+  changes nothing there.
 - **Three narrower Claude Code settings are not followed**, so with any of them set these rows
   read the wrong file:
   - `$CLAUDE_CODE_PLUGIN_CACHE_DIR` moves the installed-plugin list out of the config folder.

--- a/docs/news/unreleased-doctor-answers-for-the-claude-config-folder-in-use.md
+++ b/docs/news/unreleased-doctor-answers-for-the-claude-config-folder-in-use.md
@@ -13,8 +13,9 @@ folder no charter hook runs at all.
 reads: `$CLAUDE_CONFIG_DIR` when it is set, `~/.claude` and `~/.claude.json` when it is not.
 `plugin install` and `plugin files` already did, by asking Claude Code. A guard sighting now
 records the folder it ran under and counts for that folder only. Both guard rows stay yellow,
-and say which case it is, for a sighting from another folder, one from before this release,
-or any sighting under a relative `$CLAUDE_CONFIG_DIR`.
+and say which case it is, for a sighting from another folder, one from before this release, or
+one that names no harness. An empty or relative `$CLAUDE_CONFIG_DIR` is reported on both rows
+whatever the sightings, with the only fix that changes them: an absolute path.
 
 **What does not follow it.** The `personas` row still looks for a persona's skills under
 `~/.claude`. `charter reinit` keeps deciding from `~/.claude` on purpose: it writes the plane's

--- a/docs/news/unreleased-doctor-answers-for-the-claude-config-folder-in-use.md
+++ b/docs/news/unreleased-doctor-answers-for-the-claude-config-folder-in-use.md
@@ -14,7 +14,7 @@ reads: `$CLAUDE_CONFIG_DIR` when it is set, `~/.claude` and `~/.claude.json` whe
 `plugin install` and `plugin files` already did, by asking Claude Code. A guard sighting now
 records the folder it ran under and counts for that folder only. Both guard rows stay yellow,
 and say which case it is, for a sighting from another folder, one from before this release, or
-one that names no harness. An empty or relative `$CLAUDE_CONFIG_DIR` is reported on both rows
+one that names no harness charter knows. An empty or relative `$CLAUDE_CONFIG_DIR` is reported on both rows
 whatever the sightings, with the only fix that changes them: an absolute path.
 
 **What does not follow it.** The `personas` row still looks for a persona's skills under

--- a/docs/news/unreleased-doctor-answers-for-the-claude-config-folder-in-use.md
+++ b/docs/news/unreleased-doctor-answers-for-the-claude-config-folder-in-use.md
@@ -9,16 +9,24 @@ installed for the plane, while `plane-root guard` stayed green with *wired (enab
 charter@charter) — and it has fired here*. The green row was the wrong one: under that
 folder no charter hook runs at all.
 
-The rows about Claude Code's plugin, settings and MCP servers now read the folder Claude Code
-reads. That is `$CLAUDE_CONFIG_DIR` when it is set, and `~/.claude` and `~/.claude.json` when
-it is not. The rows are `plane-root guard`, `guard seen`, `session root` and `mcp`;
-`plugin install` and `plugin files` already asked Claude Code. A guard sighting now records
-the folder it ran under, and it vouches for that folder only. `charter reinit` asks the same
-question before writing the guard hook, so run it from the shell you start Claude Code from.
-The `personas` row does not follow the variable yet: it still looks for skills under
-`~/.claude`.
+`plane-root guard`, `guard seen`, `session root` and `mcp` now read the folder Claude Code
+reads: `$CLAUDE_CONFIG_DIR` when it is set, `~/.claude` and `~/.claude.json` when it is not.
+`plugin install` and `plugin files` already did, by asking Claude Code. A guard sighting now
+records the folder it ran under and counts for that folder only. Both guard rows stay yellow,
+and say which case it is, for a sighting from another folder, one from before this release,
+or any sighting under a relative `$CLAUDE_CONFIG_DIR`.
 
-One thing to expect after upgrading: `plane-root guard` may warn *nothing has fired here
-under ~/.claude yet* on a plane whose plugin is fine. The sighting on disk is from before the
-folder was recorded, so it cannot vouch for one. Run any Bash command in a Claude Code session
-and the next `charter doctor` is green again.
+**What does not follow it.** The `personas` row still looks for a persona's skills under
+`~/.claude`. `charter reinit` keeps deciding from `~/.claude` on purpose: it writes the plane's
+committed `.claude/settings.json`, which every folder's sessions read. Three narrower Claude
+Code settings are not followed either, so with any of them set these rows read the wrong file:
+
+- `$CLAUDE_CODE_PLUGIN_CACHE_DIR` moves the installed-plugin list that `plane-root guard` and
+  `guard seen` read.
+- `$CLAUDE_CODE_USE_COWORK_PLUGINS` renames `plugins/` to `cowork_plugins/` and
+  `settings.json` to `cowork_settings.json`.
+- `$CLAUDE_CODE_CUSTOM_OAUTH_URL` renames the `.claude.json` that the `mcp` row reads to
+  `.claude-custom-oauth.json`.
+
+After upgrading, both guard rows say the last sighting predates folder recording. Run any Bash
+command in a Claude Code session and the next `charter doctor` is green again.

--- a/docs/news/unreleased-doctor-answers-for-the-claude-config-folder-in-use.md
+++ b/docs/news/unreleased-doctor-answers-for-the-claude-config-folder-in-use.md
@@ -1,0 +1,24 @@
+---
+version: unreleased
+headline: `doctor` answers for the Claude Code config folder you are actually using
+---
+
+Run Claude Code with `$CLAUDE_CONFIG_DIR` — a second account is the usual reason — and
+`charter doctor` contradicted itself. `plugin install` said charter's plugin was not
+installed for the plane, while `plane-root guard` stayed green with *wired (enabled plugin
+charter@charter) — and it has fired here*. The green row was the wrong one: under that
+folder no charter hook runs at all.
+
+The rows about Claude Code's plugin, settings and MCP servers now read the folder Claude Code
+reads. That is `$CLAUDE_CONFIG_DIR` when it is set, and `~/.claude` and `~/.claude.json` when
+it is not. The rows are `plane-root guard`, `guard seen`, `session root` and `mcp`;
+`plugin install` and `plugin files` already asked Claude Code. A guard sighting now records
+the folder it ran under, and it vouches for that folder only. `charter reinit` asks the same
+question before writing the guard hook, so run it from the shell you start Claude Code from.
+The `personas` row does not follow the variable yet: it still looks for skills under
+`~/.claude`.
+
+One thing to expect after upgrading: `plane-root guard` may warn *nothing has fired here
+under ~/.claude yet* on a plane whose plugin is fine. The sighting on disk is from before the
+folder was recorded, so it cannot vouch for one. Run any Bash command in a Claude Code session
+and the next `charter doctor` is green again.

--- a/tests/test_doctor_answers_for_the_claude_config_folder_in_use.py
+++ b/tests/test_doctor_answers_for_the_claude_config_folder_in_use.py
@@ -470,6 +470,12 @@ class TestASightingThatNamesNoHarnessIsUnknown(ConfigFolderCase):
         r = doctor.check_guard_seen()
         self.assertEqual(r.status, WARN)
         self.assertIn("cannot tell which harness", r.detail)
+        # Said as "no harness", never as a harness named `None`. The unregistered-name branch
+        # below would catch this sighting too — the registry has no entry for `None` — and its
+        # sentence reads "names None". CI's sweep on 537d0fc found this branch deletable with
+        # the suite green for exactly that reason, so what only it says is what is pinned.
+        self.assertIn("names no harness", r.detail)
+        self.assertNotIn("None", r.detail)
 
     def test_nor_under_the_default_folder(self):
         """Not a folder mismatch: nothing about the folder in use makes it count."""

--- a/tests/test_doctor_answers_for_the_claude_config_folder_in_use.py
+++ b/tests/test_doctor_answers_for_the_claude_config_folder_in_use.py
@@ -441,6 +441,100 @@ class TestARelativeFolderNeverVouches(ConfigFolderCase):
         self.assertIn("relative", r.detail)
 
 
+class TestASightingThatNamesNoHarnessIsUnknown(ConfigFolderCase):
+    """A Claude Code session wired through settings, with `$CHARTER_HARNESS` unset, writes a
+    sighting that names no harness: `detect()` knows Claude Code only by `$CLAUDE_PLUGIN_ROOT`.
+    Deciding "Claude Code" from the name or the plugin source alone read that as another
+    harness's sighting, and it passed straight through under any folder (the #970 re-review).
+    It is unknown: it never vouches, it is never green, and the row says it cannot tell."""
+
+    def unnamed(self) -> None:
+        self.a_sighting_under(None, source=guardseen.SETTINGS, harness=None)
+
+    def test_guard_seen_is_not_green_under_a_named_folder(self):
+        self.unnamed()
+        self.use_folder(self.other)
+        r = doctor.check_guard_seen()
+        self.assertEqual(r.status, WARN)
+        self.assertIn("cannot tell which harness", r.detail)
+
+    def test_nor_under_the_default_folder(self):
+        """Not a folder mismatch: nothing about the folder in use makes it count."""
+        self.unnamed()
+        self.assertEqual(doctor.check_guard_seen().status, WARN)
+
+    def test_the_remedy_is_the_step_that_names_the_harness(self):
+        self.unnamed()
+        self.assertIn("CHARTER_HARNESS", doctor.check_guard_seen().hint)
+
+    def test_a_named_harness_other_than_claude_code_keeps_todays_behaviour(self):
+        self.a_sighting_under(self.other, source=guardseen.SETTINGS, harness="opencode")
+        self.use_the_default_folder()
+        self.assertEqual(doctor.check_guard_seen().status, OK)
+
+
+class TestARelativeFolderIsSaidWhateverTheSightings(ConfigFolderCase):
+    """A relative `$CLAUDE_CONFIG_DIR` used to be reported only beside a plugin sighting. With
+    none, or with a settings sighting, the rows read "nothing has fired here yet" and "plane not
+    worked in yet", and both hints said to run a Bash command and re-check — which records one
+    more sighting that nothing can be compared with. A remedy followed that changes nothing
+    (the #970 re-review). Whenever the folder is relative both rows say so, and name the one fix
+    that changes them."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        os.environ["CLAUDE_CONFIG_DIR"] = "cfg"
+
+    def assert_it_names_the_fix(self, r) -> None:
+        self.assertEqual(r.status, WARN)
+        self.assertIn("relative", r.detail)
+        self.assertIn("absolute path", r.hint)
+        self.assertNotIn("Bash command", r.hint)
+
+    def test_the_guard_row_with_no_sighting_at_all(self):
+        self.assert_it_names_the_fix(doctor.check_guard_wired())
+
+    def test_the_guard_row_with_a_settings_sighting_and_the_plugin_enabled(self):
+        self.install_in(config.ROOT / "cfg")
+        self.enable_in_the_plane()
+        guardseen.mark(harness="claude-code", source=guardseen.SETTINGS)
+        self.assert_it_names_the_fix(doctor.check_guard_wired())
+
+    def test_the_guard_row_even_in_a_process_the_plugin_launched(self):
+        with mock.patch.dict(os.environ, {"CLAUDE_PLUGIN_ROOT": str(self.plugin())}):
+            self.assert_it_names_the_fix(doctor.check_guard_wired())
+
+    def test_guard_seen_on_a_plane_nobody_has_worked_in(self):
+        self.assert_it_names_the_fix(doctor.check_guard_seen())
+
+    def test_guard_seen_with_a_settings_sighting_keeps_its_age(self):
+        guardseen.mark(harness="claude-code", source=guardseen.SETTINGS)
+        r = doctor.check_guard_seen()
+        self.assert_it_names_the_fix(r)
+        self.assertIn("last ran", r.detail)
+
+    def test_guard_seen_with_another_harnesses_sighting(self):
+        """Whatever the sightings: the folder is the operator's Claude Code setting, and it is
+        wrong whichever harness last fired."""
+        guardseen.mark(harness="codex", source=guardseen.SETTINGS)
+        self.assert_it_names_the_fix(doctor.check_guard_seen())
+
+
+class TestAnEmptyFolderIsCalledEmpty(ConfigFolderCase):
+    def test_both_rows_say_it_is_empty_and_what_claude_code_uses_then(self):
+        """The binary spells the folder ``CLAUDE_CONFIG_DIR ?? join(homedir(), ".claude")``, and
+        `??` keeps an empty string, so Claude Code uses its own working directory. "'.' is a
+        relative path" named nothing the operator had typed (the #970 re-review)."""
+        os.environ["CLAUDE_CONFIG_DIR"] = ""
+        for r in (doctor.check_guard_wired(), doctor.check_guard_seen()):
+            with self.subTest(row=r.name):
+                self.assertEqual(r.status, WARN)
+                self.assertIn("empty", r.detail)
+                self.assertIn("working directory", r.detail)
+                self.assertNotIn("'.'", r.detail)
+                self.assertIn("absolute path", r.hint)
+
+
 class TestOneFunctionDecidesWhetherASightingCounts(ConfigFolderCase):
     """`guardseen.folder_standing` is the only place that rule lives, with one exception
     policy, so the two rows cannot drift apart the way a writer and a checker once did."""
@@ -456,6 +550,8 @@ class TestOneFunctionDecidesWhetherASightingCounts(ConfigFolderCase):
                                side_effect=RuntimeError("Could not determine home directory.")):
             standing = guardseen.folder_standing()
         self.assertIn("cannot be resolved", standing.doubt)
+        self.assertTrue(standing.folder_in_doubt)
+        self.assertIn("HOME", standing.hint)
 
     def test_a_sighting_that_recorded_no_folder_is_a_doubt_with_nowhere_named(self):
         with mock.patch.object(claude_code, "config_home",
@@ -535,10 +631,14 @@ class TestAPathWithALiteralTildeIsNeverAbbreviated(ConfigFolderCase):
         self.assertFalse(shown.startswith("~"), shown)
 
     def test_the_guard_rows_remedy_names_the_folder_actually_read(self):
-        ws = self.rooted_in_a_workspace()
-        os.environ["CLAUDE_CONFIG_DIR"] = "~/acct2"
+        """An absolute folder with a literal `~` segment is read, and named in full. A relative
+        one never reaches this remedy: both guard rows report it as relative first."""
+        self.rooted_in_a_workspace()
+        acct = self.home / "~" / "acct2"
+        self.use_folder(acct)
         hint = doctor.check_guard_wired().hint
-        self.assertIn(os.path.join(str(ws), "~", "acct2", "settings.json"), hint)
+        self.assertIn(str(acct / "settings.json"), hint)
+        self.assertNotIn("~/~/", hint)
 
 
 if __name__ == "__main__":

--- a/tests/test_doctor_answers_for_the_claude_config_folder_in_use.py
+++ b/tests/test_doctor_answers_for_the_claude_config_folder_in_use.py
@@ -246,6 +246,13 @@ class TestMcpReadsTheClaudeJsonInsideTheFolderInUse(ConfigFolderCase):
         self.assertEqual(r.status, WARN)
         self.assertIn(str(self.other / ".claude.json"), r.detail)
 
+    def test_a_claude_json_that_is_not_an_object_is_named_by_its_path(self):
+        self.write(self.other / ".claude.json", "[]")
+        self.use_folder(self.other)
+        r = doctor.check_mcp_launchers()
+        self.assertEqual(r.status, WARN)
+        self.assertIn(f"{self.other / '.claude.json'} is not an object", r.detail)
+
 
 class TestTheFolderIsResolvedTheWayClaudeCodeResolvesIt(ConfigFolderCase):
     """Read off the 2.1.268 binary rather than guessed:
@@ -359,6 +366,9 @@ class TestGuardSeenComparesTheFolderToo(ConfigFolderCase):
         self.assertEqual(doctor.check_guard_seen().status, OK)
 
     def test_a_sighting_under_another_folder_is_not_green_and_names_both(self):
+        # The default folder's settings DO declare the guard, so the "still in" clause below is
+        # refused because this is a plugin sighting, not because that file is silent.
+        self.write(self.home / ".claude" / "settings.json", _PRETOOLUSE)
         self.a_sighting_under(None)
         self.use_folder(self.other)
         r = doctor.check_guard_seen()
@@ -372,6 +382,7 @@ class TestGuardSeenComparesTheFolderToo(ConfigFolderCase):
         r = doctor.check_guard_seen()
         self.assertEqual(r.status, WARN)
         self.assertIn("predates", r.detail)
+        self.assertIn("Run a Bash command in a Claude Code session on this config folder", r.hint)
 
     def test_another_harnesses_sighting_carries_no_claude_folder_and_is_unchanged(self):
         """`guardseen` is harness-neutral: a Codex or opencode sighting has no Claude Code
@@ -387,6 +398,8 @@ class TestGuardSeenComparesTheFolderToo(ConfigFolderCase):
         self.use_folder(self.other)
         guardseen.mark(harness=None, source=guardseen.PLUGIN)
         self.assertEqual(guardseen.last()[_FIELD], str(self.other))
+        self.assertEqual(doctor.check_guard_seen().status, OK,
+                         "and it counts: a sighting the plugin launched is not unknown")
 
     def test_a_settings_declaration_in_another_folder_is_named_not_called_gone(self):
         """The sighting came from a hook in `~/.claude/settings.json`; this session uses a
@@ -472,6 +485,23 @@ class TestASightingThatNamesNoHarnessIsUnknown(ConfigFolderCase):
         self.use_the_default_folder()
         self.assertEqual(doctor.check_guard_seen().status, OK)
 
+    def test_a_name_charter_has_no_record_of_is_unknown_too(self):
+        """`$CHARTER_HARNESS` is recorded exactly as spelled, so `claude` for `claude-code` — one
+        typo — read as another harness's sighting and stayed green under any folder (probe H in
+        the verification review of 3624287). ADR 0015 already has `doctor` warn on a harness it
+        has no record of; a sighting from one is unknown the same way."""
+        self.a_sighting_under(self.other, source=guardseen.SETTINGS, harness="claude")
+        self.use_the_default_folder()
+        r = doctor.check_guard_seen()
+        self.assertEqual(r.status, WARN)
+        self.assertIn("no record of", r.detail)
+        self.assertIn("CHARTER_HARNESS", r.hint)
+
+    def test_a_plugin_launched_guard_counts_whatever_it_was_named(self):
+        """The control: `$CLAUDE_PLUGIN_ROOT` makes it Claude Code's, typo or not."""
+        self.a_sighting_under(self.other, source=guardseen.PLUGIN, harness="claude")
+        self.assertEqual(doctor.check_guard_seen().status, OK)
+
 
 class TestARelativeFolderIsSaidWhateverTheSightings(ConfigFolderCase):
     """A relative `$CLAUDE_CONFIG_DIR` used to be reported only beside a plugin sighting. With
@@ -518,6 +548,12 @@ class TestARelativeFolderIsSaidWhateverTheSightings(ConfigFolderCase):
         wrong whichever harness last fired."""
         guardseen.mark(harness="codex", source=guardseen.SETTINGS)
         self.assert_it_names_the_fix(doctor.check_guard_seen())
+
+    def test_guard_seen_calls_an_unnamed_harness_unnamed(self):
+        guardseen.mark(harness=None, source=guardseen.SETTINGS)
+        r = doctor.check_guard_seen()
+        self.assert_it_names_the_fix(r)
+        self.assertIn("under an unnamed harness", r.detail)
 
 
 class TestAnEmptyFolderIsCalledEmpty(ConfigFolderCase):
@@ -620,6 +656,12 @@ class TestAPathWithALiteralTildeIsNeverAbbreviated(ConfigFolderCase):
         p = Path("~") / "acct2" / "settings.json"
         self.assertEqual(util.short_path(p),
                          os.path.join(os.getcwd(), "~", "acct2", "settings.json"))
+
+    def test_a_segment_that_only_starts_with_a_tilde_is_shown_absolute_too(self):
+        """`~acct2` is somebody's home to any shell, so it misleads the same way."""
+        p = Path("~acct2") / "settings.json"
+        self.assertEqual(util.short_path(p),
+                         os.path.join(os.getcwd(), "~acct2", "settings.json"))
 
     def test_a_tilde_segment_under_home_is_not_shortened_either(self):
         p = self.home / "~" / "acct2"

--- a/tests/test_doctor_answers_for_the_claude_config_folder_in_use.py
+++ b/tests/test_doctor_answers_for_the_claude_config_folder_in_use.py
@@ -13,7 +13,12 @@ plugin was not installed for this plane and, rows earlier, that the guard was wi
 fired here — while under that folder no charter hook ran at all.
 
 And "has fired here" was a sighting from an earlier session, under whichever folder THAT
-session used. A sighting is evidence for the folder it ran under and for no other.
+session used. A sighting is evidence for the folder it ran under and for no other, and one
+that cannot say which folder it ran under is evidence for none.
+
+`charter reinit` is the deliberate exception. It writes the plane's committed
+`.claude/settings.json`, and a committed file must not change with one person's shell, so its
+write decision stays on `~/.claude` (per-profile wiring is harness-profiles task 4).
 
 Every fixture states `$HOME`, `$CLAUDE_CONFIG_DIR` and `$CLAUDE_PLUGIN_ROOT` itself, so none of
 this can pass on the developer's own Claude Code install and prove nothing on CI.
@@ -28,7 +33,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from unittest import mock
 
-from charter import commands, config, doctor, guardseen
+from charter import commands, config, doctor, guardseen, util
 from charter.harness import claude_code
 from tests._isolation import PersonaIso
 
@@ -39,9 +44,12 @@ OK, WARN, FAIL = doctor.OK, doctor.WARN, doctor.FAIL
 _PRETOOLUSE = {"hooks": {"PreToolUse": [{"matcher": "Bash", "hooks": [
     {"type": "command", "command": "charter hook pretooluse"}]}]}}
 
+#: The field a Claude Code sighting records its folder in, spelled by hand for the same reason.
+_FIELD = "claude_config_dir"
+
 
 class ConfigFolderCase(PersonaIso):
-    """A plane that enables charter's plugin, a home folder, and a second config folder."""
+    """A plane, a home folder, and a second config folder."""
 
     def setUp(self) -> None:
         super().setUp()
@@ -96,8 +104,9 @@ class ConfigFolderCase(PersonaIso):
         p.parent.mkdir(parents=True, exist_ok=True)
         p.write_text(json.dumps({"enabledPlugins": {"charter@charter": True}}))
 
-    def a_sighting_under(self, folder: Path | None) -> None:
-        """The plugin's guard firing in a session that used *folder* (``None``: the default).
+    def a_sighting_under(self, folder: Path | None, source: str = guardseen.PLUGIN,
+                         harness: str = "claude-code") -> None:
+        """A guard firing in a session that used *folder* (``None``: the default).
 
         The environment is the only thing a hook process knows about its config folder, so
         the sighting is made with that environment in force."""
@@ -105,7 +114,14 @@ class ConfigFolderCase(PersonaIso):
             self.use_the_default_folder()
         else:
             self.use_folder(folder)
-        guardseen.mark(harness="claude-code", source=guardseen.PLUGIN)
+        guardseen.mark(harness=harness, source=source)
+
+    def a_sighting_from_before_folders_were_recorded(self) -> None:
+        """What every charter before this change wrote: no folder field at all."""
+        p = guardseen.path()
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(json.dumps({"ts": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+                                 "harness": "claude-code", "source": guardseen.PLUGIN}))
 
     def write(self, path: Path, doc) -> Path:
         path.parent.mkdir(parents=True, exist_ok=True)
@@ -283,7 +299,7 @@ class TestTheFolderIsResolvedTheWayClaudeCodeResolvesIt(ConfigFolderCase):
 
 
 class TestAPastSightingDoesNotVouchForAnotherFolder(ConfigFolderCase):
-    """Both folders carry the plugin, so the only thing left to decide the row is the
+    """Both folders carry the plugin, so the only thing left to decide the guard row is the
     sighting — and a sighting belongs to the folder it ran under (#261's rule, one field on)."""
 
     def setUp(self) -> None:
@@ -298,13 +314,9 @@ class TestAPastSightingDoesNotVouchForAnotherFolder(ConfigFolderCase):
         r = doctor.check_guard_wired()
         self.assertEqual(r.status, WARN)
         self.assertNotIn("and it has fired here", r.detail)
-
-    def test_the_warning_names_the_folder_it_answers_for(self):
-        """`guard seen` still reads "last ran 0m ago" on the next row, which is true. Without
-        the folder here the two rows would contradict each other, which is #969 again."""
-        self.a_sighting_under(None)
-        self.use_folder(self.other)
-        self.assertIn(str(self.other), doctor.check_guard_wired().detail)
+        # Both folders named, so the reader can see this is not `guard seen` contradicted.
+        self.assertIn(str(self.other), r.detail)
+        self.assertIn("~/.claude", r.detail)
 
     def test_a_sighting_under_the_named_folder_does(self):
         self.a_sighting_under(self.other)
@@ -312,22 +324,19 @@ class TestAPastSightingDoesNotVouchForAnotherFolder(ConfigFolderCase):
         self.assertEqual(r.status, OK)
         self.assertIn("and it has fired here", r.detail)
 
-    def test_a_sighting_from_before_the_folder_was_recorded_does_not_vouch(self):
-        """Unknown is not suspect, and it is not evidence either. The same call #261 made
-        for a sighting with no `source`: it clears on the next guarded Bash call."""
-        p = guardseen.path()
-        p.parent.mkdir(parents=True, exist_ok=True)
-        p.write_text(json.dumps({"ts": datetime.now(timezone.utc).isoformat(timespec="seconds"),
-                                 "harness": "claude-code", "source": guardseen.PLUGIN}))
-        self.assertEqual(doctor.check_guard_wired().status, WARN)
+    def test_a_sighting_from_before_folders_were_recorded_says_exactly_that(self):
+        """Neither a pass nor a claim that nothing fired (ADR 0009): something DID fire, and
+        charter cannot tell under which folder. Saying "nothing has fired here yet" beside
+        `guard seen`'s "last ran 0m ago" is #969's contradiction in a new pair of rows."""
+        self.a_sighting_from_before_folders_were_recorded()
+        r = doctor.check_guard_wired()
+        self.assertEqual(r.status, WARN)
+        self.assertIn("predates", r.detail)
+        self.assertNotIn("nothing has fired", r.detail)
 
-    def test_a_sighting_records_the_folder_it_ran_under(self):
+    def test_a_sighting_records_the_absolute_folder_it_ran_under(self):
         self.a_sighting_under(self.other)
-        self.assertEqual(guardseen.last()["claude_config_dir"], str(self.other))
-        self.assertEqual(guardseen.last_claude_config_dir(), str(self.other))
-
-    def test_no_sighting_has_no_folder(self):
-        self.assertIsNone(guardseen.last_claude_config_dir())
+        self.assertEqual(guardseen.last()[_FIELD], str(self.other))
 
     def test_a_folder_that_cannot_be_resolved_still_records_the_sighting(self):
         """`mark` runs inside the guard and never raises. `Path.home()` can, with no `$HOME`
@@ -336,80 +345,200 @@ class TestAPastSightingDoesNotVouchForAnotherFolder(ConfigFolderCase):
                                side_effect=RuntimeError("Could not determine home directory.")):
             self.assertIsNotNone(guardseen.mark(harness="claude-code", source=guardseen.PLUGIN))
         rec = guardseen.last()
-        self.assertIn("claude_config_dir", rec)
-        self.assertIsNone(rec["claude_config_dir"])
+        self.assertIn(_FIELD, rec)
+        self.assertIsNone(rec[_FIELD])
 
 
-class TestARelativeFolderIsTheOneItNamedWhereItWasRead(ConfigFolderCase):
-    """`$CLAUDE_CONFIG_DIR=cfg` names a different folder in every directory it is read from.
+class TestGuardSeenComparesTheFolderToo(ConfigFolderCase):
+    """`guard seen` is an age, never a verdict about wiring — but an age under a different
+    folder is not an age of anything in this one. Green there sat under the guard row's
+    warning and told the reader the guard had just run for them."""
 
-    Recorded as spelled, a sighting made in the plane root compared equal to a `doctor` run
-    from a workspace, where ``cfg`` is somewhere else — a false green by string equality."""
+    def test_the_same_folder_is_still_green(self):
+        self.a_sighting_under(self.other)
+        self.assertEqual(doctor.check_guard_seen().status, OK)
+
+    def test_a_sighting_under_another_folder_is_not_green_and_names_both(self):
+        self.a_sighting_under(None)
+        self.use_folder(self.other)
+        r = doctor.check_guard_seen()
+        self.assertEqual(r.status, WARN)
+        self.assertIn(str(self.other), r.detail)
+        self.assertIn("~/.claude", r.detail)
+        self.assertNotIn("still in", r.detail, "a plugin sighting has no settings file to name")
+
+    def test_a_sighting_from_before_folders_were_recorded_is_not_green(self):
+        self.a_sighting_from_before_folders_were_recorded()
+        r = doctor.check_guard_seen()
+        self.assertEqual(r.status, WARN)
+        self.assertIn("predates", r.detail)
+
+    def test_another_harnesses_sighting_carries_no_claude_folder_and_is_unchanged(self):
+        """`guardseen` is harness-neutral: a Codex or opencode sighting has no Claude Code
+        folder to be wrong about, and must not be warned over one."""
+        self.a_sighting_under(self.other, source=guardseen.SETTINGS, harness="codex")
+        self.assertNotIn(_FIELD, guardseen.last())
+        self.use_the_default_folder()
+        self.assertEqual(doctor.check_guard_seen().status, OK)
+
+    def test_a_plugin_sighting_is_claude_codes_even_with_no_harness_named(self):
+        """`$CLAUDE_PLUGIN_ROOT` is Claude Code's own variable, so a plugin-launched guard is
+        a Claude Code sighting whatever the registry could name."""
+        self.use_folder(self.other)
+        guardseen.mark(harness=None, source=guardseen.PLUGIN)
+        self.assertEqual(guardseen.last()[_FIELD], str(self.other))
+
+    def test_a_settings_declaration_in_another_folder_is_named_not_called_gone(self):
+        """The sighting came from a hook in `~/.claude/settings.json`; this session uses a
+        folder whose plugin declares the guard instead. The declaration is not gone — it is
+        in a file this folder's sessions never read — and saying it is gone sends the reader
+        looking for an edit nobody made."""
+        self.write(self.home / ".claude" / "settings.json", _PRETOOLUSE)
+        self.a_sighting_under(None, source=guardseen.SETTINGS)
+        self.install_in(self.other)
+        self.enable_in_the_plane()
+        self.use_folder(self.other)
+        r = doctor.check_guard_seen()
+        self.assertEqual(r.status, WARN)
+        self.assertNotIn("no longer there", r.detail)
+        self.assertIn("still in ~/.claude/settings.json", r.detail)
+
+    def test_a_settings_sighting_elsewhere_names_no_file_that_does_not_declare_it(self):
+        self.a_sighting_under(None, source=guardseen.SETTINGS)
+        self.use_folder(self.other)
+        r = doctor.check_guard_seen()
+        self.assertEqual(r.status, WARN)
+        self.assertNotIn("still in", r.detail)
+
+
+class TestARelativeFolderNeverVouches(ConfigFolderCase):
+    """A relative `$CLAUDE_CONFIG_DIR` stays relative inside Claude Code, and nobody has
+    measured whether a hook process and a `doctor` resolve it against the same directory. So it
+    records no folder and nothing is compared with it — and the rows say why."""
 
     def setUp(self) -> None:
         super().setUp()
-        self.ws = self.rooted_in_a_workspace()
-        # Both directories carry the plugin under `cfg` and the session's own settings enable
-        # it, so the only thing left to decide the row is which folder the sighting names.
+        # The plugin under `cfg` beside the plane and enabled there, so the guard row reaches
+        # its plugin branch and only the relative folder is left to decide it.
         self.install_in(config.ROOT / "cfg")
-        self.install_in(self.ws / "cfg")
-        self.write(self.ws / ".claude" / "settings.json",
-                   {"enabledPlugins": {"charter@charter": True}})
+        self.enable_in_the_plane()
         os.environ["CLAUDE_CONFIG_DIR"] = "cfg"
+        guardseen.mark(harness="claude-code", source=guardseen.PLUGIN)  # in this very directory
 
-    def fired_in(self, where: Path) -> None:
-        os.chdir(where)
-        guardseen.mark(harness="claude-code", source=guardseen.PLUGIN)
-        os.chdir(self.ws)
+    def test_the_sighting_records_no_folder(self):
+        rec = guardseen.last()
+        self.assertIn(_FIELD, rec)
+        self.assertIsNone(rec[_FIELD])
 
-    def test_fired_in_the_plane_root_it_does_not_vouch_for_a_workspace(self):
-        self.fired_in(config.ROOT)
+    def test_the_guard_row_says_the_folder_is_relative_and_is_not_green(self):
         r = doctor.check_guard_wired()
         self.assertEqual(r.status, WARN)
-        # The plugin's own warning, not "not wired": the plugin IS found here, so a WARN for
-        # any other reason would pass without the comparison ever being reached.
-        self.assertIn("nothing has fired here under", r.detail)
+        self.assertIn("relative", r.detail)
 
-    def test_fired_in_the_workspace_itself_it_does(self):
-        self.fired_in(self.ws)
-        r = doctor.check_guard_wired()
-        self.assertEqual(r.status, OK)
-        self.assertIn("and it has fired here", r.detail)
-
-    def test_a_working_directory_that_is_gone_still_records_the_sighting(self):
-        """Making a relative folder absolute asks for the working directory, and a deleted
-        one raises. `mark` runs inside the guard, which never fails a turn."""
-        with mock.patch("os.getcwd", side_effect=FileNotFoundError("gone")):
-            self.assertIsNotNone(guardseen.mark(harness="claude-code", source=guardseen.PLUGIN))
-        self.assertIsNone(guardseen.last()["claude_config_dir"])
+    def test_guard_seen_says_so_too(self):
+        r = doctor.check_guard_seen()
+        self.assertEqual(r.status, WARN)
+        self.assertIn("relative", r.detail)
 
 
-class TestReinitAsksTheFolderDoctorAsks(ConfigFolderCase):
-    """`charter reinit` skips writing the guard hook when an enabled plugin already dispatches
-    it, and it asks `doctor`'s own function, because a writer and a checker answering "is this
-    wired?" from different evidence is how the guard came to be declared twice. So it follows
-    `$CLAUDE_CONFIG_DIR` too. Kept on `~/.claude`, a second-account shell would hear `doctor`
-    say the guard is not wired and `reinit` answer that nothing needs doing."""
+class TestOneFunctionDecidesWhetherASightingCounts(ConfigFolderCase):
+    """`guardseen.folder_standing` is the only place that rule lives, with one exception
+    policy, so the two rows cannot drift apart the way a writer and a checker once did."""
 
-    def setUp(self) -> None:
-        super().setUp()
+    def test_no_sighting_has_nothing_to_doubt(self):
+        standing = guardseen.folder_standing()
+        self.assertIsNone(standing.doubt)
+        self.assertIsNone(standing.elsewhere)
+
+    def test_a_folder_in_use_that_cannot_be_resolved_is_a_doubt_not_a_crash(self):
+        self.a_sighting_under(self.other)
+        with mock.patch.object(claude_code, "config_home",
+                               side_effect=RuntimeError("Could not determine home directory.")):
+            standing = guardseen.folder_standing()
+        self.assertIn("cannot be resolved", standing.doubt)
+
+    def test_a_sighting_that_recorded_no_folder_is_a_doubt_with_nowhere_named(self):
+        with mock.patch.object(claude_code, "config_home",
+                               side_effect=RuntimeError("Could not determine home directory.")):
+            guardseen.mark(harness="claude-code", source=guardseen.PLUGIN)
+        self.use_folder(self.other)
+        standing = guardseen.folder_standing()
+        self.assertIn("recorded no absolute", standing.doubt)
+        self.assertIsNone(standing.elsewhere)
+
+    def test_only_a_different_recorded_folder_is_named_as_elsewhere(self):
+        self.a_sighting_under(None)
+        self.use_folder(self.other)
+        self.assertEqual(guardseen.folder_standing().elsewhere, str(self.home / ".claude"))
+
+
+class TestReinitDoesNotFollowTheShellsFolder(ConfigFolderCase):
+    """`charter reinit` writes the plane's committed `.claude/settings.json`, which the
+    sessions of EVERY config folder read. A committed file must not change with one person's
+    shell, so its write decision is exactly what it was before #969: `~/.claude`'s plugins and
+    user settings, whatever `$CLAUDE_CONFIG_DIR` says. Per-profile wiring is harness-profiles
+    task 4. Followed instead, a second-account shell with no plugin wrote the hook into that
+    file, and every `~/.claude` session with the plugin then ran the guard twice."""
+
+    def settings(self) -> Path:
+        return config.ROOT / ".claude" / "settings.json"
+
+    def test_a_plugin_in_the_default_folder_still_stops_the_write_under_another(self):
         self.install_in(self.home / ".claude")
         self.enable_in_the_plane()
-
-    def test_the_default_folder_sees_the_plugin(self):
-        self.assertEqual(commands._plugin_dispatches_guard(config.ROOT), "charter@charter")
-
-    def test_a_folder_without_the_plugin_does_not(self):
+        before = self.settings().read_text()
         self.use_folder(self.other)
-        self.assertIsNone(commands._plugin_dispatches_guard(config.ROOT))
-
-    def test_so_reinit_wires_the_hook_only_for_the_folder_without_the_plugin(self):
-        settings = config.ROOT / ".claude" / "settings.json"
         self.assertEqual(commands._ensure_guard_hook(config.ROOT)[0], "present")
-        self.assertNotIn("charter hook pretooluse", settings.read_text())
+        self.assertEqual(self.settings().read_text(), before)
+
+    def test_a_plugin_only_in_the_named_folder_does_not_stop_it(self):
+        self.install_in(self.other)
+        self.enable_in_the_plane()
         self.use_folder(self.other)
         self.assertEqual(commands._ensure_guard_hook(config.ROOT)[0], "created")
-        self.assertIn("charter hook pretooluse", settings.read_text())
+
+    def test_the_default_folders_user_settings_still_enable_the_plugin_for_it(self):
+        self.install_in(self.home / ".claude")
+        self.write(self.home / ".claude" / "settings.json",
+                   {"enabledPlugins": {"charter@charter": True}})
+        self.use_folder(self.other)
+        self.assertEqual(commands._ensure_guard_hook(config.ROOT)[0], "present")
+
+    def test_doctor_does_not_promise_a_named_folder_a_reinit_that_writes_nothing(self):
+        """The price of the rule above, said where the operator would pay it. Nothing is wired
+        here, and the plane-root row's remedy is `charter reinit` — which, under a named folder
+        whose `~/.claude` has the plugin, writes nothing (#851's remedy that is not one)."""
+        self.use_folder(self.other)
+        hint = doctor.check_guard_wired().hint
+        self.assertIn("charter doctor --fix", hint)
+        self.assertIn(str(self.other), hint)
+        self.use_the_default_folder()
+        self.assertNotIn("charter doctor --fix", doctor.check_guard_wired().hint, "the control")
+
+
+class TestAPathWithALiteralTildeIsNeverAbbreviated(ConfigFolderCase):
+    """`CLAUDE_CONFIG_DIR='~/acct2'` is read as `<cwd>/~/acct2` — nothing expands it — and a row
+    rendering that as `~/acct2/settings.json` names the home folder the code never read."""
+
+    def test_a_relative_tilde_path_is_shown_where_it_really_is(self):
+        p = Path("~") / "acct2" / "settings.json"
+        self.assertEqual(util.short_path(p),
+                         os.path.join(os.getcwd(), "~", "acct2", "settings.json"))
+
+    def test_a_tilde_segment_under_home_is_not_shortened_either(self):
+        p = self.home / "~" / "acct2"
+        self.assertEqual(util.short_path(p), str(p))
+
+    def test_with_no_working_directory_it_still_does_not_read_as_home(self):
+        with mock.patch("os.getcwd", side_effect=FileNotFoundError("gone")):
+            shown = util.short_path(Path("~") / "acct2")
+        self.assertFalse(shown.startswith("~"), shown)
+
+    def test_the_guard_rows_remedy_names_the_folder_actually_read(self):
+        ws = self.rooted_in_a_workspace()
+        os.environ["CLAUDE_CONFIG_DIR"] = "~/acct2"
+        hint = doctor.check_guard_wired().hint
+        self.assertIn(os.path.join(str(ws), "~", "acct2", "settings.json"), hint)
 
 
 if __name__ == "__main__":

--- a/tests/test_doctor_answers_for_the_claude_config_folder_in_use.py
+++ b/tests/test_doctor_answers_for_the_claude_config_folder_in_use.py
@@ -1,0 +1,416 @@
+"""`doctor` answers for the Claude Code config folder in use, not for `~/.claude` (#969).
+
+Fifth variant of the family #168, #177, #261 and #851 belong to — a checker reading a proxy
+instead of the fact. *Packaged* read as protection, *installed* read as wired, *enabled* read
+as loaded, *elsewhere* read as here. This one is **the default config folder read as the one
+in use**.
+
+`$CLAUDE_CONFIG_DIR` points Claude Code at another folder, typically for a second account.
+The `plugin install` row asks `claude plugin list --json`, which follows it. The `plane-root
+guard` row read `~/.claude/plugins/installed_plugins.json` directly, the settings rows read
+`~/.claude/settings.json`, and the `mcp` row read `~/.claude.json`. So one report said the
+plugin was not installed for this plane and, rows earlier, that the guard was wired and had
+fired here — while under that folder no charter hook ran at all.
+
+And "has fired here" was a sighting from an earlier session, under whichever folder THAT
+session used. A sighting is evidence for the folder it ran under and for no other.
+
+Every fixture states `$HOME`, `$CLAUDE_CONFIG_DIR` and `$CLAUDE_PLUGIN_ROOT` itself, so none of
+this can pass on the developer's own Claude Code install and prove nothing on CI.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import unittest
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest import mock
+
+from charter import commands, config, doctor, guardseen
+from charter.harness import claude_code
+from tests._isolation import PersonaIso
+
+OK, WARN, FAIL = doctor.OK, doctor.WARN, doctor.FAIL
+
+#: Hand-spelled, never imported from the module under test — a report compared against the
+#: constant that spells it asserts nothing.
+_PRETOOLUSE = {"hooks": {"PreToolUse": [{"matcher": "Bash", "hooks": [
+    {"type": "command", "command": "charter hook pretooluse"}]}]}}
+
+
+class ConfigFolderCase(PersonaIso):
+    """A plane that enables charter's plugin, a home folder, and a second config folder."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        (config.ROOT / "charter.toml").write_text("schema = 1\n")
+        self.enterContext(mock.patch.object(config, "HAS_CONTROL_PLANE", True))
+        self.home = self.tmp / "home"
+        (self.home / ".claude").mkdir(parents=True)
+        self.other = self.tmp / "second-account"
+        self.other.mkdir()
+        # Every environment value these rows depend on, stated. `patch.dict` restores the
+        # whole mapping on exit, so the two removals below are undone with it.
+        self.enterContext(mock.patch.dict(os.environ, {"HOME": str(self.home)}))
+        os.environ.pop("CLAUDE_CONFIG_DIR", None)
+        os.environ.pop("CLAUDE_PLUGIN_ROOT", None)
+        # Rooted at the plane, so the plane's `.claude/settings.json` is the project file the
+        # host would read for this "session" (#851).
+        self.addCleanup(os.chdir, os.getcwd())
+        os.chdir(config.ROOT)
+        self.assertTrue(doctor.session_is_the_plane(),
+                        "these tests are about a session rooted at the plane")
+        self._plugin: Path | None = None
+
+    # --- the operator's shell -------------------------------------------------------------
+
+    def use_folder(self, folder: Path) -> None:
+        """Export `$CLAUDE_CONFIG_DIR`, as a second-account shell does."""
+        os.environ["CLAUDE_CONFIG_DIR"] = str(folder)
+
+    def use_the_default_folder(self) -> None:
+        os.environ.pop("CLAUDE_CONFIG_DIR", None)
+
+    # --- what Claude Code would find ------------------------------------------------------
+
+    def plugin(self) -> Path:
+        """An installed copy of a plugin whose hooks dispatch the guard."""
+        if self._plugin is None:
+            self._plugin = self.tmp / "plugin-cache" / "charter"
+            (self._plugin / "hooks").mkdir(parents=True)
+            (self._plugin / "hooks" / "hooks.json").write_text(json.dumps(_PRETOOLUSE))
+        return self._plugin
+
+    def install_in(self, folder: Path) -> None:
+        """charter's plugin in *folder*'s manifest — the file Claude Code writes on install."""
+        man = folder / "plugins" / "installed_plugins.json"
+        man.parent.mkdir(parents=True, exist_ok=True)
+        man.write_text(json.dumps({"version": 2, "plugins": {"charter@charter": [
+            {"scope": "project", "projectPath": str(config.ROOT),
+             "installPath": str(self.plugin())}]}}))
+
+    def enable_in_the_plane(self) -> None:
+        p = config.ROOT / ".claude" / "settings.json"
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(json.dumps({"enabledPlugins": {"charter@charter": True}}))
+
+    def a_sighting_under(self, folder: Path | None) -> None:
+        """The plugin's guard firing in a session that used *folder* (``None``: the default).
+
+        The environment is the only thing a hook process knows about its config folder, so
+        the sighting is made with that environment in force."""
+        if folder is None:
+            self.use_the_default_folder()
+        else:
+            self.use_folder(folder)
+        guardseen.mark(harness="claude-code", source=guardseen.PLUGIN)
+
+    def write(self, path: Path, doc) -> Path:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(doc if isinstance(doc, str) else json.dumps(doc))
+        return path
+
+    def rooted_in_a_workspace(self) -> Path:
+        ws = (config.ROOT / "workspaces" / "fleet")
+        ws.mkdir(parents=True, exist_ok=True)
+        ws = ws.resolve()
+        os.chdir(ws)
+        return ws
+
+
+class TestAFolderWithoutThePluginIsNotGreen(ConfigFolderCase):
+    """The report, reproduced: installed and fired under `~/.claude`, run under another."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.install_in(self.home / ".claude")
+        self.enable_in_the_plane()
+        self.a_sighting_under(None)
+
+    def test_the_default_folder_is_still_green(self):
+        """The control. Without it the case below would pass on a row that is never green."""
+        self.use_the_default_folder()
+        r = doctor.check_guard_wired()
+        self.assertEqual(r.status, OK)
+        self.assertIn("and it has fired here", r.detail)
+
+    def test_a_named_folder_without_the_plugin_is_not_green(self):
+        self.use_folder(self.other)
+        r = doctor.check_guard_wired()
+        self.assertEqual(r.status, WARN)
+        self.assertIn("NOT refused", r.detail)
+        self.assertNotIn("and it has fired here", r.detail)
+
+
+class TestThePluginInTheNamedFolderIsTheOneRead(ConfigFolderCase):
+    def test_an_install_only_in_the_named_folder_wires_the_guard(self):
+        """The other direction. Refusing `~/.claude` is half a fix; a second account whose
+        own folder carries the plugin is wired, and the row has to find it there."""
+        self.install_in(self.other)
+        self.enable_in_the_plane()
+        self.a_sighting_under(self.other)
+        r = doctor.check_guard_wired()
+        self.assertEqual(r.status, OK)
+        self.assertIn("and it has fired here", r.detail)
+
+
+class TestSettingsComeFromTheFolderInUse(ConfigFolderCase):
+    def test_the_user_settings_file_is_the_default_folders_when_nothing_names_one(self):
+        self.assertEqual(doctor._settings_files()[2], self.home / ".claude" / "settings.json")
+
+    def test_the_user_settings_file_is_the_named_folders(self):
+        self.use_folder(self.other)
+        self.assertEqual(doctor._settings_files()[2], self.other / "settings.json")
+
+    def test_a_hook_only_in_the_default_folders_settings_does_not_wire_a_named_one(self):
+        self.write(self.home / ".claude" / "settings.json", _PRETOOLUSE)
+        self.assertEqual(doctor.check_guard_wired().status, OK, "the control")
+        self.use_folder(self.other)
+        self.assertEqual(doctor.check_guard_wired().status, WARN)
+
+    def test_a_hook_in_the_named_folders_settings_wires_it(self):
+        declared = self.write(self.other / "settings.json", _PRETOOLUSE)
+        self.use_folder(self.other)
+        r = doctor.check_guard_wired()
+        self.assertEqual(r.status, OK)
+        self.assertIn(str(declared), r.detail)
+
+    def test_the_remedy_names_the_named_folders_settings_file(self):
+        """A session rooted below the plane is told where to declare the guard. Naming
+        `~/.claude/settings.json` to a session that never reads it is #851's remedy-that-
+        looks-like-a-fix, one folder over."""
+        self.rooted_in_a_workspace()
+        self.use_folder(self.other)
+        hint = doctor.check_guard_wired().hint
+        self.assertIn(str(self.other / "settings.json"), hint)
+        self.assertNotIn("~/.claude/settings.json", hint)
+
+    def test_the_session_root_row_names_the_folder_it_read(self):
+        self.rooted_in_a_workspace()
+        self.assertIn("~/.claude/", doctor.check_session_root().detail, "the control")
+        self.use_folder(self.other)
+        detail = doctor.check_session_root().detail
+        self.assertIn(str(self.other), detail)
+        self.assertNotIn("~/.claude/", detail)
+
+    def test_the_session_root_row_names_it_for_a_harness_charter_has_not_measured(self):
+        """The sentence has a second spelling, for a harness with no discovery rules."""
+        self.rooted_in_a_workspace()
+        self.use_folder(self.other)
+        with mock.patch.object(doctor, "_discovery_rules", return_value=([], [])):
+            detail = doctor.check_session_root().detail
+        self.assertIn(str(self.other), detail)
+        self.assertNotIn("~/.claude/", detail)
+
+
+class TestMcpReadsTheClaudeJsonInsideTheFolderInUse(ConfigFolderCase):
+    """Measured on 2.1.268: with `$CLAUDE_CONFIG_DIR` set, Claude Code writes `.claude.json`
+    inside that folder, so its `mcpServers` are there and not in `~/.claude.json`."""
+
+    def broken(self) -> dict:
+        return {"mcpServers": {"gone": {"command": str(self.tmp / "nowhere" / "bin" / "srv")}}}
+
+    def test_a_broken_launcher_registered_under_the_named_folder_fails(self):
+        self.write(self.other / ".claude.json", self.broken())
+        self.use_folder(self.other)
+        self.assertEqual(doctor.check_mcp_launchers().status, FAIL)
+
+    def test_the_default_claude_json_is_not_read_under_a_named_folder(self):
+        self.write(self.home / ".claude.json", self.broken())
+        self.assertEqual(doctor.check_mcp_launchers().status, FAIL, "the control")
+        self.use_folder(self.other)
+        self.assertEqual(doctor.check_mcp_launchers().status, OK)
+
+    def test_an_unreadable_file_is_named_by_the_path_it_was_read_from(self):
+        self.write(self.other / ".claude.json", "{ not json")
+        self.use_folder(self.other)
+        r = doctor.check_mcp_launchers()
+        self.assertEqual(r.status, WARN)
+        self.assertIn(str(self.other / ".claude.json"), r.detail)
+
+
+class TestTheFolderIsResolvedTheWayClaudeCodeResolvesIt(ConfigFolderCase):
+    """Read off the 2.1.268 binary rather than guessed:
+
+    * the config home is ``(CLAUDE_CONFIG_DIR ?? join(homedir(), ".claude")).normalize("NFC")``
+    * `.claude.json` is ``<home>/.config.json`` when that exists, else
+      ``join(CLAUDE_CONFIG_DIR || homedir(), ".claude.json")``
+
+    `??` and `||` are not the same operator, and the empty string is where they part."""
+
+    def test_nothing_named_is_the_home_folder(self):
+        self.assertEqual(claude_code.config_home(), self.home / ".claude")
+        self.assertEqual(claude_code.global_config_file(), self.home / ".claude.json")
+
+    def test_a_named_folder_holds_both(self):
+        self.use_folder(self.other)
+        self.assertEqual(claude_code.config_home(), self.other)
+        self.assertEqual(claude_code.global_config_file(), self.other / ".claude.json")
+
+    def test_an_empty_value_names_the_working_directory_not_home(self):
+        """Measured: `CLAUDE_CONFIG_DIR= claude plugin list --json` listed a plugin from the
+        `plugins/installed_plugins.json` in the directory it ran in. An empty string is not
+        nullish, so `??` keeps it, and a relative path is relative to the working directory."""
+        os.environ["CLAUDE_CONFIG_DIR"] = ""
+        self.assertEqual(claude_code.config_home(), Path(""))
+
+    def test_an_empty_value_still_leaves_claude_json_in_home(self):
+        """`||` treats the empty string as absent, so that one file falls back to home."""
+        os.environ["CLAUDE_CONFIG_DIR"] = ""
+        self.assertEqual(claude_code.global_config_file(), self.home / ".claude.json")
+
+    def test_a_legacy_config_json_in_the_folder_is_the_file_read(self):
+        self.use_folder(self.other)
+        legacy = self.write(self.other / ".config.json", "{}")
+        self.write(self.other / ".claude.json", "{}")
+        self.assertEqual(claude_code.global_config_file(), legacy)
+
+    def test_the_folder_is_nfc_normalised_and_the_claude_json_parent_is_not(self):
+        """On a filesystem that keeps normalisation forms apart, a decomposed `é` and a
+        composed one are two directories. The binary normalises the config home and joins
+        `.claude.json` onto the raw value, so both halves are pinned as it spells them."""
+        # Escapes, not literals: an editor or a copy-paste can silently turn two spellings
+        # of an accented letter into one, and this would then compare a string with itself.
+        decomposed = str(self.tmp / "cafe\u0301")
+        composed = str(self.tmp / "caf\u00e9")
+        self.assertNotEqual(decomposed, composed)
+        os.environ["CLAUDE_CONFIG_DIR"] = decomposed
+        self.assertEqual(str(claude_code.config_home()), composed)
+        self.assertEqual(str(claude_code.global_config_file()),
+                         str(Path(decomposed) / ".claude.json"))
+
+
+class TestAPastSightingDoesNotVouchForAnotherFolder(ConfigFolderCase):
+    """Both folders carry the plugin, so the only thing left to decide the row is the
+    sighting — and a sighting belongs to the folder it ran under (#261's rule, one field on)."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.install_in(self.home / ".claude")
+        self.install_in(self.other)
+        self.enable_in_the_plane()
+
+    def test_a_sighting_under_the_default_folder_does_not_vouch_for_a_named_one(self):
+        self.a_sighting_under(None)
+        self.use_folder(self.other)
+        r = doctor.check_guard_wired()
+        self.assertEqual(r.status, WARN)
+        self.assertNotIn("and it has fired here", r.detail)
+
+    def test_the_warning_names_the_folder_it_answers_for(self):
+        """`guard seen` still reads "last ran 0m ago" on the next row, which is true. Without
+        the folder here the two rows would contradict each other, which is #969 again."""
+        self.a_sighting_under(None)
+        self.use_folder(self.other)
+        self.assertIn(str(self.other), doctor.check_guard_wired().detail)
+
+    def test_a_sighting_under_the_named_folder_does(self):
+        self.a_sighting_under(self.other)
+        r = doctor.check_guard_wired()
+        self.assertEqual(r.status, OK)
+        self.assertIn("and it has fired here", r.detail)
+
+    def test_a_sighting_from_before_the_folder_was_recorded_does_not_vouch(self):
+        """Unknown is not suspect, and it is not evidence either. The same call #261 made
+        for a sighting with no `source`: it clears on the next guarded Bash call."""
+        p = guardseen.path()
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(json.dumps({"ts": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+                                 "harness": "claude-code", "source": guardseen.PLUGIN}))
+        self.assertEqual(doctor.check_guard_wired().status, WARN)
+
+    def test_a_sighting_records_the_folder_it_ran_under(self):
+        self.a_sighting_under(self.other)
+        self.assertEqual(guardseen.last()["claude_config_dir"], str(self.other))
+        self.assertEqual(guardseen.last_claude_config_dir(), str(self.other))
+
+    def test_no_sighting_has_no_folder(self):
+        self.assertIsNone(guardseen.last_claude_config_dir())
+
+    def test_a_folder_that_cannot_be_resolved_still_records_the_sighting(self):
+        """`mark` runs inside the guard and never raises. `Path.home()` can, with no `$HOME`
+        and no passwd entry — and a sighting with no folder simply cannot vouch."""
+        with mock.patch.object(claude_code, "config_home",
+                               side_effect=RuntimeError("Could not determine home directory.")):
+            self.assertIsNotNone(guardseen.mark(harness="claude-code", source=guardseen.PLUGIN))
+        rec = guardseen.last()
+        self.assertIn("claude_config_dir", rec)
+        self.assertIsNone(rec["claude_config_dir"])
+
+
+class TestARelativeFolderIsTheOneItNamedWhereItWasRead(ConfigFolderCase):
+    """`$CLAUDE_CONFIG_DIR=cfg` names a different folder in every directory it is read from.
+
+    Recorded as spelled, a sighting made in the plane root compared equal to a `doctor` run
+    from a workspace, where ``cfg`` is somewhere else — a false green by string equality."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.ws = self.rooted_in_a_workspace()
+        # Both directories carry the plugin under `cfg` and the session's own settings enable
+        # it, so the only thing left to decide the row is which folder the sighting names.
+        self.install_in(config.ROOT / "cfg")
+        self.install_in(self.ws / "cfg")
+        self.write(self.ws / ".claude" / "settings.json",
+                   {"enabledPlugins": {"charter@charter": True}})
+        os.environ["CLAUDE_CONFIG_DIR"] = "cfg"
+
+    def fired_in(self, where: Path) -> None:
+        os.chdir(where)
+        guardseen.mark(harness="claude-code", source=guardseen.PLUGIN)
+        os.chdir(self.ws)
+
+    def test_fired_in_the_plane_root_it_does_not_vouch_for_a_workspace(self):
+        self.fired_in(config.ROOT)
+        r = doctor.check_guard_wired()
+        self.assertEqual(r.status, WARN)
+        # The plugin's own warning, not "not wired": the plugin IS found here, so a WARN for
+        # any other reason would pass without the comparison ever being reached.
+        self.assertIn("nothing has fired here under", r.detail)
+
+    def test_fired_in_the_workspace_itself_it_does(self):
+        self.fired_in(self.ws)
+        r = doctor.check_guard_wired()
+        self.assertEqual(r.status, OK)
+        self.assertIn("and it has fired here", r.detail)
+
+    def test_a_working_directory_that_is_gone_still_records_the_sighting(self):
+        """Making a relative folder absolute asks for the working directory, and a deleted
+        one raises. `mark` runs inside the guard, which never fails a turn."""
+        with mock.patch("os.getcwd", side_effect=FileNotFoundError("gone")):
+            self.assertIsNotNone(guardseen.mark(harness="claude-code", source=guardseen.PLUGIN))
+        self.assertIsNone(guardseen.last()["claude_config_dir"])
+
+
+class TestReinitAsksTheFolderDoctorAsks(ConfigFolderCase):
+    """`charter reinit` skips writing the guard hook when an enabled plugin already dispatches
+    it, and it asks `doctor`'s own function, because a writer and a checker answering "is this
+    wired?" from different evidence is how the guard came to be declared twice. So it follows
+    `$CLAUDE_CONFIG_DIR` too. Kept on `~/.claude`, a second-account shell would hear `doctor`
+    say the guard is not wired and `reinit` answer that nothing needs doing."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.install_in(self.home / ".claude")
+        self.enable_in_the_plane()
+
+    def test_the_default_folder_sees_the_plugin(self):
+        self.assertEqual(commands._plugin_dispatches_guard(config.ROOT), "charter@charter")
+
+    def test_a_folder_without_the_plugin_does_not(self):
+        self.use_folder(self.other)
+        self.assertIsNone(commands._plugin_dispatches_guard(config.ROOT))
+
+    def test_so_reinit_wires_the_hook_only_for_the_folder_without_the_plugin(self):
+        settings = config.ROOT / ".claude" / "settings.json"
+        self.assertEqual(commands._ensure_guard_hook(config.ROOT)[0], "present")
+        self.assertNotIn("charter hook pretooluse", settings.read_text())
+        self.use_folder(self.other)
+        self.assertEqual(commands._ensure_guard_hook(config.ROOT)[0], "created")
+        self.assertIn("charter hook pretooluse", settings.read_text())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_guard_enabled_is_not_loaded.py
+++ b/tests/test_guard_enabled_is_not_loaded.py
@@ -147,7 +147,10 @@ class TestASightingDoesNotOutliveItsDeclaration(GuardCase):
         """Recorded before this field existed. Unknown provenance is not evidence of a
         problem, and inventing one would be the same overreach in the other direction."""
         guardseen.path().parent.mkdir(parents=True, exist_ok=True)
-        guardseen.path().write_text('{"ts": "2026-08-18T00:00:00+00:00", "harness": "x"}')
+        # A registered harness that is not Claude Code, because the point here is the missing
+        # `source`. A name charter has no record of is unknown for a different reason and is
+        # never green (#969), so a placeholder name would be testing that instead.
+        guardseen.path().write_text('{"ts": "2026-08-18T00:00:00+00:00", "harness": "opencode"}')
         with self.not_running_under_plugin():
             r = doctor.check_guard_seen()
         self.assertEqual(r.status, doctor.OK)


### PR DESCRIPTION
## What went wrong

`$CLAUDE_CONFIG_DIR` points Claude Code at another config folder, usually for a second account. When charter's plugin was not installed in that folder, one `charter doctor` report contradicted itself. Measured on a real plane with the installed CLI, with `CLAUDE_CONFIG_DIR` set to an empty folder:

```
✓  plane-root guard  wired (enabled plugin charter@charter) — and it has fired here
✓  mcp               1 server(s), none on an absolute path
!  plugin install    charter's Claude Code plugin is not installed for this plane, so none of its hooks run here …
```

The green row was the wrong one. Under that folder no charter hook runs, so branch moves in the plane root are not refused, yet doctor told the operator they were. It exited 0, and the only warning was an optional item.

- `plugin install` asks `claude plugin list --json`, which follows the variable.
- The guard row read `~/.claude/plugins/installed_plugins.json`.
- The settings rows read `~/.claude/settings.json`.
- The `mcp` row read `~/.claude.json`.
- "Has fired here" came from a guard sighting made under whatever folder an earlier session used.

This belongs to the same family as #168, #177, #261 and #851. This time the mistake is **the default config folder read as the one in use**.

## What is true now

Same plane, running the worktree (`PYTHONPATH=<worktree> python3 -P -m charter doctor`, with the import checked to be the worktree's). With `CLAUDE_CONFIG_DIR` set to the same empty folder, at 95c2a49 (these rows did not change after it):

```
!  plane-root guard  pretooluse is not wired — branch moves in the plane root are NOT refused
!  guard seen        last ran 0m ago under claude-code, but that sighting predates charter recording which Claude Code config folder a guard ran under, so charter cannot tell which folder it came from
✓  mcp               no MCP servers registered
!  plugin install    charter's Claude Code plugin is not installed for this plane, …
```

With the default folder at 3624287, on a plane whose last sighting was written by an older charter:

```
!  plane-root guard  enabled plugin charter@charter declares it and a guard has fired from it, but that sighting predates charter recording which Claude Code config folder a guard ran under, so charter cannot tell which folder it came from. Until a guard fires under the folder in use, nothing shows the plugin is loaded there
!  guard seen        last ran 0m ago under claude-code, but that sighting predates charter recording which Claude Code config folder a guard ran under, so charter cannot tell which folder it came from
✓  plugin install    charter@charter installed (project scope)
```

That pair is the one-time state after upgrading: the next guarded Bash call records its folder, and both rows go green.

With `CLAUDE_CONFIG_DIR=cfg` at 3624287, calling the two guard rows directly so that no `claude` subprocess writes a `cfg/` into the plane:

```
!  plane-root guard  not checked — the Claude Code config folder in use is a relative path, which Claude Code resolves against its own working directory, and charter cannot see that directory, so no guard sighting can be compared with it
      → Set CLAUDE_CONFIG_DIR to an absolute path in the shell you start Claude Code from, then re-check.
!  guard seen        last ran 0m ago under claude-code, but the Claude Code config folder in use is a relative path, …
      → Set CLAUDE_CONFIG_DIR to an absolute path in the shell you start Claude Code from, then re-check.
```

**One resolver, copied from the binary.** `charter/harness/claude_code.py` gains `config_home()` and `global_config_file()`. They follow Claude Code 2.1.268 as written in its binary:
- The config folder is `(CLAUDE_CONFIG_DIR ?? join(homedir(), ".claude")).normalize("NFC")`.
- `.claude.json` is `<folder>/.config.json` when that legacy file exists. Otherwise it is `join(CLAUDE_CONFIG_DIR || homedir(), ".claude.json")`.
- `??` and `||` differ for an empty value, and I measured it: `CLAUDE_CONFIG_DIR= claude plugin list --json` read `./plugins/installed_plugins.json` from the working directory.

**A guard sighting counts only for the folder it names.** `guardseen.folder_standing()` is the one place that decides this, with one exception policy, and both guard rows call it. Each case also carries its hint: the one step that can change the row.
- A Claude Code sighting records its absolute config folder. Codex and opencode sightings carry no such field.
- A sighting under another folder names both folders.
- A sighting written before this change says it predates folder recording, so charter cannot tell which folder it came from. That is neither a pass nor a claim that nothing fired.
- A sighting that names no harness, or a name charter has no record of (`claude` for `claude-code`), and that the plugin did not launch, is unknown. It is never green; the row says charter cannot tell which harness or folder recorded it, and the hint names `$CHARTER_HARNESS` along with the registered names.
- Both rows report these whatever the sightings: an empty or relative `$CLAUDE_CONFIG_DIR`, or no home folder to resolve it from. An empty value is called empty. The hint is to set an absolute path; running a Bash command could never change these rows.

## Which rows follow `$CLAUDE_CONFIG_DIR`

**Follow it:**
- `plugin install` and `plugin files`, which ask `claude plugin list`.
- `plane-root guard`, `guard seen`, `session root` and `mcp`.
- With the variable unset they read `~/.claude` and `~/.claude.json`.

**Do not follow it:**
- `personas`, which still looks for skills under `~/.claude/plugins` and `~/.claude/skills`.
- `charter reinit`, deliberately (see below).

**Three narrower Claude Code settings are not followed**, so with any of them set these rows read the wrong file:
- `$CLAUDE_CODE_PLUGIN_CACHE_DIR` moves the installed-plugin list out of the config folder. `plane-root guard` and `guard seen` still read `<folder>/plugins/installed_plugins.json`.
- `$CLAUDE_CODE_USE_COWORK_PLUGINS` renames `plugins/` to `cowork_plugins/` and `settings.json` to `cowork_settings.json`. The guard rows still read the ordinary names.
- `$CLAUDE_CODE_CUSTOM_OAUTH_URL` renames `.claude.json` to `.claude-custom-oauth.json`. `mcp` still reads `.claude.json`.

**Accepted as is, and stated:** with an empty or relative `$CLAUDE_CONFIG_DIR`, `plane-root guard` says "not checked" even when the plane's own `.claude/settings.json` declares the guard. Its advice, to make `CLAUDE_CONFIG_DIR` absolute, is still true.

`docs/install.md` and the news entry say all of this.

## `charter reinit` keeps deciding from `~/.claude`

At 677faac, reinit shared doctor's folder-following check. In a second-account shell with no plugin, it therefore wrote the guard hook into the plane's committed `.claude/settings.json`, and every `~/.claude` session that has the plugin then ran the guard twice.

- **Reverted.** `commands._plugin_dispatches_guard` now passes `folder=~/.claude` explicitly, so reinit's write decision is exactly what it was before #969.
- **Why:** a committed file must not change with one person's shell.
- **What still shares:** doctor and reinit still call the same function; only the folder argument differs.
- **Per-profile wiring** is designed in harness-profiles task 4.
- **Cost:** under a named folder, doctor's "→ charter reinit" remedy writes nothing whenever `~/.claude` already has the plugin. The not-wired hint now says so, and names `charter doctor --fix` run from that shell.

## Reviews of 677faac, 95c2a49 and 3624287, finding by finding

| Finding | What it became |
| --- | --- |
| S1: docs claimed the rows read what Claude Code reads | Docs and news name the rows that follow the variable and the ones that do not, plus each of the three unfollowed settings and what it moves |
| S2: a sighting from before this change read as "nothing has fired here" | Both guard rows say the sighting predates folder recording: WARN, not green |
| P1: `guard seen` never compared folders | It calls `folder_standing()`: another or unknown folder is WARN |
| P2: a settings sighting from another folder was called "no longer there" | It names the file that still declares the hook (checked, not assumed) |
| P3: reinit followed the shell into a committed file | Reverted to `~/.claude`, with a test that its decision ignores `$CLAUDE_CONFIG_DIR`; the doctor hint says so |
| P4: a relative folder was resolved against two different working directories | It records no folder and never vouches; both rows say it is relative |
| P5: `~/acct2` rendered as the home folder | `util.short_path` never abbreviates a path with a literal `~` segment; it renders it absolute |
| J1: the vouching rule lived in two modules | `guardseen.folder_standing()` is the only decider, with one exception policy |
| J2: guardseen recorded a Claude folder for every harness | Only Claude Code sightings carry it |
| J3: `user` and `_cc` names | `user_folder`, `user_settings`, `_claude_code` |
| J4: why-comments treated `~/.claude.json` as the file read | Rewritten; `_claude_json()` itself is left alone |
| Re-review of 95c2a49, P1/J2: a sighting with no harness name passed under any folder | Unknown: never vouches and is never green; the row says charter cannot tell which harness or folder recorded it. Sightings from a named Codex or opencode harness are unchanged |
| Re-review, P4: a relative folder was reported only beside a plugin sighting, with a "run a Bash command" hint | Both rows report it whatever the sightings, with the hint to set `CLAUDE_CONFIG_DIR` to an absolute path |
| Re-review, nit: an empty value read as "'.' is a relative path" | Called empty: Claude Code then uses its own working directory |
| Verification of 3624287, probe H: an unregistered name (`claude`) passed as another harness's sighting | Unknown, like an unnamed sighting and in the spirit of ADR 0015; a plugin-launched guard still counts |
| Verification: the empty-value wording stacked "but … but" and "so … so" | Rewritten |

## Tests

`tests/test_doctor_answers_for_the_claude_config_folder_in_use.py` has 62 cases, each written to fail before its fix, or to pin a line the sweep found unpinned:
- **677faac, the first fix:** 28 cases were red on unfixed main (a5aa860); the rest were controls.
- **95c2a49, the review:** 22 new cases were red on 677faac, one per finding; the ones that pass there are controls.
- **3624287, the re-review:** the 11 cases added or extended for it were red on 95c2a49; the one that passes there is the named-harness control.
- **537d0fc, the verification:** the unregistered-harness case was red on 3624287. Its plugin-launched control passes there, and the remaining new cases pin the sweep's survivors.
- **75a39b3, CI's survivor:** the unnamed case now asserts "names no harness". It goes red when the unnamed branch is deleted (M8).
- Every refusal, clamp and fallback added here has a case that turns red when that line is deleted: the sweep and the hand mutation check below measure that.

Results:
- `python3 -m unittest discover -s tests` at 75a39b3: `Ran 12101 tests in 893.348s` → `OK (skipped=9)`. At 537d0fc it was `Ran 12101 tests in 912.483s` → `OK (skipped=9)`.
- `python3 tools/sweep.py` at 3624287: 48 mutations, 41 pinned, **7 survived**, 0 unresolved (65.8 min, darwin, CPython 3.14.4). Every survivor was a missing test, not dead code, and 537d0fc adds one for each:
  - in `guard seen`, the `'an unnamed harness'` fallback;
  - the settings-source half of its "still in" clause;
  - the `mcp` not-an-object branch;
  - the `guardseen._FIRE_HERE` hint text;
  - the `"source"` key and the `source != PLUGIN` half of the unnamed-sighting check;
  - `startswith` in `util.short_path`.
- **CI's deletion sweep at 537d0fc** (Linux, 3 shards): 51 mutations, 50 pinned, **1 unpinned**, 0 platform-deferred.
  - The unpinned one was `charter/guardseen.py:246`, the unnamed-sighting branch.
  - It could be deleted because the unregistered-name branch added in 537d0fc catches the same sighting: `registry.get(None)` is `None`, and that branch's sentence and hint matched everything the unnamed test asserted.
  - 75a39b3 pins what only the unnamed branch says: "names no harness", and never "None".
- **Hand mutation check at 75a39b3**, in place of another full sweep. In a scratch clone of the commit, each mutation was applied, `__pycache__` cleared, the test that pins it run, and the file restored. All 9 behaved: green before, red when mutated, green again once restored.
  - **M0:** the new unregistered-harness branch deleted.
  - **M1–M7:** the seven local survivors re-applied.
  - **M8:** CI's survivor, the unnamed-sighting branch, deleted.
- **CI's deletion sweep at 75a39b3** (Linux, 3 shards): 51 mutations, 51 pinned, 0 unpinned, 0 platform-deferred, 0 unresolved. No survivors.

## Known siblings, not changed here

The scope is `doctor`. These still read or assume the default folder and are later work:
- **dispatch:** `charter/dispatch.py:336` looks for transcripts under `Path.home()/.claude/projects`.
- **Persona skill lookup:** `persona._skill_roots` (`charter/persona.py`) searches `~/.claude/plugins` and `~/.claude/skills`, and doctor's `personas` row reaches it through `persona.lint`.
- **`plugincache`:** it runs `claude plugin … --json`, which follows the variable, and makes no direct read of the folder. Listed because the issue names it; not audited here.
- **Unverified, not changed:** `_plugin_declaring_guard` ignores an entry's `scope` and `projectPath`, while `plugin install` (`plugincache.covers`) requires `projectPath` to match the plane. The two rows can disagree about a plane that has been moved. Which one is right depends on whether Claude Code refuses to load a plugin whose `projectPath` differs, and nobody has measured that.

Fixes #969

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0196jzkD5wTUeyB4H8d7PLrz
