### PR TITLE
A heredoc body is read by whoever runs it — the reader-first leak-guard bypass (#973)

### DIFF
--- a/charter/hooks.py
+++ b/charter/hooks.py
@@ -864,6 +864,19 @@ def _heredoc_strip_plan(line: str):
     here-string `<<<x`, a `<<` inside quotes or a comment, which the regex counts and the
     lexer does not — the answer is ``None``: the line is not one this pre-pass can take
     apart, so it strips nothing and the bodies stay visible for the guard to read.
+
+    Each entry is ``(delimiter, drop, header)``. The first two are what this pre-pass acts
+    on: `delimiter` is :data:`_HEREDOC_RE`'s reading, which is what :func:`_strip_reader_heredocs`
+    matches terminator lines against, and `drop` is the verdict above. **`header` decides
+    nothing here** — it is :func:`_heredoc_header`'s answer for the same `<<`,
+    ``(delimiter after bash's quote removal, expands, the `<<-` flag, index past the
+    header)`` or ``None``, carried so a second caller has the bash-accurate facts without
+    re-parsing the line. The two delimiters differ where quoting splits a word: for
+    `<<EO'F'` the regex reads `EO` while bash reads `EOF`. Acting on the regex's shorter
+    reading is the safe direction *here* — a terminator that is never found keeps the body
+    visible — so the verdicts stay keyed on it; a caller that would DROP a body on this plan
+    must use `header` instead. A spelling the regex does not match at all (`<<\\EOF`) yields
+    no entry, so there is nothing to carry facts on.
     """
     headers = list(_HEREDOC_RE.finditer(line))
     if not headers:
@@ -873,7 +886,7 @@ def _heredoc_strip_plan(line: str):
         return None
     if sum(hc for _progs, _ex, hcounts in pipelines for hc in hcounts) != len(headers):
         return None
-    plan: list[tuple[str, bool]] = []
+    plan: list[tuple[str, bool, tuple | None]] = []
     k = 0
     for progs, executor, hcounts in pipelines:
         for prog, hc in zip(progs, hcounts):
@@ -882,7 +895,8 @@ def _heredoc_strip_plan(line: str):
                 m = headers[k]
                 k += 1
                 quoted = bool(m.group("q"))
-                plan.append((m.group("delim"), reader and quoted and not executor))
+                plan.append((m.group("delim"), reader and quoted and not executor,
+                             _heredoc_header(line, m.start())))
     return plan
 
 
@@ -1008,7 +1022,7 @@ def _strip_reader_heredocs(cmd: str) -> str:
         plan = _heredoc_strip_plan(plan_text)
         drop = {}
         if plan is not None and len(plan) == body_count:
-            drop = {idx: d for idx, (_delim, d) in enumerate(plan)}
+            drop = {idx: d for idx, (_delim, d, _head) in enumerate(plan)}
         for kind, idx, text in chunks:
             if kind == "cmd" or not drop.get(idx, False):
                 out.append(text)

--- a/charter/hooks.py
+++ b/charter/hooks.py
@@ -757,29 +757,149 @@ def _is_charter(prog: str, args: list[str]) -> bool:
 _HEREDOC_RE = re.compile(r"<<-?\s*(['\"]?)([A-Za-z_][A-Za-z0-9_]*)\1")
 
 
-def _reader_of(line: str) -> bool:
-    """Whether *line* starts by invoking a program in :data:`_READERS`.
+#: Programs that RUN a heredoc reaching their pipeline as CODE, so its body is never data.
+#: Two shapes: a shell/interpreter whose stdin (or `<<` body) IS a script (`bash <<X`,
+#: `python3 <<X`), and a program that turns the stream into a COMMAND it runs (`xargs`,
+#: `parallel`, `eval`). `awk`/`sed`/`grep` are deliberately absent — their program is an
+#: ARGUMENT and the heredoc is a data stream, which is exactly the #258 body that must stay
+#: strippable. A wrapper (`env`, `sudo`, `nohup`, `timeout`, …) is absent too: it does not
+#: run the body, the program it wraps does, and :func:`_split_env` names that program.
+#:
+#: This is a NAME list and inherits the same ceiling as :data:`_READERS`: a shell spelled a
+#: way this set misses is a missed *deny*, never a wrong one, because the fallback is to keep
+#: the body VISIBLE (the guard then scans it) rather than to strip it. Erring toward "an
+#: executor is present" only ever shows the guard more text.
+_EXECUTORS = frozenset(
+    "sh bash zsh fish dash ksh mksh csh tcsh ash busybox "
+    "python python2 python3 pypy pypy3 ipython node nodejs deno bun ts-node tsx "
+    "perl ruby irb php lua luajit tclsh osascript groovy scala jshell "
+    "julia elixir iex erl escript xargs parallel eval".split())
 
-    Goes through :func:`_split_env`, so the leading `VAR=value` assignments AND the
-    wrapper prefixes (`env`, `sudo`, `command`, …) are stripped by the same code the
-    guards use to find a program. Answering "which program is this" two different ways in
-    one module is how `env cat` ended up invisible to one of them.
+def _is_executor(name: str) -> bool:
+    """Whether *name* is a program in :data:`_EXECUTORS`, version suffix included.
+
+    The suffix (`python3.12`, `node20`) is asked of `toolgate._VERSIONED` rather than of a
+    second spelling of it here: that pattern already answers "is this binary an interpreter
+    that runs text" for the tool gate, and two regexes for one question drift apart. Its
+    over-matching is load-bearing in this direction too — a name it wrongly admits only keeps
+    a body visible. Imported at call time, the way `toolgate` imports this module: each needs
+    the other when a command is judged, never when the module loads.
     """
-    prog, _env, _argv = _split_env(line.strip().split())
-    return os.path.basename(prog).lower() in _READERS
+    from . import toolgate
+    base = os.path.basename(name).lower()
+    return base in _EXECUTORS or bool(toolgate._VERSIONED.match(base))
+
+
+def _line_pipelines(line: str):
+    """*line* as its pipelines: ``[(programs, has_executor, heredoc_counts)]``, or ``None``
+    when the line cannot be attributed safely.
+
+    Split on the control operators that separate pipelines (`;`, `&&`, `||`, `&`, `;;`) but
+    NOT on `|`, because a pipeline shares one execution fate: a body a reader opens is run
+    all the same if any command downstream of it in the pipe is a shell — in `zsh`'s
+    ``MULTIOS`` even a body a single pipe appears to discard (`cat <<A | bash <<B`) reaches
+    both. `has_executor` is therefore per PIPELINE, `programs` and `heredoc_counts` per
+    command within it (`programs[k]` opened `heredoc_counts[k]` of the `<<` on this line).
+
+    Reuses the module's own lexer, so quoting is honoured rather than re-derived — a `;` or
+    `<<` inside quotes is a word here as it is to a shell. A **group, subshell or command
+    substitution** (`{ … }`, `( … )`, `$( … )`) returns ``None`` rather than a guess: their
+    output can be re-piped (`{ cat <<X; } | bash`), so mis-reading the boundary would strip a
+    body a shell runs. ``None`` means the caller strips nothing on the line, which keeps every
+    body visible — the safe direction.
+    """
+    try:
+        toks = _split_punctuation(_lex(line))
+    except ValueError:
+        return None
+    pipelines: list = []
+    current: list[list[str]] = [[]]        # commands of the pipeline being built
+    for t in toks:
+        if not t.bare:
+            current[-1].append(t.text)
+        elif t.text in _GROUPING:
+            return None                    # a group/subshell/substitution — do not guess
+        elif t.text in ("|", "|&"):
+            current.append([])
+        elif t.text in _CONTROL_OPERATORS:
+            cmds = [c for c in current if c]
+            if cmds:
+                pipelines.append(cmds)
+            current = [[]]
+        else:
+            current[-1].append(t.text)
+    cmds = [c for c in current if c]
+    if cmds:
+        pipelines.append(cmds)
+    out = []
+    for cmds in pipelines:
+        progs = [_split_env(c)[0] for c in cmds]
+        hcounts = [sum(1 for tk in c if tk == "<<") for c in cmds]
+        executor = any(_is_executor(c[0]) or _is_executor(p)
+                       for c, p in zip(cmds, progs) if c)
+        out.append((progs, executor, hcounts))
+    return out
+
+
+def _heredoc_strip_plan(line: str):
+    """``[(delimiter, strip?)]`` for the heredocs opened on *line*, in the order their bodies
+    follow — or ``None`` when nothing on the line may be stripped.
+
+    A body is stdin DATA (strip) only when a **quoted** heredoc feeds a **reader** whose
+    **pipeline runs no executor**. Each clause earns its place:
+
+    * *quoted* — an unquoted `<<EOF` is expanded before the reader sees it, so a `$( … )` in
+      the body RUNS (`cat <<EOF\\n$(cat <vault>)\\nEOF`). Only `<<'EOF'` / `<<"EOF"` are inert.
+    * *reader* — the program that OPENS the `<<` (its segment's, via :func:`_split_env`), so
+      `env cat <<'X'` is a reader behind a wrapper and its body is still data.
+    * *no executor in the pipeline* — the defect this replaces (#973): the old pre-pass asked
+      only whether the LINE began with a reader, so `cat x && bash <<'EOF'`, `… | bash`,
+      `… || bash`, `… & bash` and `cat x; bash <<'EOF'` each dropped a body a shell ran.
+
+    Attribution comes from :func:`_line_pipelines`; the delimiters and their order come from
+    :data:`_HEREDOC_RE`. When the two disagree on how many heredocs the line opens — a
+    here-string `<<<x`, a `<<` inside quotes or a comment, which the regex counts and the
+    lexer does not — the answer is ``None``: the line is not one this pre-pass can take
+    apart, so it strips nothing and the bodies stay visible for the guard to read.
+    """
+    headers = list(_HEREDOC_RE.finditer(line))
+    if not headers:
+        return []
+    pipelines = _line_pipelines(line)
+    if pipelines is None:
+        return None
+    if sum(hc for _progs, _ex, hcounts in pipelines for hc in hcounts) != len(headers):
+        return None
+    plan: list[tuple[str, bool]] = []
+    k = 0
+    for progs, executor, hcounts in pipelines:
+        for prog, hc in zip(progs, hcounts):
+            reader = os.path.basename(prog).lower() in _READERS
+            for _ in range(hc):
+                m = headers[k]
+                k += 1
+                quoted = bool(m.group(1))
+                plan.append((m.group(2), reader and quoted and not executor))
+    return plan
 
 
 def _strip_reader_heredocs(cmd: str) -> str:
-    """Remove heredoc BODIES fed to a reader — they are stdin data, never arguments.
+    """Remove heredoc BODIES that are stdin DATA — never the ones a command runs.
 
     `_segment_argv` shlex-splits the whole command string, so `cat > file <<'DOC' … DOC`
     hands the body to the leak check as `cat`'s argv, and a document *describing* charter's
     own layout is refused as a *read* of it (#258). Documentation about charter is exactly
     the text most likely to name these paths.
 
-    Only a reader's heredoc. A body fed to `bash`/`python` is a script, not data, and
-    removing it would hide commands from a guard rather than prose — a distinction worth
-    the extra condition even though this guard does not scan such bodies today.
+    A body is dropped only when :func:`_heredoc_strip_plan` calls it data — a quoted heredoc
+    fed to a reader with no executor in its pipeline. A body fed to `bash`/`python`, or to a
+    reader whose output pipes into one, is a SCRIPT: dropping it would hide the very commands
+    the guard exists to read, so it is kept, and this guard's newline-segmentation then reads
+    each of its lines as the command it is.
+
+    The terminator is matched by ``line.strip() == delim``, which can only end a body EARLIER
+    than bash would (bash wants the line exactly, modulo the tabs a `<<-` strips). Earlier
+    hands the guard MORE text, never less — the safe direction for a security pre-pass.
     """
     if "<<" not in cmd:
         return cmd
@@ -787,17 +907,22 @@ def _strip_reader_heredocs(cmd: str) -> str:
     out: list[str] = []
     i = 0
     while i < len(lines):
-        line = lines[i]
-        out.append(line)
-        m = _HEREDOC_RE.search(line)
-        if m and _reader_of(line):
-            delim = m.group(2)
-            i += 1
-            while i < len(lines) and lines[i].strip() != delim:
-                i += 1  # drop the body
-            i += 1       # and the terminator
-            continue
+        out.append(lines[i])
+        plan = _heredoc_strip_plan(lines[i])
         i += 1
+        if not plan:
+            continue
+        # The bodies of THIS line's heredocs follow in order; consume each to its delimiter,
+        # dropping a data body and keeping a script one so the guard still sees it.
+        for delim, drop in plan:
+            while i < len(lines) and lines[i].strip() != delim:
+                if not drop:
+                    out.append(lines[i])
+                i += 1
+            if i < len(lines):                 # the terminator line itself
+                if not drop:
+                    out.append(lines[i])
+                i += 1
     return "\n".join(out)
 
 

--- a/charter/hooks.py
+++ b/charter/hooks.py
@@ -753,8 +753,11 @@ def _is_charter(prog: str, args: list[str]) -> bool:
     return False
 
 
-#: `<<DELIM`, `<<'DELIM'`, `<<"DELIM"`, `<<-DELIM` — the start of a heredoc.
-_HEREDOC_RE = re.compile(r"<<-?\s*(['\"]?)([A-Za-z_][A-Za-z0-9_]*)\1")
+#: `<<DELIM`, `<<'DELIM'`, `<<"DELIM"`, `<<-DELIM` — the start of a heredoc. `dash` records
+#: the `<<-` form (its terminator ignores leading TABS); `q` is the quote that makes the body
+#: non-expanding; `delim` is the word a body ends on.
+_HEREDOC_RE = re.compile(
+    r"<<(?P<dash>-?)\s*(?P<q>['\"]?)(?P<delim>[A-Za-z_][A-Za-z0-9_]*)(?P=q)")
 
 
 #: Programs that RUN a heredoc reaching their pipeline as CODE, so its body is never data.
@@ -878,9 +881,36 @@ def _heredoc_strip_plan(line: str):
             for _ in range(hc):
                 m = headers[k]
                 k += 1
-                quoted = bool(m.group(1))
-                plan.append((m.group(2), reader and quoted and not executor))
+                quoted = bool(m.group("q"))
+                plan.append((m.group("delim"), reader and quoted and not executor))
     return plan
+
+
+def _ends_in_line_continuation(line: str) -> bool:
+    """A bare trailing backslash: bash splices this line with the next BEFORE tokenizing, so
+    `cat <<'EOF' \\` then `| bash` is the one command `cat <<'EOF' | bash`, and the heredoc
+    body follows the spliced whole. An even run of trailing backslashes is a literal `\\`,
+    not a continuation."""
+    return line.endswith("\\") and (len(line) - len(line.rstrip("\\"))) % 2 == 1
+
+
+def _pipeline_continues(line: str) -> bool:
+    """A trailing bare `|` or `|&` pipes this command's output into the next command line —
+    which, unlike a backslash splice, sits AFTER the heredoc bodies this line opened.
+    Measured on bash, zsh and dash: `cat <<'EOF' |` then a body then `EOF` then `bash` feeds
+    that body to `bash`, which runs it. A per-physical-line plan cannot see that `bash`, so
+    the pipeline is reassembled before attribution (#973 review round 1).
+
+    `&&`, `||`, `&`, `;` are NOT this: measured, the heredoc stays with its own segment's
+    program and is not piped downstream, so a per-line plan already attributes them and they
+    are left alone. Quoting is honoured (`echo 'a |'` does not continue) and a `#` comment's
+    `|` is not a token.
+    """
+    try:
+        toks = _split_punctuation(_lex(line))
+    except ValueError:
+        return False
+    return bool(toks) and toks[-1].bare and toks[-1].text in ("|", "|&")
 
 
 def _strip_reader_heredocs(cmd: str) -> str:
@@ -897,32 +927,91 @@ def _strip_reader_heredocs(cmd: str) -> str:
     the guard exists to read, so it is kept, and this guard's newline-segmentation then reads
     each of its lines as the command it is.
 
-    The terminator is matched by ``line.strip() == delim``, which can only end a body EARLIER
-    than bash would (bash wants the line exactly, modulo the tabs a `<<-` strips). Earlier
-    hands the guard MORE text, never less — the safe direction for a security pre-pass.
+    **A pipeline can span physical lines**, and the executor can be on the continuation line
+    (`cat <<'EOF' |` … `EOF` … `bash`). So this works on the LOGICAL command, folding two
+    kinds of continuation in the order bash applies them:
+
+    * a **backslash-newline** splices before tokenizing, so it is folded into the command
+      line *before* that line's heredoc bodies are read;
+    * a trailing **`|`/`|&`** continues the pipeline onto the next command line, which sits
+      *after* the bodies — so those are read first, then the continuation is folded in.
+
+    The whole folded pipeline goes to :func:`_heredoc_strip_plan`, so a downstream executor is
+    attributed to the pipeline the body belongs to. Bodies are buffered as chunks and emitted
+    in place once the plan is known, because a body physically precedes the continuation that
+    decides its fate. A body line is never itself read as a continuation, even when it ends in
+    `|`.
+
+    The terminator is matched EXACTLY as bash does — a line equal to the delimiter, a `<<-`
+    ignoring only leading tabs. An earlier `.strip()`-lenient match looked safe (it hands the
+    guard more text) but was not: ending a KEPT shell body early spills its real read into the
+    next heredoc, whose reader body is then stripped and the read hidden. Bash's own boundary
+    is the one that attributes each line to the command that actually runs it.
     """
     if "<<" not in cmd:
         return cmd
     lines = cmd.split("\n")
     out: list[str] = []
     i = 0
-    while i < len(lines):
-        out.append(lines[i])
-        plan = _heredoc_strip_plan(lines[i])
-        i += 1
-        if not plan:
-            continue
-        # The bodies of THIS line's heredocs follow in order; consume each to its delimiter,
-        # dropping a data body and keeping a script one so the guard still sees it.
-        for delim, drop in plan:
-            while i < len(lines) and lines[i].strip() != delim:
-                if not drop:
-                    out.append(lines[i])
+    n = len(lines)
+    while i < n:
+        # One LOGICAL command: command-text lines folded for the plan, heredoc bodies
+        # buffered as chunks so their fate is decided once the whole pipeline is assembled.
+        chunks: list[tuple[str, int, str]] = []   # (kind, body_index, text); kind cmd|body
+        body_count = 0
+        plan_text = ""
+        join = ""                                 # separator carried from the previous stage
+        while i < n:
+            # A command line, with any backslash-newline splices folded in first — bash does
+            # this before it looks for heredoc bodies, so the bodies follow the folded whole.
+            folded = ""
+            while i < n:
+                line = lines[i]
+                chunks.append(("cmd", -1, line))
                 i += 1
-            if i < len(lines):                 # the terminator line itself
-                if not drop:
-                    out.append(lines[i])
-                i += 1
+                if _ends_in_line_continuation(line):
+                    folded += line[:-1]
+                    continue
+                folded += line
+                break
+            plan_text = folded if not plan_text else plan_text + join + folded
+            # This command line's heredoc bodies follow, in order; buffer each.
+            for m in _HEREDOC_RE.finditer(folded):
+                delim = m.group("delim")
+                dash = bool(m.group("dash"))
+                expands = not m.group("q")
+                idx = body_count
+                body_count += 1
+                # Bash ends the body on a line EQUAL to the delimiter — a `<<-` ignoring only
+                # leading TABS. Not `.strip()`: a lenient match ends a KEPT (shell) body early,
+                # and the real read that spills past it is then read as the next heredoc's body
+                # and, if that one is a reader's, stripped away (measured regression). In an
+                # UNQUOTED body a trailing backslash splices the next line, so that line cannot
+                # be the terminator — bash runs the body on past it (measured on bash/zsh/dash),
+                # which likewise keeps a kept shell body from ending early into a reader's.
+                spliced = False
+                while i < n:
+                    body_line = lines[i]
+                    is_terminator = not spliced and (
+                        (body_line.lstrip("\t") if dash else body_line) == delim)
+                    if is_terminator:
+                        break
+                    chunks.append(("body", idx, body_line))
+                    spliced = expands and _ends_in_line_continuation(body_line)
+                    i += 1
+                if i < n:                          # the terminator line itself
+                    chunks.append(("body", idx, lines[i]))
+                    i += 1
+            if not _pipeline_continues(folded):
+                break
+            join = " "                             # the next stage joins onto the same pipe
+        plan = _heredoc_strip_plan(plan_text)
+        drop = {}
+        if plan is not None and len(plan) == body_count:
+            drop = {idx: d for idx, (_delim, d) in enumerate(plan)}
+        for kind, idx, text in chunks:
+            if kind == "cmd" or not drop.get(idx, False):
+                out.append(text)
     return "\n".join(out)
 
 

--- a/charter/hooks.py
+++ b/charter/hooks.py
@@ -825,15 +825,11 @@ def _line_pipelines(line: str):
         elif t.text in ("|", "|&"):
             current.append([])
         elif t.text in _CONTROL_OPERATORS:
-            cmds = [c for c in current if c]
-            if cmds:
-                pipelines.append(cmds)
+            pipelines.append(current)
             current = [[]]
         else:
             current[-1].append(t.text)
-    cmds = [c for c in current if c]
-    if cmds:
-        pipelines.append(cmds)
+    pipelines.append(current)
     out = []
     for cmds in pipelines:
         progs = [_split_env(c)[0] for c in cmds]
@@ -971,7 +967,8 @@ def _strip_reader_heredocs(cmd: str) -> str:
     while i < n:
         # One LOGICAL command: command-text lines folded for the plan, heredoc bodies
         # buffered as chunks so their fate is decided once the whole pipeline is assembled.
-        chunks: list[tuple[str, int, str]] = []   # (kind, body_index, text); kind cmd|body
+        # (body index, text); a command line carries -1, which is never a key of `drop`.
+        chunks: list[tuple[int, str]] = []
         body_count = 0
         plan_text = ""
         join = ""                                 # separator carried from the previous stage
@@ -981,7 +978,7 @@ def _strip_reader_heredocs(cmd: str) -> str:
             folded = ""
             while i < n:
                 line = lines[i]
-                chunks.append(("cmd", -1, line))
+                chunks.append((-1, line))
                 i += 1
                 if _ends_in_line_continuation(line):
                     folded += line[:-1]
@@ -1010,21 +1007,21 @@ def _strip_reader_heredocs(cmd: str) -> str:
                         (body_line.lstrip("\t") if dash else body_line) == delim)
                     if is_terminator:
                         break
-                    chunks.append(("body", idx, body_line))
+                    chunks.append((idx,body_line))
                     spliced = expands and _ends_in_line_continuation(body_line)
                     i += 1
                 if i < n:                          # the terminator line itself
-                    chunks.append(("body", idx, lines[i]))
+                    chunks.append((idx,lines[i]))
                     i += 1
             if not _pipeline_continues(folded):
                 break
             join = " "                             # the next stage joins onto the same pipe
         plan = _heredoc_strip_plan(plan_text)
         drop = {}
-        if plan is not None and len(plan) == body_count:
+        if plan is not None:
             drop = {idx: d for idx, (_delim, d, _head) in enumerate(plan)}
-        for kind, idx, text in chunks:
-            if kind == "cmd" or not drop.get(idx, False):
+        for idx, text in chunks:
+            if not drop.get(idx, False):
                 out.append(text)
     return "\n".join(out)
 

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -85,7 +85,10 @@ rule while one who reads a bare refusal files an issue.
   runs it: a shell that opens the `<<` (`bash <<'EOF'`), or one anywhere in the opener's
   pipeline (`cat x && bash <<'EOF'`, `cat <<'EOF' | bash`), so a vault read on any of its
   lines is denied wherever the reader on the line stands — it is the command that opens the
-  `<<`, and its pipeline, that decide, not the first word. A **quoted** heredoc fed only to a
+  `<<`, and its pipeline, that decide, not the first word. **The pipeline is followed across
+  lines**: a trailing `|` continues onto the command after the heredoc body (`cat <<'EOF' |`
+  … `EOF` … `bash`), and a backslash-newline splices before it, so the downstream shell is
+  seen either way. A **quoted** heredoc fed only to a
   reader (`cat <<'EOF'`) is stdin data: its body is dropped, so a document naming these paths
   is not refused as a read of them ([#258](https://github.com/diazoxide/charter/issues/258)).
   An *unquoted* body stays visible instead, because the shell expands it before the reader

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -81,8 +81,15 @@ rule while one who reads a bare refusal files an issue.
   argument and not a boundary (`cat \) <vault>` reads the vault), and the `&` inside the
   redirection `>&` is not the control operator `&` (`cat 2>&1 <vault>` is one command);
   while a newline *is* a boundary exactly as `;` is — every line of a multi-line command is
-  its own command, `bash <<'EOF'` bodies included — and `#` starts a comment only where a
-  word starts. Position counts too: `{` and `}` are reserved words, so bash passes them as
+  its own command. A **heredoc body** reaches the guard as those commands whenever something
+  runs it: a shell that opens the `<<` (`bash <<'EOF'`), or one anywhere in the opener's
+  pipeline (`cat x && bash <<'EOF'`, `cat <<'EOF' | bash`), so a vault read on any of its
+  lines is denied wherever the reader on the line stands — it is the command that opens the
+  `<<`, and its pipeline, that decide, not the first word. A **quoted** heredoc fed only to a
+  reader (`cat <<'EOF'`) is stdin data: its body is dropped, so a document naming these paths
+  is not refused as a read of them ([#258](https://github.com/diazoxide/charter/issues/258)).
+  An *unquoted* body stays visible instead, because the shell expands it before the reader
+  sees it and a `$( … )` in it would run. And `#` starts a comment only where a word starts. Position counts too: `{` and `}` are reserved words, so bash passes them as
   plain arguments anywhere but command position and `cat { <vault>` is one command that
   reads the vault. Beyond that: an unparseable quote does not hide the commands after it,
   an **unquoted** `$( … )` substitution is read both as the command it runs and as the word

--- a/docs/news/unreleased-a-heredoc-body-is-read-by-whoever-runs-it.md
+++ b/docs/news/unreleased-a-heredoc-body-is-read-by-whoever-runs-it.md
@@ -1,0 +1,42 @@
+---
+version: unreleased
+headline: A heredoc body is read by whoever runs it — a reader in front of a chained shell no longer hides that shell's `<<` from the vault guard
+security: true
+---
+
+**Affected: every release carrying the heredoc pre-pass. Fixed here.** A file-reading
+program at the *start* of a line let a shell later on the same line run a vault read the
+guard never saw. `cat x && bash <<'EOF'`, `cat x | bash`, `cat x || bash`, `cat x & bash`
+and `cat x; bash <<'EOF'` — each with `cat .charter/vaults/<v>.json` as the heredoc body —
+were allowed through, because the pre-pass that strips a reader's heredoc asked only whether
+the *line began* with a reader and then dropped the body of whatever `<<` it found. The
+shell, not the reader, was opening that heredoc, and its body is a script.
+
+**One shape, and it is the one this project keeps paying for: a guard matching where a token
+*sits* instead of what the shell *does* with it.** The remedy is the same in kind as the
+sibling fixes ([#474](https://github.com/diazoxide/charter/issues/474),
+[#547](https://github.com/diazoxide/charter/issues/547),
+[#556](https://github.com/diazoxide/charter/issues/556)): attribute the thing to the command
+that owns it. Each heredoc is now attributed to the command that opens it — the program of
+the segment holding the `<<`, and the pipeline that segment belongs to — and its body is
+dropped only when a **quoted** heredoc feeds a **reader** whose pipeline runs **no executor**.
+A body reaching a shell (`bash`, `sh`, `python3`, …), or a reader whose output pipes into one
+(`cat <<'EOF' | bash`), stays visible, and the guard reads each of its lines as the command
+it is. Bodies follow their `<<` in order across the whole line, so two heredocs going to
+different programs are told apart (`cat <<'A' && bash <<'B'` drops A, keeps B).
+
+The false positive [#258](https://github.com/diazoxide/charter/issues/258) removed stays
+removed: a quoted `cat <<'X'` whose body merely names `.charter/` is stdin data and is not
+read as a read of it. An *unquoted* `<<X` body now stays visible instead, because the shell
+expands it first and a `$( … )` in it runs. Three spellings that the old regex mistook for a
+heredoc and over-stripped — a here-string `<<<x`, a `<<` inside quotes, a `<<` in a comment —
+now keep the following line in view as well.
+
+The documented ceiling is unchanged: this reads argv and heredoc *structure*, never an
+interpreter body or a shell string. `sh -c '…'`, `bash -c`, `eval`, and a body a command
+turns into arguments rather than code (`… | xargs cat`) remain outside it, and a body written
+to a file and run later (`cat <<'EOF' > x.sh && bash x.sh`) is beyond an argv guard by
+construction — see `docs/hooks.md`, *Where the secret-leak guard stops*.
+
+Nothing to adopt; the guard updates with the plugin
+([#973](https://github.com/diazoxide/charter/issues/973)).

--- a/docs/news/unreleased-a-heredoc-body-is-read-by-whoever-runs-it.md
+++ b/docs/news/unreleased-a-heredoc-body-is-read-by-whoever-runs-it.md
@@ -23,7 +23,10 @@ dropped only when a **quoted** heredoc feeds a **reader** whose pipeline runs **
 A body reaching a shell (`bash`, `sh`, `python3`, …), or a reader whose output pipes into one
 (`cat <<'EOF' | bash`), stays visible, and the guard reads each of its lines as the command
 it is. Bodies follow their `<<` in order across the whole line, so two heredocs going to
-different programs are told apart (`cat <<'A' && bash <<'B'` drops A, keeps B).
+different programs are told apart (`cat <<'A' && bash <<'B'` drops A, keeps B). The pipeline
+is followed across physical lines too: a trailing `|` continues onto the command after the
+heredoc body (`cat <<'EOF' |` then the body then `EOF` then `bash`), and a backslash-newline
+splices before it — so a shell reached on a continuation line is still seen.
 
 The false positive [#258](https://github.com/diazoxide/charter/issues/258) removed stays
 removed: a quoted `cat <<'X'` whose body merely names `.charter/` is stdin data and is not

--- a/tests/test_a_heredoc_body_is_read_by_whoever_runs_it.py
+++ b/tests/test_a_heredoc_body_is_read_by_whoever_runs_it.py
@@ -1,0 +1,217 @@
+"""A heredoc body is stripped from the leak guard's view only when it is stdin *data*.
+
+`_strip_reader_heredocs` decided that by the LINE's first token (#973): whenever a line
+*started* with a reader (`cat`, `head`, …), the body of whatever `<<` that line opened was
+dropped — even when the command actually reading that heredoc was a chained or piped shell.
+So `cat x && bash <<'EOF'` / `… | bash` / `… || bash` / `… & bash`, and `cat x; bash`, each
+fed a real vault read to a shell that ran it, and the guard never saw the body.
+
+The fix attributes each heredoc to the command that opens it — the program of the SEGMENT
+containing that `<<`, and the PIPELINE that segment belongs to — and strips a body only when
+it is a quoted (non-expanding) heredoc fed to a reader with no executor anywhere downstream
+in its pipeline. Everything else stays visible, so the guard's own newline-segmentation
+reads each body line as the command it is.
+
+Measured against real `bash`, `zsh` (the harness shell) and `dash`: a heredoc body always
+follows its `<<` operator in physical order across the whole line, whichever command opens
+it, and a shell/`xargs` anywhere in the opener's pipeline executes it — in `zsh` (`MULTIOS`)
+even a body a pipe would seem to discard. Every one of those must reach the guard.
+
+The whole matrix runs through the FULL `hooks.pretooluse`, not `_leak_reason` alone, because
+that is the surface a Bash tool call actually hits. Two direct `_leak_reason` families pin
+the #258 preservation and the terminator direction, which are unit facts about the pre-pass.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from charter import hooks
+from tests._isolation import PlaneIso, run_hook
+
+VAULT = ".charter/vaults/dev.json"
+READ = f"cat {VAULT}"          # a real read a SHELL would execute
+MENTION = f"see {VAULT} for the layout"   # prose that merely names the path
+
+#: Every separator that ends one command and starts another, in the two spellings a `<<`
+#: can straddle: a control operator and a bare newline.
+SEPARATORS = [";", "&&", "||", "|", "&", "\n"]
+#: The first word of the line — the token the old pre-pass (`_reader_of`, removed by #973)
+#: judged the whole line by.
+FIRST_WORDS = ["cat x", "head x", "true", "echo hi"]
+#: Programs that RUN the body they receive.
+SHELLS = ["bash", "sh"]
+
+
+def _deny(payload_cmd: str, cwd: str) -> bool:
+    r = run_hook(hooks.pretooluse,
+                 {"tool_input": {"command": payload_cmd}, "cwd": cwd, "session_id": "s"})
+    return (r or {}).get("hookSpecificOutput", {}).get("permissionDecision") == "deny"
+
+
+class TheGuardSeesEveryBodyAShellRuns(PlaneIso):
+    """The FULL `pretooluse` matrix: separator × first word × the shell that runs the body."""
+
+    def denies(self, cmd: str) -> bool:
+        return _deny(cmd, str(self.tmp))
+
+    def test_the_matrix_is_answered_both_ways(self):
+        """Guard against a vacuous suite: the matrix below must contain denials AND allows,
+        or an assertEqual that always holds would prove nothing."""
+        self.assertTrue(self.denies(f"bash <<'EOF'\n{READ}\nEOF"))
+        self.assertFalse(self.denies(f"cat <<'EOF'\n{READ}\nEOF"))
+
+    def test_a_shell_after_any_separator_after_any_first_word_is_denied(self):
+        for first in FIRST_WORDS:
+            for sep in SEPARATORS:
+                for shell in SHELLS:
+                    joint = f"{first}{sep}" if sep == "\n" else f"{first} {sep} "
+                    cmd = f"{joint}{shell} <<'EOF'\n{READ}\nEOF"
+                    with self.subTest(first=first, sep=repr(sep), shell=shell):
+                        self.assertTrue(self.denies(cmd), cmd)
+
+    def test_an_unquoted_shell_heredoc_is_denied_too(self):
+        """The delimiter's quoting does not change who runs the body."""
+        for shell in SHELLS:
+            cmd = f"cat x && {shell} <<EOF\n{READ}\nEOF"
+            with self.subTest(shell=shell):
+                self.assertTrue(self.denies(cmd), cmd)
+
+    def test_a_reader_after_any_separator_keeps_its_body_as_data(self):
+        """The other direction, and the #258 preservation at full volume: a quoted heredoc
+        fed to a reader is stdin data even when its text looks like a command, because the
+        reader never runs it. Denying these is the false positive #258 removed."""
+        for first in FIRST_WORDS:
+            for sep in SEPARATORS:
+                joint = f"{first}{sep}" if sep == "\n" else f"{first} {sep} "
+                cmd = f"{joint}cat <<'EOF'\n{READ}\nEOF"
+                with self.subTest(first=first, sep=repr(sep)):
+                    self.assertFalse(self.denies(cmd), cmd)
+
+
+class WhichCommandOpensTheHeredoc(PlaneIso):
+    """Attribution facts: the body follows the `<<` in physical order, and a pipeline shares
+    one execution fate."""
+
+    def denies(self, cmd: str) -> bool:
+        return _deny(cmd, str(self.tmp))
+
+    def test_two_heredocs_on_one_line_go_to_different_programs(self):
+        """`cat <<A && bash <<B`: A's body is data (dropped), B's body is a script (kept).
+        Bodies follow the operators in order, so B's read must survive A's strip."""
+        cmd = f"cat <<'A' && bash <<'B'\n{MENTION}\nA\n{READ}\nB"
+        self.assertTrue(self.denies(cmd), cmd)
+
+    def test_the_same_two_with_the_shell_first(self):
+        """`bash <<B && cat <<A`: bodies are B then A. The read is B's, ahead of A's data."""
+        cmd = f"bash <<'B' && cat <<'A'\n{READ}\nB\n{MENTION}\nA"
+        self.assertTrue(self.denies(cmd), cmd)
+
+    def test_a_reader_heredoc_piped_into_a_shell_is_not_data(self):
+        """`cat <<X | bash`: the opener is a reader, but its output pipes to a shell that
+        runs the body. An executor anywhere in the pipeline keeps the body visible."""
+        self.assertTrue(self.denies(f"cat <<'EOF' | bash\n{READ}\nEOF"))
+        self.assertTrue(self.denies(f"cat <<'EOF' | tee out | bash\n{READ}\nEOF"))
+
+    def test_a_versioned_interpreter_downstream_is_an_executor_too(self):
+        """`python3.12` is `python3` with a suffix. A name list that knew only the bare
+        spelling would call this pipeline executor-free and strip a body an interpreter
+        runs."""
+        self.assertTrue(self.denies(f"cat <<'EOF' | python3.12\n{READ}\nEOF"))
+
+    def test_a_wrapper_in_front_of_a_reader_is_not_an_executor(self):
+        """`env cat <<'X'` is a reader behind a wrapper; `env` runs `cat`, not the body. Its
+        quoted body is data, as #258 requires."""
+        self.assertFalse(self.denies(f"env cat <<'EOF'\n{READ}\nEOF"))
+
+    def test_a_heredoc_in_the_second_of_three_segments(self):
+        cmd = f"cat x; bash <<'EOF' && echo done\n{READ}\nEOF"
+        self.assertTrue(self.denies(cmd), cmd)
+
+    def test_a_reader_piped_into_a_reader_stays_data(self):
+        """No executor anywhere: `head <<X | grep foo` is a data stream both ends. Stripped,
+        so a documented mention is not read."""
+        cmd = f"head <<'EOF' | grep foo\n{MENTION}\nEOF"
+        self.assertFalse(self.denies(cmd), cmd)
+
+
+class TheTrapsBashParsesOneWay(PlaneIso):
+    """Constructs whose `;`/`&&`/`<<` a naive splitter would read wrong."""
+
+    def denies(self, cmd: str) -> bool:
+        return _deny(cmd, str(self.tmp))
+
+    def test_a_separator_inside_quotes_is_not_a_separator(self):
+        """`echo 'a; b' && bash <<'EOF'` — the quoted `;` is one word; the real boundary is
+        the `&&`, and bash runs the body."""
+        cmd = f"echo 'a; b' && bash <<'EOF'\n{READ}\nEOF"
+        self.assertTrue(self.denies(cmd), cmd)
+
+    def test_a_separator_inside_a_substitution_is_not_a_boundary(self):
+        cmd = f'echo "$(echo a; echo b)" && bash <<\'EOF\'\n{READ}\nEOF'
+        self.assertTrue(self.denies(cmd), cmd)
+
+    def test_an_escaped_semicolon_keeps_one_command(self):
+        r"""`cat x \; bash <<'EOF'` is ONE `cat` reading files `x`, `;`, `bash`; the heredoc
+        is cat's stdin *data*, so the body is not executed and stays stripped."""
+        cmd = f"cat x \\; bash <<'EOF'\n{READ}\nEOF"
+        self.assertFalse(self.denies(cmd), cmd)
+
+    def test_a_dash_heredoc_with_tab_indented_body(self):
+        cmd = f"cat x && bash <<-'EOF'\n\t{READ}\n\tEOF"
+        self.assertTrue(self.denies(cmd), cmd)
+
+    def test_a_delimiter_that_looks_like_an_operator(self):
+        """`bash <<'&&'` — the quoted delimiter is a word, not a boundary; its body runs."""
+        cmd = f"cat x && bash <<'&&'\n{READ}\n&&"
+        self.assertTrue(self.denies(cmd), cmd)
+
+    def test_a_here_string_is_not_a_heredoc(self):
+        """`cat <<<"x"` opens no heredoc, so the next line is its own command and is read.
+        The old pre-pass mistook `<<<x` for a heredoc `<<x` and stripped the read away."""
+        cmd = f'cat <<<"x"\n{READ}\nx'
+        self.assertTrue(self.denies(cmd), cmd)
+
+    def test_a_heredoc_marker_inside_a_comment_opens_nothing(self):
+        cmd = f"cat x # <<'EOF'\n{READ}\nEOF"
+        self.assertTrue(self.denies(cmd), cmd)
+
+    def test_a_quoted_heredoc_marker_opens_nothing(self):
+        cmd = f'cat "<<EOF"\n{READ}\nEOF'
+        self.assertTrue(self.denies(cmd), cmd)
+
+    def test_a_grouped_reader_piped_into_a_shell(self):
+        """`{ cat <<X; } | bash` routes the group's output to a shell. The attribution bails
+        on a group rather than guess, which keeps the body visible — the safe direction."""
+        cmd = f"{{ cat <<'EOF'\n{READ}\nEOF\n}} | bash"
+        self.assertTrue(self.denies(cmd), cmd)
+
+
+class TheStripPrePassAsAUnit(PlaneIso):
+    """`_strip_reader_heredocs` facts that are simplest asserted on the pre-pass itself."""
+
+    def test_258_quoted_reader_body_is_dropped(self):
+        """The reported #258 case, and the terminator direction: the body is removed so a
+        document naming charter's layout is not read as a read of it."""
+        cmd = f"cat > workspaces/ws/doc.md <<'DOC'\n{READ}\nDOC"
+        self.assertIsNone(hooks._leak_reason(cmd))
+
+    def test_258_unquoted_prose_body_is_allowed(self):
+        cmd = "cat > notes.md <<DOC\nsee .charter/vaults/ for the layout\nDOC"
+        self.assertIsNone(hooks._leak_reason(cmd))
+
+    def test_an_unquoted_reader_body_runs_its_substitution(self):
+        """An unquoted body is expanded by the shell before the reader sees it, so a command
+        substitution in it runs. It must NOT be stripped, unlike a quoted body."""
+        cmd = f"cat <<EOF\n$(cat {VAULT})\nEOF"
+        self.assertIsNotNone(hooks._leak_reason(cmd))
+
+    def test_a_kept_body_only_ends_where_bash_ends_it_or_earlier(self):
+        """A terminator with trailing spaces is not the terminator to bash; the pre-pass may
+        end a body earlier than bash (showing the guard more), never later."""
+        cmd = f"bash <<'EOF'\n{READ}\nEOF"
+        self.assertIsNotNone(hooks._leak_reason(cmd))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_a_heredoc_body_is_read_by_whoever_runs_it.py
+++ b/tests/test_a_heredoc_body_is_read_by_whoever_runs_it.py
@@ -275,6 +275,59 @@ class ThePlanCarriesBashsOwnDelimiter(PlaneIso):
         self.assertEqual("EOF", hooks._heredoc_header(header, header.index("<<"))[0])
 
 
+class EveryFallbackInTheAttributionGoesRedWhenDeleted(PlaneIso):
+    """The sweep's survivors in the attribution code, each pinned by the input it handles.
+
+    A guard with no test behind it is a guard nobody notices losing, and CONTRIBUTING asks
+    for a red test per fallback. The three that no input could distinguish were deleted
+    instead; these four are the ones that decide something.
+    """
+
+    def denies(self, cmd: str) -> bool:
+        return _deny(cmd, str(self.tmp))
+
+    def test_an_unlexable_command_line_is_attributed_by_nobody(self):
+        """`_line_pipelines` catches the lexer's `ValueError` and gives up on the line, which
+        strips nothing and leaves the body for the raw scan to refuse. Narrow that `except`
+        and the guard raises instead of deciding."""
+        cmd = f"cat <<'EOF' \"oops\n{READ}\nEOF"
+        try:
+            decided = self.denies(cmd)
+        except Exception as exc:                       # noqa: BLE001 — the point of the pin
+            self.fail(f"the leak guard raised instead of deciding: {exc!r}")
+        self.assertTrue(decided, cmd)
+
+    def test_a_pipeline_before_a_control_operator_is_still_attributed(self):
+        """The append at a control operator is what carries the pipeline that ENDED there.
+        Drop it and `cat <<'EOF' && echo done` loses its `cat`, the heredoc count stops
+        matching, and a documented body is refused as a read."""
+        cmd = f"cat <<'EOF' && echo done\n{READ}\nEOF"
+        self.assertFalse(self.denies(cmd), cmd)
+
+    def test_an_empty_command_slot_never_reaches_a_program_name(self):
+        """A trailing pipe with nothing after it leaves an empty command in the pipeline —
+        a syntax error in bash, zsh and dash, so nothing runs and the verdict is allowed.
+        The `if c` in the executor test is what keeps that empty slot from being asked for
+        its first word."""
+        cmd = f"cat <<'EOF' |\n{READ}\nEOF"
+        try:
+            decided = self.denies(cmd)
+        except Exception as exc:                       # noqa: BLE001
+            self.fail(f"the leak guard raised instead of deciding: {exc!r}")
+        self.assertFalse(decided, cmd)
+
+    def test_an_unterminated_body_stops_at_the_end_of_the_command(self):
+        """A heredoc whose delimiter never arrives runs to the end of the input — bash takes
+        the rest as body, so nothing after it executes. The bound on the terminator append is
+        what stops the walk reading past the last line."""
+        cmd = f"cat > notes.md <<'DOC'\n{READ}"
+        try:
+            decided = self.denies(cmd)
+        except Exception as exc:                       # noqa: BLE001
+            self.fail(f"the leak guard raised instead of deciding: {exc!r}")
+        self.assertFalse(decided, cmd)
+
+
 class TheHeaderCountBailIsLoadBearing(PlaneIso):
     """`_heredoc_strip_plan` bails when the header regex and the lexer disagree on how many
     heredocs a line opens. Deleting the bail raises `IndexError` in `_leak_reason` here, and

--- a/tests/test_a_heredoc_body_is_read_by_whoever_runs_it.py
+++ b/tests/test_a_heredoc_body_is_read_by_whoever_runs_it.py
@@ -217,6 +217,15 @@ class TheTerminatorMatchesBashExactly(PlaneIso):
         cmd = f"bash <<A && cat <<'B'\necho a\\\nA\n{READ}\nA\ndata\nB"
         self.assertTrue(self.denies(cmd), cmd)
 
+    def test_a_quoted_body_does_not_splice_a_trailing_backslash(self):
+        """The other half of the splice rule, and a leak-hider without it. A QUOTED body is
+        literal, so a line ending in `\\` splices nothing and the next line still terminates
+        it. Splicing regardless of quoting would run `cat`'s body on past its `A`, swallow the
+        read meant for `bash <<'B'` into the dropped reader body, and allow a command that
+        leaks in bash, zsh and dash."""
+        cmd = f"cat <<'A' && bash <<'B'\ndata\\\nA\n{READ}\nB"
+        self.assertTrue(self.denies(cmd), cmd)
+
     def test_a_dash_terminator_still_strips_leading_tabs(self):
         """`<<-` strips leading tabs from body and terminator alike, so a tab-indented
         terminator still ends the body. A quoted reader body naming a path stays data (#258),

--- a/tests/test_a_heredoc_body_is_read_by_whoever_runs_it.py
+++ b/tests/test_a_heredoc_body_is_read_by_whoever_runs_it.py
@@ -176,8 +176,38 @@ class TheTrapsBashParsesOneWay(PlaneIso):
         cmd = f"cat x # <<'EOF'\n{READ}\nEOF"
         self.assertTrue(self.denies(cmd), cmd)
 
+    def test_an_unquoted_heredoc_marker_in_a_comment_opens_nothing(self):
+        """The #972-reviewer shape: `# <<EOF` is comment text, so the next line is a command
+        and is read. The old regex matched the `<<EOF` and stripped to end of input, hiding
+        it. Measured allowed on main `a5aa860`."""
+        cmd = f"cat notes.txt # <<EOF\n{READ}"
+        self.assertTrue(self.denies(cmd), cmd)
+
+    def test_a_heredoc_marker_in_single_quotes_is_an_argument(self):
+        """`grep '<<EOF' file` searches for the literal text `<<EOF`; it opens no heredoc, so
+        the next line is read. Measured allowed on main `a5aa860`."""
+        cmd = f"grep '<<EOF' file\n{READ}"
+        self.assertTrue(self.denies(cmd), cmd)
+
+    def test_an_escaped_heredoc_operator_opens_nothing(self):
+        r"""`cat x \<<EOF` — the `\<` is not the heredoc operator, so no body is opened and
+        the next line is a command. Measured allowed on main `a5aa860`."""
+        cmd = f"cat x \\<<EOF\n{READ}"
+        self.assertTrue(self.denies(cmd), cmd)
+
     def test_a_quoted_heredoc_marker_opens_nothing(self):
         cmd = f'cat "<<EOF"\n{READ}\nEOF'
+        self.assertTrue(self.denies(cmd), cmd)
+
+    def test_a_real_heredoc_after_a_comment_marker_still_works(self):
+        """The comment's fake `<<EOF` must not swallow a genuine heredoc on a later line. The
+        real one is a quoted reader body — stdin data — so its prose mention stays allowed
+        (#258), proving the comment did not derail heredoc detection."""
+        cmd = f"cat notes.txt # <<EOF\ncat <<'DOC'\n{MENTION}\nDOC"
+        self.assertFalse(self.denies(cmd), cmd)
+
+    def test_a_real_shell_heredoc_after_a_comment_marker_is_still_denied(self):
+        cmd = f"echo hi # <<EOF\nbash <<'DOC'\n{READ}\nDOC"
         self.assertTrue(self.denies(cmd), cmd)
 
     def test_a_grouped_reader_piped_into_a_shell(self):

--- a/tests/test_a_heredoc_body_is_read_by_whoever_runs_it.py
+++ b/tests/test_a_heredoc_body_is_read_by_whoever_runs_it.py
@@ -135,6 +135,122 @@ class WhichCommandOpensTheHeredoc(PlaneIso):
         self.assertFalse(self.denies(cmd), cmd)
 
 
+class APipelineContinuesAcrossPhysicalLines(PlaneIso):
+    """A trailing pipe continues the pipeline onto the next command line — the line AFTER the
+    heredoc bodies. The executor is on that continuation line, so a per-physical-line plan
+    would miss it and strip a body a shell runs. Measured on bash, zsh AND dash: every
+    `SECRET RAN` shape below runs a planted secret; the `&&`/`||` shapes do not, because there
+    the heredoc stays with its own segment's program and is not piped downstream.
+    """
+
+    def denies(self, cmd: str) -> bool:
+        return _deny(cmd, str(self.tmp))
+
+    def test_trailing_pipe_then_a_shell_on_the_next_line(self):
+        """The reviewer's shape: `cat <<'EOF' |` \\n body \\n EOF \\n bash — bash runs the
+        body. Allowed on base; must deny."""
+        for tail in ("bash", "sh"):
+            cmd = f"cat <<'EOF' |\n{READ}\nEOF\n{tail}"
+            with self.subTest(tail=tail):
+                self.assertTrue(self.denies(cmd), cmd)
+
+    def test_trailing_pipe_with_a_reader_opener(self):
+        cmd = f"head <<'EOF' |\n{READ}\nEOF\nbash"
+        self.assertTrue(self.denies(cmd), cmd)
+
+    def test_a_writer_opener_piped_onward_to_a_shell(self):
+        """`tee x <<'EOF' |` \\n … \\n bash — tee reproduces the body to the pipe, bash runs
+        it."""
+        cmd = f"tee x <<'EOF' |\n{READ}\nEOF\nbash"
+        self.assertTrue(self.denies(cmd), cmd)
+
+    def test_a_three_stage_pipeline_across_lines(self):
+        cmd = f"cat <<'EOF' |\n{READ}\nEOF\ntee y |\nbash"
+        self.assertTrue(self.denies(cmd), cmd)
+
+    def test_a_backslash_newline_continuation_into_a_pipe(self):
+        r"""`cat <<'EOF' \` \\n `| bash` folds to `cat <<'EOF' | bash`, and the body follows."""
+        cmd = f"cat <<'EOF' \\\n| bash\n{READ}\nEOF"
+        self.assertTrue(self.denies(cmd), cmd)
+
+    def test_and_continuation_leaves_the_heredoc_with_its_own_segment(self):
+        """`cat <<'EOF' &&` \\n body \\n EOF \\n bash — measured on bash/zsh/dash: the body is
+        NOT piped to bash (that is a separate command), so a body that only mentions a path is
+        data and stays allowed."""
+        cmd = f"cat <<'EOF' &&\n{MENTION}\nEOF\nbash"
+        self.assertFalse(self.denies(cmd), cmd)
+
+    def test_or_continuation_the_same(self):
+        cmd = f"cat <<'EOF' ||\n{MENTION}\nEOF\nbash"
+        self.assertFalse(self.denies(cmd), cmd)
+
+    def test_a_trailing_ampersand_is_not_a_pipeline_continuation(self):
+        """`cat <<'EOF' &` backgrounds cat; `bash` on the next line is a separate command that
+        never receives the body. Measured: the secret does not run."""
+        cmd = f"cat <<'EOF' &\n{MENTION}\nEOF\nbash\nwait"
+        self.assertFalse(self.denies(cmd), cmd)
+
+
+class TheTerminatorMatchesBashExactly(PlaneIso):
+    """A heredoc ends where bash ends it, not at the first `.strip()`-equal line. A lenient
+    match ends a KEPT (shell) body EARLY, and the real body lines that spill past it are then
+    read as the NEXT heredoc's body — which, if that one is a reader's, gets stripped, hiding
+    the read. Measured on bash, zsh and dash: the secret runs; denied on main; the lenient
+    pre-pass had regressed it to allowed."""
+
+    def denies(self, cmd: str) -> bool:
+        return _deny(cmd, str(self.tmp))
+
+    def test_a_lenient_terminator_does_not_end_a_shell_body_early(self):
+        """`bash <<'A'` whose body contains a line ` A` (leading space) — not the terminator
+        to bash — followed by the real read, then the exact `A`. The read is inside bash's
+        body, and a following `cat <<'B'` must not swallow and strip it."""
+        cmd = f"bash <<'A' && cat <<'B'\necho hi\n A\n{READ}\nB\nA\ndata\nB"
+        self.assertTrue(self.denies(cmd), cmd)
+
+    def test_an_unquoted_body_backslash_splices_over_a_terminator(self):
+        """An UNQUOTED heredoc body splices a trailing backslash with the next line, so a
+        line that looks like the terminator is eaten and the body runs on. Measured on
+        bash/zsh/dash: `bash <<A` … `echo a\\` … `A` … read … `A` runs the read. The kept
+        shell body must extend past the spliced `A`, not hand the read to a later reader
+        heredoc to strip."""
+        cmd = f"bash <<A && cat <<'B'\necho a\\\nA\n{READ}\nA\ndata\nB"
+        self.assertTrue(self.denies(cmd), cmd)
+
+    def test_a_dash_terminator_still_strips_leading_tabs(self):
+        """`<<-` strips leading tabs from body and terminator alike, so a tab-indented
+        terminator still ends the body. A quoted reader body naming a path stays data (#258),
+        proving the tab-aware match did not run the body off the end."""
+        cmd = "cat > notes.md <<-'DOC'\n\t.charter/vaults/db.json\n\tDOC"
+        self.assertIsNone(hooks._leak_reason(cmd))
+
+
+class TheHeaderCountBailIsLoadBearing(PlaneIso):
+    """`_heredoc_strip_plan` bails when the header regex and the lexer disagree on how many
+    heredocs a line opens. Deleting the bail raises `IndexError` in `_leak_reason` here, and
+    flips a here-string classification — so it is pinned, not incidental (review M4)."""
+
+    def denies(self, cmd: str) -> bool:
+        return _deny(cmd, str(self.tmp))
+
+    def test_a_dangling_heredoc_operator_returns_a_decision_without_raising(self):
+        """`cat <<'EOF' | bash <<` — the second `<<` names no delimiter, so the lexer counts
+        two `<<` and the regex one. The bail must return a clean verdict, not raise."""
+        cmd = f"cat <<'EOF' | bash <<\n{READ}\nEOF"
+        try:
+            decided = self.denies(cmd)
+        except Exception as exc:                       # noqa: BLE001 — the point of the pin
+            self.fail(f"_leak_reason raised instead of deciding: {exc!r}")
+        self.assertTrue(decided, cmd)                  # a shell still runs the body
+
+    def test_a_here_string_before_a_heredoc_keeps_its_verdict(self):
+        """`cat <<<x <<'EOF'` — a here-string then a heredoc. The counts disagree, so the
+        pre-pass strips nothing; pin the resulting verdict so the bail cannot silently flip
+        it."""
+        cmd = f"cat <<<x <<'EOF'\n{READ}\nEOF"
+        self.assertTrue(self.denies(cmd), cmd)
+
+
 class TheTrapsBashParsesOneWay(PlaneIso):
     """Constructs whose `;`/`&&`/`<<` a naive splitter would read wrong."""
 

--- a/tests/test_a_heredoc_body_is_read_by_whoever_runs_it.py
+++ b/tests/test_a_heredoc_body_is_read_by_whoever_runs_it.py
@@ -225,6 +225,47 @@ class TheTerminatorMatchesBashExactly(PlaneIso):
         self.assertIsNone(hooks._leak_reason(cmd))
 
 
+class ThePlanCarriesBashsOwnDelimiter(PlaneIso):
+    """Each plan entry carries `_heredoc_header`'s answer as DATA, so a second caller has the
+    bash-accurate delimiter without re-parsing — and decides nothing here.
+
+    Where quoting splits the delimiter word, the two readings differ: for `<<EO'F'` the
+    pre-pass's regex reads `EO` while bash reads `EOF` (measured against bash, zsh and dash).
+    Acting on the shorter reading is the safe direction *here* — a terminator that is never
+    found leaves the body visible — so the verdicts stay keyed on it. A caller that would DROP
+    a body (a `charter handoff` brief, say) must use the carried header instead, or it would
+    drop to end of input and swallow the commands after the heredoc.
+    """
+
+    SPLIT_QUOTED = ["EO'F'", "'EO'F", '"EO"F']
+
+    def test_every_split_quote_spelling_exposes_bashs_delimiter(self):
+        for spell in self.SPLIT_QUOTED:
+            header = "cat <<" + spell
+            with self.subTest(spelling=spell):
+                plan = hooks._heredoc_strip_plan(header)
+                self.assertEqual(1, len(plan), header)
+                self.assertEqual("EOF", plan[0][2][0], "carried delimiter is bash's")
+                self.assertEqual("EO", plan[0][0], "the pre-pass still matches on its own")
+
+    def test_the_carried_header_decides_nothing(self):
+        """The verdicts of those spellings are exactly what they were before the facts were
+        carried — the data is inert."""
+        for spell, denied in (("EO'F'", True), ("'EO'F", False), ('"EO"F', False),
+                              ("\\EOF", True)):
+            cmd = f"cat <<{spell}\nbody\nEOF\n{READ}"
+            with self.subTest(spelling=spell):
+                self.assertEqual(denied, _deny(cmd, str(self.tmp)), cmd)
+
+    def test_a_backslash_delimiter_has_no_entry_to_carry(self):
+        """`<<\\EOF` is not matched by the pre-pass's header regex at all, so there is no
+        entry — the bash-accurate fact is still one `_heredoc_header` call away, and nothing
+        is stripped, which is why the verdict above is a denial."""
+        header = "cat <<\\EOF"
+        self.assertEqual([], hooks._heredoc_strip_plan(header))
+        self.assertEqual("EOF", hooks._heredoc_header(header, header.index("<<"))[0])
+
+
 class TheHeaderCountBailIsLoadBearing(PlaneIso):
     """`_heredoc_strip_plan` bails when the header regex and the lexer disagree on how many
     heredocs a line opens. Deleting the bail raises `IndexError` in `_leak_reason` here, and


### PR DESCRIPTION
Closes #973.

`_strip_reader_heredocs` dropped a heredoc body from the leak guard's view whenever the
LINE *started* with a reader (`cat`, `head`, …) — it judged the whole line by its first
token (`_reader_of`) and stripped whatever `<<` it found, regardless of which command
actually opened that heredoc. So a reader in front of a chained or piped shell fed the shell
a vault read the guard never saw.

Measured through the full `hooks.pretooluse` in `tests._isolation.PlaneIso` (main
`a5aa860`, this branch's base; `origin/main` is now `6526928`, which adds only two files
under `docs/superpowers/` and changes no code or test), with `cat .charter/vaults/dev.json`
as the heredoc body:

## Decision matrix

| Command | main `a5aa860` | this PR |
| --- | --- | --- |
| `cat .charter/vaults/dev.json` | deny | deny |
| `bash <<'EOF'` (no prefix) | deny | deny |
| `true; bash <<'EOF'` / `true && bash <<'EOF'` | deny | deny |
| `cat x; bash <<'EOF'` | **allow** | **deny** |
| `cat x && bash <<'EOF'` | **allow** | **deny** |
| `cat x \|\| bash <<'EOF'` | **allow** | **deny** |
| `cat x \| bash <<'EOF'` | **allow** | **deny** |
| `cat x & bash <<'EOF'` | **allow** | **deny** |
| `cat x && sh <<'EOF'` | **allow** | **deny** |
| `head x && bash <<EOF` (unquoted) | **allow** | **deny** |
| `cat <<'EOF' \| bash` | **allow** | **deny** |
| `cat <<'EOF' \| tee o \| bash` | **allow** | **deny** |
| `{ cat <<'EOF'; } \| bash` | **allow** | **deny** |
| `cat <<'A' && bash <<'B'` (A mentions, B reads) | deny | deny |
| `bash <<'B' && cat <<'A'` (B reads, A mentions) | deny | deny |
| `cat x; bash <<'EOF' && echo done` (heredoc in 2nd of 3 segments) | **allow** | **deny** |
| `cat <<<"x"` then a read line (here-string, not a heredoc) | **allow** | **deny** |
| `cat x # <<'EOF'` then a read line (`<<` in a comment) | **allow** | **deny** |
| `cat "<<EOF"` then a read line (`<<` in quotes) | **allow** | **deny** |
| `cat notes.txt # <<EOF` then a read line (`<<` in a comment, unquoted) | **allow** | **deny** |
| `grep '<<EOF' file` then a read line (delimiter in single quotes) | **allow** | **deny** |
| `cat x \<<EOF` then a read line (escaped operator) | **allow** | **deny** |
| `cat notes.txt # <<EOF` then a genuine `cat <<'DOC'` reader body | allow | allow |
| `cat <<EOF` … `$(cat <vault>)` … `EOF` (unquoted reader body) | **allow** | **deny** |
| `cat <<'EOF'` whose body is `cat <vault>` (quoted, reader) — #258 | allow | allow |
| `cat > notes.md <<DOC` … prose naming `.charter/` … `DOC` — #258 | allow | allow |
| `head <<'EOF' \| grep foo` (reader → reader, no executor) | allow | allow |
| `cat x \; bash <<'EOF'` (escaped `;` → one `cat`, body is data) | allow | allow |

## The fix

Each heredoc is attributed to the command that opens it — the program of the segment
holding the `<<`, and the pipeline that segment belongs to (split on `;`, `&&`, `||`, `&`,
`;;` and newlines, `|`/`|&` kept inside the pipeline), reusing `_lex` / `_split_env`. A body
is stripped **only** when a *quoted* (non-expanding) heredoc feeds a *reader* whose pipeline
runs *no executor*. A body reaching a shell (`bash`, `sh`, `python3`, …), or a reader whose
output pipes into one, stays visible, and the guard's own newline-segmentation reads each of
its lines as the command it is. Bodies follow their `<<` in physical order across the whole
line, so two heredocs going to different programs are told apart. When the header regex and
the tokenizer disagree on how many heredocs a line opens — a here-string `<<<x`, a `<<` in
quotes or a comment — or the line holds a group/subshell/`$( … )` whose output could be
re-piped, the pre-pass strips nothing and leaves every body visible (the deny-more
direction).

## A `<<` in a comment or quotes (a PR #972 review finding)

A #972 reviewer noted that the old `_HEREDOC_RE` also matched a `<<` inside a comment
(`cat notes.txt # <<EOF`) or inside quotes (`grep '<<EOF' file`) and stripped from there to
end of input, hiding a later real read. Measured through `_leak_reason` on pristine main
`a5aa860`, all three shapes (comment, single-quoted delimiter, escaped `\<<`) followed by
`cat .charter/vaults/dev.json` were **allowed**; on this branch all three **deny**, and a
genuine heredoc on a later line still works. Same class, same fix: a heredoc is counted only
where the lexer emits a **bare** `<<` token, so a `<<` in a comment, in quotes or escaped is
not one, the header count disagrees, and the pre-pass strips nothing. Pinned in the trap
tests.

## #258 preservation

The false positive [#258](https://github.com/diazoxide/charter/issues/258) removed stays
removed: a quoted `cat <<'X'` whose body merely names `.charter/`, with no executor
downstream, is stdin data and is dropped. Its existing tests
(`tests/test_leak_guard_readers_that_write.py`) are unchanged and pass. An *unquoted* `<<X`
body now stays visible, because the shell expands it first and a `$( … )` in it would run —
which is also what keeps nine `guard_denied_by_main` corpus rows denied.

## Verification

- `tests/test_a_heredoc_body_is_read_by_whoever_runs_it.py` — the full matrix above through
  `hooks.pretooluse` in `PlaneIso`, plus the traps (quoted/escaped separators, `$( … )`,
  `<<-` tab bodies, an operator-like delimiter, two heredocs to different programs, a
  heredoc in the second of three segments) and the pre-pass units.
- `tools/sweep.py`: local sweep running (30 mutations); CI sweep shards on push.
- Full suite on the fix commit: **12063 tests, OK (9 skipped)**
  (`python3 -m unittest discover -s tests`). The pins are a separate tests-only commit.

## Ceiling unchanged

This reads argv and heredoc *structure*, never an interpreter body or a shell string.
`sh -c '…'`, `bash -c`, `eval`, a body a command turns into arguments rather than code
(`… | xargs cat`), and a body written to a file and run later
(`cat <<'EOF' > x.sh && bash x.sh`) all remain outside it, exactly as `docs/hooks.md`
(*Where the secret-leak guard stops*) documents. The corrected heredoc sentence in
`docs/hooks.md` and a `security:` news entry ship with the fix.

---

## Review round 1 (commit `2a4a9fb`)

**HIGH — a pipeline that spans physical lines.** The plan was computed per physical line, so
a trailing `|` that continued the pipeline onto the command *after* the heredoc bodies was
missed, and a body the downstream shell runs was stripped. Measured on bash 3.2, zsh 5.9 and
dash with a planted secret in a throwaway dir (never a real vault): `cat <<'EOF' |` ⏎ body ⏎
`EOF` ⏎ `bash` runs it, and so do the `sh`, `tee x <<'EOF' |`, `head` opener, three-stage
`… ⏎ tee y | ⏎ bash`, and backslash-newline `cat <<'EOF' \` ⏎ `| bash` variants. Allowed on
base, denied now.

`_strip_reader_heredocs` now works on the **logical command**, folding two continuations in
the order bash applies them: a **backslash-newline** is spliced into the command line
*before* its heredoc bodies are read, and a trailing **`|`/`|&`** continues onto the command
line *after* them. The folded pipeline goes to `_heredoc_strip_plan`, so a downstream
executor is attributed to the pipeline the body belongs to; bodies are buffered and emitted
in place once the plan is known. A body line is never read as a continuation.

**`&&` / `||` continuation, measured.** `cat <<'EOF' &&` ⏎ `cat secret.txt` ⏎ `EOF` ⏎ `bash`
prints the literal line `cat secret.txt` on bash, zsh and dash — the body is `cat`'s stdin
data and `bash` is a separate command that never receives it; `||` is the same, and a
trailing `&` backgrounds `cat` with the same result. So those stay per-segment, pinned as
allowed (`test_and_continuation_leaves_the_heredoc_with_its_own_segment`,
`test_or_continuation_the_same`, `test_a_trailing_ampersand_is_not_a_pipeline_continuation`).

**Found while measuring — two shapes this PR had made weaker than main.** Both came from the
terminator rule, and both run a planted secret on bash, zsh and dash:
`bash <<'A' && cat <<'B'` with a body line ` A` (leading space), and `bash <<A && cat <<'B'`
with a body line ending in `\` before `A`. The old `.strip() == delim` ended the *kept* shell
body early, the read that spilled past was taken as `B`'s body, and `B` (a reader's) was
stripped. The terminator now matches bash exactly — a line equal to the delimiter, a `<<-`
ignoring only leading tabs — and an **unquoted** body splices a trailing backslash, so the
spliced line cannot end it. Denied again; pinned in `TheTerminatorMatchesBashExactly`. The
differential corpus holds no multi-heredoc or trailing-space-terminator row, which is why it
could not see this.

**MEDIUM (M4) — the header-count bail is pinned.** Neutralising
`if sum(...) != len(headers): return None` makes
`test_a_dangling_heredoc_operator_returns_a_decision_without_raising` fail with
`IndexError` (hand mutation, red; restored, green). `cat <<<x <<'EOF'` keeps its verdict.

### The 10 CI survivors on `1acd902`, resolved

Every fallback in the attribution code now either goes red when its own line is deleted, or
is gone. Each "pinned" row below was verified by hand: apply that one mutation, the named
test fails; restore it, the module is green again. Each "deleted" row is an equivalent
mutant — no input distinguishes it, so it cannot be pinned, and CONTRIBUTING makes it a
deletion.

| # | Guard (old line on `1acd902`) | Resolution |
| --- | --- | --- |
| 1 | `_line_pipelines` :813 — `except ValueError: return None` | **pinned** — `test_an_unlexable_command_line_is_attributed_by_nobody` |
| 2 | `_line_pipelines` :826 — the append that carries a pipeline ending at a control operator | **pinned** — `test_a_pipeline_before_a_control_operator_is_still_attributed` |
| 3 | `_line_pipelines` :825 — `[c for c in current if c]` at a control operator | **deleted** (`14f7d5f`) — an empty command yields program `""` and zero heredocs, so it reaches no decision; 0 of 11,486 verdicts change. Its now-always-true `if cmds:` went with it; the append itself is row 2 and stays |
| 4 | `_line_pipelines` :831 — the same filter after the loop | **deleted** (`14f7d5f`) — same reason, same measurement |
| 5 | `_line_pipelines` :839 — `… if c` in the executor scan | **kept and pinned** — `test_an_empty_command_slot_never_reaches_a_program_name`. It was masked by rows 3 and 4; once they are gone it is the one guard stopping an empty slot from being asked for its first word |
| 6 | `_heredoc_strip_plan` :866 — `if not headers: return []` | **kept and pinned** — `test_a_backslash_delimiter_has_no_entry_to_carry`. Settled by measurement, not assumption: deleting the line turns that plan from `[]` into `None` and the test goes red |
| 7 | `_heredoc_strip_plan` :871 — the header-count bail | **pinned** — `test_a_dangling_heredoc_operator_returns_a_decision_without_raising` (deleting it raises `IndexError`) |
| 8 | `_strip_reader_heredocs` :918 — `lines[i].strip() != delim` | **removed by round 1** — the terminator matches bash exactly now, which is what closed two leaks of its own (`TheTerminatorMatchesBashExactly`) |
| 9 | `_strip_reader_heredocs` :922 — the bound on the terminator append | **pinned** — `test_an_unterminated_body_stops_at_the_end_of_the_command` |
| 10 | `_strip_reader_heredocs` :923 — the emit condition | **split**: the `kind == "cmd"` half is **deleted** (`14f7d5f`) — a command line carries body index `-1`, never a key of `drop`, so it could not decide anything — and the `not drop.get(…)` half is **pinned** by #258's `test_a_readers_heredoc_body_is_still_data` (33 tests go red without it) |

Two more, beyond CI's ten:

- **`expands and` in the splice test** (`hooks.py` ~:1000) — the round-1 reviewer proved it a real
  leak-hider rather than an equivalent mutant. **Pinned** by
  `test_a_quoted_body_does_not_splice_a_trailing_backslash`: without the conjunct,
  `cat <<'A' && bash <<'B'` with a `data\` line, then `A`, then the read, then `B` flips from
  deny to allow — and that shape runs a planted secret on bash 3.2, zsh 5.9 and dash.
- **`len(plan) == body_count`** beside the `plan is not None` check — **deleted** (`14f7d5f`): a
  logical command is folded only after a trailing pipe, so no heredoc header can straddle the
  join, and the plan and the buffered bodies are counted off the same regex over the same
  text. 0 of 11,486 verdicts change.

Final count of the ten: **6 pinned, 2 deleted, 1 removed by round 1, 1 split** (half deleted,
half pinned) — plus one more pin and one more deletion beyond them. The deletions were
measured inert over the leak rows of `guard_denied_by_main.txt` plus generated heredoc
shapes, 11,486 inputs, exceptions included.


Full suite on `26d8541`: **12,089 tests, OK (9 skipped)**. `docs/hooks.md` and the news entry state
multi-line pipelines. Ceiling unchanged: write-then-run (`cat <<'EOF' > x.sh && bash x.sh`)
and `… | xargs cat <path>` (a bare path becomes an argument, not a command) stay outside an
argv guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
