### PR TITLE
Charter reads harness profiles from a file it keeps out of git, and lists them

### DIFF
--- a/charter/cli.py
+++ b/charter/cli.py
@@ -664,7 +664,10 @@ def command_words() -> frozenset[str]:
     """
     subparsers = next(action for action in build_parser()._actions
                       if isinstance(action, argparse._SubParsersAction))
-    return frozenset(subparsers.choices) - {h.cli_name for h in harness.all() if h.cli_name}
+    # No `if h.cli_name` filter: a harness with no launcher contributes "", which names no
+    # subcommand, so subtracting it changes nothing — the deletion sweep measured the filter
+    # as a line the suite could lose, and a line nothing can observe is a line to delete.
+    return frozenset(subparsers.choices) - {h.cli_name for h in harness.all()}
 
 
 def _add_frame_parsers(sub) -> None:

--- a/charter/cli.py
+++ b/charter/cli.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import functools
 import os
 import sys
 
@@ -646,6 +647,24 @@ def _add_workspace_parser(sub) -> None:
     aus.set_defaults(func=commands_workspace.cmd_workspace_autosave)
     pbg = wsub.add_parser("_pushbg")    # internal: background push half of autosave
     pbg.set_defaults(func=commands_workspace.cmd_workspace_pushbg)
+
+
+@functools.cache
+def command_words() -> frozenset[str]:
+    """Every word `charter <word>` already means, minus the registered kinds' own launchers.
+
+    A harness profile named like one of these could never launch — `charter doctor` is
+    `doctor` whatever `charter.local.toml` says — so `profiles.current` refuses it by name.
+    Asked of the parser `main` dispatches through rather than of a list kept beside it, so a
+    command added tomorrow is a word no profile can take on the day it is added. The kinds
+    are left out because a declared profile named after its kind is how plain `claude` gets
+    pinned.
+
+    Built once per process: the parser does not change for the life of one.
+    """
+    subparsers = next(action for action in build_parser()._actions
+                      if isinstance(action, argparse._SubParsersAction))
+    return frozenset(subparsers.choices) - {h.cli_name for h in harness.all() if h.cli_name}
 
 
 def _add_frame_parsers(sub) -> None:

--- a/charter/commands.py
+++ b/charter/commands.py
@@ -7,8 +7,8 @@ import json
 import re
 from pathlib import Path
 
-from . import (config, contain, docsrc, doctor, gitstate, instance, inventory, profiles,
-               render, tui, util, workspace, worktree)
+from . import (config, contain, docsrc, doctor, gitstate, instance, inventory, render,
+               tui, util, workspace, worktree)
 # One committer for the control plane, in charter/planegit.py. Re-exported rather
 # than moved-and-updated so every existing caller and test keeps working — the point
 # of the extraction is that there is ONE implementation, not that callers churn.
@@ -1661,9 +1661,10 @@ def _ensure_local_settings_ignored(root: Path) -> None:
 #: profile's command runs on a click with no permission prompt in between, so the file it
 #: lives in is safe only while git will not carry it (harness-profiles spec, *Where profiles
 #: live*). In the baseline for a fresh plane, and backfilled by `reinit` for one made before
-#: it — `LOCAL_SETTINGS_IGNORE`'s shape, for the same reason. Built from the filename
-#: `profiles` reads, so the two cannot name different files.
-LOCAL_PROFILES_IGNORE = "/" + profiles.LOCAL_FILE
+#: it — `LOCAL_SETTINGS_IGNORE`'s shape, for the same reason. Spelled out rather than built
+#: from `profiles.LOCAL_FILE`: importing `charter.profiles` here would put it on the import
+#: path of every command (ruling 43), and a test keeps the two naming the same file.
+LOCAL_PROFILES_IGNORE = "/charter.local.toml"
 
 
 def _ensure_local_profiles_ignored(root: Path) -> bool:

--- a/charter/commands.py
+++ b/charter/commands.py
@@ -7,8 +7,8 @@ import json
 import re
 from pathlib import Path
 
-from . import (config, contain, docsrc, doctor, gitstate, instance, inventory, render,
-               tui, util, workspace, worktree)
+from . import (config, contain, docsrc, doctor, gitstate, instance, inventory, profiles,
+               render, tui, util, workspace, worktree)
 # One committer for the control plane, in charter/planegit.py. Re-exported rather
 # than moved-and-updated so every existing caller and test keeps working — the point
 # of the extraction is that there is ONE implementation, not that callers churn.
@@ -1661,12 +1661,20 @@ def _ensure_local_settings_ignored(root: Path) -> None:
 #: profile's command runs on a click with no permission prompt in between, so the file it
 #: lives in is safe only while git will not carry it (harness-profiles spec, *Where profiles
 #: live*). In the baseline for a fresh plane, and backfilled by `reinit` for one made before
-#: it — `LOCAL_SETTINGS_IGNORE`'s shape, for the same reason.
-LOCAL_PROFILES_IGNORE = "/charter.local.toml"
+#: it — `LOCAL_SETTINGS_IGNORE`'s shape, for the same reason. Built from the filename
+#: `profiles` reads, so the two cannot name different files.
+LOCAL_PROFILES_IGNORE = "/" + profiles.LOCAL_FILE
 
 
 def _ensure_local_profiles_ignored(root: Path) -> bool:
     """Backfill :data:`LOCAL_PROFILES_IGNORE` into a plane made before it. True iff it wrote.
+
+    **This goes past ADR 0017 as written, and says so.** That rule has charter ignore a path
+    it creates that carries credentials; `charter.local.toml` is neither — charter never
+    writes it, and a profile holds no credential. It is ignored because its whole meaning is
+    "not committed": the harness-profiles spec's *"Ignored" is guaranteed, not hoped for*
+    records the decision, and the ADR's own amendment follows with the records the plan's
+    Task 6 writes.
 
     `reinit` is the remedy both `profiles.NOT_IGNORED` and `doctor`'s `harness profiles` row
     name, so it has to be the command that makes the promise true. Whole-line and additive

--- a/charter/commands.py
+++ b/charter/commands.py
@@ -1037,6 +1037,10 @@ _GITIGNORE_BASELINE = """\
 # sibling `.claude/settings.json` is deliberately NOT ignored — that one is the team's.
 /.claude/settings.local.json
 
+# This machine's harness profiles (commands, config folders). Never committed: a profile's
+# command runs on a click, and a merged edit would run it on every machine.
+/charter.local.toml
+
 # Python
 __pycache__/
 *.py[cod]
@@ -1071,6 +1075,8 @@ def _ensure_gitignore(root: Path) -> bool:
         missing.append("/.charter/")
     if LOCAL_SETTINGS_IGNORE not in existing_lines:
         missing.append(LOCAL_SETTINGS_IGNORE)
+    if LOCAL_PROFILES_IGNORE not in existing_lines:
+        missing.append(LOCAL_PROFILES_IGNORE)
     if not missing:
         return False
     # The write itself goes through the one shared appender — `charter browser install`
@@ -1649,6 +1655,27 @@ def _ensure_local_settings_ignored(root: Path) -> None:
         return
     util.append_gitignore(root, [LOCAL_SETTINGS_IGNORE],
                           "added by `charter guard --local`")
+
+
+#: The `.gitignore` line that keeps this machine's harness profiles out of every commit. A
+#: profile's command runs on a click with no permission prompt in between, so the file it
+#: lives in is safe only while git will not carry it (harness-profiles spec, *Where profiles
+#: live*). In the baseline for a fresh plane, and backfilled by `reinit` for one made before
+#: it — `LOCAL_SETTINGS_IGNORE`'s shape, for the same reason.
+LOCAL_PROFILES_IGNORE = "/charter.local.toml"
+
+
+def _ensure_local_profiles_ignored(root: Path) -> bool:
+    """Backfill :data:`LOCAL_PROFILES_IGNORE` into a plane made before it. True iff it wrote.
+
+    `reinit` is the remedy both `profiles.NOT_IGNORED` and `doctor`'s `harness profiles` row
+    name, so it has to be the command that makes the promise true. Whole-line and additive
+    through the one shared appender, which already answers "present" by writing nothing — so
+    what it wrote is the whole answer, and `reinit` reports what it changed (ADR 0013).
+    """
+    return bool(util.append_gitignore(
+        root, [LOCAL_PROFILES_IGNORE],
+        "added by `charter reinit` — harness profiles stay on this machine"))
 
 
 def add_ask_rule(root: Path, rule: str, local: bool = False,
@@ -2514,6 +2541,12 @@ def cmd_reinit(args) -> int:
     from . import instance as _instance
 
     created, present, blocked = _create_baseline_dirs(config.ROOT)
+
+    # A plane made before harness profiles has no ignore line for the file they live in, and
+    # `profiles.ignored_refusal` refuses every profile in it until it does — so this is the
+    # command that refusal names.
+    if _ensure_local_profiles_ignored(config.ROOT):
+        created.append(f".gitignore ({LOCAL_PROFILES_IGNORE})")
 
     # The plane-root guard, on the SAME terms as init. `doctor`'s hint for an unwired plane
     # names `charter reinit`, so reinit has to be the command that actually wires it (#168).

--- a/charter/commands_harness.py
+++ b/charter/commands_harness.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 import sys
 
-from . import config, contain, profiles, tui, util
+from . import config, contain, tui, util
 from .harness import codex, registry
 
 
@@ -33,6 +33,10 @@ def _list_profiles() -> None:
     read. When git would carry the file, every profile it declares is listed refused with
     that state's reason (F1), and one line names the state's fix.
     """
+    # Imported here and not at the top: `cli` imports this module for every command, and
+    # ruling 43 keeps `charter.profiles` off every command's import path.
+    from . import profiles
+
     check = profiles.ignore_check(config.ROOT)
     profile_set = profiles.with_ignore_check(profiles.current(), check)
     order = list(profiles.builtins())

--- a/charter/commands_harness.py
+++ b/charter/commands_harness.py
@@ -30,11 +30,13 @@ def _list_profiles() -> None:
     carriage return in it could otherwise redraw this line (ruling 35).
 
     The git check runs here because a person typed this command; it never runs on a config
-    read.
+    read. When git would carry the file, every profile it declares is listed refused with
+    that state's reason (F1), and one line names the state's fix.
     """
-    read = profiles.current()
+    check = profiles.ignore_check(config.ROOT)
+    profile_set = profiles.with_ignore_check(profiles.current(), check)
     order = list(profiles.builtins())
-    rows = sorted(read["profiles"].values(),
+    rows = sorted(profile_set.profiles.values(),
                   key=lambda p: (p.name not in order,
                                  order.index(p.name) if p.name in order else 0, p.name))
     heads = ("NAME", "KIND", "COMMAND")
@@ -46,15 +48,14 @@ def _list_profiles() -> None:
 
     print(line("  ", heads, "FROM"), file=sys.stderr)
     for p, cells in zip(rows, body):
-        print(line("* " if p.name == read["default"] else "  ", cells, p.source),
+        print(line("* " if p.name == profile_set.default else "  ", cells, p.source),
               file=sys.stderr)
-    if read["refused"]:
+    if profile_set.refused:
         print("refused:", file=sys.stderr)
-        for r in read["refused"]:
+        for r in profile_set.refused:
             print(f"  {r.name or r.source}: {r.reason}", file=sys.stderr)
-    ignored = profiles.ignored_refusal(config.ROOT)
-    if ignored:
-        util.warn(ignored)
+    if check.fix:
+        util.warn(f"to use the profiles in {profiles.LOCAL_FILE}: {check.fix}")
 
 
 def cmd_harness_list(args) -> int:

--- a/charter/commands_harness.py
+++ b/charter/commands_harness.py
@@ -9,12 +9,59 @@ consent), and nothing here is ever done as a side effect of something else.
 
 from __future__ import annotations
 
-from . import util
+import sys
+
+from . import config, contain, profiles, tui, util
 from .harness import codex, registry
 
 
+def _list_profiles() -> None:
+    """Every harness profile this machine has, the file it came from, and why any was refused.
+
+    There is no `charter harness add` — a chat can run a command as easily as it can edit the
+    file, so a command could never stand for the operator's approval — so this is how an
+    operator who edited `charter.local.toml` reads back what charter made of it.
+
+    Read through `profiles.current`, what every launch surface reads, so a name that clashes
+    with a command is listed as refused here too. Built-ins first in registry order (a
+    declared replacement keeps its kind's place), then declared profiles by name. Widths are
+    measured from the cells (`tui.column`, `cmd_workspace_list`'s rule), and every cell that
+    came out of the file is contained first: a command is text a chat can write, and a
+    carriage return in it could otherwise redraw this line (ruling 35).
+
+    The git check runs here because a person typed this command; it never runs on a config
+    read.
+    """
+    read = profiles.current()
+    order = list(profiles.builtins())
+    rows = sorted(read["profiles"].values(),
+                  key=lambda p: (p.name not in order,
+                                 order.index(p.name) if p.name in order else 0, p.name))
+    heads = ("NAME", "KIND", "COMMAND")
+    body = [(contain.readable(p.name), p.kind, profiles.display(p)) for p in rows]
+    widths = [tui.column(h, [row[i] for row in body]) for i, h in enumerate(heads)]
+
+    def line(mark: str, cells, last: str) -> str:
+        return (mark + "".join(tui.pad(c, w) for c, w in zip(cells, widths)) + last).rstrip()
+
+    print(line("  ", heads, "FROM"), file=sys.stderr)
+    for p, cells in zip(rows, body):
+        print(line("* " if p.name == read["default"] else "  ", cells, p.source),
+              file=sys.stderr)
+    if read["refused"]:
+        print("refused:", file=sys.stderr)
+        for r in read["refused"]:
+            print(f"  {r.name or r.source}: {r.reason}", file=sys.stderr)
+    ignored = profiles.ignored_refusal(config.ROOT)
+    if ignored:
+        util.warn(ignored)
+
+
 def cmd_harness_list(args) -> int:
-    """Every registered harness, its ceilings, and which one this session is in."""
+    """Every harness profile, then every registered harness, its ceilings, and which one this
+    session is in."""
+    _list_profiles()
+    print(file=sys.stderr)
     live = registry.current()
     for h in registry.all():
         mark = "*" if h.name == live else " "

--- a/charter/config.py
+++ b/charter/config.py
@@ -721,7 +721,11 @@ def derive(root: Path, start: Path | None = None) -> dict:
     #: read off the profiles. A file read and nothing more — no git call and no subprocess —
     #: because every hook process runs this derivation; whether git would carry the file is
     #: `profiles.ignored_refusal`, asked by the surfaces a person runs.
-    d["PROFILES"] = _profiles.derive(root, cfg)
+    #:
+    #: Held as `ProfileSet._asdict()`, and `profiles.current` rebuilds the tuple: the read
+    #: guard in `tests/_planeguard` stands a refusing `dict` in for a guarded setting, and it
+    #: can stand in for nothing else.
+    d["PROFILES"] = _profiles.derive(root, cfg)._asdict()
 
     #: What bare ``charter`` launches — ``{"default": None, "refused": None}`` unless the
     #: plane opts in with ``[harness] default``. ``default`` is a name out of charter's own

--- a/charter/config.py
+++ b/charter/config.py
@@ -24,7 +24,6 @@ from pathlib import Path
 
 from . import instance as _instance
 from . import legacyenv as _legacyenv
-from . import profiles as _profiles
 from . import root as _root
 
 #: Fallbacks used when a control plane declares nothing (or none was found).
@@ -714,20 +713,11 @@ def derive(root: Path, start: Path | None = None) -> dict:
     #: charter does not recognise degrades to exactly that.
     d["UPDATE"] = _instance.update_of(cfg)
 
-    #: Every harness profile this machine has — the built-ins and what `charter.local.toml`
-    #: declares — and every declared one refused, with its reason. See `charter.profiles`.
-    #:
-    #: Derived BEFORE ``HARNESS`` (review 14): what ``[harness] default`` resolves against is
-    #: read off the profiles. A file read and nothing more — no git call and no subprocess —
-    #: because every hook process runs this derivation. Whether git would carry the file is
-    #: `profiles.ignore_check`, which `charter harness list` and `charter doctor` run —
-    #: including the doctor the SessionStart hook runs, until the plan's Task 4 gives it a
-    #: `--preflight` mode (ruling 40).
-    #:
-    #: Held as `ProfileSet._asdict()`, and `profiles.current` rebuilds the tuple: the read
-    #: guard in `tests/_planeguard` stands a refusing `dict` in for a guarded setting, and it
-    #: can stand in for nothing else.
-    d["PROFILES"] = _profiles.derive(root, cfg)._asdict()
+    # Harness profiles are deliberately NOT derived here (ruling 43, superseding review 14):
+    # nothing reads `charter.local.toml` and no `charter.profiles` code runs on this path.
+    # Every command and every hook process derives config, so a read here was paid on every
+    # tool call, and the deletion sweep charged each line of `charter.profiles` to the whole
+    # suite. `profiles.current()` reads and validates the file when a surface asks.
 
     #: What bare ``charter`` launches — ``{"default": None, "refused": None}`` unless the
     #: plane opts in with ``[harness] default``. ``default`` is a name out of charter's own

--- a/charter/config.py
+++ b/charter/config.py
@@ -24,6 +24,7 @@ from pathlib import Path
 
 from . import instance as _instance
 from . import legacyenv as _legacyenv
+from . import profiles as _profiles
 from . import root as _root
 
 #: Fallbacks used when a control plane declares nothing (or none was found).
@@ -712,6 +713,15 @@ def derive(root: Path, start: Path | None = None) -> dict:
     #: `charter.channel`. ``{"channel": "stable"}`` unless the plane opts in, and a value
     #: charter does not recognise degrades to exactly that.
     d["UPDATE"] = _instance.update_of(cfg)
+
+    #: Every harness profile this machine has — the built-ins and what `charter.local.toml`
+    #: declares — and every declared one refused, with its reason. See `charter.profiles`.
+    #:
+    #: Derived BEFORE ``HARNESS`` (review 14): what ``[harness] default`` resolves against is
+    #: read off the profiles. A file read and nothing more — no git call and no subprocess —
+    #: because every hook process runs this derivation; whether git would carry the file is
+    #: `profiles.ignored_refusal`, asked by the surfaces a person runs.
+    d["PROFILES"] = _profiles.derive(root, cfg)
 
     #: What bare ``charter`` launches — ``{"default": None, "refused": None}`` unless the
     #: plane opts in with ``[harness] default``. ``default`` is a name out of charter's own

--- a/charter/config.py
+++ b/charter/config.py
@@ -719,8 +719,10 @@ def derive(root: Path, start: Path | None = None) -> dict:
     #:
     #: Derived BEFORE ``HARNESS`` (review 14): what ``[harness] default`` resolves against is
     #: read off the profiles. A file read and nothing more — no git call and no subprocess —
-    #: because every hook process runs this derivation; whether git would carry the file is
-    #: `profiles.ignored_refusal`, asked by the surfaces a person runs.
+    #: because every hook process runs this derivation. Whether git would carry the file is
+    #: `profiles.ignore_check`, which `charter harness list` and `charter doctor` run —
+    #: including the doctor the SessionStart hook runs, until the plan's Task 4 gives it a
+    #: `--preflight` mode (ruling 40).
     #:
     #: Held as `ProfileSet._asdict()`, and `profiles.current` rebuilds the tuple: the read
     #: guard in `tests/_planeguard` stands a refusing `dict` in for a guarded setting, and it

--- a/charter/doctor.py
+++ b/charter/doctor.py
@@ -712,10 +712,14 @@ def check_harness_profiles() -> Result:
     from . import config as _config, profiles
 
     name = "harness profiles"
+    # Read first, whatever git says, the way `charter harness list` does: the ignore check
+    # answers from git without opening the file, and a row that skipped the read on a
+    # committable file would be the one surface that reached the operator's own profiles with
+    # no read the suite's guard could see (`tests/_planeguard`, ruling 43).
+    profile_set = profiles.current()
     check = profiles.ignore_check(_config.ROOT)
     if check.reason:
         return Result(name, WARN, detail=check.reason, hint=check.fix)
-    profile_set = profiles.current()
     names = ", ".join(profile_set.profiles)
     refused = profile_set.refused
     if refused:

--- a/charter/doctor.py
+++ b/charter/doctor.py
@@ -691,6 +691,47 @@ def check_plane_root() -> Result:
     )
 
 
+def check_harness_profiles() -> Result:
+    """This machine's harness profiles, as `charter.local.toml` declares them now — and
+    whether git would carry that file.
+
+    Read from `instance.load` and `profiles.derive` rather than `config.PROFILES`, the way the
+    `charter.toml` row reads `instance.harness_of`: the row is about the FILE, and `derive`
+    ran before anybody could have fixed it. Through `profiles.current`, so a name that clashes
+    with a command reads here as it does everywhere else.
+
+    The git check lives here and not in `derive` because a person runs `doctor`, and every
+    hook process runs `derive`. `profiles.ignored_refusal` never raises, so one slow git costs
+    this row and nothing more: `_checks` builds every row in one list with no per-check guard.
+    """
+    from . import config as _config, instance as _instance, profiles
+
+    name = "harness profiles"
+    ignored = profiles.ignored_refusal(_config.ROOT)
+    if ignored:
+        return Result(name, WARN, detail=ignored, hint="charter reinit")
+    # A malformed `charter.toml` is the `charter.toml` row's to name; this row still reads
+    # the local file rather than reporting on nothing.
+    try:
+        cfg = _instance.load(_config.ROOT)
+    except Exception:
+        cfg = {}
+    read = profiles.current(profiles.derive(_config.ROOT, cfg))
+    names = ", ".join(read["profiles"])
+    refused = read["refused"]
+    if refused:
+        return Result(name, WARN,
+                      detail=f"{len(refused)} refused: "
+                             f"{', '.join(r.name or r.source for r in refused)}",
+                      hint=refused[0].reason)
+    if read["default_refused"] is not None:
+        return Result(name, WARN,
+                      detail=profiles.DEFAULT_REFUSED.format(value=read["default_refused"],
+                                                             names=names),
+                      hint="the selector will start on no row until it names one")
+    return Result(name, OK, detail=f"{len(read['profiles'])} profile(s): {names}")
+
+
 def check_index_lock() -> Result:
     """A ``.git/index.lock`` left in the plane's own repository — noticed *before* a save
     runs into it.
@@ -3317,7 +3358,8 @@ def _checks():
     for forge in declared_or_default_forges():
         results.append(check_forge_cli(forge))
         results.append(check_forge_auth(forge))
-    results += [check_ssh(), check_control_plane_config(), check_control_plane_schema(),
+    results += [check_ssh(), check_control_plane_config(), check_harness_profiles(),
+                check_control_plane_schema(),
                 check_plane_root(), check_index_lock(),
                 check_session_root(), check_session_layer(),
                 check_harness(), check_frame(), check_guard_wired(), check_guard_seen(), check_nested_plane(),
@@ -3360,7 +3402,7 @@ def _checks():
 _FIXED_CHECK_NAMES = (
     "python3", "git", "git identity",
     # ← the forge cli/auth pair is spliced in here, see `check_names`
-    "git auth", "charter.toml", "schema", "plane root", "index lock",
+    "git auth", "charter.toml", "harness profiles", "schema", "plane root", "index lock",
     "session root", "session layer",
     "harness", "frame",
     "plane-root guard", "guard seen", "nested plane", "workspace clones",

--- a/charter/doctor.py
+++ b/charter/doctor.py
@@ -695,15 +695,13 @@ def check_harness_profiles() -> Result:
     """This machine's harness profiles, as `charter.local.toml` declares them now — and
     whether git would carry that file.
 
-    Read from `instance.load` and `profiles.derive` rather than `config.PROFILES`, the way the
-    `charter.toml` row reads `instance.harness_of`: the row is about the FILE, and `derive`
-    ran before anybody could have fixed it. Through `profiles.current`, so a name that clashes
-    with a command reads here as it does everywhere else.
+    Through `profiles.current()`, the one reader (ruling 43): it reads the file as it is now,
+    and applies the refusals every surface sees, a name that clashes with a command included.
 
-    The git check lives here and not in `derive` because a person runs `doctor`, and every
-    hook process runs `derive` — though `charter doctor` is also what the SessionStart hook
-    runs, so until doctor has a preflight mode, a session start on a plane with the file
-    pays this one lock-free `git status`. `profiles.ignore_check` never raises, so one slow
+    The git check lives here and not in `profiles.current()` because a person runs `doctor` —
+    though `charter doctor` is also what the SessionStart hook runs, so until doctor has a
+    preflight mode, a session start on a plane with the file pays this one lock-free
+    `git status`. `profiles.ignore_check` never raises, so one slow
     git costs this row and nothing more: `_checks` builds every row in one list with no
     per-check guard.
 
@@ -711,19 +709,13 @@ def check_harness_profiles() -> Result:
     that fixes a committable file only. WARN rather than FAIL even for a tracked file: its
     profiles are refused, so nothing runs.
     """
-    from . import config as _config, instance as _instance, profiles
+    from . import config as _config, profiles
 
     name = "harness profiles"
     check = profiles.ignore_check(_config.ROOT)
     if check.reason:
         return Result(name, WARN, detail=check.reason, hint=check.fix)
-    # A malformed `charter.toml` is the `charter.toml` row's to name; this row still reads
-    # the local file rather than reporting on nothing.
-    try:
-        cfg = _instance.load(_config.ROOT)
-    except Exception:
-        cfg = {}
-    profile_set = profiles.current(profiles.derive(_config.ROOT, cfg))
+    profile_set = profiles.current()
     names = ", ".join(profile_set.profiles)
     refused = profile_set.refused
     if refused:

--- a/charter/doctor.py
+++ b/charter/doctor.py
@@ -701,35 +701,42 @@ def check_harness_profiles() -> Result:
     with a command reads here as it does everywhere else.
 
     The git check lives here and not in `derive` because a person runs `doctor`, and every
-    hook process runs `derive`. `profiles.ignored_refusal` never raises, so one slow git costs
-    this row and nothing more: `_checks` builds every row in one list with no per-check guard.
+    hook process runs `derive` — though `charter doctor` is also what the SessionStart hook
+    runs, so until doctor has a preflight mode, a session start on a plane with the file
+    pays this one lock-free `git status`. `profiles.ignore_check` never raises, so one slow
+    git costs this row and nothing more: `_checks` builds every row in one list with no
+    per-check guard.
+
+    Each state's hint is that state's own fix (F3): `charter reinit` adds the ignore line, and
+    that fixes a committable file only. WARN rather than FAIL even for a tracked file: its
+    profiles are refused, so nothing runs.
     """
     from . import config as _config, instance as _instance, profiles
 
     name = "harness profiles"
-    ignored = profiles.ignored_refusal(_config.ROOT)
-    if ignored:
-        return Result(name, WARN, detail=ignored, hint="charter reinit")
+    check = profiles.ignore_check(_config.ROOT)
+    if check.reason:
+        return Result(name, WARN, detail=check.reason, hint=check.fix)
     # A malformed `charter.toml` is the `charter.toml` row's to name; this row still reads
     # the local file rather than reporting on nothing.
     try:
         cfg = _instance.load(_config.ROOT)
     except Exception:
         cfg = {}
-    read = profiles.current(profiles.derive(_config.ROOT, cfg))
-    names = ", ".join(read["profiles"])
-    refused = read["refused"]
+    profile_set = profiles.current(profiles.derive(_config.ROOT, cfg))
+    names = ", ".join(profile_set.profiles)
+    refused = profile_set.refused
     if refused:
         return Result(name, WARN,
                       detail=f"{len(refused)} refused: "
                              f"{', '.join(r.name or r.source for r in refused)}",
                       hint=refused[0].reason)
-    if read["default_refused"] is not None:
+    if profile_set.default_refused is not None:
         return Result(name, WARN,
-                      detail=profiles.DEFAULT_REFUSED.format(value=read["default_refused"],
+                      detail=profiles.DEFAULT_REFUSED.format(value=profile_set.default_refused,
                                                              names=names),
-                      hint="the selector will start on no row until it names one")
-    return Result(name, OK, detail=f"{len(read['profiles'])} profile(s): {names}")
+                      hint=profiles.DEFAULT_FIX.format(names=names))
+    return Result(name, OK, detail=f"{len(profile_set.profiles)} profile(s): {names}")
 
 
 def check_index_lock() -> Result:

--- a/charter/profiles.py
+++ b/charter/profiles.py
@@ -147,6 +147,11 @@ LOCAL_SECTION = (
 NOT_A_TABLE = (
     "[harness] {name} in charter.local.toml is not a table — a profile is [harness.{name}] "
     "with kind, command and optionally env.")
+NESTED_TABLE = (
+    "[harness.{parent}] holds a table {key}, which charter reads neither way — {key} is not a "
+    "key a profile has (kind, command and env), and if a profile named '{dotted}' was meant, a "
+    "profile's name is letters, digits, '_' and '-', with no dot, because a dot breaks tmux "
+    "targets. Rename the key, or give that profile a name of its own.")
 ILLEGAL_NAME = (
     "profile '{name}' is not a name charter accepts — letters, digits, '_' and '-', starting "
     "with a letter or digit, and no dot, because a dot breaks tmux targets. Rename the table.")
@@ -331,11 +336,16 @@ def derive(root: Path, cfg: dict) -> ProfileSet:
             default, default_from = table, LOCAL_FILE
             continue
         if isinstance(table, dict):
+            # A table under a key that is not a profile key. Once parsed it is either a dotted
+            # name written without quotes or a typo'd key holding an inline table — the two
+            # cannot be told apart — so the refusal names both readings. A table under `kind`,
+            # `command` or `env` is that key's value and is judged as one below.
             nested = [key for key, value in table.items()
-                      if key != _ENV and isinstance(value, dict)]
+                      if key not in _PROFILE_KEYS and isinstance(value, dict)]
             for key in nested:
                 dotted = contain.readable(f"{name}.{key}")
-                refused.append(Refused(dotted, LOCAL_FILE, ILLEGAL_NAME.format(name=dotted)))
+                refused.append(Refused(dotted, LOCAL_FILE, NESTED_TABLE.format(
+                    parent=contain.readable(name), key=contain.readable(key), dotted=dotted)))
             # A parent holding nothing but sub-tables declares nothing, and the built-in of
             # its name stays. One with keys of its own is validated WITH its nested tables:
             # once parsed, `[harness.claude.alt]` and a typo'd `enviroment = { … }` are the
@@ -379,12 +389,15 @@ def _narrowed(derived: ProfileSet, found: dict, refused: list) -> ProfileSet:
 _last: list = []
 
 
-def _bytes(path: Path) -> bytes | None:
-    """*path*'s bytes, or ``None`` when there is nothing to read — part of a memo key."""
+def _bytes(path: Path) -> bytes | tuple | None:
+    """*path*'s bytes, as part of a memo key: ``None`` when there is no such file, and a marker
+    of its own when there is one that cannot be read — so the two never share an answer."""
     try:
         return path.read_bytes()
-    except OSError:
+    except FileNotFoundError:
         return None
+    except OSError as e:
+        return ("unreadable", e.errno)
 
 
 def current() -> ProfileSet:

--- a/charter/profiles.py
+++ b/charter/profiles.py
@@ -1,0 +1,390 @@
+"""Harness profiles — a named way to launch one harness kind, read from `charter.local.toml`.
+
+Charter launched one program per harness kind, one way: `Harness.binary` is a class
+attribute and `launch_argv` returns `[binary, *extra]`. An operator with two Claude Code
+accounts — a work `CLAUDE_CONFIG_DIR` and a personal one — or a Codex pinned to an older
+release had no way to tell charter so, and a shell alias cannot help, because nothing charter
+launches runs through a shell. A profile is that way: a kind, a command, an environment
+(`docs/superpowers/specs/2026-09-11-harness-profiles.md`).
+
+**Only in `charter.local.toml`, beside `charter.toml` and never committed.** A profile's
+command runs on a click with no harness permission prompt in between, so a command in the
+committed file could be changed by a merged PR or by a chat and then run on every machine. A
+`[harness.<name>]` table in `charter.toml` is refused with a pointer here. The local file
+carries `[harness]` and nothing else: a full overlay would let an ignored file change plane
+policy — `[[forge]]` hosts steer the credential guard — with no trace in git.
+
+**Reading costs no subprocess.** :func:`derive` runs inside `config.derive`, which every
+hook process runs, and `hooks/hooks.json` fires on Bash, Read, Grep, Write, Edit, Task, Skill
+and SendMessage. The one git call — would git carry this file? — is :func:`ignored_refusal`,
+and only the surfaces a person runs ask it.
+
+**A broken profile is refused alone, by name, with its reason**, and the rest still load.
+`[[frame.component]]` refuses its whole arrangement over one bad entry, and that is the right
+trade there: a missing panel is easy to miss, while a missing profile is a row that is not in
+the list.
+
+**Every piece of profile-derived text is contained before charter shows it** (ruling 35).
+The file is one a chat can write, and a carriage return or an ESC in a command could
+otherwise redraw a line to show a harmless command while another one runs.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import shlex
+import tomllib
+from pathlib import Path
+from typing import NamedTuple
+
+from . import contain
+from . import root as _root
+
+#: The file profiles live in, beside the plane's `charter.toml`. Named after
+#: `.claude/settings.local.json`, which planes already ignore, and so it sorts beside the
+#: file it sits next to.
+LOCAL_FILE = "charter.local.toml"
+
+#: Words an env NAME may not contain, matched case-insensitively. Anything set on the
+#: harness process reaches the shell the model runs — measured on Claude Code and Codex — so
+#: charter declines to hold a credential in a profile. A pattern can refuse an innocent name;
+#: the docs say so.
+SECRET_WORDS = ("KEY", "TOKEN", "SECRET", "PASSWORD")
+
+#: What a refused secret-shaped name is pointed at instead, by registry name: the harness's
+#: own login, kept in the config folder a profile's environment already moves.
+LOGIN = {"claude-code": "set CLAUDE_CONFIG_DIR and run /login inside Claude Code",
+         "codex": "set CODEX_HOME and run codex login",
+         "opencode": "set XDG_DATA_HOME and run opencode auth login"}
+
+#: Ruling 5. No dot: a dot in a workspace name broke tmux targets in #695, and a profile's
+#: name reaches the same places. Always `fullmatch`: `$` also matches before a final newline,
+#: and a quoted TOML key can end in one.
+NAME_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_-]*$")
+
+#: `Profile.source` for a registered kind nobody declared.
+BUILTIN = "built-in"
+
+#: The one key under `[harness]` that is not a profile: the row a selector starts on.
+_DEFAULT = "default"
+
+#: Everything a profile table may hold. Any other key refuses the profile (review 13): a typo
+#: such as `enviroment` would otherwise drop `CLAUDE_CONFIG_DIR` and launch the default
+#: account without a word.
+_PROFILE_KEYS = frozenset({"kind", "command", "env"})
+
+#: The prefix of charter's own variables. The launcher sets those at exec, and a profile's
+#: value would tell every hook the wrong harness or plane (Ruling 14).
+_CHARTER_PREFIX = "CHARTER_"
+
+
+class Profile(NamedTuple):
+    name: str                          # "claude-work"; a built-in is named after its kind
+    kind: str                          # the word after `charter`: "claude" | "codex" | "opencode"
+    harness: str                       # the registry NAME: "claude-code" | "codex" | "opencode"
+    command: tuple[str, ...]           # as declared, before `~` expansion
+    env: tuple[tuple[str, str], ...]   # as declared, sorted by name
+    source: str                        # BUILTIN | LOCAL_FILE
+
+
+class Refused(NamedTuple):
+    name: str      # contained with contain.readable; "" for a whole-file refusal
+    source: str    # LOCAL_FILE | "charter.toml"
+    reason: str    # one sentence: the rule, then the fix
+
+
+# Each refusal says the rule worked and names the fix in the same breath (CONTEXT.md,
+# *A refusal is the rule working*). Every `{}` field is filled with a contained value, and no
+# value of `env` is ever repeated back — only its NAME.
+PROFILE_IN_COMMITTED = (
+    "[harness.{name}] is in charter.toml, which is committed — a profile's command runs on a "
+    "click, so charter reads profiles only from charter.local.toml, which stays on this "
+    "machine. Move the table there; charter.toml's [harness] keeps `default` alone.")
+LOCAL_UNREADABLE = (
+    "charter.local.toml could not be read ({why}), so no declared profile was loaded — the "
+    "built-in profiles still are. Fix the file and run charter harness list.")
+LOCAL_SECTION = (
+    "[{section}] in charter.local.toml is not read — that file carries [harness] and nothing "
+    "else, because an ignored file must not change plane policy with no trace in git. Put "
+    "[{section}] in charter.toml.")
+NOT_A_TABLE = (
+    "[harness] {name} in charter.local.toml is not a table — a profile is [harness.{name}] "
+    "with kind, command and optionally env.")
+ILLEGAL_NAME = (
+    "profile '{name}' is not a name charter accepts — letters, digits, '_' and '-', starting "
+    "with a letter or digit. Rename the table.")
+RESERVED_NAME = (
+    "a profile cannot be named 'default' — [harness] default names which profile the selector "
+    "starts on. Rename the table.")
+UNKNOWN_KIND = (
+    "profile '{name}' has kind {kind}, which is not a harness charter can launch — one of: "
+    "{kinds}. Set kind to one of them.")
+BAD_COMMAND = (
+    "profile '{name}' has no usable command — command is a list of arguments, [\"claude\"], "
+    "never a shell string, because no shell runs it. Write it as a list.")
+BAD_ENV = (
+    "profile '{name}' has an env that is not a table of text values — write "
+    "env = {{ NAME = \"value\" }}.")
+SECRET_ENV = (
+    "profile '{name}' sets {var}, which is named like a credential — charter holds no "
+    "credential in a profile, because anything set on the harness reaches the model's own "
+    "shell. Log in inside that harness instead: {login}.")
+CHARTER_ENV = (
+    "profile '{name}' sets {var}, one of charter's own variables — the launcher sets those at "
+    "exec, and a profile's value would tell every hook the wrong harness or plane. Remove it.")
+CHARTER_COMMAND = (
+    "profile '{name}' runs charter itself — a new chat on it would open the profile selector "
+    "again, forever. Give it the harness's own command.")
+UNKNOWN_PROFILE_KEY = (
+    "profile '{name}' has {key}, which charter does not read — a profile is kind, command and "
+    "env. Remove it.")
+CLASHING_NAME = (
+    "profile '{name}' is named like the charter command `charter {name}`, which would keep it "
+    "from ever launching. Rename the table.")
+TRACKED = (
+    "git tracks charter.local.toml, so the profiles in it would reach every clone of this "
+    "plane — charter refuses them until it is untracked: git rm --cached charter.local.toml, "
+    "then charter reinit.")
+NOT_IGNORED = (
+    "git would commit charter.local.toml, so the profiles in it are refused until it is "
+    "ignored — charter reinit adds /charter.local.toml to .gitignore.")
+GIT_CANNOT_TELL = (
+    "git could not say whether charter.local.toml is ignored ({why}), so the profiles in it "
+    "are refused — an unknown is not a pass. Nothing was started. Check it by hand: git "
+    "check-ignore -v charter.local.toml")
+DEFAULT_REFUSED = (
+    "[harness] default = \"{value}\" names no profile this machine has — one of: {names}.")
+
+
+def builtins() -> dict[str, Profile]:
+    """One profile per registered harness with a `cli_name`, named after its kind.
+
+    `command` is the harness's own `binary`, which is what `charter <kind>` runs today, so a
+    plane that declares nothing sees no change. Asked of the registry rather than listed:
+    a kind registered tomorrow is a profile the day it is registered.
+    """
+    from .harness import registry
+
+    return {h.cli_name: Profile(h.cli_name, h.cli_name, h.name, (h.binary,), (), BUILTIN)
+            for h in registry.all() if h.cli_name}
+
+
+def _read_local(root: Path) -> tuple[dict, str]:
+    """The local file's top level, and why it could not be read — ``""`` when it could.
+
+    An absent file declares nothing and is not a refusal. Anything else that stops the read
+    is, because a file that is there and says nothing is indistinguishable from one nobody
+    wrote.
+    """
+    try:
+        return tomllib.loads((Path(root) / LOCAL_FILE).read_bytes().decode("utf-8")), ""
+    except FileNotFoundError:
+        return {}, ""
+    except (OSError, UnicodeDecodeError, tomllib.TOMLDecodeError) as e:
+        return {}, str(e)
+
+
+def _profile_refusal(name: str, table, kinds: dict) -> str:
+    """Why the profile *name* is refused, or ``""``. The first failure wins, in the order the
+    rules are written, so one profile gets one sentence."""
+    shown = contain.readable(name)
+    if not isinstance(table, dict):
+        return NOT_A_TABLE.format(name=shown)
+    if NAME_RE.fullmatch(name) is None:
+        return ILLEGAL_NAME.format(name=shown)
+    if name == _DEFAULT:
+        return RESERVED_NAME
+    kind = table.get("kind", "")
+    if not isinstance(kind, str) or kind not in kinds:
+        from . import instance
+
+        return UNKNOWN_KIND.format(name=shown, kind=contain.readable(kind),
+                                   kinds=", ".join(instance.launchable_harnesses()))
+    command = table.get("command")
+    if not (isinstance(command, list) and command
+            and all(isinstance(word, str) and word for word in command)):
+        return BAD_COMMAND.format(name=shown)
+    env = table.get("env", {})
+    if not (isinstance(env, dict) and all(isinstance(v, str) for v in env.values())):
+        return BAD_ENV.format(name=shown)
+    for var in sorted(env):
+        if var.upper().startswith(_CHARTER_PREFIX):
+            return CHARTER_ENV.format(name=shown, var=contain.readable(var))
+    for var in sorted(env):
+        if any(word in var.upper() for word in SECRET_WORDS):
+            # `.get`, never an index: this runs inside `config.derive`, where a kind
+            # registered without a login sentence must cost a sentence, not every command.
+            login = LOGIN.get(kinds[kind].name, "log in inside that harness")
+            return SECRET_ENV.format(name=shown, var=contain.readable(var), login=login)
+    for key in table:
+        if key not in _PROFILE_KEYS:
+            return UNKNOWN_PROFILE_KEY.format(name=shown, key=contain.readable(key))
+    return ""
+
+
+def derive(root: Path, cfg: dict) -> dict:
+    """Every profile this plane has, and every declared one refused with its reason.
+
+    ``{"profiles": {name: Profile}, "refused": tuple[Refused, ...], "default": str | None,
+    "default_from": str | None, "default_refused": str | None}``.
+
+    Never raises and runs no subprocess: `config.derive` calls it for every command and
+    every hook, `charter --version` included.
+
+    1. The built-ins, in registry order.
+    2. `charter.toml`'s `[harness]`: a table there is refused with a pointer to the local
+       file; `default` is the candidate default; any other key is ignored as it always was
+       (review 13 — no warning on a plane that did nothing wrong).
+    3. The local file: only `[harness]` is read; `default` there wins; every other key is a
+       profile, validated by :func:`_profile_refusal`. A declared profile named like a
+       built-in replaces it. A REFUSED one takes the name with it: the operator said how that
+       name runs, and the built-in standing in would run the command they replaced — review
+       13's `enviroment` typo launching the default account, and ruling 19's reason for
+       never falling back to a replaced built-in.
+    4. The default, kept only when it names a profile in the result.
+    """
+    from .harness import registry
+
+    kinds = {h.cli_name: h for h in registry.all() if h.cli_name}
+    found = builtins()
+    refused: list[Refused] = []
+    default = default_from = None
+
+    committed = cfg.get("harness") if isinstance(cfg, dict) else None
+    if isinstance(committed, dict):
+        for key, value in committed.items():
+            if isinstance(value, dict):
+                shown = contain.readable(key)
+                refused.append(Refused(shown, _root.MARKER,
+                                       PROFILE_IN_COMMITTED.format(name=shown)))
+            elif key == _DEFAULT:
+                default, default_from = value, _root.MARKER
+
+    top, why = _read_local(root)
+    if why:
+        refused.append(Refused("", LOCAL_FILE,
+                               LOCAL_UNREADABLE.format(why=contain.readable(why))))
+    for key in top:
+        if key != "harness":
+            shown = contain.readable(key)
+            refused.append(Refused(shown, LOCAL_FILE, LOCAL_SECTION.format(section=shown)))
+    local = top.get("harness", {})
+    if not isinstance(local, dict):
+        refused.append(Refused("", LOCAL_FILE,
+                               LOCAL_UNREADABLE.format(why="[harness] is not a table")))
+        local = {}
+    for name, table in local.items():
+        if name == _DEFAULT and not isinstance(table, dict):
+            default, default_from = table, LOCAL_FILE
+            continue
+        reason = _profile_refusal(name, table, kinds)
+        if reason:
+            found.pop(name, None)
+            refused.append(Refused(contain.readable(name), LOCAL_FILE, reason))
+            continue
+        h = kinds[table["kind"]]
+        found[name] = Profile(name, h.cli_name, h.name, tuple(table["command"]),
+                              tuple(sorted(table.get("env", {}).items())), LOCAL_FILE)
+
+    default_refused = None
+    if default_from is not None:
+        if isinstance(default, str) and default in found:
+            # The result's own name, never the object the file supplied — the rule
+            # `instance.harness_of` keeps for a value that ends up on a command line.
+            default = found[default].name
+        else:
+            default, default_refused = None, contain.readable(default)
+    return {"profiles": found, "refused": tuple(refused), "default": default,
+            "default_from": default_from, "default_refused": default_refused}
+
+
+def current(read: dict | None = None) -> dict:
+    """:func:`derive`'s answer — ``config.PROFILES`` unless *read* is given — with the two
+    refusals that need charter's own commands to decide.
+
+    - A name `charter <name>` already means (`cli.command_words`), with
+      :data:`CLASHING_NAME`. The kind clash in `cli._add_frame_parsers` raises at
+      `build_parser()` and takes every command down, which is right for a registry mistake CI
+      sees and wrong for one machine's file, so a profile is refused by name instead.
+    - A command whose first word is charter itself, with :data:`CHARTER_COMMAND` (Ruling 14).
+      `hooks._is_charter` already knows `charter`, `edm` and `python -m charter`, so there is
+      no second list.
+
+    A separate pass because `config.derive` runs before `cli` and `hooks` can be imported,
+    and importing either there would be a cycle. Every surface reads this, never
+    ``config.PROFILES`` directly. *read* is for a caller whose question is the file as it is
+    now rather than as this process derived it — `doctor`'s row.
+    """
+    from . import cli, config, hooks
+
+    if read is None:
+        read = config.PROFILES
+    words = cli.command_words()
+    found = dict(read["profiles"])
+    refused = list(read["refused"])
+    for name, p in list(found.items()):
+        shown = contain.readable(name)
+        if name in words:
+            reason = CLASHING_NAME.format(name=shown)
+        elif hooks._is_charter(p.command[0], list(p.command[1:])):
+            reason = CHARTER_COMMAND.format(name=shown)
+        else:
+            continue
+        del found[name]
+        refused.append(Refused(shown, p.source, reason))
+    default, default_refused = read["default"], read["default_refused"]
+    if default is not None and default not in found:
+        default, default_refused = None, contain.readable(default)
+    return {"profiles": found, "refused": tuple(refused), "default": default,
+            "default_from": read["default_from"], "default_refused": default_refused}
+
+
+def expanded_command(p: Profile) -> list[str]:
+    """*p*'s command with a leading `~` expanded in its first word only — the program. No
+    shell runs it, so nothing else would; an argument is the harness's to interpret."""
+    return [os.path.expanduser(p.command[0]), *p.command[1:]]
+
+
+def expanded_env(p: Profile) -> dict[str, str]:
+    """*p*'s environment with a leading `~` expanded in every value, which is where a config
+    folder is named and no shell is there to do it."""
+    return {name: os.path.expanduser(value) for name, value in p.env}
+
+
+def display(p: Profile) -> str:
+    """*p* as one line a person reads: `NAME=value` for each variable, then the command.
+
+    Each piece through `contain.readable`, so a control byte is shown escaped and never
+    interpreted (ruling 35): the file is one a chat can write.
+    """
+    pieces = [contain.readable(f"{name}={value}") for name, value in p.env]
+    pieces.append(contain.readable(shlex.join(p.command)))
+    return " ".join(pieces)
+
+
+def ignored_refusal(root: Path) -> str:
+    """Why git would carry *root*'s local file, or ``""`` when it would not.
+
+    ``""`` when the file is absent (it declares nothing), when the plane is not a git
+    repository (nothing to commit to), or when git ignores the file and tracks it not.
+    :data:`TRACKED`, :data:`NOT_IGNORED` or :data:`GIT_CANNOT_TELL` otherwise — an answer git
+    could not give is not a pass.
+
+    The only function here that runs git, and never on a config read: one
+    `util.git_path_state` call, which takes no `index.lock` (ruling 34) and never raises.
+    """
+    from . import util
+
+    # `os.path.exists` and not `Path.exists`: on 3.11 the latter raises for a directory
+    # nobody may search, and a check that raised would cost `doctor` every row after it.
+    if not os.path.exists(os.path.join(root, LOCAL_FILE)):
+        return ""
+    state, why = util.git_path_state(root, LOCAL_FILE)
+    if state == util.TRACKED:
+        return TRACKED
+    if state == util.COMMITTABLE:
+        return NOT_IGNORED
+    if state == util.UNKNOWN_GIT:
+        return GIT_CANNOT_TELL.format(why=contain.readable(why))
+    return ""

--- a/charter/profiles.py
+++ b/charter/profiles.py
@@ -270,8 +270,9 @@ def _profile_refusal(name: str, table, kinds: dict) -> str:
             return CHARTER_ENV.format(name=shown, var=contain.readable(var))
     for var in sorted(env):
         if any(word in var.upper() for word in SECRET_WORDS):
-            # `.get`, never an index: this runs inside `config.derive`, where a kind
-            # registered without a login sentence must cost a sentence, not every command.
+            # `.get`, never an index: `current()` runs this for doctor's row and the
+            # listing, and doctor is what the operator runs when something is wrong, so a
+            # kind registered without a login sentence costs a sentence, not the row.
             login = LOGIN.get(kinds[kind].name, "log in inside that harness")
             return SECRET_ENV.format(name=shown, var=contain.readable(var), login=login)
     for key in table:

--- a/charter/profiles.py
+++ b/charter/profiles.py
@@ -16,7 +16,7 @@ policy — `[[forge]]` hosts steer the credential guard — with no trace in git
 
 **Reading costs no subprocess.** :func:`derive` runs inside `config.derive`, which every
 hook process runs, and `hooks/hooks.json` fires on Bash, Read, Grep, Write, Edit, Task, Skill
-and SendMessage. The one git call — would git carry this file? — is :func:`ignored_refusal`,
+and SendMessage. The one git call — would git carry this file? — is :func:`ignore_check`,
 and only the surfaces a person runs ask it.
 
 **A broken profile is refused alone, by name, with its reason**, and the rest still load.
@@ -66,16 +66,21 @@ NAME_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_-]*$")
 #: `Profile.source` for a registered kind nobody declared.
 BUILTIN = "built-in"
 
-#: The one key under `[harness]` that is not a profile: the row a selector starts on.
+#: The one key under `[harness]` that is not a profile: it names the default profile rather
+#: than declaring one.
 _DEFAULT = "default"
+
+#: The one table a profile's own table may hold: its environment. Any other table inside it
+#: is a dotted name written without quotes — `[harness.claude.alt]` — and is refused by that
+#: spelling (F4).
+_ENV = "env"
 
 #: Everything a profile table may hold. Any other key refuses the profile (review 13): a typo
 #: such as `enviroment` would otherwise drop `CLAUDE_CONFIG_DIR` and launch the default
 #: account without a word.
-_PROFILE_KEYS = frozenset({"kind", "command", "env"})
+_PROFILE_KEYS = frozenset({"kind", "command", _ENV})
 
-#: The prefix of charter's own variables. The launcher sets those at exec, and a profile's
-#: value would tell every hook the wrong harness or plane (Ruling 14).
+#: The prefix of charter's own variables, which charter sets itself (Ruling 14).
 _CHARTER_PREFIX = "CHARTER_"
 
 
@@ -94,9 +99,33 @@ class Refused(NamedTuple):
     reason: str    # one sentence: the rule, then the fix
 
 
+class ProfileSet(NamedTuple):
+    """Every profile a plane has, every declared one refused, and the default.
+
+    :func:`derive`, :func:`current` and :func:`with_ignore_check` all answer in this shape,
+    so a caller reads attributes, and a misspelt one is an `AttributeError` at the line that
+    misspelt it rather than a `KeyError` wherever the dict was next read. `config.PROFILES`
+    holds it as ``._asdict()``, for one reason: `tests/_planeguard` refuses a test's read of a
+    setting by standing a refusing `dict` in for it, and it can stand in for nothing else.
+    """
+    profiles: dict[str, Profile]
+    refused: tuple[Refused, ...]
+    default: str | None
+    default_from: str | None
+    default_refused: str | None
+
+
+class IgnoreCheck(NamedTuple):
+    """Whether git would carry the local file: the refusal, and the one fix for its state.
+    Both are ``""`` when the file may be used."""
+    reason: str
+    fix: str
+
+
 # Each refusal says the rule worked and names the fix in the same breath (CONTEXT.md,
-# *A refusal is the rule working*). Every `{}` field is filled with a contained value, and no
-# value of `env` is ever repeated back — only its NAME.
+# *A refusal is the rule working*), and says only what is true of this charter — no feature a
+# later release brings. Every `{}` field is filled with a contained value, and no value of
+# `env` is ever repeated back — only its NAME.
 PROFILE_IN_COMMITTED = (
     "[harness.{name}] is in charter.toml, which is committed — a profile's command runs on a "
     "click, so charter reads profiles only from charter.local.toml, which stays on this "
@@ -104,6 +133,10 @@ PROFILE_IN_COMMITTED = (
 LOCAL_UNREADABLE = (
     "charter.local.toml could not be read ({why}), so no declared profile was loaded — the "
     "built-in profiles still are. Fix the file and run charter harness list.")
+HARNESS_NOT_A_TABLE = (
+    "harness in charter.local.toml is not a table, so no declared profile was read — the "
+    "file holds a [harness] table with one [harness.<name>] table per profile. Write it that "
+    "way.")
 LOCAL_SECTION = (
     "[{section}] in charter.local.toml is not read — that file carries [harness] and nothing "
     "else, because an ignored file must not change plane policy with no trace in git. Put "
@@ -113,10 +146,10 @@ NOT_A_TABLE = (
     "with kind, command and optionally env.")
 ILLEGAL_NAME = (
     "profile '{name}' is not a name charter accepts — letters, digits, '_' and '-', starting "
-    "with a letter or digit. Rename the table.")
+    "with a letter or digit, and no dot, because a dot breaks tmux targets. Rename the table.")
 RESERVED_NAME = (
-    "a profile cannot be named 'default' — [harness] default names which profile the selector "
-    "starts on. Rename the table.")
+    "a profile cannot be named 'default' — `default` is the one key under [harness] that is "
+    "not a profile. Rename the table.")
 UNKNOWN_KIND = (
     "profile '{name}' has kind {kind}, which is not a harness charter can launch — one of: "
     "{kinds}. Set kind to one of them.")
@@ -131,43 +164,61 @@ SECRET_ENV = (
     "credential in a profile, because anything set on the harness reaches the model's own "
     "shell. Log in inside that harness instead: {login}.")
 CHARTER_ENV = (
-    "profile '{name}' sets {var}, one of charter's own variables — the launcher sets those at "
-    "exec, and a profile's value would tell every hook the wrong harness or plane. Remove it.")
+    "profile '{name}' sets {var}, one of charter's own variables — charter sets those itself, "
+    "and a profile's value would tell every hook the wrong harness or plane. Remove it.")
 CHARTER_COMMAND = (
-    "profile '{name}' runs charter itself — a new chat on it would open the profile selector "
-    "again, forever. Give it the harness's own command.")
+    "profile '{name}' runs charter itself — a profile names the harness a chat runs, and "
+    "charter is not a harness. Give it the harness's own command.")
 UNKNOWN_PROFILE_KEY = (
     "profile '{name}' has {key}, which charter does not read — a profile is kind, command and "
     "env. Remove it.")
 CLASHING_NAME = (
-    "profile '{name}' is named like the charter command `charter {name}`, which would keep it "
-    "from ever launching. Rename the table.")
-TRACKED = (
+    "profile '{name}' is named like the command `charter {name}`, and that name belongs to "
+    "the command. Rename the table.")
+TRACKED_FILE = (
     "git tracks charter.local.toml, so the profiles in it would reach every clone of this "
     "plane — charter refuses them until it is untracked: git rm --cached charter.local.toml, "
-    "then charter reinit.")
+    "commit that removal, then charter reinit.")
 NOT_IGNORED = (
     "git would commit charter.local.toml, so the profiles in it are refused until it is "
     "ignored — charter reinit adds /charter.local.toml to .gitignore.")
 GIT_CANNOT_TELL = (
     "git could not say whether charter.local.toml is ignored ({why}), so the profiles in it "
-    "are refused — an unknown is not a pass. Nothing was started. Check it by hand: git "
-    "check-ignore -v charter.local.toml")
+    "are refused — an unknown is not a pass. Run git status --ignored -- charter.local.toml "
+    "in the plane to see what git says.")
 DEFAULT_REFUSED = (
     "[harness] default = \"{value}\" names no profile this machine has — one of: {names}.")
 
+# One fix per state (F3). `charter reinit` adds the ignore line, which fixes exactly one of
+# the three: it does not untrack a tracked file — until the removal is committed, status
+# still prints `D ` beside `!!` — and it does not make git answer.
+FIX_NOT_IGNORED = "charter reinit"
+FIX_TRACKED = "git rm --cached charter.local.toml, commit that removal, then charter reinit"
+FIX_CANNOT_TELL = ("run git status --ignored -- charter.local.toml in the plane by hand; "
+                   "git said: {why}")
+DEFAULT_FIX = "set [harness] default to one of: {names}, or delete the key"
 
-def builtins() -> dict[str, Profile]:
+
+def _kinds() -> dict:
+    """Every launchable kind, by the word typed after `charter`, in registry order — the order
+    `instance.launchable_harnesses` reports them in."""
+    from .harness import registry
+
+    return {h.cli_name: h for h in registry.all() if h.cli_name}
+
+
+def builtins(kinds: dict | None = None) -> dict[str, Profile]:
     """One profile per registered harness with a `cli_name`, named after its kind.
 
     `command` is the harness's own `binary`, which is what `charter <kind>` runs today, so a
     plane that declares nothing sees no change. Asked of the registry rather than listed:
-    a kind registered tomorrow is a profile the day it is registered.
+    a kind registered tomorrow is a profile the day it is registered. *kinds* is
+    :func:`derive`'s own answer, passed through so one read asks the registry once.
     """
-    from .harness import registry
-
-    return {h.cli_name: Profile(h.cli_name, h.cli_name, h.name, (h.binary,), (), BUILTIN)
-            for h in registry.all() if h.cli_name}
+    if kinds is None:
+        kinds = _kinds()
+    return {word: Profile(word, word, h.name, (h.binary,), (), BUILTIN)
+            for word, h in kinds.items()}
 
 
 def _read_local(root: Path) -> tuple[dict, str]:
@@ -197,15 +248,13 @@ def _profile_refusal(name: str, table, kinds: dict) -> str:
         return RESERVED_NAME
     kind = table.get("kind", "")
     if not isinstance(kind, str) or kind not in kinds:
-        from . import instance
-
         return UNKNOWN_KIND.format(name=shown, kind=contain.readable(kind),
-                                   kinds=", ".join(instance.launchable_harnesses()))
+                                   kinds=", ".join(kinds))
     command = table.get("command")
     if not (isinstance(command, list) and command
             and all(isinstance(word, str) and word for word in command)):
         return BAD_COMMAND.format(name=shown)
-    env = table.get("env", {})
+    env = table.get(_ENV, {})
     if not (isinstance(env, dict) and all(isinstance(v, str) for v in env.values())):
         return BAD_ENV.format(name=shown)
     for var in sorted(env):
@@ -223,11 +272,8 @@ def _profile_refusal(name: str, table, kinds: dict) -> str:
     return ""
 
 
-def derive(root: Path, cfg: dict) -> dict:
+def derive(root: Path, cfg: dict) -> ProfileSet:
     """Every profile this plane has, and every declared one refused with its reason.
-
-    ``{"profiles": {name: Profile}, "refused": tuple[Refused, ...], "default": str | None,
-    "default_from": str | None, "default_refused": str | None}``.
 
     Never raises and runs no subprocess: `config.derive` calls it for every command and
     every hook, `charter --version` included.
@@ -237,17 +283,19 @@ def derive(root: Path, cfg: dict) -> dict:
        file; `default` is the candidate default; any other key is ignored as it always was
        (review 13 — no warning on a plane that did nothing wrong).
     3. The local file: only `[harness]` is read; `default` there wins; every other key is a
-       profile, validated by :func:`_profile_refusal`. A declared profile named like a
-       built-in replaces it. A REFUSED one takes the name with it: the operator said how that
-       name runs, and the built-in standing in would run the command they replaced — review
-       13's `enviroment` typo launching the default account, and ruling 19's reason for
-       never falling back to a replaced built-in.
+       profile, validated by :func:`_profile_refusal`.
+       - A table inside a profile's table, other than `env`, is a dotted name written without
+         quotes, and is refused by its dotted spelling for the dot, as `[harness."a.b"]` is.
+         The parent is a declaration only when it carries keys of its own (F4), so
+         `[harness.claude.alt]` alone leaves the built-in `claude` alone.
+       - A declared profile named like a built-in replaces it. A REFUSED one takes the name
+         with it (ruling 37, extending ruling 19): the operator said how that name runs, and
+         the built-in standing in would run the command they replaced — review 13's
+         `enviroment` typo launching the default account is that case exactly.
     4. The default, kept only when it names a profile in the result.
     """
-    from .harness import registry
-
-    kinds = {h.cli_name: h for h in registry.all() if h.cli_name}
-    found = builtins()
+    kinds = _kinds()
+    found = builtins(kinds)
     refused: list[Refused] = []
     default = default_from = None
 
@@ -271,13 +319,27 @@ def derive(root: Path, cfg: dict) -> dict:
             refused.append(Refused(shown, LOCAL_FILE, LOCAL_SECTION.format(section=shown)))
     local = top.get("harness", {})
     if not isinstance(local, dict):
-        refused.append(Refused("", LOCAL_FILE,
-                               LOCAL_UNREADABLE.format(why="[harness] is not a table")))
+        # Its own sentence (F5): the file parsed, so calling it unreadable would send the
+        # reader to fix TOML that is fine — ADR 0009's rule that an answer says its kind.
+        refused.append(Refused("", LOCAL_FILE, HARNESS_NOT_A_TABLE))
         local = {}
     for name, table in local.items():
         if name == _DEFAULT and not isinstance(table, dict):
             default, default_from = table, LOCAL_FILE
             continue
+        if isinstance(table, dict):
+            nested = [key for key, value in table.items()
+                      if key != _ENV and isinstance(value, dict)]
+            for key in nested:
+                dotted = contain.readable(f"{name}.{key}")
+                refused.append(Refused(dotted, LOCAL_FILE, ILLEGAL_NAME.format(name=dotted)))
+            # A parent holding nothing but sub-tables declares nothing, and the built-in of
+            # its name stays. One with keys of its own is validated WITH its nested tables:
+            # once parsed, `[harness.claude.alt]` and a typo'd `enviroment = { … }` are the
+            # same thing — a table under the profile — and review 13 needs the typo to
+            # refuse the profile rather than drop `CLAUDE_CONFIG_DIR` in silence.
+            if nested and len(nested) == len(table):
+                continue
         reason = _profile_refusal(name, table, kinds)
         if reason:
             found.pop(name, None)
@@ -285,7 +347,7 @@ def derive(root: Path, cfg: dict) -> dict:
             continue
         h = kinds[table["kind"]]
         found[name] = Profile(name, h.cli_name, h.name, tuple(table["command"]),
-                              tuple(sorted(table.get("env", {}).items())), LOCAL_FILE)
+                              tuple(sorted(table.get(_ENV, {}).items())), LOCAL_FILE)
 
     default_refused = None
     if default_from is not None:
@@ -295,12 +357,21 @@ def derive(root: Path, cfg: dict) -> dict:
             default = found[default].name
         else:
             default, default_refused = None, contain.readable(default)
-    return {"profiles": found, "refused": tuple(refused), "default": default,
-            "default_from": default_from, "default_refused": default_refused}
+    return ProfileSet(found, tuple(refused), default, default_from, default_refused)
 
 
-def current(read: dict | None = None) -> dict:
-    """:func:`derive`'s answer — ``config.PROFILES`` unless *read* is given — with the two
+def _narrowed(derived: ProfileSet, found: dict, refused: list) -> ProfileSet:
+    """*derived* with *found* as its profiles and *refused* as its refusals, and a default
+    that named a profile no longer found refused by value."""
+    default, default_refused = derived.default, derived.default_refused
+    if default is not None and default not in found:
+        default, default_refused = None, contain.readable(default)
+    return derived._replace(profiles=found, refused=tuple(refused), default=default,
+                            default_refused=default_refused)
+
+
+def current(derived: ProfileSet | None = None) -> ProfileSet:
+    """:func:`derive`'s answer — ``config.PROFILES`` unless *derived* is given — with the two
     refusals that need charter's own commands to decide.
 
     - A name `charter <name>` already means (`cli.command_words`), with
@@ -313,16 +384,16 @@ def current(read: dict | None = None) -> dict:
 
     A separate pass because `config.derive` runs before `cli` and `hooks` can be imported,
     and importing either there would be a cycle. Every surface reads this, never
-    ``config.PROFILES`` directly. *read* is for a caller whose question is the file as it is
-    now rather than as this process derived it — `doctor`'s row.
+    ``config.PROFILES`` directly. *derived* is for a caller whose question is the file as it
+    is now rather than as this process derived it — `doctor`'s row.
     """
     from . import cli, config, hooks
 
-    if read is None:
-        read = config.PROFILES
+    if derived is None:
+        derived = ProfileSet(**config.PROFILES)
     words = cli.command_words()
-    found = dict(read["profiles"])
-    refused = list(read["refused"])
+    found = dict(derived.profiles)
+    refused = list(derived.refused)
     for name, p in list(found.items()):
         shown = contain.readable(name)
         if name in words:
@@ -333,11 +404,25 @@ def current(read: dict | None = None) -> dict:
             continue
         del found[name]
         refused.append(Refused(shown, p.source, reason))
-    default, default_refused = read["default"], read["default_refused"]
-    if default is not None and default not in found:
-        default, default_refused = None, contain.readable(default)
-    return {"profiles": found, "refused": tuple(refused), "default": default,
-            "default_from": read["default_from"], "default_refused": default_refused}
+    return _narrowed(derived, found, refused)
+
+
+def with_ignore_check(derived: ProfileSet, check: IgnoreCheck) -> ProfileSet:
+    """*derived* with every profile the local file declares refused, when *check* says git
+    would carry that file (F1).
+
+    `NOT_IGNORED`, `TRACKED_FILE` and `GIT_CANNOT_TELL` each say "the profiles in it are
+    refused", so a surface that asked must show them refused — not as ordinary rows with a
+    warning under them. A declared replacement of a built-in is refused with the rest and the
+    built-in does not stand in (ruling 19). Takes the check rather than running it, so a
+    caller that also prints the state's fix asks git once.
+    """
+    if not check.reason:
+        return derived
+    found = {name: p for name, p in derived.profiles.items() if p.source != LOCAL_FILE}
+    moved = [Refused(contain.readable(name), LOCAL_FILE, check.reason)
+             for name, p in derived.profiles.items() if p.source == LOCAL_FILE]
+    return _narrowed(derived, found, [*derived.refused, *moved])
 
 
 def expanded_command(p: Profile) -> list[str]:
@@ -363,13 +448,13 @@ def display(p: Profile) -> str:
     return " ".join(pieces)
 
 
-def ignored_refusal(root: Path) -> str:
-    """Why git would carry *root*'s local file, or ``""`` when it would not.
+def ignore_check(root: Path) -> IgnoreCheck:
+    """Whether git would carry *root*'s local file, as a refusal and the fix for its state.
 
-    ``""`` when the file is absent (it declares nothing), when the plane is not a git
-    repository (nothing to commit to), or when git ignores the file and tracks it not.
-    :data:`TRACKED`, :data:`NOT_IGNORED` or :data:`GIT_CANNOT_TELL` otherwise — an answer git
-    could not give is not a pass.
+    A pass — both ``""`` — when the file is absent (it declares nothing), when the plane is
+    not a git repository (nothing to commit to), or when git ignores the file and tracks it
+    not. Otherwise :data:`TRACKED_FILE`, :data:`NOT_IGNORED` or :data:`GIT_CANNOT_TELL`, each
+    with its own fix (F3) — an answer git could not give is not a pass.
 
     The only function here that runs git, and never on a config read: one
     `util.git_path_state` call, which takes no `index.lock` (ruling 34) and never raises.
@@ -379,12 +464,18 @@ def ignored_refusal(root: Path) -> str:
     # `os.path.exists` and not `Path.exists`: on 3.11 the latter raises for a directory
     # nobody may search, and a check that raised would cost `doctor` every row after it.
     if not os.path.exists(os.path.join(root, LOCAL_FILE)):
-        return ""
+        return IgnoreCheck("", "")
     state, why = util.git_path_state(root, LOCAL_FILE)
     if state == util.TRACKED:
-        return TRACKED
+        return IgnoreCheck(TRACKED_FILE, FIX_TRACKED)
     if state == util.COMMITTABLE:
-        return NOT_IGNORED
+        return IgnoreCheck(NOT_IGNORED, FIX_NOT_IGNORED)
     if state == util.UNKNOWN_GIT:
-        return GIT_CANNOT_TELL.format(why=contain.readable(why))
-    return ""
+        shown = contain.readable(why)
+        return IgnoreCheck(GIT_CANNOT_TELL.format(why=shown), FIX_CANNOT_TELL.format(why=shown))
+    return IgnoreCheck("", "")
+
+
+def ignored_refusal(root: Path) -> str:
+    """:func:`ignore_check`'s refusal alone — ``""`` when the file may be used."""
+    return ignore_check(root).reason

--- a/charter/profiles.py
+++ b/charter/profiles.py
@@ -17,7 +17,9 @@ policy — `[[forge]]` hosts steer the credential guard — with no trace in git
 **Reading costs no subprocess.** :func:`derive` runs inside `config.derive`, which every
 hook process runs, and `hooks/hooks.json` fires on Bash, Read, Grep, Write, Edit, Task, Skill
 and SendMessage. The one git call — would git carry this file? — is :func:`ignore_check`,
-and only the surfaces a person runs ask it.
+and `charter harness list` and `charter doctor` ask it. Doctor is also what the SessionStart
+hook runs, so until the plan's Task 4 gives it a `--preflight` mode, a session start on a
+plane that has the file pays that one lock-free `git status` (ruling 40).
 
 **A broken profile is refused alone, by name, with its reason**, and the rest still load.
 `[[frame.component]]` refuses its whole arrangement over one bad entry, and that is the right

--- a/charter/profiles.py
+++ b/charter/profiles.py
@@ -14,12 +14,15 @@ committed file could be changed by a merged PR or by a chat and then run on ever
 carries `[harness]` and nothing else: a full overlay would let an ignored file change plane
 policy — `[[forge]]` hosts steer the credential guard — with no trace in git.
 
-**Reading costs no subprocess.** :func:`derive` runs inside `config.derive`, which every
-hook process runs, and `hooks/hooks.json` fires on Bash, Read, Grep, Write, Edit, Task, Skill
-and SendMessage. The one git call — would git carry this file? — is :func:`ignore_check`,
-and `charter harness list` and `charter doctor` ask it. Doctor is also what the SessionStart
-hook runs, so until the plan's Task 4 gives it a `--preflight` mode, a session start on a
-plane that has the file pays that one lock-free `git status` (ruling 40).
+**Nothing here runs on import (ruling 43).** `config` reads nothing from
+`charter.local.toml` and runs none of this code: every command and every hook process
+derives config, and `hooks/hooks.json` fires on Bash, Read, Grep, Write, Edit, Task, Skill
+and SendMessage — and the deletion sweep charged every line imported there to the whole
+suite. :func:`current` reads and validates the file when a surface asks — `charter harness
+list` and `charter doctor` today — and runs no subprocess. The one git call — would git
+carry this file? — is :func:`ignore_check`, asked by the same two surfaces. Doctor is also
+what the SessionStart hook runs, so until the plan's Task 4 gives it a `--preflight` mode, a
+session start on a plane that has the file pays that one lock-free `git status` (ruling 40).
 
 **A broken profile is refused alone, by name, with its reason**, and the rest still load.
 `[[frame.component]]` refuses its whole arrangement over one bad entry, and that is the right
@@ -106,9 +109,7 @@ class ProfileSet(NamedTuple):
 
     :func:`derive`, :func:`current` and :func:`with_ignore_check` all answer in this shape,
     so a caller reads attributes, and a misspelt one is an `AttributeError` at the line that
-    misspelt it rather than a `KeyError` wherever the dict was next read. `config.PROFILES`
-    holds it as ``._asdict()``, for one reason: `tests/_planeguard` refuses a test's read of a
-    setting by standing a refusing `dict` in for it, and it can stand in for nothing else.
+    misspelt it rather than a `KeyError` wherever the dict was next read.
     """
     profiles: dict[str, Profile]
     refused: tuple[Refused, ...]
@@ -277,8 +278,8 @@ def _profile_refusal(name: str, table, kinds: dict) -> str:
 def derive(root: Path, cfg: dict) -> ProfileSet:
     """Every profile this plane has, and every declared one refused with its reason.
 
-    Never raises and runs no subprocess: `config.derive` calls it for every command and
-    every hook, `charter --version` included.
+    Never raises and runs no subprocess. :func:`current` is its one caller outside the
+    tests, and nothing calls it on import (ruling 43).
 
     1. The built-ins, in registry order.
     2. `charter.toml`'s `[harness]`: a table there is refused with a pointer to the local
@@ -372,9 +373,30 @@ def _narrowed(derived: ProfileSet, found: dict, refused: list) -> ProfileSet:
                             default_refused=default_refused)
 
 
-def current(derived: ProfileSet | None = None) -> ProfileSet:
-    """:func:`derive`'s answer — ``config.PROFILES`` unless *derived* is given — with the two
-    refusals that need charter's own commands to decide.
+#: The last answer :func:`current` gave, with the key it was computed for: the plane's root
+#: and the bytes its two files held. One slot, per process — a second caller asks no parse
+#: and no validation again, and an edit changes the key, so the answer is never stale.
+_last: list = []
+
+
+def _bytes(path: Path) -> bytes | None:
+    """*path*'s bytes, or ``None`` when there is nothing to read — part of a memo key."""
+    try:
+        return path.read_bytes()
+    except OSError:
+        return None
+
+
+def current() -> ProfileSet:
+    """Every profile this plane has, validated — the one place profiles are read (ruling 43).
+
+    `config` reads nothing from `charter.local.toml`, so this reads `charter.toml` and the
+    local file itself, as they are now: `charter harness list` and `charter doctor` call it
+    today, and the launcher, bare launch, `+` and the selector will from Task 2 on. The
+    local `default` is resolved here and nowhere else, which is why `config.HARNESS` — what
+    bare `charter` launches — stays exactly `charter.toml`'s.
+
+    On top of :func:`derive`, the two refusals that need charter's own commands to decide:
 
     - A name `charter <name>` already means (`cli.command_words`), with
       :data:`CLASHING_NAME`. The kind clash in `cli._add_frame_parsers` raises at
@@ -384,15 +406,21 @@ def current(derived: ProfileSet | None = None) -> ProfileSet:
       `hooks._is_charter` already knows `charter`, `edm` and `python -m charter`, so there is
       no second list.
 
-    A separate pass because `config.derive` runs before `cli` and `hooks` can be imported,
-    and importing either there would be a cycle. Every surface reads this, never
-    ``config.PROFILES`` directly. *derived* is for a caller whose question is the file as it
-    is now rather than as this process derived it — `doctor`'s row.
+    Memoized per process, keyed on what the two files hold (:data:`_last`).
     """
-    from . import cli, config, hooks
+    from . import cli, config, hooks, instance
 
-    if derived is None:
-        derived = ProfileSet(**config.PROFILES)
+    root = Path(config.ROOT)
+    key = (str(root), _bytes(root / LOCAL_FILE), _bytes(root / _root.MARKER))
+    if _last and _last[0][0] == key:
+        return _last[0][1]
+    try:
+        cfg = instance.load(root)
+    except Exception:
+        # A malformed or too-new `charter.toml` is the `charter.toml` doctor row's to name;
+        # the local file is still read rather than reporting on nothing.
+        cfg = {}
+    derived = derive(root, cfg)
     words = cli.command_words()
     found = dict(derived.profiles)
     refused = list(derived.refused)
@@ -406,7 +434,9 @@ def current(derived: ProfileSet | None = None) -> ProfileSet:
             continue
         del found[name]
         refused.append(Refused(shown, p.source, reason))
-    return _narrowed(derived, found, refused)
+    answer = _narrowed(derived, found, refused)
+    _last[:] = [(key, answer)]
+    return answer
 
 
 def with_ignore_check(derived: ProfileSet, check: IgnoreCheck) -> ProfileSet:

--- a/charter/util.py
+++ b/charter/util.py
@@ -451,8 +451,13 @@ NOT_A_REPO, TRACKED, IGNORED, COMMITTABLE, UNKNOWN_GIT = (
 #: The letters porcelain v1 uses for a path git tracks, in either column.
 _TRACKED_STATUS = frozenset(" MTADRCU")
 
+#: How long :func:`git_path_state` waits for its one `git status`, in seconds. A constant
+#: rather than a parameter: no caller has ever needed another, and a knob nobody turns is a
+#: second place the answer could come from.
+_GIT_STATE_TIMEOUT = 5.0
 
-def git_path_state(root, path, *, timeout: float = 5.0) -> tuple[str, str]:
+
+def git_path_state(root, path) -> tuple[str, str]:
     """``(state, why)`` for the existing *path* inside *root*: one of :data:`NOT_A_REPO`,
     :data:`TRACKED`, :data:`IGNORED`, :data:`COMMITTABLE` or :data:`UNKNOWN_GIT`, and, for
     that last one, what git said. Never raises.
@@ -482,7 +487,7 @@ def git_path_state(root, path, *, timeout: float = 5.0) -> tuple[str, str]:
     cmd = ["git", "--no-optional-locks", "-C", str(root), "status", "--porcelain=v1",
            "--ignored=matching", "--untracked-files=all", "--", str(path)]
     try:
-        proc = run(cmd, check=False, timeout=timeout, env={"LC_ALL": "C"})
+        proc = run(cmd, check=False, timeout=_GIT_STATE_TIMEOUT, env={"LC_ALL": "C"})
     except (ProcTimeout, OSError) as e:
         return UNKNOWN_GIT, str(e)
     said = (proc.stderr or "").strip()
@@ -490,17 +495,20 @@ def git_path_state(root, path, *, timeout: float = 5.0) -> tuple[str, str]:
         if proc.returncode == 128 and "not a git repository" in said:
             return NOT_A_REPO, ""
         return UNKNOWN_GIT, said.splitlines()[0] if said else f"git exited {proc.returncode}"
-    codes = set()
-    for line in (proc.stdout or "").splitlines():
+    # What the porcelain lines say, kept apart from the states they decide: a tracked line
+    # anywhere wins, because the next commit carries the file whatever else is printed.
+    lines = (proc.stdout or "").splitlines()
+    tracked = untracked = False
+    for line in lines:
         code = line[:2]
-        if code in ("??", "!!"):
-            codes.add(code)
+        if code == "??":
+            untracked = True
+        elif code == "!!":
+            continue
         elif set(code) <= _TRACKED_STATUS:
-            codes.add(TRACKED)
+            tracked = True
         else:
             return UNKNOWN_GIT, f"git status printed {line!r}"
-    if not codes or TRACKED in codes:
+    if tracked or not lines:
         return TRACKED, ""
-    if "??" in codes:
-        return COMMITTABLE, ""
-    return IGNORED, ""
+    return (COMMITTABLE, "") if untracked else (IGNORED, "")

--- a/charter/util.py
+++ b/charter/util.py
@@ -505,7 +505,7 @@ def git_path_state(root, path) -> tuple[str, str]:
             untracked = True
         elif code == "!!":
             continue
-        elif set(code) <= _TRACKED_STATUS:
+        elif set(code).issubset(_TRACKED_STATUS):
             tracked = True
         else:
             return UNKNOWN_GIT, f"git status printed {line!r}"

--- a/charter/util.py
+++ b/charter/util.py
@@ -440,3 +440,67 @@ def git_ignores(root, path) -> bool | None:
         return None
     return run(["git", "-C", str(root), "check-ignore", "-q", str(path)],
                check=False).returncode == 0
+
+
+#: What git says about one path, as :func:`git_path_state` reports it. Five answers and not
+#: :func:`git_ignores`' ``bool | None``, because "git could not look" has to be one of them: a
+#: probe whose failure reads as its benign answer is a check that fails open (#917).
+NOT_A_REPO, TRACKED, IGNORED, COMMITTABLE, UNKNOWN_GIT = (
+    "not-a-repo", "tracked", "ignored", "committable", "unknown")
+
+#: The letters porcelain v1 uses for a path git tracks, in either column.
+_TRACKED_STATUS = frozenset(" MTADRCU")
+
+
+def git_path_state(root, path, *, timeout: float = 5.0) -> tuple[str, str]:
+    """``(state, why)`` for the existing *path* inside *root*: one of :data:`NOT_A_REPO`,
+    :data:`TRACKED`, :data:`IGNORED`, :data:`COMMITTABLE` or :data:`UNKNOWN_GIT`, and, for
+    that last one, what git said. Never raises.
+
+    Beside :func:`git_ignores` and not a change to it (review 4): `commands_secrets` and
+    `doctor.check_credential_paths` read that one's ``None`` for every non-zero `rev-parse`
+    as "not a repository", and a timeout added there would raise into both.
+
+    **One git call** (re-review N8), measured on git 2.50.1 for a file that exists:
+
+    - rc 0, ``?? <path>`` — git would commit it: :data:`COMMITTABLE`.
+    - rc 0, ``!! <path>`` — ignored and untracked: :data:`IGNORED`.
+    - rc 0 and nothing printed, or any tracked status (`` M``, or ``D `` beside ``!!`` after
+      `git rm --cached` and before the commit): :data:`TRACKED`, ignored or not, because the
+      next commit still carries it.
+    - rc 128 with ``not a git repository``: :data:`NOT_A_REPO`.
+    - anything else — another rc 128 such as ``dubious ownership``, git missing, a timeout, a
+      status line this cannot read: :data:`UNKNOWN_GIT`. An unknown is not a pass.
+
+    ``--no-optional-locks`` because a plain `status` refreshes the index and takes
+    `index.lock` when it can, and this runs often enough to break a concurrent `charter save`
+    — #917's failure (ruling 34). ``LC_ALL=C`` because "not a git repository" is git's own
+    sentence and a translated git says it in another language (ruling 32).
+    ``--untracked-files=all`` overrides an operator's `status.showUntrackedFiles=no`, which
+    would otherwise hide ``??``.
+    """
+    cmd = ["git", "--no-optional-locks", "-C", str(root), "status", "--porcelain=v1",
+           "--ignored=matching", "--untracked-files=all", "--", str(path)]
+    try:
+        proc = run(cmd, check=False, timeout=timeout, env={"LC_ALL": "C"})
+    except (ProcTimeout, OSError) as e:
+        return UNKNOWN_GIT, str(e)
+    said = (proc.stderr or "").strip()
+    if proc.returncode != 0:
+        if proc.returncode == 128 and "not a git repository" in said:
+            return NOT_A_REPO, ""
+        return UNKNOWN_GIT, said.splitlines()[0] if said else f"git exited {proc.returncode}"
+    codes = set()
+    for line in (proc.stdout or "").splitlines():
+        code = line[:2]
+        if code in ("??", "!!"):
+            codes.add(code)
+        elif set(code) <= _TRACKED_STATUS:
+            codes.add(TRACKED)
+        else:
+            return UNKNOWN_GIT, f"git status printed {line!r}"
+    if not codes or TRACKED in codes:
+        return TRACKED, ""
+    if "??" in codes:
+        return COMMITTABLE, ""
+    return IGNORED, ""

--- a/docs/control-plane.md
+++ b/docs/control-plane.md
@@ -522,11 +522,11 @@ A broken profile is refused alone, by name, and every other profile still loads.
 |---|---|---|
 | a `kind` charter cannot launch | nothing could start it | `claude`, `opencode` or `codex` |
 | a `command` that is not a non-empty list of text | no shell runs it, so `"claude --resume x"` names one program | `["claude", "--resume", "x"]` |
-| a `command` whose first word is charter itself | a new chat on it would open charter again, forever | the harness's own command |
-| a name holding a dot or any other character, or named `default` | a dot breaks tmux targets; `default` names the starting row | rename the table |
+| a `command` whose first word is charter itself | a profile names the harness a chat runs, and charter is not a harness | the harness's own command |
+| a name holding a dot or any other character, or named `default` | a dot breaks tmux targets; `default` is the one key under `[harness]` that is not a profile | rename the table |
 | a name `charter` already uses — `doctor`, `workspace`, `frame` | `charter doctor` would always be the command, never the profile | rename the table |
 | an `env` that is not a table of text | a variable holds text | `env = { NAME = "value" }` |
-| an `env` name starting with `CHARTER_` | the launcher sets those itself, and a profile's own setting would tell charter's hooks the wrong harness or plane | delete the variable |
+| an `env` name starting with `CHARTER_` | charter sets those itself, and a profile's own setting would tell charter's hooks the wrong harness or plane | delete the variable |
 | an `env` name containing `KEY`, `TOKEN`, `SECRET` or `PASSWORD` | a variable set on the harness reaches the model's shell, as the next section measures | log in inside the harness |
 | a key other than `kind`, `command` and `env` | a typo such as `enviroment` would drop `CLAUDE_CONFIG_DIR` and launch the default account without a word | remove or respell it |
 | a file that is not valid TOML | nothing in it can be read | fix the file; the built-ins still load |
@@ -552,22 +552,30 @@ script on `PATH` can still export a key. Charter declines to hold one; it cannot
 `charter init` writes `/charter.local.toml` into a new plane's `.gitignore`, and
 `charter reinit` adds it to a plane made before this existed. The line is not trusted
 blindly: `charter harness list` and `charter doctor` ask git, and while git tracks the file
-or would commit it, every profile declared there is refused:
+or would commit it, every profile declared there is listed refused, with the reason, and one
+line names the fix:
 
 ```
-! git would commit charter.local.toml, so the profiles in it are refused until it is ignored — charter reinit adds /charter.local.toml to .gitignore.
+refused:
+  claude-work: git would commit charter.local.toml, so the profiles in it are refused until it is ignored — charter reinit adds /charter.local.toml to .gitignore.
+! to use the profiles in charter.local.toml: charter reinit
 ```
 
-A tracked file stays refused after the ignore line is added, because the next commit still
-carries it: `git rm --cached charter.local.toml`, then `charter reinit`. A plane that is not
-a git repository has nothing to commit to, and passes. Any other answer git cannot give — git
-missing, a timeout, an answer it cannot read — refuses too: an unknown is not a pass.
+Each state has its own fix. A committable file needs the ignore line, which `charter reinit`
+adds. A tracked file stays refused after the ignore line is added, because the next commit
+still carries it — even after `git rm --cached`, until that removal is committed — so its fix
+is `git rm --cached charter.local.toml`, commit that removal, then `charter reinit`. A plane
+that is not a git repository has nothing to commit to, and passes. Any other answer git cannot
+give — git missing, a timeout, an answer it cannot read — refuses too, because an unknown is
+not a pass; the fix names the command to run by hand, `git status --ignored --
+charter.local.toml`, beside what git said.
 
 The check is one `git --no-optional-locks status`, which takes no `index.lock` from a commit
 running beside it. It runs when a person asks — `charter harness list`, `charter doctor` —
-and never when charter merely reads its config, so no hook pays a git call for it.
-`charter doctor`'s `harness profiles` row warns for each refusal above, and for a `default`
-that names no profile this machine has.
+and not when charter merely reads its config. One hook does pay it: the SessionStart hook
+runs `charter doctor`, so on a plane that has `charter.local.toml`, each session start makes
+that one `git status`. `charter doctor`'s `harness profiles` row warns for each refusal
+above, with each state's own fix, and for a `default` that names no profile this machine has.
 
 ### `default` — bare `charter`
 

--- a/docs/control-plane.md
+++ b/docs/control-plane.md
@@ -526,8 +526,8 @@ A broken profile is refused alone, by name, and every other profile still loads.
 | a name holding a dot or any other character, or named `default` | a dot breaks tmux targets; `default` names the starting row | rename the table |
 | a name `charter` already uses — `doctor`, `workspace`, `frame` | `charter doctor` would always be the command, never the profile | rename the table |
 | an `env` that is not a table of text | a variable holds text | `env = { NAME = "value" }` |
-| an `env` name starting with `CHARTER_` | the launcher sets those, and a profile's value would tell every hook the wrong harness or plane | remove it |
-| an `env` name containing `KEY`, `TOKEN`, `SECRET` or `PASSWORD` | see *No credentials in a profile* below | log in inside the harness |
+| an `env` name starting with `CHARTER_` | the launcher sets those itself, and a profile's own setting would tell charter's hooks the wrong harness or plane | delete the variable |
+| an `env` name containing `KEY`, `TOKEN`, `SECRET` or `PASSWORD` | a variable set on the harness reaches the model's shell, as the next section measures | log in inside the harness |
 | a key other than `kind`, `command` and `env` | a typo such as `enviroment` would drop `CLAUDE_CONFIG_DIR` and launch the default account without a word | remove or respell it |
 | a file that is not valid TOML | nothing in it can be read | fix the file; the built-ins still load |
 

--- a/docs/control-plane.md
+++ b/docs/control-plane.md
@@ -90,6 +90,9 @@ share = "local"                  # "local" | "commit" | "push". Default: "local"
 default = "default"              # Default: "default".
 
 # What bare `charter` opens. Opt-in; absent, `charter` on its own prints the usage list.
+# `default` is the only key read here. Harness profiles — a command and an environment
+# each — live in charter.local.toml, which is never committed, and a [harness.<name>]
+# table in this file is refused. See "[harness] — profiles, and the default" below.
 [harness]
 default = "claude"               # "claude" | "opencode" | "codex" — the word you would
                                   # have typed after `charter`. No default: charter does
@@ -455,7 +458,118 @@ On a plane that declares the [dev channel](install.md#4-the-dev-channel--trying-
 `charter version` never suggests this command, because a pin and the dev channel cannot
 both be declared. It names `charter update` instead.
 
-## `[harness].default` — bare `charter`
+## `[harness]` — profiles, and the default
+
+Two Claude Code accounts, work in one config folder and personal in another, or a Codex
+pinned to an older release: charter ran one program per harness, one way, and had no way to
+be told otherwise. A shell alias does not help — charter runs the harness with no shell, so
+the alias never resolves. A **harness profile** is the way: a kind, a command and an
+environment, declared in a file that stays on your machine.
+
+**Profiles are listed by `charter harness list`; launching one arrives in a later release.**
+Today charter reads them, refuses the broken ones by name, and keeps the file out of git.
+`charter claude`, bare `charter` and every chat still start exactly as they did.
+
+### Profiles live in `charter.local.toml`, never in `charter.toml`
+
+```toml
+# charter.local.toml — beside charter.toml, never committed
+[harness]
+default = "claude-work"                          # optional
+
+[harness.claude-work]
+kind = "claude"
+command = ["claude"]
+env = { CLAUDE_CONFIG_DIR = "~/.claude-work" }
+
+[harness.codex-pinned]
+kind = "codex"
+command = ["npx", "-y", "@openai/codex@0.140.0"]
+```
+
+A profile's command runs on a click, with no harness permission prompt in between. In the
+committed file a merged PR, or a chat, could change that command and have it run on every
+machine that pulls it. So charter reads profiles only from `charter.local.toml`, and a
+`[harness.<name>]` table in `charter.toml` is refused with a pointer to the local file.
+`charter.toml`'s `[harness]` keeps `default`; any other key there is ignored, as it always
+was. A `default` in the local file wins over the committed one.
+
+**The local file carries `[harness]` and nothing else.** Any other section in it is refused
+by name. An ignored file that could override `[[forge]]` — whose hosts steer the
+one-credential guard — would change plane policy with no trace in git.
+
+- `kind` — which harness program: `claude`, `opencode` or `codex`, the word you would type
+  after `charter`.
+- `command` — a list of arguments, never a shell string, because no shell runs it. A leading
+  `~` in its first word is expanded, since no shell is there to do it.
+- `env` — optional: variables set on the harness, each value's leading `~` expanded.
+- The table's name is letters, digits, `_` and `-`, starting with a letter or digit. No dot:
+  a dot in a name broke tmux targets once (#695).
+
+**Every harness is also a built-in profile named after itself** — `claude` runs `claude`,
+with no extra environment — so a plane that declares nothing sees no change. A declared
+profile of the same name replaces it, which is how plain `claude` gets pinned. A built-in
+cannot be hidden, but a replacement that is refused takes the name with it rather than
+letting the built-in stand in: you said how `claude` runs, and running the default in its
+place would run the command you replaced.
+
+### What is refused, and the fix
+
+A broken profile is refused alone, by name, and every other profile still loads.
+`charter harness list` and `charter doctor` both say which one and why.
+
+| Refused | Why | Fix |
+|---|---|---|
+| a `kind` charter cannot launch | nothing could start it | `claude`, `opencode` or `codex` |
+| a `command` that is not a non-empty list of text | no shell runs it, so `"claude --resume x"` names one program | `["claude", "--resume", "x"]` |
+| a `command` whose first word is charter itself | a new chat on it would open charter again, forever | the harness's own command |
+| a name holding a dot or any other character, or named `default` | a dot breaks tmux targets; `default` names the starting row | rename the table |
+| a name `charter` already uses — `doctor`, `workspace`, `frame` | `charter doctor` would always be the command, never the profile | rename the table |
+| an `env` that is not a table of text | a variable holds text | `env = { NAME = "value" }` |
+| an `env` name starting with `CHARTER_` | the launcher sets those, and a profile's value would tell every hook the wrong harness or plane | remove it |
+| an `env` name containing `KEY`, `TOKEN`, `SECRET` or `PASSWORD` | see *No credentials in a profile* below | log in inside the harness |
+| a key other than `kind`, `command` and `env` | a typo such as `enviroment` would drop `CLAUDE_CONFIG_DIR` and launch the default account without a word | remove or respell it |
+| a file that is not valid TOML | nothing in it can be read | fix the file; the built-ins still load |
+
+### No credentials in a profile
+
+Anything set on the harness process reaches the shell the model runs — measured on Claude
+Code, and on Codex, whose default `shell_environment_policy` passed a `*_TOKEN` variable
+straight through. A vault reference would change nothing: the key would only rest somewhere
+else before landing in the same shell. So a variable named like a credential is refused, and
+the refusal names the harness's own login, kept in the config folder the profile already
+moves:
+
+- Claude Code: set `CLAUDE_CONFIG_DIR` and run `/login` inside Claude Code.
+- Codex: set `CODEX_HOME` and run `codex login`.
+- opencode: set `XDG_DATA_HOME` and run `opencode auth login`.
+
+The pattern can refuse an innocent name — `KEYBOARD_LAYOUT` holds `KEY` — and a wrapper
+script on `PATH` can still export a key. Charter declines to hold one; it cannot prevent one.
+
+### Kept out of git, and checked
+
+`charter init` writes `/charter.local.toml` into a new plane's `.gitignore`, and
+`charter reinit` adds it to a plane made before this existed. The line is not trusted
+blindly: `charter harness list` and `charter doctor` ask git, and while git tracks the file
+or would commit it, every profile declared there is refused:
+
+```
+! git would commit charter.local.toml, so the profiles in it are refused until it is ignored — charter reinit adds /charter.local.toml to .gitignore.
+```
+
+A tracked file stays refused after the ignore line is added, because the next commit still
+carries it: `git rm --cached charter.local.toml`, then `charter reinit`. A plane that is not
+a git repository has nothing to commit to, and passes. Any other answer git cannot give — git
+missing, a timeout, an answer it cannot read — refuses too: an unknown is not a pass.
+
+The check is one `git --no-optional-locks status`, which takes no `index.lock` from a commit
+running beside it. It runs when a person asks — `charter harness list`, `charter doctor` —
+and never when charter merely reads its config, so no hook pays a git call for it.
+`charter doctor`'s `harness profiles` row warns for each refusal above, and for a `default`
+that names no profile this machine has.
+
+### `default` — bare `charter`
 
 **Opt-in.** Absent, `charter` on its own prints the usage list, exactly as it always has.
 
@@ -470,9 +584,13 @@ everything else the launcher does are the same behaviours, not a second set of t
 subcommand keeps working untouched, `charter claude` included.
 
 The value is one of the words you would type after `charter`: `claude`, `opencode`,
-`codex` — whatever `charter harness list` shows, read out of charter's own registry rather
-than a list in this page, so a harness added to charter becomes a legal default the day it
-is registered.
+`codex` — the built-in profiles `charter harness list` shows, read out of charter's own
+registry rather than a list in this page, so a harness added to charter becomes a legal
+default the day it is registered. **Until launching a profile arrives, bare `charter` reads
+this key from `charter.toml` alone, and only as one of those words.** A `default` in
+`charter.local.toml` marks its row in `charter harness list` and launches nothing yet, and a
+declared profile's name in `charter.toml` is reported below like any other name charter
+cannot launch.
 
 **Charter does not pick one for you.** No default and you get the usage message, not
 "whatever is installed" (a machine with two of them has no answer, and the answer would

--- a/docs/frame.md
+++ b/docs/frame.md
@@ -20,7 +20,7 @@ plane places it*, below). The middle pane is the harness's and charter draws not
 
 `charter` on its own opens the frame once the plane says which harness it means —
 `[harness] default = "claude"` in `charter.toml`, documented in
-[control-plane.md](control-plane.md#harnessdefault--bare-charter). It is a rewrite of the
+[control-plane.md](control-plane.md#default--bare-charter). It is a rewrite of the
 command rather than a route of its own: `charter` becomes `charter claude` and everything
 below applies to it unchanged. A plane that names no default keeps the usage list, and so
 does `charter` with its output piped or redirected — a script asking whether charter is

--- a/docs/harnesses.md
+++ b/docs/harnesses.md
@@ -8,11 +8,16 @@ each: the plane-root guard, the one-credential rule, the secret-leak check, and 
 persona's declared tools.
 
 ```bash
-charter harness list          # every harness, what it can't carry, and which one you're in
+charter harness list          # every profile, every harness, what it can't carry, and which one you're in
 charter harness install codex # Codex only — see below
 ```
 
 ```
+  NAME      KIND      COMMAND   FROM
+* claude    claude    claude    built-in
+  opencode  opencode  opencode  built-in
+  codex     codex     codex     built-in
+
   claude-code
 * opencode
       ↳ status-bar: no status-bar socket: opencode has no `statusLine` config …
@@ -26,9 +31,49 @@ charter harness install codex # Codex only — see below
       ↳ wiring-scope: no project-level config: hooks live only in `~/.codex/config.toml` …
 ```
 
-The `*` is the harness this session is in, and those names are what `$CHARTER_HARNESS`
+The profiles come first, and there `*` marks `[harness] default` (see [Profiles](#profiles)).
+Below them, `*` is the harness this session is in, and those names are what `$CHARTER_HARNESS`
 holds. A harness charter has no record of is reported too, as a warning rather than a clean
 row — an unverified integration and a complete one must not read the same.
+
+## Profiles
+
+A harness profile is a named way to launch one harness: its kind, its command, its
+environment. Every harness charter knows is a built-in profile named after itself. Two
+Claude Code accounts, or a Codex pinned to an older release, are profiles you declare in
+`charter.local.toml`, a file charter keeps out of git. The shape, what is refused and why,
+and how the file is kept uncommitted are in
+[control-plane.md](control-plane.md#harness--profiles-and-the-default).
+
+`charter harness list` shows every profile charter read, before the harnesses' ceilings:
+
+```
+  NAME          KIND      COMMAND                                  FROM
+  claude        claude    claude                                   built-in
+  opencode      opencode  opencode                                 built-in
+  codex         codex     codex                                    built-in
+* claude-work   claude    CLAUDE_CONFIG_DIR=~/.claude-work claude  charter.local.toml
+  codex-pinned  codex     npx -y @openai/codex@0.140.0             charter.local.toml
+refused:
+  claude.alt: profile 'claude.alt' is not a name charter accepts — letters, digits, '_' and '-', starting with a letter or digit. Rename the table.
+```
+
+- **NAME** — what the profile is called; `*` marks `[harness] default`.
+- **KIND** — which harness program it launches.
+- **COMMAND** — the environment it sets, then its command. A control character in either is
+  shown escaped, never interpreted: the file is one a chat can write, and a carriage return
+  could otherwise redraw the line to show a different command.
+- **FROM** — `built-in`, or the file that declared it.
+
+Then `refused:`, one line per profile charter would not read and why, and a warning while
+git would commit the file.
+
+**There is no `charter harness add`.** A profile is added by editing `charter.local.toml`. A
+chat can run a command as easily as it can edit a file, so a command could never stand for
+your approval of what a profile runs; it would only save typing.
+
+Launching a profile arrives in a later release. Today the list is what charter read, and
+every launch is the one it always was.
 
 ## What each harness lets charter offer
 

--- a/docs/harnesses.md
+++ b/docs/harnesses.md
@@ -31,12 +31,13 @@ charter harness install codex # Codex only — see below
       ↳ wiring-scope: no project-level config: hooks live only in `~/.codex/config.toml` …
 ```
 
-The profiles come first, and there `*` marks `[harness] default` (see [Profiles](#profiles)).
+The profiles come first, and there `*` marks `[harness] default` (see
+[Two accounts of one harness](#two-accounts-of-one-harness-or-one-version-pinned)).
 Below them, `*` is the harness this session is in, and those names are what `$CHARTER_HARNESS`
 holds. A harness charter has no record of is reported too, as a warning rather than a clean
 row — an unverified integration and a complete one must not read the same.
 
-## Profiles
+## Two accounts of one harness, or one version pinned
 
 A harness profile is a named way to launch one harness: its kind, its command, its
 environment. Every harness charter knows is a built-in profile named after itself. Two

--- a/docs/harnesses.md
+++ b/docs/harnesses.md
@@ -56,7 +56,7 @@ and how the file is kept uncommitted are in
 * claude-work   claude    CLAUDE_CONFIG_DIR=~/.claude-work claude  charter.local.toml
   codex-pinned  codex     npx -y @openai/codex@0.140.0             charter.local.toml
 refused:
-  claude.alt: profile 'claude.alt' is not a name charter accepts — letters, digits, '_' and '-', starting with a letter or digit. Rename the table.
+  claude.alt: profile 'claude.alt' is not a name charter accepts — letters, digits, '_' and '-', starting with a letter or digit, and no dot, because a dot breaks tmux targets. Rename the table.
 ```
 
 - **NAME** — what the profile is called; `*` marks `[harness] default`.

--- a/docs/install.md
+++ b/docs/install.md
@@ -327,7 +327,7 @@ inside a Claude Code session, restart that session first — the plugin loads at
 
 `init` writes no `[harness] default`, so bare `charter` prints its usage until the plane
 names a harness — one key in `charter.toml`
-([control-plane.md](control-plane.md#harnessdefault--bare-charter)):
+([control-plane.md](control-plane.md#default--bare-charter)):
 
 ```toml
 [harness]

--- a/docs/news/unreleased-harness-profiles.md
+++ b/docs/news/unreleased-harness-profiles.md
@@ -25,8 +25,9 @@ instead.
 
 A profile's command will run on a click, so the file must never be committed. `charter init`
 writes `/charter.local.toml` into a new plane's `.gitignore` and `charter reinit` adds it to
-yours; `charter doctor` warns on its `harness profiles` row while git tracks the file or would
-commit it.
+yours. While git tracks the file or would commit it, `charter harness list` shows every
+profile in it refused and names the fix, and `charter doctor` warns on its `harness profiles`
+row.
 
 This release does not launch a profile yet. `charter claude`, bare `charter` and every chat
 start exactly as they did.

--- a/docs/news/unreleased-harness-profiles.md
+++ b/docs/news/unreleased-harness-profiles.md
@@ -1,0 +1,32 @@
+---
+version: unreleased
+headline: Charter reads harness profiles from charter.local.toml, a file it keeps out of git
+adopt: reinit
+---
+
+Two Claude Code accounts in two config folders, or a Codex pinned to an older release, had no
+way to reach charter. It ran one program per harness, one way, with no shell in between, so an
+alias never resolved. A **harness profile** is that way: a kind, a command and an environment,
+declared in `charter.local.toml` beside `charter.toml`.
+
+```toml
+[harness.claude-work]
+kind = "claude"
+command = ["claude"]
+env = { CLAUDE_CONFIG_DIR = "~/.claude-work" }
+```
+
+`charter harness list` now shows every profile charter read — a built-in for each harness,
+named after it, and yours — with the file each came from and why any was refused: a kind
+charter cannot launch, a command written as a shell string, a name `charter` already uses, a
+variable named like a credential. Charter holds no credential in a profile, because anything
+set on the harness reaches the model's own shell; that refusal names the harness's own login
+instead.
+
+A profile's command will run on a click, so the file must never be committed. `charter init`
+writes `/charter.local.toml` into a new plane's `.gitignore` and `charter reinit` adds it to
+yours; `charter doctor` warns on its `harness profiles` row while git tracks the file or would
+commit it.
+
+This release does not launch a profile yet. `charter claude`, bare `charter` and every chat
+start exactly as they did.

--- a/tests/_planeguard.py
+++ b/tests/_planeguard.py
@@ -265,6 +265,43 @@ from charter import root as _root        # noqa: E402
 #: exactly like safety. Computed once, at install; the per-call check is a string compare.
 _REAL: tuple[str, ...] = ()
 
+#: The real plane's own ``charter.local.toml``, in both spellings — refused for READS as well
+#: as for writes. Ruling 43 moved the read of this file out of `config` and into
+#: `profiles.current()`, which runs when a surface asks, so no derived setting stands between
+#: a test and the operator's own profiles any more. The file is that operator's accounts and
+#: commands, in no commit, and a test that read it would assert against a fixture only this
+#: machine has. Filled at install, from the same markers `_REAL` holds.
+_REAL_LOCAL_PROFILES: tuple[str, ...] = ()
+
+
+def _reads_real_profiles(path) -> bool:
+    """Is *path* the real plane's ``charter.local.toml``? The basename is compared first — a
+    string test — so the hot path of every other `open` in the suite costs no syscall."""
+    if not _REAL_LOCAL_PROFILES:
+        return False
+    try:
+        p = os.fspath(path)
+    except TypeError:
+        return False                      # an int fd, or something not a path at all
+    if isinstance(p, bytes):
+        p = os.fsdecode(p)
+    if os.path.basename(p) != "charter.local.toml":
+        return False
+    here = os.path.abspath(p)
+    return here in _REAL_LOCAL_PROFILES or os.path.realpath(here) in _REAL_LOCAL_PROFILES
+
+
+def _explain_profiles_read(path) -> str:
+    return (
+        f"REFUSED: read of {path}\n"
+        f"{_current_test()} is reading the developer's own `charter.local.toml` — this "
+        f"machine's harness profiles, which are in no commit — so what it asserts depends on "
+        f"whoever runs the suite. `profiles.current()` reads the file when a surface asks "
+        f"(ruling 43), so `charter harness list`, `charter doctor` and every launch surface "
+        f"reach it. Derive the case from `tests._isolation.PersonaIso`, whose `config.ROOT` is "
+        f"a tmp plane. `isolate_state_dir` does not move this file: it sits at the plane root, "
+        f"not in `.charter/`.")
+
 
 class RealPlaneWrite(BaseException):
     """A test tried to write into the developer's own control-plane state directory."""
@@ -1730,7 +1767,7 @@ def _guard_spawns() -> None:
 
 def install() -> None:
     """Wrap every write primitive. Idempotent; called once at `tests` package import."""
-    global _REAL
+    global _REAL, _REAL_LOCAL_PROFILES
     if _REAL:
         return
     from charter import config
@@ -1773,6 +1810,8 @@ def install() -> None:
         for name in (_root.MARKER, "charter.local.toml")
         for m in _both_spellings(Path(r) / name)))
     _REAL = ((written,) if written == resolved else (written, resolved)) + markers
+    _REAL_LOCAL_PROFILES = tuple(m for m in markers
+                                 if os.path.basename(m) == "charter.local.toml")
 
     # `os.mkdir` covers `Path.mkdir` AND `os.makedirs` (which calls the module global by
     # name, so it goes through this wrapper too) — one wrapper, both spellings.
@@ -1809,6 +1848,10 @@ def install() -> None:
     def open_(file, mode="r", *args, **kw):
         if any(c in mode for c in "wxa+") and _hits(file):
             raise RealPlaneWrite(_explain(f"open(..., {mode!r})", file))
+        # A READ of the real plane's `charter.local.toml` as well (ruling 43): see
+        # `_REAL_LOCAL_PROFILES`. A write to it is refused just above, through `_REAL`.
+        if _reads_real_profiles(file):
+            raise RealPlaneRead(_explain_profiles_read(file))
         return original_open(file, mode, *args, **kw)
 
     builtins.open = open_

--- a/tests/_planeguard.py
+++ b/tests/_planeguard.py
@@ -365,11 +365,7 @@ def _guard_os(name: str, *, arg: int = 0, both: bool = False) -> None:
 #: run it. Values that are dicts, and only dicts: the refusal works by handing back an
 #: object that will not answer, and a `str` or a `Path` cannot be made to refuse without
 #: breaking the formatting of every message that legitimately quotes it.
-#:
-#: ``PROFILES`` is the same shape with the dial turned up: it is read off
-#: ``charter.local.toml``, a file that by design exists on one machine and in no commit, so a
-#: test reading the developer's own profiles asserts against a fixture no other run can see.
-_GUARDED_SETTINGS = ("UPDATE", "HARNESS", "PROFILES")
+_GUARDED_SETTINGS = ("UPDATE", "HARNESS")
 
 
 class RealPlaneRead(BaseException):
@@ -1769,11 +1765,12 @@ def install() -> None:
     #
     # `charter.local.toml` beside each, for the reason the marker is guarded and one more: it
     # holds which command a click runs on this machine, and it is in no commit, so a test that
-    # rewrote it would leave nothing to restore it from.
-    from charter import profiles as _profiles
+    # rewrote it would leave nothing to restore it from. Spelled out rather than imported
+    # from `charter.profiles`: this runs as the `tests` package is imported, ruling 43 keeps
+    # that module off every import path, and a test keeps the two names the same.
     markers = tuple(dict.fromkeys(
         m for r in (str(config.ROOT), *plane)
-        for name in (_root.MARKER, _profiles.LOCAL_FILE)
+        for name in (_root.MARKER, "charter.local.toml")
         for m in _both_spellings(Path(r) / name)))
     _REAL = ((written,) if written == resolved else (written, resolved)) + markers
 

--- a/tests/_planeguard.py
+++ b/tests/_planeguard.py
@@ -365,7 +365,11 @@ def _guard_os(name: str, *, arg: int = 0, both: bool = False) -> None:
 #: run it. Values that are dicts, and only dicts: the refusal works by handing back an
 #: object that will not answer, and a `str` or a `Path` cannot be made to refuse without
 #: breaking the formatting of every message that legitimately quotes it.
-_GUARDED_SETTINGS = ("UPDATE", "HARNESS")
+#:
+#: ``PROFILES`` is the same shape with the dial turned up: it is read off
+#: ``charter.local.toml``, a file that by design exists on one machine and in no commit, so a
+#: test reading the developer's own profiles asserts against a fixture no other run can see.
+_GUARDED_SETTINGS = ("UPDATE", "HARNESS", "PROFILES")
 
 
 class RealPlaneRead(BaseException):
@@ -1762,9 +1766,15 @@ def install() -> None:
     # Every marker the pin moved past, because in a worktree they are different files and
     # the wrong one to write is the one nobody is looking at. Two from a worktree of the
     # plane; three from a worktree of a workspace clone (#944).
+    #
+    # `charter.local.toml` beside each, for the reason the marker is guarded and one more: it
+    # holds which command a click runs on this machine, and it is in no commit, so a test that
+    # rewrote it would leave nothing to restore it from.
+    from charter import profiles as _profiles
     markers = tuple(dict.fromkeys(
         m for r in (str(config.ROOT), *plane)
-        for m in _both_spellings(Path(r) / _root.MARKER)))
+        for name in (_root.MARKER, _profiles.LOCAL_FILE)
+        for m in _both_spellings(Path(r) / name)))
     _REAL = ((written,) if written == resolved else (written, resolved)) + markers
 
     # `os.mkdir` covers `Path.mkdir` AND `os.makedirs` (which calls the module global by

--- a/tests/test_charter_harness_list_shows_profiles.py
+++ b/tests/test_charter_harness_list_shows_profiles.py
@@ -83,6 +83,19 @@ class HarnessListShowsProfiles(PersonaIso):
                 self.assertTrue(self._row(out, name).rstrip().endswith("built-in"), out)
         self.assertNotIn("refused:", out)
 
+    def test_built_ins_come_first_in_registry_order_then_declared_by_name(self):
+        """The plan's order. A declared replacement keeps its kind's place, and a declared
+        name that sorts early still comes after every built-in. Registry order is not
+        alphabetical — `opencode` is registered before `codex` — so a listing that sorted
+        built-ins by name would put `codex` second and fail here."""
+        out = self._list('[harness.zzz-last]\nkind = "claude"\ncommand = ["claude"]\n'
+                         '[harness.codex]\nkind = "codex"\ncommand = ["/opt/codex"]\n'
+                         '[harness.aaa-first]\nkind = "claude"\ncommand = ["claude"]\n')
+        names = [line[2:].split()[0] for line in self._profiles_block(out).splitlines()
+                 if line[2:].split() and line[2:].split()[0] != "NAME"
+                 and not line.startswith(("refused:", "!", "  refused"))]
+        self.assertEqual(names, ["claude", "opencode", "codex", "aaa-first", "zzz-last"], out)
+
     def test_a_declared_profile_shows_its_command_env_and_file(self):
         row = self._row(self._list(_WORK), "claude-work")
         self.assertIn("CLAUDE_CONFIG_DIR=~/.claude-work claude", row)

--- a/tests/test_charter_harness_list_shows_profiles.py
+++ b/tests/test_charter_harness_list_shows_profiles.py
@@ -167,6 +167,26 @@ command = ["claude\r\u001B[2Kharmless"]
         self.assertNotIn("\x1b", out)
         self.assertIn(contain.readable("claude\r\x1b[2Kharmless"), out)
 
+    def test_the_fix_for_the_files_state_is_its_own_line(self):
+        """Sweep survivor [17/156]. Every refused line already carries its state's reason, so
+        a test that looks for "charter reinit" anywhere in the listing passes with the fix
+        line gone. This reads the `!` line itself, for a committable file and for a tracked
+        one, whose fix is not `charter reinit` alone."""
+        env = {**os.environ, **_gitguard.environment()}
+        subprocess.run(["git", "-C", str(config.ROOT), "init", "-q"], check=True,
+                       capture_output=True, env=env)
+        out = self._list(_OK)
+        fixes = [ln for ln in self._profiles_block(out).splitlines() if ln.startswith("!")]
+        self.assertEqual(len(fixes), 1, out)
+        self.assertTrue(fixes[0].rstrip().endswith(": charter reinit"), fixes[0])
+        for args in (["add", "-f", "charter.local.toml"], ["commit", "-q", "-m", "tracked"]):
+            subprocess.run(["git", "-C", str(config.ROOT), *args], check=True,
+                           capture_output=True, env=env)
+        out = self._list()
+        fixes = [ln for ln in self._profiles_block(out).splitlines() if ln.startswith("!")]
+        self.assertEqual(len(fixes), 1, out)
+        self.assertIn("git rm --cached charter.local.toml, commit that removal", fixes[0])
+
     def test_a_name_that_skipped_validation_is_still_listed_escaped(self):
         """Ruling 35 at the NAME cell itself. A declared name passes `NAME_RE` before it can
         reach a row, so today no name carries a control byte — but the listing does not lean

--- a/tests/test_charter_harness_list_shows_profiles.py
+++ b/tests/test_charter_harness_list_shows_profiles.py
@@ -120,6 +120,29 @@ class HarnessListShowsProfiles(PersonaIso):
         self.assertNotIn("doctor", self._rows(out))
         self.assertIn("charter doctor", self._profiles_block(out).split("refused:", 1)[1])
 
+    def test_a_committable_files_profile_is_listed_as_refused_not_as_a_row(self):
+        """F1. `NOT_IGNORED` says the profiles in the file are refused, so the listing shows
+        exactly that — not an ordinary row with a warning under it."""
+        subprocess.run(["git", "-C", str(config.ROOT), "init", "-q"], check=True,
+                       capture_output=True, env={**os.environ, **_gitguard.environment()})
+        out = self._list(_WORK)
+        self.assertNotIn("claude-work", self._rows(out))
+        block = self._profiles_block(out)
+        (line,) = [ln for ln in block.split("refused:", 1)[1].splitlines()
+                   if ln.strip().startswith("claude-work:")]
+        self.assertIn("git would commit", line)
+        self.assertIn("charter reinit", block)
+
+    def test_ruling_37_a_refused_replacement_is_listed_refused_and_its_built_in_is_not(self):
+        """Pin. Ruling 37 in the listing: the name shows refused, with its reason, and no
+        built-in row stands in for it."""
+        out = self._list('[harness.claude]\nkind = "claude"\ncommand = ["claude"]\n'
+                         'enviroment = { CLAUDE_CONFIG_DIR = "~/.claude-work" }\n')
+        self.assertNotIn("claude", self._rows(out))
+        (line,) = [ln for ln in self._profiles_block(out).split("refused:", 1)[1].splitlines()
+                   if ln.strip().startswith("claude:")]
+        self.assertIn("does not read", line)
+
     def test_a_committable_file_is_said(self):
         subprocess.run(["git", "-C", str(config.ROOT), "init", "-q"], check=True,
                        capture_output=True, env={**os.environ, **_gitguard.environment()})

--- a/tests/test_charter_harness_list_shows_profiles.py
+++ b/tests/test_charter_harness_list_shows_profiles.py
@@ -1,0 +1,140 @@
+"""`charter harness list` shows every profile charter read, the file it came from, and why
+any was refused.
+
+There is no `charter harness add`: a chat can run a command as easily as it can edit a
+file, so a command could never stand for the operator's approval, and all it would buy is
+typing (spec, *Where profiles live*). This listing is how an operator who edited the file
+reads back what charter made of it. A profile's command comes from a file a chat can
+write, so a carriage return or an ESC in one is shown escaped and never interpreted: it
+could otherwise redraw a line to show a harmless command (ruling 35).
+
+Everything is on stderr, where `util.info` and `util.warn` already put this command's output
+(review 11).
+"""
+
+from __future__ import annotations
+
+import io
+import os
+import subprocess
+import unittest
+from contextlib import redirect_stderr
+from types import SimpleNamespace
+from unittest import mock
+
+from charter import commands_harness, config, contain
+from tests import _gitguard
+from tests._isolation import PersonaIso
+
+_WORK = """
+[harness.claude-work]
+kind = "claude"
+command = ["claude"]
+env = { CLAUDE_CONFIG_DIR = "~/.claude-work" }
+"""
+
+_OK = """
+[harness.ok]
+kind = "claude"
+command = ["claude"]
+"""
+
+
+class HarnessListShowsProfiles(PersonaIso):
+    def setUp(self) -> None:
+        super().setUp()
+        # The listing asks git whether the file is ignored. Stated, so a temp directory that
+        # sits inside a repository on somebody's machine is not read as belonging to it.
+        self.enterContext(mock.patch.dict(
+            os.environ, {"GIT_CEILING_DIRECTORIES": str(self.tmp.resolve().parent)}))
+
+    def _list(self, text: str | None = None) -> str:
+        if text is not None:
+            (config.ROOT / "charter.local.toml").write_text(text)
+        config.use(config.ROOT)
+        err = io.StringIO()
+        with redirect_stderr(err):
+            self.assertEqual(commands_harness.cmd_harness_list(SimpleNamespace()), 0)
+        return err.getvalue()
+
+    @staticmethod
+    def _profiles_block(text: str) -> str:
+        # The profiles come first, and a blank line separates them from the kinds' ceilings,
+        # whose `codex` and `opencode` rows would otherwise read as a built-in's.
+        return text.split("\n\n", 1)[0]
+
+    def _rows(self, text: str) -> dict[str, str]:
+        rows = {}
+        for line in self._profiles_block(text).splitlines():
+            cells = line[2:].split()
+            if cells:
+                rows.setdefault(cells[0], line)
+        return rows
+
+    def _row(self, text: str, name: str) -> str:
+        rows = self._rows(text)
+        self.assertIn(name, rows, text)
+        return rows[name]
+
+    def test_every_built_in_is_listed_as_built_in(self):
+        out = self._list()
+        for name in ("claude", "codex", "opencode"):
+            with self.subTest(name=name):
+                self.assertTrue(self._row(out, name).rstrip().endswith("built-in"), out)
+        self.assertNotIn("refused:", out)
+
+    def test_a_declared_profile_shows_its_command_env_and_file(self):
+        row = self._row(self._list(_WORK), "claude-work")
+        self.assertIn("CLAUDE_CONFIG_DIR=~/.claude-work claude", row)
+        self.assertIn("charter.local.toml", row)
+
+    def test_the_default_is_marked(self):
+        out = self._list('[harness]\ndefault = "claude-work"\n' + _WORK)
+        self.assertTrue(self._row(out, "claude-work").startswith("*"), out)
+        self.assertFalse(self._row(out, "claude").startswith("*"), out)
+
+    def test_a_refused_profile_is_listed_with_its_reason(self):
+        out = self._list('[harness.broken]\nkind = "claude"\ncommand = "claude --resume"\n')
+        block = self._profiles_block(out)
+        self.assertIn("refused:", block)
+        (line,) = [ln for ln in block.split("refused:", 1)[1].splitlines() if "broken" in ln]
+        self.assertIn("never a shell string", line)
+        self.assertNotIn("broken", self._rows(out))
+
+    def test_a_profile_named_like_a_command_is_listed_as_refused(self):
+        """The listing reads what every launch surface reads, clashes included."""
+        out = self._list('[harness.doctor]\nkind = "claude"\ncommand = ["claude"]\n')
+        self.assertNotIn("doctor", self._rows(out))
+        self.assertIn("charter doctor", self._profiles_block(out).split("refused:", 1)[1])
+
+    def test_a_committable_file_is_said(self):
+        subprocess.run(["git", "-C", str(config.ROOT), "init", "-q"], check=True,
+                       capture_output=True, env={**os.environ, **_gitguard.environment()})
+        self.assertIn("charter reinit adds", self._list(_OK))
+
+    def test_an_ignored_file_says_nothing_about_git(self):
+        subprocess.run(["git", "-C", str(config.ROOT), "init", "-q"], check=True,
+                       capture_output=True, env={**os.environ, **_gitguard.environment()})
+        (config.ROOT / ".gitignore").write_text("/charter.local.toml\n")
+        out = self._list(_OK)
+        block = self._profiles_block(out)
+        self.assertNotIn("git", block)
+        self.assertEqual([ln for ln in block.splitlines() if ln.startswith("!")], [], out)
+
+    def test_a_command_with_control_bytes_is_listed_escaped(self):
+        out = self._list(r'''
+[harness.sneaky]
+kind = "claude"
+command = ["claude\r\u001B[2Kharmless"]
+''')
+        self.assertNotIn("\r", out)
+        self.assertNotIn("\x1b", out)
+        self.assertIn(contain.readable("claude\r\x1b[2Kharmless"), out)
+
+    def test_the_kinds_ceilings_are_still_listed(self):
+        out = self._list()
+        self.assertIn("↳", out.split("\n\n", 1)[1])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_charter_harness_list_shows_profiles.py
+++ b/tests/test_charter_harness_list_shows_profiles.py
@@ -167,6 +167,21 @@ command = ["claude\r\u001B[2Kharmless"]
         self.assertNotIn("\x1b", out)
         self.assertIn(contain.readable("claude\r\x1b[2Kharmless"), out)
 
+    def test_a_name_that_skipped_validation_is_still_listed_escaped(self):
+        """Ruling 35 at the NAME cell itself. A declared name passes `NAME_RE` before it can
+        reach a row, so today no name carries a control byte — but the listing does not lean
+        on every future source of names validating them first. The rendering layer alone
+        would turn a carriage return into a space, which is a different name; the escaped
+        spelling is what says which one this is."""
+        from charter import profiles
+        odd = profiles.Profile("a\rb", "claude", "claude-code", ("claude",), (),
+                               "charter.local.toml")
+        unvalidated = profiles.ProfileSet({"a\rb": odd}, (), None, None, None)
+        with mock.patch.object(profiles, "current", return_value=unvalidated):
+            out = self._list()
+        self.assertNotIn("\r", out)
+        self.assertIn(contain.readable("a\rb"), out)
+
     def test_the_kinds_ceilings_are_still_listed(self):
         out = self._list()
         self.assertIn("↳", out.split("\n\n", 1)[1])

--- a/tests/test_cmd_harness.py
+++ b/tests/test_cmd_harness.py
@@ -12,7 +12,7 @@ from types import SimpleNamespace
 from unittest import mock
 
 from charter import commands_harness
-from tests import _envguard
+from tests._isolation import PersonaIso
 
 
 def _run(fn, args) -> tuple[int, str]:
@@ -22,12 +22,10 @@ def _run(fn, args) -> tuple[int, str]:
     return rc, out.getvalue() + err.getvalue()
 
 
-class HarnessList(unittest.TestCase):
-    def setUp(self) -> None:
-        # Outside a frame, with no session id and no pinned workspace: stated here
-        # rather than inherited from the shell the suite was launched from
-        # (#519, #521, #528).
-        _envguard.unset_all()
+class HarnessList(PersonaIso):
+    """Against a throwaway plane, outside a frame (`PersonaIso`). The listing now starts with
+    this plane's harness profiles, and those are read off `charter.local.toml` — a file that
+    exists only on the machine running the suite, so `_planeguard` refuses the real one."""
 
     def test_it_names_every_registered_harness_and_its_ceilings(self):
         rc, text = _run(commands_harness.cmd_harness_list, SimpleNamespace())

--- a/tests/test_doctor_mcp_launchers.py
+++ b/tests/test_doctor_mcp_launchers.py
@@ -30,8 +30,7 @@ import unittest
 from pathlib import Path
 
 from charter import doctor
-from tests import _envguard
-from tests._isolation import PersonaIso, pin_update_channel
+from tests._isolation import PersonaIso
 
 
 class LauncherCase(PersonaIso):
@@ -185,15 +184,10 @@ class TestProjectScopedServersAreChecked(LauncherCase):
         self.assertEqual(self.check().status, doctor.OK)
 
 
-class TestItIsWiredIn(unittest.TestCase):
-    def setUp(self) -> None:
-        # Outside a frame, with no session id and no pinned workspace: stated here
-        # rather than inherited from the shell the suite was launched from
-        # (#519, #521, #528).
-        _envguard.unset_all()
-
-        # `run_all` reaches `check_plugin_freshness`, and so the channel (#459).
-        pin_update_channel(self)
+class TestItIsWiredIn(PersonaIso):
+    """On a throwaway plane (`PersonaIso` also states the environment and the channel):
+    `run_all` reaches `charter.local.toml` through the `harness profiles` row, and the real
+    plane's file is the operator's own — `tests/_planeguard` refuses the read."""
 
     def test_the_check_runs_in_doctor(self):
         """A check nothing calls is the same silence it was written to end."""

--- a/tests/test_doctor_personas.py
+++ b/tests/test_doctor_personas.py
@@ -16,7 +16,7 @@ import unittest
 
 from charter import config, doctor, persona
 from tests import _envguard
-from tests._isolation import PersonaIso, pin_update_channel
+from tests._isolation import PersonaIso
 
 
 class PersonaCheck(PersonaIso):
@@ -138,10 +138,6 @@ class RunTakesATimeoutAndDoctorStreams(unittest.TestCase):
         # (#519, #521, #528).
         _envguard.unset_all()
 
-        # The two cases that drive the real `iter_all`/`run_all` reach
-        # `check_plugin_freshness`, and so the channel (#459).
-        pin_update_channel(self)
-
     def test_run_raises_a_charter_error_not_subprocess_timeoutexpired(self):
         """`cli.main` catches `KeyboardInterrupt` and nothing else, so a bare
         `TimeoutExpired` reached the user as a traceback from inside charter."""
@@ -154,18 +150,6 @@ class RunTakesATimeoutAndDoctorStreams(unittest.TestCase):
     def test_a_command_without_a_timeout_is_unbounded_as_before(self):
         from charter import util
         self.assertEqual(util.run(["true"], check=False).returncode, 0)
-
-    def test_doctor_yields_results_one_at_a_time(self):
-        """The streaming half: what makes a killed preflight say where it stopped."""
-        from charter import doctor
-        it = doctor.iter_all()
-        first = next(it)
-        self.assertIsInstance(first, doctor.Result)
-        self.assertTrue(first.name)
-
-    def test_run_all_still_returns_them_all(self):
-        from charter import doctor
-        self.assertEqual(len(doctor.run_all()), len(list(doctor.iter_all())))
 
     def test_a_timed_out_vault_is_its_own_state(self):
         """Not "unhealthy" — the vault is fine, the provider CLI did not answer, and the
@@ -180,6 +164,22 @@ class RunTakesATimeoutAndDoctorStreams(unittest.TestCase):
             res = doctor.check_vaults()
         self.assertEqual(res.status, doctor.WARN)
         self.assertIn("timed out", res.hint)
+
+
+class DoctorStreamsOnAThrowawayPlane(PersonaIso):
+    """The two cases that drive the whole preflight, on a throwaway plane. `run_all` reaches
+    `charter.local.toml` through the `harness profiles` row, and the real plane's file is the
+    operator's own — `tests/_planeguard` refuses the read."""
+
+    def test_doctor_yields_results_one_at_a_time(self):
+        """The streaming half: what makes a killed preflight say where it stopped."""
+        it = doctor.iter_all()
+        first = next(it)
+        self.assertIsInstance(first, doctor.Result)
+        self.assertTrue(first.name)
+
+    def test_run_all_still_returns_them_all(self):
+        self.assertEqual(len(doctor.run_all()), len(list(doctor.iter_all())))
 
 
 if __name__ == "__main__":

--- a/tests/test_harness_profiles_are_read_from_the_local_file.py
+++ b/tests/test_harness_profiles_are_read_from_the_local_file.py
@@ -21,7 +21,7 @@ import unittest
 from pathlib import Path
 from unittest import mock
 
-from charter import cli, config, contain, instance, profiles
+from charter import cli, config, contain, instance, profiles, util
 from tests import _envguard, _isolation
 from tests._isolation import PersonaIso
 
@@ -79,6 +79,31 @@ class TheLocalFileIsRead(_LocalFile):
         self.assertEqual(self._read().profiles["claude"],
                          profiles.Profile("claude", "claude", "claude-code", ("claude",), (),
                                           "built-in"))
+
+    def test_a_harness_registered_without_a_cli_name_is_no_kind_and_no_profile(self):
+        """`Harness.cli_name` defaults to "", and a harness with no word after `charter` is not
+        launchable as one. Without the filter in `_kinds` it would be a kind named "" and a
+        built-in profile nobody can type. Every harness registered today has a word, so only
+        a registry with one that does not can show the filter doing anything."""
+        from types import SimpleNamespace
+
+        from charter.harness import registry
+
+        headless = SimpleNamespace(name="headless", cli_name="")
+        with mock.patch.object(registry, "all", return_value=[*registry.all(), headless]):
+            self.assertNotIn("", profiles._kinds())
+            self.assertEqual(set(profiles.builtins()), _BUILT_INS)
+
+    def test_a_cfg_that_is_not_a_table_declares_nothing_and_raises_nothing(self):
+        """`derive`'s docstring promises it never raises, and `current` hands it whatever
+        `instance.load` returned. A value that is not a table declares nothing: the built-ins,
+        and no refusal. The sweep of `ce7f5d8` collapsed the `isinstance(cfg, dict)` guard to
+        `cfg.get("harness")` with the suite still green."""
+        for cfg in (None, [], "schema = 1"):
+            with self.subTest(cfg=cfg):
+                r = profiles.derive(config.ROOT, cfg)
+                self.assertEqual(set(r.profiles), _BUILT_INS)
+                self.assertEqual(r.refused, ())
 
     def test_a_declared_profile_is_read_with_its_kind_command_and_env(self):
         p = self._local(_WORK).profiles["claude-work"]
@@ -354,6 +379,26 @@ class ABrokenProfileIsRefusedAlone(_LocalFile):
                 with self.subTest(harness=h.name):
                     self.assertIn(h.name, profiles.LOGIN)
 
+    def test_a_kind_registered_without_a_login_sentence_still_gets_one(self):
+        """The pin above holds for every kind today. This is what a kind registered without a
+        login sentence costs: a general sentence in the refusal, not the row — doctor reads
+        through here, and doctor is what the operator runs when something is wrong."""
+        with mock.patch.dict(profiles.LOGIN, clear=True):
+            reason = self._refused('[harness.s]\nkind = "claude"\ncommand = ["claude"]\n'
+                                   'env = { API_KEY = "v" }\n', "s")
+        self.assertIn("log in inside that harness", reason)
+
+    def test_a_refusal_names_the_first_offending_variable_by_name(self):
+        """By name, not by where it was written: reordering a table changes no sentence. The
+        sweep of `ce7f5d8` swapped the `sorted` for `list` with the suite still green."""
+        for env, first, later in (('{ CHARTER_Z = "1", CHARTER_A = "2" }', "CHARTER_A", "CHARTER_Z"),
+                                  ('{ Z_TOKEN = "1", A_KEY = "2" }', "A_KEY", "Z_TOKEN")):
+            with self.subTest(env=env):
+                reason = self._refused('[harness.v]\nkind = "claude"\ncommand = ["claude"]\n'
+                                       f'env = {env}\n', "v")
+                self.assertIn(first, reason)
+                self.assertNotIn(later, reason)
+
     def test_an_unreadable_local_file_keeps_the_built_ins(self):
         r = self._local(_OK + "[harness")
         self.assertEqual(set(r.profiles), _BUILT_INS)
@@ -457,6 +502,74 @@ class ABrokenProfileIsRefusedAlone(_LocalFile):
             with self.subTest(name=name):
                 reason = self._refused(f"[harness.{name}]\n", name)
                 self.assertIn('has kind ""', reason)
+
+
+class EveryLayerEscapesWhatItRepeats(_LocalFile):
+    """Ruling 35 at each layer that repeats a value, not only where the value is first read.
+
+    A name reaching these layers today has passed `NAME_RE` or is a built-in's word, so it
+    carries no control byte — but a layer that leaned on that would print whatever a future
+    source of names hands it. Survivor [12] asked this of `harness list`'s NAME cell; the
+    sweep of `ce7f5d8` asked it of the three layers below. Git's own words come from outside
+    charter whatever validates the rest."""
+
+    _ODD = "a" + chr(13) + "b"
+
+    def _unvalidated(self, command=("claude",)) -> profiles.ProfileSet:
+        odd = profiles.Profile(self._ODD, "claude", "claude-code", command, (),
+                               "charter.local.toml")
+        return profiles.ProfileSet({self._ODD: odd}, (), self._ODD, "charter.local.toml", None)
+
+    def test_the_ignore_check_refuses_an_unvalidated_name_escaped(self):
+        """`with_ignore_check` names each profile it moves, and `_narrowed` names the default
+        it had to drop."""
+        r = profiles.with_ignore_check(self._unvalidated(),
+                                       profiles.IgnoreCheck("git would carry it", "fix"))
+        self.assertEqual([x.name for x in r.refused], [contain.readable(self._ODD)])
+        self.assertIsNone(r.default)
+        self.assertEqual(r.default_refused, contain.readable(self._ODD))
+
+    def test_current_refuses_an_unvalidated_name_escaped(self):
+        """`current()` names a profile it refuses for a command that is charter itself."""
+        profiles._last.clear()
+        self.addCleanup(profiles._last.clear)
+        with mock.patch.object(profiles, "derive", return_value=self._unvalidated(("charter",))):
+            r = profiles.current()
+        [refused] = [x for x in r.refused if x.source == "charter.local.toml"]
+        self.assertEqual(refused.name, contain.readable(self._ODD))
+        self.assertIn(contain.readable(self._ODD), refused.reason)
+        self.assertNotIn(chr(13), refused.reason)
+
+    def test_gits_own_words_are_escaped_in_the_refusal_and_the_fix(self):
+        (config.ROOT / "charter.local.toml").write_text(_OK)
+        said = "fatal: " + self._ODD
+        with mock.patch.object(util, "git_path_state", return_value=(util.UNKNOWN_GIT, said)):
+            check = profiles.ignore_check(config.ROOT)
+        for text in check:
+            self.assertIn(contain.readable(said), text)
+            self.assertNotIn(chr(13), text)
+
+    def test_the_parsers_own_words_are_escaped(self):
+        """Why the file could not be read is `tomllib`'s or the operating system's text, and
+        `LOCAL_UNREADABLE` repeats it."""
+        said = "bad " + self._ODD
+        with mock.patch.object(profiles, "_read_local", return_value=({}, said)):
+            r = self._read()
+        [refused] = [x for x in r.refused if x.source == "charter.local.toml"]
+        self.assertIn(contain.readable(said), refused.reason)
+        self.assertNotIn(chr(13), refused.reason)
+
+
+class TheIgnoreCheckMovesOnlyWhatTheLocalFileDeclares(_LocalFile):
+    def test_a_built_in_stays_a_profile_and_is_not_also_refused(self):
+        """F1 refuses what `charter.local.toml` declares, because that file is the one git
+        would carry. A built-in comes from the registry, so it stays a profile — and appears
+        once: refused as well, it would read as broken while it still launches. The sweep of
+        `ce7f5d8` dropped the `p.source == LOCAL_FILE` filter with the suite still green."""
+        r = profiles.with_ignore_check(self._local(_OK),
+                                       profiles.IgnoreCheck("git would carry it", "fix"))
+        self.assertEqual(set(r.profiles), _BUILT_INS)
+        self.assertEqual([x.name for x in r.refused], ["ok"])
 
 
 class CharterTomlCarriesNoProfile(_LocalFile):

--- a/tests/test_harness_profiles_are_read_from_the_local_file.py
+++ b/tests/test_harness_profiles_are_read_from_the_local_file.py
@@ -474,6 +474,8 @@ class ABrokenProfileIsRefusedAlone(_LocalFile):
              "u", f"envi{cr}ronment"),
             ("NESTED_TABLE", _OK + '[harness.n."a\\rb"]\n' + tail,
              esc(f"n.a{cr}b"), f"a{cr}b"),
+            ("NESTED_TABLE, the parent", _OK + '[harness."p\\rq".sub]\n' + tail,
+             esc(f"p{cr}q.sub"), f"p{cr}q"),
             ("LOCAL_SECTION", _OK + '["for\\rge"]\nhost = "x"\n',
              esc(f"for{cr}ge"), f"for{cr}ge"),
         ]

--- a/tests/test_harness_profiles_are_read_from_the_local_file.py
+++ b/tests/test_harness_profiles_are_read_from_the_local_file.py
@@ -1,0 +1,417 @@
+"""A harness profile is read from `charter.local.toml`, and a broken one is refused alone.
+
+Charter launched one program per harness kind, one way (`Harness.binary`), so an operator
+with a work and a personal Claude Code account, or a Codex pinned to an older release, had
+no way to tell charter so. A profile is that way: a kind, a command and an environment,
+declared in a file that stays on this machine
+(`docs/superpowers/specs/2026-09-11-harness-profiles.md`). These cases pin what is read,
+what is refused and why, and that reading costs no subprocess, because every hook process
+derives config.
+
+The filename is spelled out in every fixture rather than read off `profiles.LOCAL_FILE`: a
+round trip through the constant cannot pin the name an operator types.
+"""
+
+from __future__ import annotations
+
+import os
+import unittest
+from unittest import mock
+
+from charter import cli, config, instance, profiles
+from tests._isolation import PersonaIso
+
+#: The spec's own example: a second Claude Code account in its own config folder.
+_WORK = """
+[harness.claude-work]
+kind = "claude"
+command = ["claude"]
+env = { CLAUDE_CONFIG_DIR = "~/.claude-work" }
+"""
+
+#: A good profile declared beside every broken one, so "refused alone" is observable.
+_OK = """
+[harness.ok]
+kind = "claude"
+command = ["claude"]
+"""
+
+_BUILT_INS = {"claude", "codex", "opencode"}
+
+
+class _LocalFile(PersonaIso):
+    """Writes the throwaway plane's local file and reads profiles the two ways charter does."""
+
+    def _local(self, text: str) -> dict:
+        (config.ROOT / "charter.local.toml").write_text(text)
+        return profiles.derive(config.ROOT, instance.load(config.ROOT))
+
+    def _current(self, text: str) -> dict:
+        (config.ROOT / "charter.local.toml").write_text(text)
+        # Re-derived, so `config.PROFILES` is this plane's; `PersonaIso`'s own snapshot is
+        # the one its cleanup puts back.
+        config.use(config.ROOT)
+        return profiles.current()
+
+    def _charter_toml(self, text: str) -> None:
+        (config.ROOT / "charter.toml").write_text("schema = 1\n" + text)
+
+    def _read(self) -> dict:
+        return profiles.derive(config.ROOT, instance.load(config.ROOT))
+
+
+class TheLocalFileIsRead(_LocalFile):
+    def test_a_plane_with_no_local_file_has_exactly_the_built_ins(self):
+        """A plane that declared nothing sees no change: every kind is still launchable as
+        the word it always was."""
+        r = self._read()
+        self.assertEqual(set(r["profiles"]), _BUILT_INS)
+        for p in r["profiles"].values():
+            self.assertEqual(p.source, "built-in")
+        self.assertEqual(r["refused"], ())
+
+    def test_a_built_in_runs_its_kind_with_no_environment(self):
+        self.assertEqual(self._read()["profiles"]["claude"],
+                         profiles.Profile("claude", "claude", "claude-code", ("claude",), (),
+                                          "built-in"))
+
+    def test_a_declared_profile_is_read_with_its_kind_command_and_env(self):
+        p = self._local(_WORK)["profiles"]["claude-work"]
+        self.assertEqual(p.kind, "claude")
+        self.assertEqual(p.harness, "claude-code")
+        self.assertEqual(p.command, ("claude",))
+        self.assertEqual(p.env, (("CLAUDE_CONFIG_DIR", "~/.claude-work"),))
+        self.assertEqual(p.source, "charter.local.toml")
+
+    def test_a_declared_profile_replaces_the_built_in_of_its_name(self):
+        """How plain `claude` gets pinned."""
+        r = self._local('[harness.claude]\nkind = "claude"\ncommand = ["/opt/claude"]\n')
+        self.assertEqual(r["profiles"]["claude"].command, ("/opt/claude",))
+        self.assertEqual(r["profiles"]["claude"].source, "charter.local.toml")
+
+    def test_env_is_optional(self):
+        self.assertEqual(self._local(_OK)["profiles"]["ok"].env, ())
+
+    def test_env_is_kept_sorted_by_name(self):
+        """One order for one environment, so two reads of the same file compare equal."""
+        r = self._local('[harness.w]\nkind = "claude"\ncommand = ["claude"]\n'
+                        'env = { Z_LAST = "z", A_FIRST = "a" }\n')
+        self.assertEqual(r["profiles"]["w"].env, (("A_FIRST", "a"), ("Z_LAST", "z")))
+
+    def test_the_local_default_wins_over_charter_toml(self):
+        self._charter_toml('[harness]\ndefault = "codex"\n')
+        r = self._local('[harness]\ndefault = "claude-work"\n' + _WORK)
+        self.assertEqual(r["default"], "claude-work")
+        self.assertEqual(r["default_from"], "charter.local.toml")
+        self.assertIsNone(r["default_refused"])
+
+    def test_a_default_naming_no_profile_is_refused_by_value(self):
+        r = self._local('[harness]\ndefault = "nope"\n')
+        self.assertIsNone(r["default"])
+        self.assertEqual(r["default_refused"], "nope")
+
+    def test_a_default_that_is_not_text_is_refused_by_value(self):
+        """`tomllib` hands back lists and tables too. A value of the wrong type is as
+        declared, and as not in force, as a misspelt name — `instance.harness_of`'s rule."""
+        r = self._local('[harness]\ndefault = ["claude"]\n')
+        self.assertIsNone(r["default"])
+        self.assertIn("claude", r["default_refused"])
+
+    def test_no_default_declared_is_not_a_refusal(self):
+        r = self._read()
+        self.assertIsNone(r["default"])
+        self.assertIsNone(r["default_from"])
+        self.assertIsNone(r["default_refused"])
+
+
+class WhatALaunchWillBeHanded(_LocalFile):
+    """The command and environment as declared, and the two expansions no shell does."""
+
+    def test_a_leading_tilde_is_expanded_in_the_first_word_and_every_env_value(self):
+        r = self._local('[harness.w]\nkind = "claude"\n'
+                        'command = ["~/bin/claude", "~/not-expanded"]\n'
+                        'env = { CLAUDE_CONFIG_DIR = "~/.claude-work", B = "~/b" }\n')
+        p = r["profiles"]["w"]
+        with mock.patch.dict(os.environ, {"HOME": "/home/op"}):
+            self.assertEqual(profiles.expanded_command(p),
+                             ["/home/op/bin/claude", "~/not-expanded"])
+            self.assertEqual(profiles.expanded_env(p),
+                             {"B": "/home/op/b", "CLAUDE_CONFIG_DIR": "/home/op/.claude-work"})
+        self.assertEqual(p.command, ("~/bin/claude", "~/not-expanded"))
+
+    def test_display_shows_the_environment_then_the_command(self):
+        p = self._local(_WORK)["profiles"]["claude-work"]
+        self.assertEqual(profiles.display(p), "CLAUDE_CONFIG_DIR=~/.claude-work claude")
+
+    def test_display_escapes_control_bytes_in_an_env_value_too(self):
+        """Ruling 35: a value from a file a chat can write is shown, never interpreted."""
+        p = self._local('[harness.w]\nkind = "claude"\ncommand = ["claude"]\n'
+                        'env = { CLAUDE_CONFIG_DIR = "~/x\\r\\u001B[2Kfine" }\n')["profiles"]["w"]
+        shown = profiles.display(p)
+        self.assertNotIn("\r", shown)
+        self.assertNotIn("\x1b", shown)
+
+
+class ABrokenProfileIsRefusedAlone(_LocalFile):
+    def _refused(self, body: str, name: str, *, read: dict | None = None) -> str:
+        r = read if read is not None else self._local(_OK + body)
+        self.assertIn("ok", r["profiles"], "a broken profile took a good one down with it")
+        self.assertNotIn(name, r["profiles"])
+        reasons = [x.reason for x in r["refused"] if x.name == name]
+        self.assertEqual(len(reasons), 1, r["refused"])
+        return reasons[0]
+
+    def test_an_unknown_kind_is_refused_naming_the_kinds(self):
+        for kind in ('kind = "gemini"\n', "", 'kind = "claude-code"\n'):
+            with self.subTest(kind=kind):
+                reason = self._refused(f'[harness.gem]\n{kind}command = ["gemini"]\n', "gem")
+                self.assertIn("claude, opencode, codex", reason)
+
+    def test_a_command_written_as_a_string_is_refused(self):
+        reason = self._refused('[harness.s]\nkind = "claude"\ncommand = "claude --resume x"\n',
+                               "s")
+        self.assertIn("never a shell string", reason)
+
+    def test_an_empty_command_is_refused(self):
+        for command in ("command = []\n", ""):
+            with self.subTest(command=command):
+                reason = self._refused(f'[harness.e]\nkind = "claude"\n{command}', "e")
+                self.assertIn("never a shell string", reason)
+
+    def test_a_command_holding_a_non_string_is_refused(self):
+        for command in ('["claude", 3]', '[""]'):
+            with self.subTest(command=command):
+                reason = self._refused(f'[harness.n]\nkind = "claude"\ncommand = {command}\n',
+                                       "n")
+                self.assertIn("never a shell string", reason)
+
+    def test_a_profile_named_default_is_refused(self):
+        """`default` is the one key under `[harness]` that is not a profile."""
+        reason = self._refused('[harness.default]\nkind = "claude"\ncommand = ["claude"]\n',
+                               "default")
+        self.assertIn("cannot be named 'default'", reason)
+
+    def test_a_name_with_a_dot_is_refused(self):
+        """Ruling 5: a dot in a name broke tmux targets in #695."""
+        reason = self._refused('[harness."claude.work"]\nkind = "claude"\ncommand = ["claude"]\n',
+                               "claude.work")
+        self.assertIn("letters, digits", reason)
+
+    def test_a_name_with_a_trailing_newline_is_refused(self):
+        """`$` matches before a final newline, so the alphabet has to be a whole match."""
+        r = self._local(_OK + '[harness."work\\n"]\nkind = "claude"\ncommand = ["claude"]\n')
+        self.assertIn("ok", r["profiles"])
+        self.assertNotIn("work\n", r["profiles"])
+        (refusal,) = [x for x in r["refused"] if "letters, digits" in x.reason]
+        self.assertNotIn("\n", refusal.name)
+
+    def test_a_profile_that_is_not_a_table_is_refused_by_name(self):
+        reason = self._refused('[harness]\nwork = "claude"\n', "work")
+        self.assertIn("is not a table", reason)
+
+    def test_an_env_that_is_not_text_is_refused(self):
+        for env in ("env = { N = 3 }\n", 'env = "CLAUDE_CONFIG_DIR=~/x"\n'):
+            with self.subTest(env=env):
+                reason = self._refused(f'[harness.v]\nkind = "claude"\ncommand = ["claude"]\n{env}',
+                                       "v")
+                self.assertIn("table of text values", reason)
+
+    def test_an_unknown_profile_key_is_refused(self):
+        """Review 13: a typo'd `env` would otherwise drop `CLAUDE_CONFIG_DIR` and launch the
+        default account without a word."""
+        reason = self._refused('[harness.t]\nkind = "claude"\ncommand = ["claude"]\n'
+                               'enviroment = { CLAUDE_CONFIG_DIR = "~/.claude-work" }\n', "t")
+        self.assertIn("does not read", reason)
+
+    def test_a_refused_replacement_of_a_built_in_takes_its_name_with_it(self):
+        """Review 13's reason, followed through. The operator declared how `claude` runs; if
+        that declaration is refused and the built-in stood in, `claude` would run the default
+        account — the launch the refusal exists to stop, and ruling 19's reason for refusing
+        a replaced built-in rather than falling back to it."""
+        reason = self._refused('[harness.claude]\nkind = "claude"\ncommand = ["claude"]\n'
+                               'enviroment = { CLAUDE_CONFIG_DIR = "~/.claude-work" }\n',
+                               "claude")
+        self.assertIn("does not read", reason)
+
+    def test_an_env_name_starting_with_charter_is_refused(self):
+        """Ruling 14: it would tell every hook the wrong harness or plane."""
+        for var in ('CHARTER_HARNESS = "codex"', 'charter_root = "/elsewhere"'):
+            with self.subTest(var=var):
+                reason = self._refused(f'[harness.c]\nkind = "claude"\ncommand = ["claude"]\n'
+                                       f'env = {{ {var} }}\n', "c")
+                self.assertIn("one of charter's own variables", reason)
+
+    def test_a_command_that_is_charter_itself_is_refused_by_current(self):
+        """Ruling 14: a new chat on it would open the selector again, forever."""
+        for command in ('["charter"]', '["/usr/local/bin/charter", "claude"]',
+                        '["python3", "-m", "charter"]', '["edm"]'):
+            with self.subTest(command=command):
+                body = f'[harness.loop]\nkind = "claude"\ncommand = {command}\n'
+                reason = self._refused(body, "loop", read=self._current(_OK + body))
+                self.assertIn("runs charter itself", reason)
+        read = self._current(_OK + '[harness.near]\nkind = "claude"\ncommand = ["charterize"]\n')
+        self.assertIn("near", read["profiles"])
+
+    def test_a_replacement_that_runs_charter_takes_its_name_with_it_too(self):
+        read = self._current(_OK + '[harness.claude]\nkind = "claude"\ncommand = ["charter"]\n')
+        self._refused("", "claude", read=read)
+
+    def test_a_secret_shaped_env_name_is_refused_for_each_word(self):
+        """Anything set on the harness reaches the model's own shell (measured on Claude Code
+        and Codex), so charter holds no credential in a profile and points at the harness's
+        own login instead. The value is never repeated back."""
+        for var in ("MY_KEY", "MY_TOKEN", "MY_SECRET", "MY_PASSWORD", "api_key"):
+            with self.subTest(var=var):
+                body = (f'[harness.leaky]\nkind = "claude"\ncommand = ["claude"]\n'
+                        f'env = {{ {var} = "sk-live-123" }}\n')
+                r = self._local(_OK + body)
+                reason = self._refused(body, "leaky", read=r)
+                self.assertIn(var, reason)
+                self.assertIn("CLAUDE_CONFIG_DIR and run /login", reason)
+                self.assertNotIn("sk-live-123", repr(r["refused"]))
+        for kind, login in (("codex", "CODEX_HOME and run codex login"),
+                            ("opencode", "XDG_DATA_HOME and run opencode auth login")):
+            with self.subTest(kind=kind):
+                body = (f'[harness.leaky]\nkind = "{kind}"\ncommand = ["{kind}"]\n'
+                        f'env = {{ API_TOKEN = "sk-live-123" }}\n')
+                reason = self._refused(body, "leaky")
+                self.assertIn(login, reason)
+                self.assertNotIn("sk-live-123", reason)
+
+    def test_every_kind_charter_can_launch_names_its_login(self):
+        """A kind registered without a login sentence would refuse a credential and point at
+        nothing in particular."""
+        from charter.harness import registry
+
+        for h in registry.all():
+            if h.cli_name:
+                with self.subTest(harness=h.name):
+                    self.assertIn(h.name, profiles.LOGIN)
+
+    def test_an_unreadable_local_file_keeps_the_built_ins(self):
+        r = self._local(_OK + "[harness")
+        self.assertEqual(set(r["profiles"]), _BUILT_INS)
+        self.assertEqual(len(r["refused"]), 1)
+        self.assertEqual(r["refused"][0].name, "")
+        self.assertEqual(r["refused"][0].source, "charter.local.toml")
+
+    def test_a_harness_that_is_not_a_table_is_refused_whole(self):
+        r = self._local('harness = "claude-work"\n')
+        self.assertEqual(set(r["profiles"]), _BUILT_INS)
+        self.assertEqual([x.name for x in r["refused"]], [""])
+
+    def test_a_section_other_than_harness_is_refused_by_name(self):
+        """An ignored file must not change plane policy with no trace in git: `[[forge]]`
+        hosts steer the credential guard."""
+        reason = self._refused('[forge]\nhost = "example.com"\n', "forge")
+        self.assertIn("charter.toml", reason)
+
+    def test_each_refusal_says_a_different_thing(self):
+        """Every refusal is asked about one profile named `x` where its rule allows, so two
+        rules sharing a sentence cannot hide behind two different names."""
+        profile = '[harness.x]\nkind = "claude"\ncommand = ["claude"]\n'
+        bodies = [
+            '[harness."x.y"]\nkind = "claude"\ncommand = ["claude"]\n',
+            '[harness.default]\nkind = "claude"\ncommand = ["claude"]\n',
+            '[harness.x]\nkind = "gemini"\ncommand = ["claude"]\n',
+            '[harness.x]\nkind = "claude"\ncommand = "claude"\n',
+            profile + 'env = { N = 3 }\n',
+            profile + 'env = { CHARTER_ROOT = "/x" }\n',
+            profile + 'env = { API_KEY = "v" }\n',
+            profile + 'enviroment = {}\n',
+            '[harness]\nx = "claude"\n',
+            '[x]\n',
+            '[harness',
+        ]
+        reasons = [self._local(b)["refused"][0].reason for b in bodies]
+        reasons.append(self._current('[harness.doctor]\nkind = "claude"\ncommand = ["claude"]\n')
+                       ["refused"][0].reason)
+        reasons.append(self._current('[harness.x]\nkind = "claude"\ncommand = ["charter"]\n')
+                       ["refused"][0].reason)
+        (config.ROOT / "charter.local.toml").unlink()
+        self._charter_toml(profile)
+        reasons.append(self._read()["refused"][0].reason)
+        self.assertEqual(len(set(reasons)), len(reasons), reasons)
+
+
+class CharterTomlCarriesNoProfile(_LocalFile):
+    def test_a_profile_table_in_charter_toml_is_refused_with_a_pointer(self):
+        """A committed command could be changed by a merged PR or by a chat and then run on
+        every machine, so the committed file is refused as a home for one."""
+        self._charter_toml('[harness.x]\nkind = "claude"\ncommand = ["claude"]\n')
+        r = self._read()
+        (refusal,) = r["refused"]
+        self.assertEqual(refusal.source, "charter.toml")
+        self.assertIn("move the table", refusal.reason.lower())
+        self.assertNotIn("x", r["profiles"])
+
+    def test_a_committed_table_named_like_a_built_in_leaves_the_built_in(self):
+        """charter.toml's tables are not read as profiles at all, so one there has no power
+        to take a launcher away from somebody else's machine."""
+        self._charter_toml('[harness.claude]\nkind = "claude"\ncommand = ["/opt/claude"]\n')
+        r = self._read()
+        self.assertEqual(r["profiles"]["claude"].source, "built-in")
+        self.assertEqual([x.source for x in r["refused"]], ["charter.toml"])
+
+    def test_charter_toml_default_is_still_read(self):
+        self._charter_toml('[harness]\ndefault = "codex"\n')
+        r = self._read()
+        self.assertEqual(r["default"], "codex")
+        self.assertEqual(r["default_from"], "charter.toml")
+
+    def test_other_keys_in_charter_tomls_harness_are_still_ignored(self):
+        """Pin. Review 13 dropped this refusal: no `doctor` warning on a plane that did
+        nothing wrong."""
+        self._charter_toml('[harness]\nnothing = "here"\n')
+        self.assertEqual([x for x in self._read()["refused"] if x.source == "charter.toml"], [])
+
+
+class NamesThatClashWithACommand(_LocalFile):
+    def test_a_profile_named_like_a_command_is_refused_by_current(self):
+        """The kind clash in `cli._add_frame_parsers` raises and takes every command down,
+        which is right for a registry mistake CI sees and wrong for one machine's file."""
+        read = self._current(_OK + '[harness.doctor]\nkind = "claude"\ncommand = ["claude"]\n')
+        self.assertIn("ok", read["profiles"])
+        self.assertNotIn("doctor", read["profiles"])
+        (refusal,) = [x for x in read["refused"] if x.name == "doctor"]
+        self.assertIn("charter doctor", refusal.reason)
+
+    def test_a_default_naming_a_clashing_profile_is_refused(self):
+        read = self._current('[harness]\ndefault = "doctor"\n'
+                             '[harness.doctor]\nkind = "claude"\ncommand = ["claude"]\n')
+        self.assertIsNone(read["default"])
+        self.assertEqual(read["default_refused"], "doctor")
+
+    def test_the_command_words_hold_the_core_commands_and_not_the_kinds(self):
+        self.assertLessEqual({"doctor", "workspace", "frame", "frame-new-chat"},
+                             cli.command_words())
+        self.assertNotIn("claude", cli.command_words())
+
+
+class TheConfigReadIsCheap(_LocalFile):
+    def test_deriving_profiles_runs_no_subprocess(self):
+        """Every hook process runs `config.derive`, and `hooks/hooks.json` fires on Bash,
+        Read, Grep, Write, Edit, Task, Skill and SendMessage — so the git check belongs to
+        the surfaces a person runs, never to this read. The file here is one git would
+        commit, which is exactly when a git call would be tempting."""
+        (config.ROOT / "charter.local.toml").write_text(_WORK)
+        with mock.patch("subprocess.run", side_effect=AssertionError("a config read ran git")), \
+             mock.patch("subprocess.Popen", side_effect=AssertionError("a config read spawned")):
+            config.use(config.ROOT)
+        self.assertIn("claude-work", config.PROFILES["profiles"])
+
+    def test_config_carries_the_profiles(self):
+        (config.ROOT / "charter.local.toml").write_text(_WORK)
+        config.use(config.ROOT)
+        self.assertIn("claude-work", config.PROFILES["profiles"])
+
+
+class ProfilesAreDerivedBeforeTheHarnessDefault(unittest.TestCase):
+    def test_profiles_come_first(self):
+        """Review 14: what `[harness] default` resolves against is read off the profiles, so
+        they have to exist by the time it is derived."""
+        self.assertLess(config.DERIVED.index("PROFILES"), config.DERIVED.index("HARNESS"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_harness_profiles_are_read_from_the_local_file.py
+++ b/tests/test_harness_profiles_are_read_from_the_local_file.py
@@ -15,11 +15,18 @@ round trip through the constant cannot pin the name an operator types.
 from __future__ import annotations
 
 import os
+import subprocess
+import sys
 import unittest
+from pathlib import Path
 from unittest import mock
 
 from charter import cli, config, instance, profiles
+from tests import _envguard, _isolation
 from tests._isolation import PersonaIso
+
+#: The checkout these tests were loaded from: a child `python -c` run here imports it.
+REPO = Path(__file__).resolve().parents[1]
 
 #: The spec's own example: a second Claude Code account in its own config folder.
 _WORK = """
@@ -46,11 +53,9 @@ class _LocalFile(PersonaIso):
         (config.ROOT / "charter.local.toml").write_text(text)
         return profiles.derive(config.ROOT, instance.load(config.ROOT))
 
-    def _current(self, text: str) -> dict:
+    def _current(self, text: str) -> profiles.ProfileSet:
+        # `profiles.current()` reads the file itself (ruling 43): nothing to re-derive.
         (config.ROOT / "charter.local.toml").write_text(text)
-        # Re-derived, so `config.PROFILES` is this plane's; `PersonaIso`'s own snapshot is
-        # the one its cleanup puts back.
-        config.use(config.ROOT)
         return profiles.current()
 
     def _charter_toml(self, text: str) -> None:
@@ -432,22 +437,94 @@ class NamesThatClashWithACommand(_LocalFile):
         self.assertNotIn("claude", cli.command_words())
 
 
-class TheConfigReadIsCheap(_LocalFile):
-    def test_deriving_profiles_runs_no_subprocess(self):
-        """Every hook process runs `config.derive`, and `hooks/hooks.json` fires on Bash,
-        Read, Grep, Write, Edit, Task, Skill and SendMessage — so the git check belongs to
-        the surfaces a person runs, never to this read. The file here is one git would
-        commit, which is exactly when a git call would be tempting."""
+class ReadingProfilesIsCheap(_LocalFile):
+    def test_reading_profiles_runs_no_subprocess(self):
+        """The git check belongs to the ignore check a surface asks for, never to the read
+        itself. The file here is one git would commit, which is exactly when a git call in
+        the read would be tempting."""
         (config.ROOT / "charter.local.toml").write_text(_WORK)
-        with mock.patch("subprocess.run", side_effect=AssertionError("a config read ran git")), \
-             mock.patch("subprocess.Popen", side_effect=AssertionError("a config read spawned")):
-            config.use(config.ROOT)
-        self.assertIn("claude-work", config.PROFILES["profiles"])
+        with mock.patch("subprocess.run", side_effect=AssertionError("reading profiles ran git")), \
+             mock.patch("subprocess.Popen", side_effect=AssertionError("reading profiles spawned")):
+            read = profiles.current()
+        self.assertIn("claude-work", read.profiles)
 
-    def test_config_carries_the_profiles(self):
+
+class ImportingConfigReadsNoProfile(unittest.TestCase):
+    """Ruling 43. `config.derive` runs for every command and every hook process, so a profile
+    read there is paid on every tool call — and the deletion sweep charged every line of
+    `charter.profiles` to the whole suite, 347 test modules a mutation, which no CI shard could
+    finish. So importing config opens no `charter.local.toml` and runs no profiles code, and
+    `profiles.current()` reads the file when a surface asks."""
+
+    def setUp(self) -> None:
+        # Outside a frame, with no session id: stated rather than inherited from the shell.
+        _envguard.unset_all()
+
+    def test_importing_config_opens_no_local_file_and_runs_no_profiles_code(self):
+        plane, env = _isolation.child_plane_env(self)
+        (plane / "charter.local.toml").write_text(_WORK)
+        probe = (
+            "import sys\n"
+            "opened = []\n"
+            "sys.addaudithook(lambda event, args: opened.append(str(args[0])) "
+            "if event == 'open' and 'charter.local.toml' in str(args[0]) else None)\n"
+            "import charter.config\n"
+            "print('charter.profiles' in sys.modules, bool(opened), "
+            "hasattr(charter.config, 'PROFILES'))\n")
+        done = subprocess.run([sys.executable, "-c", probe], cwd=REPO, env=env,
+                              capture_output=True, text=True, timeout=60)
+        self.assertEqual(done.stdout.strip(), "False False False", done.stderr)
+
+    def test_config_derives_no_profiles(self):
+        """Ruling 43 supersedes review 14's "PROFILES derived before HARNESS"."""
+        self.assertNotIn("PROFILES", config.DERIVED)
+
+
+class BareCharterIsUnchanged(_LocalFile):
+    def test_a_local_default_naming_a_declared_profile_leaves_the_harness_default_alone(self):
+        """Pin, ruling 43 point 3. Bare `charter` reads `config.HARNESS`, which keeps exactly
+        `charter.toml`'s `[harness] default`: a local `default` naming a declared profile must
+        not reach it until launching a profile exists — while `harness list` and doctor, which
+        ask `profiles.current()`, still see it."""
+        for committed in ("", '[harness]\ndefault = "codex"\n'):
+            with self.subTest(committed=committed):
+                self._charter_toml(committed)
+                (config.ROOT / "charter.local.toml").unlink(missing_ok=True)
+                config.use(config.ROOT)
+                without = dict(config.HARNESS)
+                (config.ROOT / "charter.local.toml").write_text(
+                    '[harness]\ndefault = "claude-work"\n' + _WORK)
+                config.use(config.ROOT)
+                self.assertEqual(dict(config.HARNESS), without)
+                self.assertEqual(profiles.current().default, "claude-work")
+
+
+class CurrentIsReadOncePerFile(_LocalFile):
+    """`profiles.current()` is memoized per process (ruling 43), and the memo is keyed on what
+    the two files hold, so an edit is read again without anybody re-deriving config."""
+
+    def test_the_answer_is_memoized_while_the_files_are_unchanged(self):
         (config.ROOT / "charter.local.toml").write_text(_WORK)
-        config.use(config.ROOT)
-        self.assertIn("claude-work", config.PROFILES["profiles"])
+        self.assertIs(profiles.current(), profiles.current())
+
+    def test_an_edited_local_file_is_read_again(self):
+        (config.ROOT / "charter.local.toml").write_text(_WORK)
+        self.assertIn("claude-work", profiles.current().profiles)
+        (config.ROOT / "charter.local.toml").write_text(_OK)
+        now = profiles.current()
+        self.assertIn("ok", now.profiles)
+        self.assertNotIn("claude-work", now.profiles)
+
+    def test_an_edited_charter_toml_is_read_again(self):
+        self._charter_toml('[harness]\ndefault = "codex"\n')
+        self.assertEqual(profiles.current().default, "codex")
+        self._charter_toml('[harness]\ndefault = "opencode"\n')
+        self.assertEqual(profiles.current().default, "opencode")
+
+    def test_the_file_is_the_one_other_places_spell_out(self):
+        """`commands.LOCAL_PROFILES_IGNORE` and `tests/_planeguard` spell the name rather than
+        import this module (ruling 43: importing it would put it on every import path)."""
+        self.assertEqual(profiles.LOCAL_FILE, "charter.local.toml")
 
 
 class TheSentencesSayOnlyWhatIsTrueNow(unittest.TestCase):
@@ -460,11 +537,6 @@ class TheSentencesSayOnlyWhatIsTrueNow(unittest.TestCase):
                     self.assertNotIn("selector", value.lower())
 
 
-class ProfilesAreDerivedBeforeTheHarnessDefault(unittest.TestCase):
-    def test_profiles_come_first(self):
-        """Review 14: what `[harness] default` resolves against is read off the profiles, so
-        they have to exist by the time it is derived."""
-        self.assertLess(config.DERIVED.index("PROFILES"), config.DERIVED.index("HARNESS"))
 
 
 if __name__ == "__main__":

--- a/tests/test_harness_profiles_are_read_from_the_local_file.py
+++ b/tests/test_harness_profiles_are_read_from_the_local_file.py
@@ -219,6 +219,18 @@ class ABrokenProfileIsRefusedAlone(_LocalFile):
                 self.assertEqual(r.profiles["claude"].source, "built-in")
                 self.assertIn("ok", r.profiles)
 
+    def test_ruling_41_an_env_table_alone_declares_the_profile_and_refuses_the_name(self):
+        """Pin, ruling 41. `[harness.claude.env]` is the TOML spelling of profile `claude`'s
+        `env`, not a dotted name: `env` is a profile key. So it declares how `claude` runs,
+        and a replacement with no `kind` or `command` refuses the name — the built-in does
+        not stand in (ruling 37). Reading `env` as a dotted child instead would leave the
+        built-in running the default account."""
+        r = self._local(_OK + '[harness.claude.env]\nCLAUDE_CONFIG_DIR = "~/.claude-work"\n')
+        self.assertIn("ok", r.profiles)
+        self.assertNotIn("claude", r.profiles)
+        self.assertEqual([x.name for x in r.refused], ["claude"])
+        self.assertIn("claude, opencode, codex", r.refused[0].reason)
+
     def test_a_declared_profile_holding_a_dotted_child_is_refused_for_it_too(self):
         """F4's other half. A parent with keys of its own is a declaration, and it is read
         with its nested table in place: once parsed, `[harness.work.alt]` is the same thing as

--- a/tests/test_harness_profiles_are_read_from_the_local_file.py
+++ b/tests/test_harness_profiles_are_read_from_the_local_file.py
@@ -224,6 +224,27 @@ class ABrokenProfileIsRefusedAlone(_LocalFile):
                 self.assertEqual(r.profiles["claude"].source, "built-in")
                 self.assertIn("ok", r.profiles)
 
+    def test_an_inline_table_under_a_typo_names_both_readings(self):
+        """Once parsed, `enviroment = { … }` under `[harness.claude]` is the same thing as a table
+        `[harness.claude.enviroment]`, so the refusal names both readings: it is not a key charter
+        reads, and a profile named `claude.enviroment` could not carry a dot. The profile itself
+        stays refused, for the key it does not read."""
+        r = self._local(_OK + '[harness.claude]\nkind = "claude"\ncommand = ["claude"]\n'
+                              'enviroment = { CLAUDE_CONFIG_DIR = "~/.claude-work" }\n')
+        refusals = {x.name: x.reason for x in r.refused}
+        self.assertEqual(set(refusals), {"claude.enviroment", "claude"})
+        self.assertIn("not a key", refusals["claude.enviroment"])
+        self.assertIn("dot", refusals["claude.enviroment"])
+        self.assertIn("does not read", refusals["claude"])
+        self.assertNotIn("claude", r.profiles)
+
+    def test_a_table_under_a_profile_key_is_that_keys_value_not_a_dotted_name(self):
+        """`kind`, `command` and `env` are a profile's own keys, so a table under one of them is a
+        wrong value for that key and refused as one — never read as a profile named `k.kind`."""
+        r = self._local(_OK + '[harness.k]\ncommand = ["claude"]\n[harness.k.kind]\nx = 1\n')
+        self.assertEqual([x.name for x in r.refused], ["k"])
+        self.assertIn("claude, opencode, codex", r.refused[0].reason)
+
     def test_ruling_41_an_env_table_alone_declares_the_profile_and_refuses_the_name(self):
         """Pin, ruling 41. `[harness.claude.env]` is the TOML spelling of profile `claude`'s
         `env`, not a dotted name: `env` is a profile key. So it declares how `claude` runs,
@@ -520,6 +541,15 @@ class CurrentIsReadOncePerFile(_LocalFile):
         self.assertEqual(profiles.current().default, "codex")
         self._charter_toml('[harness]\ndefault = "opencode"\n')
         self.assertEqual(profiles.current().default, "opencode")
+
+    def test_an_unreadable_file_and_an_absent_one_are_different_answers(self):
+        """A file that cannot be read and no file at all must not share a memo key, or the
+        second answer is the first's. A directory stands in for the unreadable file."""
+        local = config.ROOT / "charter.local.toml"
+        local.mkdir()
+        self.assertEqual([x.name for x in profiles.current().refused], [""])
+        local.rmdir()
+        self.assertEqual(profiles.current().refused, ())
 
     def test_the_file_is_the_one_other_places_spell_out(self):
         """`commands.LOCAL_PROFILES_IGNORE` and `tests/_planeguard` spell the name rather than

--- a/tests/test_harness_profiles_are_read_from_the_local_file.py
+++ b/tests/test_harness_profiles_are_read_from_the_local_file.py
@@ -21,7 +21,7 @@ import unittest
 from pathlib import Path
 from unittest import mock
 
-from charter import cli, config, instance, profiles
+from charter import cli, config, contain, instance, profiles
 from tests import _envguard, _isolation
 from tests._isolation import PersonaIso
 
@@ -402,6 +402,61 @@ class ABrokenProfileIsRefusedAlone(_LocalFile):
         self._charter_toml(profile)
         reasons.append(self._read().refused[0].reason)
         self.assertEqual(len(set(reasons)), len(reasons), reasons)
+
+    def test_every_value_a_refusal_repeats_back_is_escaped(self):
+        """Ruling 35: a name, kind, key or variable from a file a chat can write is shown,
+        never interpreted. `harness list` prints a refusal as `derive` returned it, so each
+        sentence has to carry the escaped spelling itself. Every case puts a carriage return
+        into the one value its sentence repeats. No test held such a value until the sweep of
+        `ce7f5d8` deleted three of these `contain.readable` calls with the suite still green:
+        the name in `_profile_refusal`, the variable `SECRET_ENV` names, and the dotted name
+        `NESTED_TABLE` gives."""
+        cr, esc = chr(13), contain.readable
+        tail = 'kind = "claude"\ncommand = ["claude"]\n'
+        cases = [
+            # (the sentence, the local file, the refused entry's name, the value repeated)
+            ("ILLEGAL_NAME", _OK + '[harness."we\\rird"]\n' + tail,
+             esc(f"we{cr}ird"), f"we{cr}ird"),
+            ("NOT_A_TABLE", '[harness]\n"we\\rird" = "claude"\n' + _OK,
+             esc(f"we{cr}ird"), f"we{cr}ird"),
+            ("UNKNOWN_KIND", _OK + '[harness.k]\nkind = "cl\\raude"\ncommand = ["claude"]\n',
+             "k", f"cl{cr}aude"),
+            ("CHARTER_ENV", _OK + '[harness.c]\n' + tail + 'env = { "CHARTER_\\rX" = "v" }\n',
+             "c", f"CHARTER_{cr}X"),
+            ("SECRET_ENV", _OK + '[harness.s]\n' + tail + 'env = { "API_\\rKEY" = "v" }\n',
+             "s", f"API_{cr}KEY"),
+            ("UNKNOWN_PROFILE_KEY", _OK + '[harness.u]\n' + tail + '"envi\\rronment" = "x"\n',
+             "u", f"envi{cr}ronment"),
+            ("NESTED_TABLE", _OK + '[harness.n."a\\rb"]\n' + tail,
+             esc(f"n.a{cr}b"), f"a{cr}b"),
+            ("LOCAL_SECTION", _OK + '["for\\rge"]\nhost = "x"\n',
+             esc(f"for{cr}ge"), f"for{cr}ge"),
+        ]
+        for sentence, text, name, value in cases:
+            with self.subTest(sentence=sentence):
+                reason = self._refused("", name, read=self._local(text))
+                self.assertIn(esc(value), reason)
+                self.assertNotIn(cr, reason)
+        with self.subTest(sentence="a refused default"):
+            r = self._local('[harness]\ndefault = "no\\rpe"\n' + _OK)
+            self.assertEqual(r.default_refused, esc(f"no{cr}pe"))
+        with self.subTest(sentence="PROFILE_IN_COMMITTED"):
+            self._charter_toml('[harness."we\\rird"]\n' + tail)
+            reason = self._refused("", esc(f"we{cr}ird"), read=self._local(_OK))
+            self.assertIn(esc(f"we{cr}ird"), reason)
+            self.assertNotIn(cr, reason)
+
+    def test_a_header_with_nothing_under_it_is_refused_not_skipped(self):
+        """`[harness.work]` alone declares a profile with no kind and no command, and a broken
+        profile is refused by name like any other. Skipped, it would be neither listed nor
+        refused, and `[harness.claude]` alone would leave the built-in running where the
+        operator declared a replacement (ruling 37). Only a parent holding nothing but
+        sub-tables declares nothing (F4) — the `nested and` in `derive` is what keeps an empty
+        table from counting as one, and the sweep of `ce7f5d8` found no test for it."""
+        for name in ("work", "claude"):
+            with self.subTest(name=name):
+                reason = self._refused(f"[harness.{name}]\n", name)
+                self.assertIn('has kind ""', reason)
 
 
 class CharterTomlCarriesNoProfile(_LocalFile):

--- a/tests/test_harness_profiles_are_read_from_the_local_file.py
+++ b/tests/test_harness_profiles_are_read_from_the_local_file.py
@@ -65,18 +65,18 @@ class TheLocalFileIsRead(_LocalFile):
         """A plane that declared nothing sees no change: every kind is still launchable as
         the word it always was."""
         r = self._read()
-        self.assertEqual(set(r["profiles"]), _BUILT_INS)
-        for p in r["profiles"].values():
+        self.assertEqual(set(r.profiles), _BUILT_INS)
+        for p in r.profiles.values():
             self.assertEqual(p.source, "built-in")
-        self.assertEqual(r["refused"], ())
+        self.assertEqual(r.refused, ())
 
     def test_a_built_in_runs_its_kind_with_no_environment(self):
-        self.assertEqual(self._read()["profiles"]["claude"],
+        self.assertEqual(self._read().profiles["claude"],
                          profiles.Profile("claude", "claude", "claude-code", ("claude",), (),
                                           "built-in"))
 
     def test_a_declared_profile_is_read_with_its_kind_command_and_env(self):
-        p = self._local(_WORK)["profiles"]["claude-work"]
+        p = self._local(_WORK).profiles["claude-work"]
         self.assertEqual(p.kind, "claude")
         self.assertEqual(p.harness, "claude-code")
         self.assertEqual(p.command, ("claude",))
@@ -86,42 +86,42 @@ class TheLocalFileIsRead(_LocalFile):
     def test_a_declared_profile_replaces_the_built_in_of_its_name(self):
         """How plain `claude` gets pinned."""
         r = self._local('[harness.claude]\nkind = "claude"\ncommand = ["/opt/claude"]\n')
-        self.assertEqual(r["profiles"]["claude"].command, ("/opt/claude",))
-        self.assertEqual(r["profiles"]["claude"].source, "charter.local.toml")
+        self.assertEqual(r.profiles["claude"].command, ("/opt/claude",))
+        self.assertEqual(r.profiles["claude"].source, "charter.local.toml")
 
     def test_env_is_optional(self):
-        self.assertEqual(self._local(_OK)["profiles"]["ok"].env, ())
+        self.assertEqual(self._local(_OK).profiles["ok"].env, ())
 
     def test_env_is_kept_sorted_by_name(self):
         """One order for one environment, so two reads of the same file compare equal."""
         r = self._local('[harness.w]\nkind = "claude"\ncommand = ["claude"]\n'
                         'env = { Z_LAST = "z", A_FIRST = "a" }\n')
-        self.assertEqual(r["profiles"]["w"].env, (("A_FIRST", "a"), ("Z_LAST", "z")))
+        self.assertEqual(r.profiles["w"].env, (("A_FIRST", "a"), ("Z_LAST", "z")))
 
     def test_the_local_default_wins_over_charter_toml(self):
         self._charter_toml('[harness]\ndefault = "codex"\n')
         r = self._local('[harness]\ndefault = "claude-work"\n' + _WORK)
-        self.assertEqual(r["default"], "claude-work")
-        self.assertEqual(r["default_from"], "charter.local.toml")
-        self.assertIsNone(r["default_refused"])
+        self.assertEqual(r.default, "claude-work")
+        self.assertEqual(r.default_from, "charter.local.toml")
+        self.assertIsNone(r.default_refused)
 
     def test_a_default_naming_no_profile_is_refused_by_value(self):
         r = self._local('[harness]\ndefault = "nope"\n')
-        self.assertIsNone(r["default"])
-        self.assertEqual(r["default_refused"], "nope")
+        self.assertIsNone(r.default)
+        self.assertEqual(r.default_refused, "nope")
 
     def test_a_default_that_is_not_text_is_refused_by_value(self):
         """`tomllib` hands back lists and tables too. A value of the wrong type is as
         declared, and as not in force, as a misspelt name — `instance.harness_of`'s rule."""
         r = self._local('[harness]\ndefault = ["claude"]\n')
-        self.assertIsNone(r["default"])
-        self.assertIn("claude", r["default_refused"])
+        self.assertIsNone(r.default)
+        self.assertIn("claude", r.default_refused)
 
     def test_no_default_declared_is_not_a_refusal(self):
         r = self._read()
-        self.assertIsNone(r["default"])
-        self.assertIsNone(r["default_from"])
-        self.assertIsNone(r["default_refused"])
+        self.assertIsNone(r.default)
+        self.assertIsNone(r.default_from)
+        self.assertIsNone(r.default_refused)
 
 
 class WhatALaunchWillBeHanded(_LocalFile):
@@ -131,7 +131,7 @@ class WhatALaunchWillBeHanded(_LocalFile):
         r = self._local('[harness.w]\nkind = "claude"\n'
                         'command = ["~/bin/claude", "~/not-expanded"]\n'
                         'env = { CLAUDE_CONFIG_DIR = "~/.claude-work", B = "~/b" }\n')
-        p = r["profiles"]["w"]
+        p = r.profiles["w"]
         with mock.patch.dict(os.environ, {"HOME": "/home/op"}):
             self.assertEqual(profiles.expanded_command(p),
                              ["/home/op/bin/claude", "~/not-expanded"])
@@ -140,13 +140,13 @@ class WhatALaunchWillBeHanded(_LocalFile):
         self.assertEqual(p.command, ("~/bin/claude", "~/not-expanded"))
 
     def test_display_shows_the_environment_then_the_command(self):
-        p = self._local(_WORK)["profiles"]["claude-work"]
+        p = self._local(_WORK).profiles["claude-work"]
         self.assertEqual(profiles.display(p), "CLAUDE_CONFIG_DIR=~/.claude-work claude")
 
     def test_display_escapes_control_bytes_in_an_env_value_too(self):
         """Ruling 35: a value from a file a chat can write is shown, never interpreted."""
         p = self._local('[harness.w]\nkind = "claude"\ncommand = ["claude"]\n'
-                        'env = { CLAUDE_CONFIG_DIR = "~/x\\r\\u001B[2Kfine" }\n')["profiles"]["w"]
+                        'env = { CLAUDE_CONFIG_DIR = "~/x\\r\\u001B[2Kfine" }\n').profiles["w"]
         shown = profiles.display(p)
         self.assertNotIn("\r", shown)
         self.assertNotIn("\x1b", shown)
@@ -155,10 +155,10 @@ class WhatALaunchWillBeHanded(_LocalFile):
 class ABrokenProfileIsRefusedAlone(_LocalFile):
     def _refused(self, body: str, name: str, *, read: dict | None = None) -> str:
         r = read if read is not None else self._local(_OK + body)
-        self.assertIn("ok", r["profiles"], "a broken profile took a good one down with it")
-        self.assertNotIn(name, r["profiles"])
-        reasons = [x.reason for x in r["refused"] if x.name == name]
-        self.assertEqual(len(reasons), 1, r["refused"])
+        self.assertIn("ok", r.profiles, "a broken profile took a good one down with it")
+        self.assertNotIn(name, r.profiles)
+        reasons = [x.reason for x in r.refused if x.name == name]
+        self.assertEqual(len(reasons), 1, r.refused)
         return reasons[0]
 
     def test_an_unknown_kind_is_refused_naming_the_kinds(self):
@@ -200,10 +200,38 @@ class ABrokenProfileIsRefusedAlone(_LocalFile):
     def test_a_name_with_a_trailing_newline_is_refused(self):
         """`$` matches before a final newline, so the alphabet has to be a whole match."""
         r = self._local(_OK + '[harness."work\\n"]\nkind = "claude"\ncommand = ["claude"]\n')
-        self.assertIn("ok", r["profiles"])
-        self.assertNotIn("work\n", r["profiles"])
-        (refusal,) = [x for x in r["refused"] if "letters, digits" in x.reason]
+        self.assertIn("ok", r.profiles)
+        self.assertNotIn("work\n", r.profiles)
+        (refusal,) = [x for x in r.refused if "letters, digits" in x.reason]
         self.assertNotIn("\n", refusal.name)
+
+    def test_a_dotted_name_is_refused_by_its_dotted_spelling_in_either_spelling(self):
+        """F4. `[harness.claude.alt]` is TOML for a table `alt` inside `claude`, and it is how
+        a dotted name gets written without quotes. Both spellings mean one name, so both are
+        refused as `claude.alt`, for the dot — and `claude`, which holds only the sub-table,
+        declares nothing, so the built-in stays."""
+        for spelling in ("[harness.claude.alt]", '[harness."claude.alt"]'):
+            with self.subTest(spelling=spelling):
+                r = self._local(_OK + f'{spelling}\nkind = "claude"\ncommand = ["claude"]\n')
+                self.assertEqual([x.name for x in r.refused], ["claude.alt"])
+                self.assertIn("dot", r.refused[0].reason)
+                self.assertIn("letters, digits", r.refused[0].reason)
+                self.assertEqual(r.profiles["claude"].source, "built-in")
+                self.assertIn("ok", r.profiles)
+
+    def test_a_declared_profile_holding_a_dotted_child_is_refused_for_it_too(self):
+        """F4's other half. A parent with keys of its own is a declaration, and it is read
+        with its nested table in place: once parsed, `[harness.work.alt]` is the same thing as
+        a typo'd `enviroment = { … }`, and review 13 needs that one to refuse the profile. So
+        the child is refused for its dot and the parent for a key charter does not read."""
+        r = self._local(_OK + '[harness.work]\nkind = "claude"\ncommand = ["claude"]\n'
+                              '[harness.work.alt]\nkind = "claude"\ncommand = ["claude"]\n')
+        self.assertIn("ok", r.profiles)
+        self.assertNotIn("work", r.profiles)
+        refusals = {x.name: x.reason for x in r.refused}
+        self.assertEqual(set(refusals), {"work.alt", "work"})
+        self.assertIn("dot", refusals["work.alt"])
+        self.assertIn("does not read", refusals["work"])
 
     def test_a_profile_that_is_not_a_table_is_refused_by_name(self):
         reason = self._refused('[harness]\nwork = "claude"\n', "work")
@@ -223,11 +251,11 @@ class ABrokenProfileIsRefusedAlone(_LocalFile):
                                'enviroment = { CLAUDE_CONFIG_DIR = "~/.claude-work" }\n', "t")
         self.assertIn("does not read", reason)
 
-    def test_a_refused_replacement_of_a_built_in_takes_its_name_with_it(self):
-        """Review 13's reason, followed through. The operator declared how `claude` runs; if
+    def test_ruling_37_a_refused_replacement_never_falls_back_to_the_built_in(self):
+        """Ruling 37, which extends ruling 19. The operator declared how `claude` runs; if
         that declaration is refused and the built-in stood in, `claude` would run the default
-        account — the launch the refusal exists to stop, and ruling 19's reason for refusing
-        a replaced built-in rather than falling back to it."""
+        account — a command the operator replaced, and review 13's `enviroment` typo is
+        exactly that. So the name is refused, with its reason, and nothing takes its place."""
         reason = self._refused('[harness.claude]\nkind = "claude"\ncommand = ["claude"]\n'
                                'enviroment = { CLAUDE_CONFIG_DIR = "~/.claude-work" }\n',
                                "claude")
@@ -250,7 +278,7 @@ class ABrokenProfileIsRefusedAlone(_LocalFile):
                 reason = self._refused(body, "loop", read=self._current(_OK + body))
                 self.assertIn("runs charter itself", reason)
         read = self._current(_OK + '[harness.near]\nkind = "claude"\ncommand = ["charterize"]\n')
-        self.assertIn("near", read["profiles"])
+        self.assertIn("near", read.profiles)
 
     def test_a_replacement_that_runs_charter_takes_its_name_with_it_too(self):
         read = self._current(_OK + '[harness.claude]\nkind = "claude"\ncommand = ["charter"]\n')
@@ -268,7 +296,7 @@ class ABrokenProfileIsRefusedAlone(_LocalFile):
                 reason = self._refused(body, "leaky", read=r)
                 self.assertIn(var, reason)
                 self.assertIn("CLAUDE_CONFIG_DIR and run /login", reason)
-                self.assertNotIn("sk-live-123", repr(r["refused"]))
+                self.assertNotIn("sk-live-123", repr(r.refused))
         for kind, login in (("codex", "CODEX_HOME and run codex login"),
                             ("opencode", "XDG_DATA_HOME and run opencode auth login")):
             with self.subTest(kind=kind):
@@ -290,15 +318,19 @@ class ABrokenProfileIsRefusedAlone(_LocalFile):
 
     def test_an_unreadable_local_file_keeps_the_built_ins(self):
         r = self._local(_OK + "[harness")
-        self.assertEqual(set(r["profiles"]), _BUILT_INS)
-        self.assertEqual(len(r["refused"]), 1)
-        self.assertEqual(r["refused"][0].name, "")
-        self.assertEqual(r["refused"][0].source, "charter.local.toml")
+        self.assertEqual(set(r.profiles), _BUILT_INS)
+        self.assertEqual(len(r.refused), 1)
+        self.assertEqual(r.refused[0].name, "")
+        self.assertEqual(r.refused[0].source, "charter.local.toml")
 
     def test_a_harness_that_is_not_a_table_is_refused_whole(self):
+        """F5. The file parsed, so it is not unreadable; a sentence that says it is sends
+        the reader to fix TOML that is fine (ADR 0009's rule for an answer's kind)."""
         r = self._local('harness = "claude-work"\n')
-        self.assertEqual(set(r["profiles"]), _BUILT_INS)
-        self.assertEqual([x.name for x in r["refused"]], [""])
+        self.assertEqual(set(r.profiles), _BUILT_INS)
+        (refusal,) = r.refused
+        self.assertIn("not a table", refusal.reason)
+        self.assertNotIn("could not be read", refusal.reason)
 
     def test_a_section_other_than_harness_is_refused_by_name(self):
         """An ignored file must not change plane policy with no trace in git: `[[forge]]`
@@ -323,14 +355,14 @@ class ABrokenProfileIsRefusedAlone(_LocalFile):
             '[x]\n',
             '[harness',
         ]
-        reasons = [self._local(b)["refused"][0].reason for b in bodies]
+        reasons = [self._local(b).refused[0].reason for b in bodies]
         reasons.append(self._current('[harness.doctor]\nkind = "claude"\ncommand = ["claude"]\n')
-                       ["refused"][0].reason)
+                       .refused[0].reason)
         reasons.append(self._current('[harness.x]\nkind = "claude"\ncommand = ["charter"]\n')
-                       ["refused"][0].reason)
+                       .refused[0].reason)
         (config.ROOT / "charter.local.toml").unlink()
         self._charter_toml(profile)
-        reasons.append(self._read()["refused"][0].reason)
+        reasons.append(self._read().refused[0].reason)
         self.assertEqual(len(set(reasons)), len(reasons), reasons)
 
 
@@ -340,30 +372,30 @@ class CharterTomlCarriesNoProfile(_LocalFile):
         every machine, so the committed file is refused as a home for one."""
         self._charter_toml('[harness.x]\nkind = "claude"\ncommand = ["claude"]\n')
         r = self._read()
-        (refusal,) = r["refused"]
+        (refusal,) = r.refused
         self.assertEqual(refusal.source, "charter.toml")
         self.assertIn("move the table", refusal.reason.lower())
-        self.assertNotIn("x", r["profiles"])
+        self.assertNotIn("x", r.profiles)
 
     def test_a_committed_table_named_like_a_built_in_leaves_the_built_in(self):
         """charter.toml's tables are not read as profiles at all, so one there has no power
         to take a launcher away from somebody else's machine."""
         self._charter_toml('[harness.claude]\nkind = "claude"\ncommand = ["/opt/claude"]\n')
         r = self._read()
-        self.assertEqual(r["profiles"]["claude"].source, "built-in")
-        self.assertEqual([x.source for x in r["refused"]], ["charter.toml"])
+        self.assertEqual(r.profiles["claude"].source, "built-in")
+        self.assertEqual([x.source for x in r.refused], ["charter.toml"])
 
     def test_charter_toml_default_is_still_read(self):
         self._charter_toml('[harness]\ndefault = "codex"\n')
         r = self._read()
-        self.assertEqual(r["default"], "codex")
-        self.assertEqual(r["default_from"], "charter.toml")
+        self.assertEqual(r.default, "codex")
+        self.assertEqual(r.default_from, "charter.toml")
 
     def test_other_keys_in_charter_tomls_harness_are_still_ignored(self):
         """Pin. Review 13 dropped this refusal: no `doctor` warning on a plane that did
         nothing wrong."""
         self._charter_toml('[harness]\nnothing = "here"\n')
-        self.assertEqual([x for x in self._read()["refused"] if x.source == "charter.toml"], [])
+        self.assertEqual([x for x in self._read().refused if x.source == "charter.toml"], [])
 
 
 class NamesThatClashWithACommand(_LocalFile):
@@ -371,16 +403,16 @@ class NamesThatClashWithACommand(_LocalFile):
         """The kind clash in `cli._add_frame_parsers` raises and takes every command down,
         which is right for a registry mistake CI sees and wrong for one machine's file."""
         read = self._current(_OK + '[harness.doctor]\nkind = "claude"\ncommand = ["claude"]\n')
-        self.assertIn("ok", read["profiles"])
-        self.assertNotIn("doctor", read["profiles"])
-        (refusal,) = [x for x in read["refused"] if x.name == "doctor"]
+        self.assertIn("ok", read.profiles)
+        self.assertNotIn("doctor", read.profiles)
+        (refusal,) = [x for x in read.refused if x.name == "doctor"]
         self.assertIn("charter doctor", refusal.reason)
 
     def test_a_default_naming_a_clashing_profile_is_refused(self):
         read = self._current('[harness]\ndefault = "doctor"\n'
                              '[harness.doctor]\nkind = "claude"\ncommand = ["claude"]\n')
-        self.assertIsNone(read["default"])
-        self.assertEqual(read["default_refused"], "doctor")
+        self.assertIsNone(read.default)
+        self.assertEqual(read.default_refused, "doctor")
 
     def test_the_command_words_hold_the_core_commands_and_not_the_kinds(self):
         self.assertLessEqual({"doctor", "workspace", "frame", "frame-new-chat"},
@@ -404,6 +436,16 @@ class TheConfigReadIsCheap(_LocalFile):
         (config.ROOT / "charter.local.toml").write_text(_WORK)
         config.use(config.ROOT)
         self.assertIn("claude-work", config.PROFILES["profiles"])
+
+
+class TheSentencesSayOnlyWhatIsTrueNow(unittest.TestCase):
+    def test_no_refusal_speaks_of_the_selector(self):
+        """F2. The profile selector arrives in a later task. A refusal that explains itself by
+        a feature the reader cannot find reads as a bug waiting to be filed."""
+        for name, value in vars(profiles).items():
+            if name.isupper() and isinstance(value, str):
+                with self.subTest(constant=name):
+                    self.assertNotIn("selector", value.lower())
 
 
 class ProfilesAreDerivedBeforeTheHarnessDefault(unittest.TestCase):

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -230,7 +230,7 @@ class TestGitignorePresenceCheckIsPrecise(InitIso):
         idempotence while actually exercising the append path."""
         (self.root / ".gitignore").write_text(
             "/workspaces/*/*\n!/workspaces/.gitkeep\n/.charter/\n"
-            f"{commands.LOCAL_SETTINGS_IGNORE}\n")
+            f"{commands.LOCAL_SETTINGS_IGNORE}\n{commands.LOCAL_PROFILES_IGNORE}\n")
         before = (self.root / ".gitignore").read_text()
         self._init()
         after = (self.root / ".gitignore").read_text()

--- a/tests/test_memory_index_health.py
+++ b/tests/test_memory_index_health.py
@@ -105,14 +105,20 @@ class DoctorCheck(unittest.TestCase):
         """Runs from SessionStart — WARN at worst, never FAIL."""
         self.assertIn(doctor.check_memory_indexes().status, (doctor.OK, doctor.WARN))
 
-    def test_check_is_wired_into_run_all(self):
-        self.assertIn("memory indexes", [r.name for r in doctor.run_all()])
-
     def test_ok_result_states_how_many_bases_were_checked(self):
         """'ok' with no detail would hide a check that examined nothing."""
         r = doctor.check_memory_indexes()
         if r.status == doctor.OK and "not checked" not in (r.detail or ""):
             self.assertRegex(r.detail or "", r"\d+ base\(s\)")
+
+
+class DoctorRunsTheCheck(PersonaIso):
+    """On a throwaway plane: `run_all` reaches `charter.local.toml` through the `harness
+    profiles` row, and the real plane's file is the operator's own — `tests/_planeguard`
+    refuses the read."""
+
+    def test_check_is_wired_into_run_all(self):
+        self.assertIn("memory indexes", [r.name for r in doctor.run_all()])
 
 
 

--- a/tests/test_no_test_reads_the_operators_channel.py
+++ b/tests/test_no_test_reads_the_operators_channel.py
@@ -34,6 +34,15 @@ class WhatIsGuarded(unittest.TestCase):
     def test_the_channel_is_on_the_guarded_list(self):
         self.assertIn("UPDATE", _planeguard._GUARDED_SETTINGS)
 
+    def test_the_profiles_are_guarded_like_the_harness_default(self):
+        """`config.PROFILES` is read off the developer's own `charter.local.toml` — a file
+        that exists only on their machine, which is the `channel = "dev"` situation with the
+        dial turned up: nobody else's run can even see the fixture."""
+        self.assertIn("PROFILES", _planeguard._GUARDED_SETTINGS)
+        self.assertIn("PROFILES", config.DERIVED)
+        with TemporaryDirectory() as tmp:
+            self.assertIsInstance(config.derive(Path(tmp))["PROFILES"], dict)
+
     def test_every_guarded_name_is_a_setting_config_actually_derives(self):
         """A typo here would guard nothing and say nothing — the shape of a silent hole."""
         for name in _planeguard._GUARDED_SETTINGS:

--- a/tests/test_no_test_reads_the_operators_channel.py
+++ b/tests/test_no_test_reads_the_operators_channel.py
@@ -34,14 +34,12 @@ class WhatIsGuarded(unittest.TestCase):
     def test_the_channel_is_on_the_guarded_list(self):
         self.assertIn("UPDATE", _planeguard._GUARDED_SETTINGS)
 
-    def test_the_profiles_are_guarded_like_the_harness_default(self):
-        """`config.PROFILES` is read off the developer's own `charter.local.toml` — a file
-        that exists only on their machine, which is the `channel = "dev"` situation with the
-        dial turned up: nobody else's run can even see the fixture."""
-        self.assertIn("PROFILES", _planeguard._GUARDED_SETTINGS)
-        self.assertIn("PROFILES", config.DERIVED)
-        with TemporaryDirectory() as tmp:
-            self.assertIsInstance(config.derive(Path(tmp))["PROFILES"], dict)
+    def test_profiles_are_no_derived_setting_so_there_is_none_to_guard(self):
+        """Ruling 43: `config` reads no `charter.local.toml`, so no setting holds what it
+        declares. The file is read by `profiles.current()` when a surface asks, and what
+        `_planeguard` guards is the real file itself, against writes."""
+        self.assertNotIn("PROFILES", config.DERIVED)
+        self.assertNotIn("PROFILES", _planeguard._GUARDED_SETTINGS)
 
     def test_every_guarded_name_is_a_setting_config_actually_derives(self):
         """A typo here would guard nothing and say nothing — the shape of a silent hole."""

--- a/tests/test_plane_write_guard.py
+++ b/tests/test_plane_write_guard.py
@@ -54,6 +54,16 @@ class WhatIsGuarded(unittest.TestCase):
                               "a test could rewrite the file that makes that directory a "
                               "control plane")
 
+    def test_the_guarded_files_include_this_planes_local_profiles(self):
+        """`charter.local.toml` is the one file whose loss or rewrite changes which command a
+        click runs on this machine, and it is in no commit to restore it from. Asserted on the
+        guard as installed rather than on a patched one, so deleting the line that adds it
+        fails here."""
+        for real in _planeguard._REAL_ROOT:
+            with self.subTest(plane=real):
+                self.assertIn(os.path.join(real, "charter.local.toml"), _planeguard._REAL,
+                              "a test could rewrite the operator's harness profiles")
+
     def test_the_suite_reads_the_checkout_these_modules_were_loaded_from(self):
         """#785. `root._plane_of` sends a linked worktree's plane back to the tree it was
         cut from, so without the pin in `_planeguard.install` a run in a worktree asserts
@@ -407,6 +417,26 @@ class WritesAreRefused(_FakePlane):
         with self.assertRaises(_planeguard.RealPlaneWrite):
             os.replace(self.elsewhere / "spare", marker)
         self.assertEqual(marker.read_text(), "schema = 1\n")
+
+    def test_the_planes_local_profiles_file_cannot_be_written(self):
+        """The same spellings as the marker above, for the file beside it that holds this
+        machine's harness profiles. `WhatIsGuarded` pins that the installed guard names it;
+        this pins that a name in the guard refuses every way a rewrite arrives."""
+        local = self.elsewhere / "charter.local.toml"
+        local.write_text("[harness]\n")
+        self.enterContext(mock.patch.object(
+            _planeguard, "_REAL", (*_planeguard._REAL, str(local))))
+        for mode in ("w", "a", "r+"):
+            with self.subTest(mode=mode), self.assertRaises(_planeguard.RealPlaneWrite):
+                builtins.open(local, mode)
+        with self.assertRaises(_planeguard.RealPlaneWrite):
+            local.write_text("")
+        with self.assertRaises(_planeguard.RealPlaneWrite):
+            os.unlink(local)
+        (self.elsewhere / "spare").write_text("new file")
+        with self.assertRaises(_planeguard.RealPlaneWrite):
+            os.replace(self.elsewhere / "spare", local)
+        self.assertEqual(local.read_text(), "[harness]\n")
 
     def test_it_is_that_one_file_and_not_the_directory_holding_it(self):
         """The boundary this entry has to keep, or it becomes the "stream of false alarms"

--- a/tests/test_plane_write_guard.py
+++ b/tests/test_plane_write_guard.py
@@ -64,6 +64,27 @@ class WhatIsGuarded(unittest.TestCase):
                 self.assertIn(os.path.join(real, "charter.local.toml"), _planeguard._REAL,
                               "a test could rewrite the operator's harness profiles")
 
+    def test_the_planes_local_profiles_cannot_be_read_either(self):
+        """Ruling 43 made `profiles.current()` read `charter.local.toml` when a surface asks, so
+        no `config` setting stands between a test and the operator's own profiles any more. The
+        read itself is refused, before anything is opened — so whether the file exists on this
+        machine does not change the answer."""
+        for real in _planeguard._REAL_ROOT:
+            local = os.path.join(real, "charter.local.toml")
+            with self.subTest(plane=real, via="open"), \
+                 self.assertRaises(_planeguard.RealPlaneRead):
+                builtins.open(local)
+            with self.subTest(plane=real, via="Path.read_bytes"), \
+                 self.assertRaises(_planeguard.RealPlaneRead):
+                Path(local).read_bytes()
+
+    def test_reading_profiles_off_the_real_plane_is_refused(self):
+        """What the review of `a36194d` measured: with no isolation, `profiles.current()` read
+        whatever `charter.local.toml` sat at the real plane's root."""
+        from charter import profiles
+        with self.assertRaises(_planeguard.RealPlaneRead):
+            profiles.current()
+
     def test_the_suite_reads_the_checkout_these_modules_were_loaded_from(self):
         """#785. `root._plane_of` sends a linked worktree's plane back to the tree it was
         cut from, so without the pin in `_planeguard.install` a run in a worktree asserts

--- a/tests/test_the_end_of_a_name_is_the_end_of_the_string.py
+++ b/tests/test_the_end_of_a_name_is_the_end_of_the_string.py
@@ -209,6 +209,10 @@ ADMITTERS: dict[str, str] = {
     # accepted `"e0c9d13\n"`, putting a newline into a git argv out of a file a hand edit
     # or a half-written append can reach.
     "commands_change._SHA_RE": "e0c9d13",
+    # A harness profile's name, read out of `charter.local.toml` — a file a chat can write —
+    # and bound for a command line and a tmux target. `.match` would have admitted
+    # `"claude-work\n"` as a name.
+    "profiles.NAME_RE": "claude-work",
 }
 
 #: **Detectors** — "is this token one I must account for?". Over-matching makes the guard

--- a/tests/test_the_local_file_stays_out_of_git.py
+++ b/tests/test_the_local_file_stays_out_of_git.py
@@ -198,6 +198,28 @@ class TheFileMustBeIgnoredToBeUsed(PersonaIso):
                 self.assertEqual(util.git_path_state(config.ROOT, "charter.local.toml"),
                                  (util.UNKNOWN_GIT, "git exited 1"))
 
+    def test_the_reason_git_gave_is_trimmed_at_both_ends(self):
+        """The reason is repeated inside a sentence, so it is git's first line without the
+        whitespace around it. The sweep of `ce7f5d8` swapped the `strip` for `lstrip` with
+        the suite still green."""
+        self._declare()
+        with mock.patch("charter.util.run",
+                        return_value=_answer(128, "", "  fatal: detected dubious ownership  \n")):
+            self.assertEqual(util.git_path_state(config.ROOT, "charter.local.toml"),
+                             (util.UNKNOWN_GIT, "fatal: detected dubious ownership"))
+
+    def test_a_git_that_prints_nothing_reads_as_tracked_even_with_nothing_captured(self):
+        """rc 0 with nothing printed is a tracked file (the docstring's measured table), and
+        `git_path_state` never raises, so a `run` that captured no stdout at all reads as
+        nothing printed. The sweep of `ce7f5d8` dropped the `or ""` with the suite still
+        green."""
+        self._declare()
+        for out in ("", None):
+            with self.subTest(out=out), \
+                 mock.patch("charter.util.run", return_value=_answer(0, out, "")):
+                self.assertEqual(util.git_path_state(config.ROOT, "charter.local.toml"),
+                                 (util.TRACKED, ""))
+
     def test_the_ignore_check_takes_no_index_lock(self):
         """Ruling 34: this runs at launch, in the pane, in the selector, in `harness list`
         and in doctor, often enough to break a concurrent commit on a plain `status`."""

--- a/tests/test_the_local_file_stays_out_of_git.py
+++ b/tests/test_the_local_file_stays_out_of_git.py
@@ -283,7 +283,8 @@ class TheFileMustBeIgnoredToBeUsed(PersonaIso):
 
 class DoctorWarns(PersonaIso):
     """The row reads the file as it is now: `config` was derived in `setUp`, before any of
-    these files existed, so a row reading `config.PROFILES` would pass every one of them."""
+    these files existed, so a row reading a value derived with `config` (as `config.PROFILES`
+    was, before ruling 43 removed it) would pass every one of them."""
 
     def setUp(self) -> None:
         super().setUp()

--- a/tests/test_the_local_file_stays_out_of_git.py
+++ b/tests/test_the_local_file_stays_out_of_git.py
@@ -28,7 +28,7 @@ from unittest import mock
 
 from charter import commands, config, doctor, instance, profiles, util
 from charter.doctor import OK, WARN
-from tests import _gitguard
+from tests import _gitguard, _planeguard
 from tests._isolation import PersonaIso
 from tests.test_init import InitIso
 
@@ -379,6 +379,35 @@ class DoctorWarns(PersonaIso):
         names = doctor.check_names()
         self.assertEqual(names.index("harness profiles"), names.index("charter.toml") + 1)
         self.assertIn("harness profiles", [r.name for r in doctor.run_all()])
+
+
+class EverySurfaceIsRefusedTheOperatorsFile(PersonaIso):
+    """The review of `a36194d` put a sentinel `charter.local.toml` at the real plane's root and
+    ran with no isolation: `profiles.current()`, `harness list` and doctor all read it. Here a
+    throwaway plane stands in for the real one, as far as `tests/_planeguard`'s read refusal
+    is concerned. Its file is one git would commit, which is exactly when doctor's ignore
+    check could answer from git alone and never open the file for the guard to see."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        local = config.ROOT / "charter.local.toml"
+        local.write_text(_OK)
+        _git(config.ROOT, "init", "-q")
+        self.enterContext(mock.patch.object(
+            _planeguard, "_REAL_LOCAL_PROFILES", _planeguard._both_spellings(local)))
+
+    def test_reading_profiles_is_refused(self):
+        with self.assertRaises(_planeguard.RealPlaneRead):
+            profiles.current()
+
+    def test_harness_list_is_refused(self):
+        from charter import commands_harness
+        with redirect_stderr(io.StringIO()), self.assertRaises(_planeguard.RealPlaneRead):
+            commands_harness.cmd_harness_list(SimpleNamespace())
+
+    def test_doctor_is_refused_even_where_git_alone_could_answer(self):
+        with self.assertRaises(_planeguard.RealPlaneRead):
+            doctor.check_harness_profiles()
 
 
 if __name__ == "__main__":

--- a/tests/test_the_local_file_stays_out_of_git.py
+++ b/tests/test_the_local_file_stays_out_of_git.py
@@ -1,0 +1,339 @@
+"""`charter.local.toml` stays out of git, and charter checks that rather than hoping.
+
+A profile's command runs on a click, with no harness permission prompt in between. In a
+committed file a merged PR or a chat could change that command and have it run on every
+machine, so profiles live only in `charter.local.toml`, and "ignored" is guaranteed:
+`init` writes `/charter.local.toml` into `.gitignore`, `reinit` backfills it, and a file git
+tracks or would commit has its profiles refused (spec, *Where profiles live*).
+
+The check is one `git --no-optional-locks status` under `LC_ALL=C`. A plain `status` takes
+`index.lock` and would break a concurrent `charter save` (#917, ruling 34); git's "not a git
+repository", the one failure that passes, is English only under `C` (ruling 32). Anything
+else git cannot answer, a timeout included, is not a pass (review 4).
+"""
+
+from __future__ import annotations
+
+import inspect
+import io
+import os
+import shutil
+import subprocess
+import tempfile
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
+
+from charter import commands, config, doctor, instance, profiles, util
+from charter.doctor import OK, WARN
+from tests import _gitguard
+from tests._isolation import PersonaIso
+from tests.test_init import InitIso
+
+_OK = """
+[harness.ok]
+kind = "claude"
+command = ["claude"]
+"""
+
+#: Every rule a fresh `.gitignore` carried before this feature, so an append is the
+#: profiles line and nothing else.
+_BEFORE = "/workspaces/*/*\n!/workspaces/.gitkeep\n/.charter/\n/.claude/settings.local.json\n"
+
+
+def _git(root: Path, *args: str) -> None:
+    subprocess.run(["git", "-C", str(root), *args], check=True, capture_output=True,
+                   env={**os.environ, **_gitguard.environment()})
+
+
+def _answer(rc: int, out: str = "", err: str = "") -> subprocess.CompletedProcess:
+    return subprocess.CompletedProcess(["git"], rc, out, err)
+
+
+class InitAndReinitIgnoreIt(InitIso):
+    def setUp(self) -> None:
+        super().setUp()
+        self.addCleanup(shutil.rmtree, self.root, True)
+        # `init` and `reinit` install opencode's shim where opencode reads it for every
+        # project, `$XDG_CONFIG_HOME`, so it is stated here and never the operator's own.
+        xdg = Path(tempfile.mkdtemp(prefix="charter-xdg-"))
+        self.addCleanup(shutil.rmtree, xdg, True)
+        self.enterContext(mock.patch.dict(os.environ, {"XDG_CONFIG_HOME": str(xdg)}))
+        self.said = io.StringIO()
+        self.enterContext(redirect_stdout(self.said))
+        self.enterContext(redirect_stderr(self.said))
+
+    def _gitignore(self) -> Path:
+        return self.root / ".gitignore"
+
+    def _reinit(self) -> int:
+        (self.root / "charter.toml").write_text(f"schema = {instance.SCHEMA}\n")
+        config.use(self.root)            # `point_config_at`'s snapshot still restores
+        return commands.cmd_reinit(SimpleNamespace())
+
+    def test_a_fresh_plane_ignores_the_local_file(self):
+        self.assertEqual(self._init(), 0)
+        self.assertIn("/charter.local.toml", self._gitignore().read_text().splitlines())
+
+    def test_an_existing_gitignore_gains_the_line_once(self):
+        self._gitignore().write_text(_BEFORE)
+        self.assertTrue(commands._ensure_gitignore(self.root))
+        body = self._gitignore().read_text()
+        self.assertEqual(body.splitlines().count("/charter.local.toml"), 1)
+        self.assertFalse(commands._ensure_gitignore(self.root))
+        self.assertEqual(self._gitignore().read_text(), body)
+
+    def test_a_rule_that_merely_contains_the_name_does_not_count(self):
+        self._gitignore().write_text(_BEFORE + "build/charter.local.toml.bak\n")
+        commands._ensure_gitignore(self.root)
+        self.assertIn("/charter.local.toml", self._gitignore().read_text().splitlines())
+
+    def test_reinit_adds_it_to_a_plane_made_before_it(self):
+        self._gitignore().write_text(_BEFORE)
+        self.assertEqual(self._reinit(), 0)
+        self.assertIn("/charter.local.toml", self._gitignore().read_text().splitlines())
+        self.assertIn("/charter.local.toml", self.said.getvalue())
+
+    def test_reinit_leaves_a_plane_that_has_it_alone(self):
+        """Pin: it passes where reinit never touches `.gitignore`, and keeps the additive
+        rule now that it does."""
+        self._gitignore().write_text(_BEFORE + "/charter.local.toml\n")
+        before = self._gitignore().read_bytes()
+        self._reinit()
+        self.assertEqual(self._gitignore().read_bytes(), before)
+        self.assertNotIn("charter.local.toml", self.said.getvalue())
+
+    def test_the_backfill_says_whether_it_wrote(self):
+        """`reinit` reports what it changed, not what it asked for (ADR 0013)."""
+        self._gitignore().write_text(_BEFORE)
+        self.assertTrue(commands._ensure_local_profiles_ignored(self.root))
+        self.assertFalse(commands._ensure_local_profiles_ignored(self.root))
+
+
+class TheFileMustBeIgnoredToBeUsed(PersonaIso):
+    def setUp(self) -> None:
+        super().setUp()
+        _git(config.ROOT, "init", "-q")
+
+    def _declare(self, root: Path | None = None) -> None:
+        ((root or config.ROOT) / "charter.local.toml").write_text(_OK)
+
+    def _not_a_repository(self) -> Path:
+        plane = Path(tempfile.mkdtemp(prefix="charter-not-a-repo-")).resolve()
+        self.addCleanup(shutil.rmtree, plane, True)
+        # git walks upward looking for a repository. Stated, so a temp directory that sits
+        # inside one on somebody's machine is not read as belonging to it.
+        self.enterContext(mock.patch.dict(os.environ,
+                                          {"GIT_CEILING_DIRECTORIES": str(plane.parent)}))
+        self._declare(plane)
+        return plane
+
+    def test_an_absent_file_needs_no_git(self):
+        """A file that is not there declares nothing, so there is nothing to refuse."""
+        with mock.patch("charter.util.run",
+                        side_effect=AssertionError("git ran for a file that is not there")):
+            self.assertEqual(profiles.ignored_refusal(config.ROOT), "")
+
+    def test_an_ignored_untracked_file_is_fine(self):
+        (config.ROOT / ".gitignore").write_text("/charter.local.toml\n")
+        self._declare()
+        self.assertEqual(profiles.ignored_refusal(config.ROOT), "")
+
+    def test_a_file_git_would_commit_is_refused(self):
+        self._declare()
+        self.assertIn("charter reinit adds", profiles.ignored_refusal(config.ROOT))
+
+    def test_a_tracked_file_is_refused_even_when_ignored(self):
+        """An ignore rule does not untrack a file: the next commit still carries it."""
+        (config.ROOT / ".gitignore").write_text("/charter.local.toml\n")
+        self._declare()
+        _git(config.ROOT, "add", "-f", "charter.local.toml")
+        _git(config.ROOT, "commit", "-q", "-m", "a profile committed by mistake")
+        self.assertIn("git rm --cached", profiles.ignored_refusal(config.ROOT))
+
+    def test_a_plane_that_is_not_a_repository_is_not_refused(self):
+        self.assertEqual(profiles.ignored_refusal(self._not_a_repository()), "")
+
+    def test_git_saying_not_a_repository_is_the_only_pass(self):
+        """Review 4: `git_ignores` reads every non-zero answer as "not a repository", which
+        its callers depend on and this check must not."""
+        self._declare()
+        cases = (
+            (128, "fatal: not a git repository (or any of the parent directories): .git\n", ""),
+            (128, "fatal: detected dubious ownership in repository at '/x'\n", "could not say"),
+            (1, "fatal: not a git repository\n", "could not say"),
+        )
+        for rc, err, expected in cases:
+            with self.subTest(rc=rc, err=err), \
+                 mock.patch("charter.util.run", return_value=_answer(rc, "", err)):
+                said = profiles.ignored_refusal(config.ROOT)
+                if expected:
+                    self.assertIn(expected, said)
+                else:
+                    self.assertEqual(said, "")
+
+    def test_the_reason_git_gave_is_named(self):
+        self._declare()
+        with mock.patch("charter.util.run",
+                        return_value=_answer(128, "", "fatal: detected dubious ownership\n")):
+            self.assertIn("dubious ownership", profiles.ignored_refusal(config.ROOT))
+
+    def test_the_ignore_check_takes_no_index_lock(self):
+        """Ruling 34: this runs at launch, in the pane, in the selector, in `harness list`
+        and in doctor, often enough to break a concurrent commit on a plain `status`."""
+        self._declare()
+        with mock.patch("charter.util.run",
+                        return_value=_answer(0, "!! charter.local.toml\n")) as run:
+            profiles.ignored_refusal(config.ROOT)
+        self.assertEqual(run.call_args.args[0][:5],
+                         ["git", "--no-optional-locks", "-C", str(config.ROOT), "status"])
+        self.assertIsNotNone(run.call_args.kwargs.get("timeout"))
+
+    def test_one_git_call_answers_every_state(self):
+        """Re-review N8: one `status` tells committable, ignored and tracked apart."""
+        real = util.run
+
+        def ask() -> str:
+            with mock.patch("charter.util.run", side_effect=real) as run:
+                state, _why = util.git_path_state(config.ROOT, "charter.local.toml")
+            self.assertEqual(run.call_count, 1)
+            return state
+
+        self._declare()
+        self.assertEqual(ask(), util.COMMITTABLE)
+        (config.ROOT / ".gitignore").write_text("/charter.local.toml\n")
+        self.assertEqual(ask(), util.IGNORED)
+        _git(config.ROOT, "add", "-f", "charter.local.toml")
+        _git(config.ROOT, "commit", "-q", "-m", "tracked")
+        self.assertEqual(ask(), util.TRACKED)
+        (config.ROOT / "charter.local.toml").write_text(_OK + "# changed\n")
+        self.assertEqual(ask(), util.TRACKED)
+
+    def test_a_non_english_locale_still_reads_not_a_repository(self):
+        """Re-review N8: git's own sentence is the only thing that tells "not a repository"
+        from every other rc 128, and it is only English under `LC_ALL=C`."""
+        plane = self._not_a_repository()
+        real = util.run
+        env = {"PATH": os.environ["PATH"], **_gitguard.environment(),
+               "GIT_CEILING_DIRECTORIES": str(plane.parent),
+               "LANG": "de_DE.UTF-8", "LC_ALL": "de_DE.UTF-8"}
+        with mock.patch.dict(os.environ, env, clear=True), \
+             mock.patch("charter.util.run", side_effect=real) as run:
+            self.assertEqual(profiles.ignored_refusal(plane), "")
+        self.assertEqual(run.call_args.kwargs["env"]["LC_ALL"], "C")
+
+    def test_git_missing_is_not_a_pass(self):
+        self._declare()
+        with mock.patch("charter.util.run",
+                        side_effect=FileNotFoundError(2, "No such file or directory", "git")):
+            self.assertIn("could not say", profiles.ignored_refusal(config.ROOT))
+
+    def test_a_git_that_times_out_is_not_a_pass_and_does_not_raise(self):
+        self._declare()
+        with mock.patch("charter.util.run",
+                        side_effect=util.ProcTimeout(["git", "status"], 5.0)):
+            self.assertIn("could not say", profiles.ignored_refusal(config.ROOT))
+
+    def test_an_unparseable_status_is_not_a_pass(self):
+        self._declare()
+        with mock.patch("charter.util.run", return_value=_answer(0, "?! charter.local.toml\n")):
+            self.assertIn("could not say", profiles.ignored_refusal(config.ROOT))
+
+    def test_a_tracked_line_wins_over_an_ignored_one(self):
+        """Measured on git 2.50.1: after `git rm --cached` and before the commit, status
+        prints `D ` and `!!` for the one path. The next commit still carries it."""
+        self._declare()
+        with mock.patch("charter.util.run",
+                        return_value=_answer(0, "D  charter.local.toml\n!! charter.local.toml\n")):
+            self.assertIn("git rm --cached", profiles.ignored_refusal(config.ROOT))
+
+    def test_the_existing_callers_see_git_ignores_unchanged(self):
+        """Pin. `commands_secrets` and `doctor.check_credential_paths` read `None` as "not a
+        repository"; a timeout added there would raise into both (review 4)."""
+        self.assertNotIn("timeout", inspect.signature(util.git_ignores).parameters)
+        with mock.patch("charter.util.run",
+                        return_value=_answer(128, "", "fatal: detected dubious ownership\n")):
+            self.assertIsNone(util.git_ignores(config.ROOT, "charter.local.toml"))
+
+
+class DoctorWarns(PersonaIso):
+    """The row reads the file as it is now: `config` was derived in `setUp`, before any of
+    these files existed, so a row reading `config.PROFILES` would pass every one of them."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        _git(config.ROOT, "init", "-q")
+
+    def _row(self, text: str, *, ignored: bool = True) -> doctor.Result:
+        if ignored:
+            (config.ROOT / ".gitignore").write_text("/charter.local.toml\n")
+        (config.ROOT / "charter.local.toml").write_text(text)
+        return doctor.check_harness_profiles()
+
+    def test_a_committable_local_file_is_a_warning_naming_reinit(self):
+        r = self._row(_OK, ignored=False)
+        self.assertEqual(r.status, WARN)
+        self.assertEqual(r.hint, "charter reinit")
+
+    def test_a_refused_profile_is_a_warning_naming_it(self):
+        r = self._row(_OK + '[harness.broken]\nkind = "gemini"\ncommand = ["gemini"]\n')
+        self.assertEqual(r.status, WARN)
+        self.assertIn("broken", r.detail)
+
+    def test_a_profile_named_like_a_command_is_a_warning_too(self):
+        r = self._row('[harness.doctor]\nkind = "claude"\ncommand = ["claude"]\n')
+        self.assertEqual(r.status, WARN)
+        self.assertIn("doctor", r.detail)
+        self.assertIn("charter doctor", r.hint)
+
+    def test_a_default_naming_no_profile_is_a_warning(self):
+        r = self._row('[harness]\ndefault = "nope"\n')
+        self.assertEqual(r.status, WARN)
+        self.assertIn("names no profile", r.detail)
+
+    def test_a_malformed_charter_toml_costs_this_row_nothing(self):
+        """The `charter.toml` row names that file. This one still reads the local file,
+        because `doctor` is what somebody runs when charter is already misbehaving."""
+        (config.ROOT / "charter.toml").write_text("schema = [\n")
+        r = self._row(_OK + '[harness.broken]\nkind = "gemini"\ncommand = ["gemini"]\n')
+        self.assertEqual(r.status, WARN)
+        self.assertIn("broken", r.detail)
+
+    def test_a_clean_file_is_ok_with_no_hint(self):
+        r = self._row(_OK)
+        self.assertEqual(r.status, OK)
+        self.assertEqual(r.hint, "")
+        self.assertIn("ok", r.detail)
+
+    def test_a_git_that_hangs_costs_one_row(self):
+        """`doctor._checks` builds its rows in one list with no per-check guard, so a check
+        that raised would cost every row after it."""
+        (config.ROOT / "charter.local.toml").write_text(_OK)
+        real = util.run
+
+        def hung_git(cmd, *args, **kwargs):
+            # Only the ignore check's own call hangs. `check_git` runs `git --version` with no
+            # timeout caught (`doctor.check_git` on main at 6526928), so hanging every git
+            # would take doctor down before this row ever ran — that gap is its own finding,
+            # and it is not this row's to hide.
+            if list(cmd[:2]) == ["git", "--no-optional-locks"]:
+                raise util.ProcTimeout(cmd, 5.0)
+            return real(cmd, *args, **kwargs)
+
+        with mock.patch("charter.util.run", side_effect=hung_git):
+            rows = doctor.run_all()
+        self.assertEqual([r.name for r in rows], doctor.check_names())
+        (row,) = [r for r in rows if r.name == "harness profiles"]
+        self.assertEqual(row.status, WARN)
+        self.assertIn("could not say", row.detail)
+
+    def test_the_row_is_named_in_the_preflight(self):
+        names = doctor.check_names()
+        self.assertEqual(names.index("harness profiles"), names.index("charter.toml") + 1)
+        self.assertIn("harness profiles", [r.name for r in doctor.run_all()])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_the_local_file_stays_out_of_git.py
+++ b/tests/test_the_local_file_stays_out_of_git.py
@@ -249,6 +249,23 @@ class TheFileMustBeIgnoredToBeUsed(PersonaIso):
                         return_value=_answer(0, "D  charter.local.toml\n!! charter.local.toml\n")):
             self.assertIn("git rm --cached", profiles.ignored_refusal(config.ROOT))
 
+    def test_untracking_takes_a_commit_before_the_file_passes(self):
+        """F3, on real git. The plan's fix — `git rm --cached`, then `charter reinit` — never
+        reaches a pass: until the removal is committed, status prints `D ` beside `!!`, which
+        the next commit still carries. So the sentence names the commit, and this walks the
+        whole fix to the pass."""
+        (config.ROOT / ".gitignore").write_text("/charter.local.toml\n")
+        self._declare()
+        _git(config.ROOT, "add", "-f", ".gitignore", "charter.local.toml")
+        _git(config.ROOT, "commit", "-q", "-m", "a profile committed by mistake")
+        self.assertIn("commit that removal", profiles.ignored_refusal(config.ROOT))
+        _git(config.ROOT, "rm", "-q", "--cached", "charter.local.toml")
+        self.assertIn("git rm --cached", profiles.ignored_refusal(config.ROOT),
+                      "a staged removal is still carried by the next commit")
+        _git(config.ROOT, "commit", "-q", "-m", "untrack the profiles")
+        commands._ensure_local_profiles_ignored(config.ROOT)
+        self.assertEqual(profiles.ignored_refusal(config.ROOT), "")
+
     def test_the_existing_callers_see_git_ignores_unchanged(self):
         """Pin. `commands_secrets` and `doctor.check_credential_paths` read `None` as "not a
         repository"; a timeout added there would raise into both (review 4)."""
@@ -306,6 +323,29 @@ class DoctorWarns(PersonaIso):
         self.assertEqual(r.status, OK)
         self.assertEqual(r.hint, "")
         self.assertIn("ok", r.detail)
+
+    def test_each_state_names_its_own_fix(self):
+        """F3. `charter reinit` adds the ignore line, which fixes one state of three: it does
+        not untrack a tracked file, and it does not make git answer."""
+        committable = self._row(_OK, ignored=False)
+        self.assertEqual(committable.hint, "charter reinit")
+        _git(config.ROOT, "add", "-f", "charter.local.toml")
+        _git(config.ROOT, "commit", "-q", "-m", "tracked")
+        tracked = doctor.check_harness_profiles()
+        self.assertIn("git rm --cached charter.local.toml", tracked.hint)
+        self.assertIn("commit", tracked.hint.split("git rm --cached charter.local.toml", 1)[1])
+        dubious = "fatal: detected dubious ownership in repository at '/x'\n"
+        with mock.patch("charter.util.run", return_value=_answer(128, "", dubious)):
+            unknown = doctor.check_harness_profiles()
+        self.assertIn("git status", unknown.hint)
+        self.assertIn("dubious ownership", unknown.hint)
+        self.assertEqual(len({committable.hint, tracked.hint, unknown.hint}), 3)
+
+    def test_a_default_that_names_nothing_is_given_a_fix_not_a_consequence(self):
+        """F2. Every hint names what to do."""
+        r = self._row('[harness]\ndefault = "nope"\n')
+        self.assertIn("[harness] default", r.hint)
+        self.assertNotIn("selector", r.hint)
 
     def test_a_git_that_hangs_costs_one_row(self):
         """`doctor._checks` builds its rows in one list with no per-check guard, so a check

--- a/tests/test_the_local_file_stays_out_of_git.py
+++ b/tests/test_the_local_file_stays_out_of_git.py
@@ -105,6 +105,12 @@ class InitAndReinitIgnoreIt(InitIso):
         self.assertEqual(self._gitignore().read_bytes(), before)
         self.assertNotIn("charter.local.toml", self.said.getvalue())
 
+    def test_the_ignore_line_names_the_file_profiles_reads(self):
+        """`LOCAL_PROFILES_IGNORE` spells the name instead of importing `charter.profiles`
+        (ruling 43), so this is what keeps the ignored file and the read file the same one."""
+        from charter import profiles
+        self.assertEqual(commands.LOCAL_PROFILES_IGNORE, "/" + profiles.LOCAL_FILE)
+
     def test_the_backfill_says_whether_it_wrote(self):
         """`reinit` reports what it changed, not what it asked for (ADR 0013)."""
         self._gitignore().write_text(_BEFORE)

--- a/tests/test_the_local_file_stays_out_of_git.py
+++ b/tests/test_the_local_file_stays_out_of_git.py
@@ -186,6 +186,18 @@ class TheFileMustBeIgnoredToBeUsed(PersonaIso):
                         return_value=_answer(128, "", "fatal: detected dubious ownership\n")):
             self.assertIn("dubious ownership", profiles.ignored_refusal(config.ROOT))
 
+    def test_a_git_that_fails_saying_nothing_is_named_by_its_exit(self):
+        """`git_path_state` never raises (its docstring), and a git that failed in silence is
+        still an answer to name: git exited, and with what. The sweep of `ce7f5d8` collapsed
+        the `else` to `said.splitlines()[0]`, which raises on an empty stderr, and dropped the
+        `or ""`, which raises when nothing was captured at all."""
+        self._declare()
+        for err in ("", None):
+            with self.subTest(err=err), \
+                 mock.patch("charter.util.run", return_value=_answer(1, "", err)):
+                self.assertEqual(util.git_path_state(config.ROOT, "charter.local.toml"),
+                                 (util.UNKNOWN_GIT, "git exited 1"))
+
     def test_the_ignore_check_takes_no_index_lock(self):
         """Ruling 34: this runs at launch, in the pane, in the selector, in `harness list`
         and in doctor, often enough to break a concurrent commit on a plain `status`."""


### PR DESCRIPTION
Task 1 of `docs/superpowers/plans/2026-09-11-harness-profiles.md`, **Profiles are read**. Spec: `docs/superpowers/specs/2026-09-11-harness-profiles.md`. Decisions and rulings 1–43: `workspaces/harness-profiles/workspace.md` in the plane.

## The failure this prevents

Charter launched one program per harness kind, one way (`Harness.binary`, `launch_argv`), with no shell in between, so an operator with a work and a personal Claude Code account, or a Codex pinned to an older release, had no way to tell charter so. The feature that answers it puts a command that runs on a click into a file — and a command in a committed file can be changed by a merged PR or by a chat and then run on every machine that pulls it.

This task builds the reading half with that hazard closed first:
- Profiles are read only from `charter.local.toml`.
- Every broken one is refused by name with its reason, while the rest still load.
- Charter asks git whether the file stays uncommitted instead of hoping it does, and while git would carry it, every profile it declares is refused.

**Nothing launches differently.** `config.HARNESS`, `_bare_launch`, `_same_harness_as` and `_reopen_one` are untouched.

## What changed

- **`charter/profiles.py`** (new):
  - `Profile`, `Refused`, `ProfileSet` and `IgnoreCheck`, all NamedTuples.
  - `builtins()`, `derive(root, cfg)`, `current()`, `with_ignore_check()`, `expanded_command`, `expanded_env`, `display`, `ignore_check()` and `ignored_refusal()`.
  - `derive` runs only inside `current()` (ruling 43). It never raises and never spawns anything.
  - Built-ins come first, one per registered kind, named after its kind.
  - **`charter.toml`'s `[harness]`:** a table there is refused with a pointer; `default` is kept; any other key is ignored as before (review 13).
  - **`charter.local.toml`:**
    - Only `[harness]` is read; any other section is refused by name.
    - Each profile goes through the plan's eight checks in order: name alphabet (`fullmatch`), `default` reserved, kind, command, env shape, `CHARTER_`, credential words with the kind's login pointer, then unknown key.
    - A dotted name written without quotes is refused by its dotted spelling.
  - **Containment:** every name, key, kind and variable a sentence repeats back goes through `contain.readable`, and no env value is ever repeated.
- **`profiles.current()`** is the one reader (ruling 43). It reads `charter.toml` and `charter.local.toml` as they are now, resolves the local default, validates, and moves two kinds of profile into the refused list: a name `charter` already uses (`cli.command_words()`), and a command that is charter itself (`hooks._is_charter`). It is memoized per process, keyed on what the two files hold.
- **`profiles.with_ignore_check()`** moves every profile the local file declares into the refused list when git would carry the file, with that state's reason. `harness list` runs it; doctor's row reports the state and its own fix.
- **`config` reads no profile** (ruling 43). There is no `config.PROFILES`: importing `charter.config` opens no `charter.local.toml` and runs no `charter.profiles` code. `config.HARNESS` keeps exactly `charter.toml`'s `[harness] default`, so bare `charter` launches as it does on `main`.
- **`cli.command_words()`**: every subcommand the parser registers, minus the kinds, built once per process.
- **`util.git_path_state(root, path) -> (state, why)`**: one `git --no-optional-locks -C <root> status --porcelain=v1 --ignored=matching --untracked-files=all -- <path>`, run under `LC_ALL=C`.
  - The state is classified from the porcelain codes, never from message text. The one exception is git's own rc 128 "not a git repository", which is the only failure that passes.
  - Git missing, `ProcTimeout`, any other failure and an unreadable line all come back as `UNKNOWN_GIT`, with the reason.
  - `util.git_ignores` is untouched (review 4).
- **`commands`**:
  - `/charter.local.toml` joins `_GITIGNORE_BASELINE` and `_ensure_gitignore`'s whole-line check.
  - `LOCAL_PROFILES_IGNORE` spells `/charter.local.toml` out, because importing `charter.profiles` there would put it on every command's import path (ruling 43). A test pins it to `profiles.LOCAL_FILE`.
  - `_ensure_local_profiles_ignored` backfills the line, and `reinit` reports `.gitignore (/charter.local.toml)` among what it added.
- **`charter harness list`**, in order:
  - The profiles, in measured columns (NAME, KIND, COMMAND, FROM), `*` on the default; built-ins in registry order, then declared profiles by name.
  - A `refused:` block.
  - One line naming the fix when git would carry the file.
  - A blank line, then today's ceilings block, unchanged.
- **`doctor.check_harness_profiles()`**: the `harness profiles` row, placed after `charter.toml` in `_checks` and `_FIXED_CHECK_NAMES`. It reads through `profiles.current()` first, whatever git says, as the listing does, and then asks git.
  - WARN when git would carry the file, with that state's own fix as the hint.
  - WARN when a profile is refused, with the first reason as the hint.
  - WARN when the default names no profile, with the fix to set or delete it.
  - Otherwise OK, with no hint.
- **`tests/_planeguard.py`**:
  - `charter.local.toml` joins the refused-write markers in both spellings, spelled out rather than imported (ruling 43).
  - `open_` also refuses a *read* of the real plane's `charter.local.toml`, in both spellings, so no test reads the operator's profiles. See the guard review, below.
- **Docs:**
  - `docs/control-plane.md`: the config block, and `## [harness] — profiles, and the default`. It covers:
    - the file, and why only `[harness]` is read there;
    - the shape;
    - built-ins, and replacing one;
    - the refusals, each with its fix;
    - no credentials in a profile, with the three logins;
    - the ignore guarantee, with each state's fix and what doctor says.
  - The bare-`charter` text is now its `### default` subsection, which says plainly that nothing launches a profile yet.
  - `docs/harnesses.md`: gains `## Two accounts of one harness, or one version pinned`.
  - `docs/install.md` and `docs/frame.md`: two links follow the moved anchor.
- **News:** `docs/news/unreleased-harness-profiles.md`, with `adopt: reinit` and no `check:`.

## Ruling 43: no profile is read on import

`config.derive` reads nothing from `charter.local.toml` and runs no `charter.profiles` code, and `config.PROFILES` is gone. `profiles.current()` alone resolves the effective default (the local `default` wins) and does all the validation, memoized per process. Only the surfaces that use profiles call it: `charter harness list` and doctor today, and the launcher, bare launch, `+` and the selector from Task 2 on.

- **Measurability.** `profiles.py` was charged to 347 test modules per mutation, which covered 117 of the branch's 156 mutations. Every CI sweep shard on `e1cf89f` then hit its 60-minute limit with no verdict. After the move, CI's sizing of `a36194d`:
  - 157 mutations over 7 shards, sized by measured cost;
  - 157 minutes of predicted test time across 473 test modules, and the heaviest shard is 1,612 s against a 1,680 s budget;
  - `profiles.py` is 125 minutes for its ~117 mutations, about a minute each;
  - `commands.py` is 14 minutes, `util.py` 10, `commands_harness.py` and `doctor.py` 3 each, and `cli.py` 1;
  - `config.py` is charged with no time, because its only change is now a comment.
  - On `e81251e`, after the guard review, CI sized 161 mutations over 7 shards, 164 minutes of predicted test time, and the heaviest shard at 1,675 s against the same 1,680 s budget. `profiles.py` is 132 minutes, and `commands_harness.py` 4.
- **Hooks.** Every hook process paid the parse and validation. Rulings 11 and 32 keep profile work off hook paths.
- **Launching is unchanged.** `config.HARNESS` stays `charter.toml`-only, so bare `charter` behaves exactly as on `main`, even with a local `default` naming a declared profile. `test_a_local_default_naming_a_declared_profile_leaves_the_harness_default_alone` pins it.
- **Superseded:** review ruling 14 ("PROFILES derived before HARNESS"), and the plan's `harness_of(cfg, profiles=…)` interface. Task 2 resolves the effective default through `profiles.current()` where it uses it.
- **The plane guard.** The write guard on the real `charter.local.toml` stays, and both of its tests still fail with it removed. The `PROFILES` read guard left with the setting, and that left a test free to read the operator's file. The guard review of `a36194d` found this. A read refusal in `open_` now closes it (below).
- **Red first.** The pins went red on `e1cf89f`'s code, 7 failures of 15:
  - importing config opened the local file and imported `charter.profiles`, which the subprocess probe caught with an audit hook;
  - `current()` was neither memoized nor fresh after an edit;
  - `PROFILES` was still derived.
- **After the change,** the 33 affected modules pass, 844 tests. The full suite on `a36194d`: `Ran 12203 tests in 760.588s`, `OK (skipped=9)`.

## The guard review of `a36194d`

**The finding (blocking).** Once ruling 43 removed `config.PROFILES`, and its read guard with it, nothing stopped a test from reading the operator's real `charter.local.toml`. With a sentinel file at `config.ROOT` and no isolation, `profiles.current()`, `charter harness list` and doctor's row all read it, and four doctor tests reached it on every run.

**What the ruling became (`e81251e`):**
- **`tests/_planeguard.py`'s `open_` refuses a read of the real plane's `charter.local.toml`**, in both spellings. These are the `charter.local.toml` entries `_REAL` already lists, kept as `_REAL_LOCAL_PROFILES`. The refusal names `PersonaIso` as the fix, and says that `isolate_state_dir` does not move the file.
  - Pinned by `WhatIsGuarded.test_the_planes_local_profiles_cannot_be_read_either` (`open` and `Path.read_bytes`, for each real root) and by `test_reading_profiles_off_the_real_plane_is_refused`.
  - **Hand deletion check** (`tests/` is outside the sweep): with the refusal deleted from `open_` and `__pycache__` cleared, the first test errors and the second fails. With it restored, both pass.
- **The four tests moved onto `PersonaIso`.** The guard is not weakened for any of them.
  - `test_doctor_personas`: `test_doctor_yields_results_one_at_a_time` and `test_run_all_still_returns_them_all` leave `RunTakesATimeoutAndDoctorStreams(TestCase)` for `DoctorStreamsOnAThrowawayPlane(PersonaIso)`. The class they left no longer runs doctor whole, so its `pin_update_channel` and that import are gone.
  - `test_doctor_mcp_launchers.TestItIsWiredIn` now derives from `PersonaIso`.
  - `test_memory_index_health`: `test_check_is_wired_into_run_all` moves to `DoctorRunsTheCheck(PersonaIso)`.
- **The sentinel probe, rerun.** Its first rerun found doctor's row still unrefused. On a file git would commit, the row answered from git alone and returned before reading, so the guard never saw a read. The row now reads through `profiles.current()` first, as `harness list` does. On the next rerun, `profiles.current()`, `harness list` and doctor's row each raised `RealPlaneRead`. The sentinel was then removed.
  - The probe is now a test class, `EverySurfaceIsRefusedTheOperatorsFile(PersonaIso)`, which points `_planeguard._REAL_LOCAL_PROFILES` at its throwaway plane's file. Its tests: `test_reading_profiles_is_refused`, `test_harness_list_is_refused` and `test_doctor_is_refused_even_where_git_alone_could_answer`.
  - With doctor's old order restored by hand, the last one fails with `RealPlaneRead not raised`.

**The nits:**
- A table under a key that is not a profile key is refused with both readings named. The key is not one charter reads, and a profile named with the dot could not exist, because a dot breaks tmux targets. Pinned by `test_an_inline_table_under_a_typo_names_both_readings`.
  - A table under `kind`, `command` or `env` is judged as that key's value, not as a dotted name. Pinned by `test_a_table_under_a_profile_key_is_that_keys_value_not_a_dotted_name`.
- An unreadable `charter.local.toml` gets a memo key of its own, `("unreadable", errno)`, not the `None` an absent file gets. So `current()` reports an unreadable file as unreadable, even after it memoized an absent one. Pinned by `test_an_unreadable_file_and_an_absent_one_are_different_answers`.

**Evidence:**
- **Red first:** on the unfixed tree, the new and moved tests gave `failures=4, errors=6`.
- **After the fix:** the 36 affected modules pass, 900 tests. The 37 modules that reach doctor or the profiles reader also pass, 878 tests.
- **Whole suite on `e81251e`:** `Ran 12211 tests in 818.106s`, `OK (skipped=9)`, with no `RealPlaneRead` anywhere in its output.
- **`ce7f5d8`** fixes two sentences that still placed profile reading on the import path: the comment on `LOGIN.get` in `charter/profiles.py`, and `DoctorWarns`' docstring. Behaviour is unchanged. The touched modules pass, 187 tests.

## Review findings, and what each became

| Finding | What it became | Pinned by |
|---|---|---|
| **F1** A committable file's profiles printed as ordinary rows under a warning | `harness list` runs the ignore check. Every profile from a file in NOT_IGNORED, TRACKED or GIT_CANNOT_TELL is listed refused with that state's reason, followed by one line naming the fix | `test_a_committable_files_profile_is_listed_as_refused_not_as_a_row` |
| **F2** `RESERVED_NAME`, `CHARTER_COMMAND` and doctor's default hint mentioned the selector (Task 5) | Reworded to what is true now. The default hint names the fix: set `[harness] default` to one of the profiles, or delete the key | `test_no_refusal_speaks_of_the_selector`, `test_a_default_that_names_nothing_is_given_a_fix_not_a_consequence` |
| **F3** The plan's TRACKED fix never reaches a pass; doctor hinted `charter reinit` for every state | One fix per state. NOT_IGNORED → `charter reinit`. TRACKED → `git rm --cached charter.local.toml`, commit that removal, then `charter reinit`. GIT_CANNOT_TELL → run `git status --ignored -- charter.local.toml` by hand, with git's own error | `test_each_state_names_its_own_fix`, `test_untracking_takes_a_commit_before_the_file_passes` (real git: the staged removal still reads tracked, and the commit gets it to a pass) |
| **F4** `[harness.claude.alt]` was refused as `claude` with kind `""`, and the built-in vanished | Refused as `claude.alt` for the dot, in both spellings. A parent holding only sub-tables leaves the built-in alone. A parent with keys of its own is refused for the table it cannot read: once parsed, a sub-table is indistinguishable from a typo'd `enviroment = { … }`, which review 13 requires to refuse the profile. Since the guard review, the sentence names both readings | `test_a_dotted_name_is_refused_by_its_dotted_spelling_in_either_spelling`, `test_a_declared_profile_holding_a_dotted_child_is_refused_for_it_too`, `test_an_inline_table_under_a_typo_names_both_readings` |
| **F5** "`[harness]` is not a table" reused `LOCAL_UNREADABLE` | Its own sentence, `HARNESS_NOT_A_TABLE`; a file that parsed is not called unreadable | `test_a_harness_that_is_not_a_table_is_refused_whole` |
| **F6** `## Profiles` was a noun heading | `## Two accounts of one harness, or one version pinned` | — |
| **F7** The ignore line goes past ADR 0017 | Stated below, and in the comment on `_ensure_local_profiles_ignored` | — |
| **Re-review leftovers** (none changes behaviour) | `docs/harnesses.md` quotes the current `ILLEGAL_NAME`, with "and no dot, because a dot breaks tmux targets". The comments in `charter/profiles.py` and `charter/config.py` now say doctor runs `profiles.ignore_check`, including at SessionStart, until Task 4's `--preflight` (ruling 40). | — |
| **Structure** | NamedTuples replace the result dict. `profiles.TRACKED` is now `TRACKED_FILE`, beside `util.TRACKED`. `git_path_state` keeps porcelain facts apart from states. `read` is no longer a variable name for a result. `LOCAL_PROFILES_IGNORE` was built from `LOCAL_FILE`, and ruling 43 spells it out again, pinned equal by a test. The kinds are computed once and passed through. `git_path_state` has no `timeout=` | the existing suite |

Every finding's test went red on `f0bc0bd` before its fix: 10 tests run, `failures=9, errors=1`, with both ruling-37 pins passing as pins.

## ADR 0017, contradicted as written

Writing `/charter.local.toml` into `.gitignore` goes past ADR 0017. That ADR has charter ignore a path it creates that carries credentials, and this file is neither: charter never writes it, and a profile holds no credential. It is ignored because its whole meaning is "not committed". The spec records the decision under *"Ignored" is guaranteed, not hoped for*. The plan's Task 6 writes the amendment into the ADR. The comment on `_ensure_local_profiles_ignored` cites the spec for the same reason.

## Rulings that change nothing here, stated

- **The git check on a hook path.** SessionStart runs `charter doctor`. So on a plane with `charter.local.toml`, `check_harness_profiles` makes one lock-free `git status` at every session start. It stays until Task 4 adds `--preflight`. `docs/control-plane.md` says so, instead of claiming no hook pays for it.
- **Ruling 37, extending ruling 19.** A refused replacement of a built-in refuses that name and never falls back to the built-in: running the built-in in its place would run a command the operator replaced. The listing shows the name refused, with its reason. Pinned by `test_ruling_37_a_refused_replacement_never_falls_back_to_the_built_in` and `test_ruling_37_a_refused_replacement_is_listed_refused_and_its_built_in_is_not`.
- **Ruling 41.** `[harness.claude.env]` on its own is the TOML spelling of profile `claude`'s `env`, not a dotted name, because `env` is a profile key. So it declares how `claude` runs, and a replacement with no `kind` or `command` refuses the name rather than falling back to the built-in (ruling 37). Pinned by `test_ruling_41_an_env_table_alone_declares_the_profile_and_refuses_the_name`, which also fails when the `key != _ENV` conjunct is deleted by hand.
- **A tracked file is a WARN in doctor, not a FAIL.** Its profiles are refused, so nothing runs.
- **`util.git_path_state` returns `(state, why)`, not the plan's `str`**, because `GIT_CANNOT_TELL` has to name git's reason. Task 2 should call `profiles.ignore_check()` or `ignored_refusal()`, which wrap it.

## Departures from the plan, and what in the plan proved false

**Proved false in the code** (main at `6526928`, then `01eb08f`):
- `tests/test_cmd_harness.py::HarnessList` does not "keep passing". It is a plain `TestCase` against the real plane, and with `PROFILES` in `_GUARDED_SETTINGS` its read was refused (`RealPlaneRead`). It now derives from `PersonaIso`, and stays isolated now that ruling 43 has removed that setting.
- `test_a_git_that_hangs_costs_one_row` as the plan writes it hangs *every* git call and expects doctor to return every other row. But `doctor.check_git` runs `git --version` with no timeout caught, so doctor stops at its second row. The test hangs only the ignore check's own call. The `check_git` gap is outside this task and is not fixed here.
- The plan's breakage lists miss `tests/test_the_end_of_a_name_is_the_end_of_the_string.py::TestTheInventoryIsClassified`. `profiles.NAME_RE` is filed there as an ADMITTER.
- The plan's TRACKED fix (`git rm --cached`, then `charter reinit`) never reaches a pass. That was F3, above.

**Departures, each with its reason:**
- **`profiles.current()` takes no argument** since ruling 43. It reads the files itself, so doctor's row and the listing ask the same reader.
- **Two refusals the plan does not list**, both under `instance.harness_of`'s rule that a value of the wrong type is as declared, and as not in force, as a misspelt one:
  - a local `harness` key that is not a table (`HARNESS_NOT_A_TABLE`);
  - a local `default` that is not text (`default_refused`).
- **`LOGIN.get(…)` rather than an index**, because doctor's row runs `derive` through `current()`, and a kind registered without a login sentence should cost a sentence, not the row. A test pins a login sentence for every launchable kind.
- **Fixtures:**
  - `InitAndReinitIgnoreIt` derives from `tests.test_init.InitIso`, and states `XDG_CONFIG_HOME`, because `init` and `reinit` write opencode's shim there.
  - The locale test's `clear=True` environment carries `_gitguard.environment()` and `GIT_CEILING_DIRECTORIES`.
  - Every test that asks git about a temp directory pins `GIT_CEILING_DIRECTORIES`.
- **The write-guard case.** The plan's `:391` shape patches `_REAL`, so it stays green with the `_planeguard` line deleted. It is kept, and `WhatIsGuarded.test_the_guarded_files_include_this_planes_local_profiles` asserts on the guard as installed.
- **Docs anchors.** Two links to `control-plane.md#harnessdefault--bare-charter` now point at `#default--bare-charter`.

## Test evidence

- **Red before any code** (the first round): the three new modules, the two new guard cases and the `test_init` fixture — 36 tests, `failures=12, errors=5`.
- **Whole suite against the first change** (ruling 31): `Ran 12121 tests`, `FAILED (failures=1, errors=3, skipped=9)`. Those were the breakages listed as proved false above.
- **Whole suite on `6593b93`**: `Ran 12123 tests`, `FAILED (failures=2, skipped=9)`. Both failures were `tests/test_claims.py` judging two rows of the new refusals table as vault claims; `2447eb3` rewords both cells.
- **Hand deletion check for the two `tests/_planeguard.py` lines, on `0e527f1`** (the sweep does not mutate `tests/`). Ruling 43 later removed the `PROFILES` line and its test, and the guard review's read refusal has its own check, above. In a scratch copy the unmutated tree passes. Removing `"PROFILES"` from `_GUARDED_SETTINGS` fails `test_the_profiles_are_guarded_like_the_harness_default`, and removing `LOCAL_FILE` from the markers fails `test_the_guarded_files_include_this_planes_local_profiles`.
- **Rebased onto #970 (`01eb08f`) before this PR opened.** `git merge-tree` predicted no conflict, and #970's guard pin (`folder=Path.home() / ".claude"`) is untouched by this branch. The affected modules passed on the rebased head: 32 modules, 785 tests.
- **`main` moved again after the rebase**, to `c48cc5b` (#974, the heredoc leak-guard fix).
  - It changes `charter/hooks.py`, `docs/hooks.md`, a news entry and one new test module. This branch touches none of them.
  - It leaves `hooks._is_charter` and `_CHARTER_PROGS` unchanged, and `profiles.current` relies on both.
  - `git merge-tree` predicts a clean merge.
  - So the branch was not rebased a second time, under this round's no-rewrite rule, and this PR's pull_request CI tests the merge with it.
- **Review findings, red on `f0bc0bd` before their fix:** 10 tests run, `failures=9, errors=1`, with both ruling-37 pins green.
- **After the fixes (`0e527f1`):** the 32 affected modules pass, 793 tests. A real `charter harness list` on a throwaway plane shows a committable file's `claude-work` refused with its reason, followed by `! to use the profiles in charter.local.toml: charter reinit`. A tracked file prints its own fix.
- **CI on `0e527f1`** (push run `34613872371`, each job read on its own): test (3.11) success, test (3.12) success, test (3.13) success, test (3.14) success; dev-channel install skipped.
- **Whole suite on `0e527f1`**, as the sweep's unmutated baseline in its own clean clone: `Ran 12194 tests — OK in 848s`.
- **After `0e527f1`:** `ce68fc1` changes only comments, docs and tests: the re-review leftovers, the ruling-41 pin, and the test for sweep survivor `[12]`. The 21 modules those touch pass, 477 tests. `e1cf89f` adds the test for sweep survivor `[17]`. The full suite on `e1cf89f`: `Ran 12197 tests in 692.669s`, `OK (skipped=9)`.

## Sweep

**Earlier runs, on trees that no longer ship.**
- On `ea1adcc`: the unmutated baseline passed, `Ran 12123 tests — OK in 742s`. The run was stopped at 24 of 162 mutations when #970 landed. Its two survivors are closed in `f0bc0bd`:
  - `[5]` `cli.py` `command_words`, `if h.cli_name` — **deleted**, because it could not change the answer;
  - `[16]` `commands_harness.py`, the registry-order sort key — **pinned** by `test_built_ins_come_first_in_registry_order_then_declared_by_name`.
- On `f0bc0bd`: stopped at its baseline when the review rulings changed the code.

**The local sweep on `0e527f1` stopped at 27 of 156 mutations.** The system killed it when the shared machine ran low on memory; nothing here stopped it. Its unmutated baseline passed, `Ran 12194 tests — OK in 848s`. Of the 27, 25 were pinned. The two survivors were confirmed against the full suite, and both are pinned now:
- `[12/156]` `commands_harness.py:43`, `uncontain` of `contain.readable(p.name)` in the NAME cell. **Pinned in `ce68fc1`.**
  - A declared name passes `NAME_RE` before it can reach a row, so no test could see the call.
  - Ruling 35 keeps the containment.
  - `test_a_name_that_skipped_validation_is_still_listed_escaped` hands the listing a name that skipped validation and holds a carriage return, and reads back its escaped spelling.
  - With the call deleted by hand, the row shows the carriage return as a space: `a b`, a different name.
- `[17/156]` `commands_harness.py:57`, `drop-if` of the fix line, `if check.fix: util.warn(…)`. **Pinned in `e1cf89f`** by `test_the_fix_for_the_files_state_is_its_own_line`, which fails with the line's `if` deleted by hand.
  - The committable-file test looked for "charter reinit" anywhere in the block, and the refused line's own reason already holds that phrase.
  - The new test reads the `!` line itself, for both a committable and a tracked file.

**CI's full sharded sweep on the PR head replaces the local run.** It sweeps the same added lines, on a tree that already carries both survivor tests. Three earlier CI sweeps gave no verdict about the code:
- `e1cf89f`: every shard hit its 60-minute limit, before ruling 43.
- `a36194d`: cancelled 20 minutes in by the push of `e81251e`, under `sweep.yml`'s `cancel-in-progress`. Its verdict job still published `no verdict: 2 of 7 shards did not report; 49 of 112 measured, 63 out of time`, a line about the cancellation, not the code.
- `e81251e`: cancelled the same way by the push of `ce7f5d8`, soon after its sizing. That sizing: 161 mutations over 7 shards, 164 minutes predicted, and `profiles.py` 132 minutes.

**CI's sweep on `ce7f5d8`** (run 34641426760) is the first CI sweep of this branch to finish: 161 mutations over 7 shards. Its verdict job is named `29 survivors`: 131 pinned, 29 survived and 1 platform-deferred, with nothing out of time, unresolved or refused.

The shards found these deletions with the whole suite still green, all in `charter/profiles.py` unless a row says otherwise. Each is pinned in `106f4a2`, `d38cbfe`, `0e09d4a` or `d10a95e`, except line 508, which no test can pin. Every test was checked by hand: it fails with its line changed and passes on the code as it is.

| Line | What was deleted or changed | Why no test saw it | Pinned by |
|---|---|---|---|
| 250, 259, 270, 277, 280, 315, 327, 347, 349, 373 | The `contain.readable` around a name, kind, variable, unknown key, `charter.toml` profile name, section, nested key or parent, or refused default that a refusal repeats | No test put a control byte into any of them | `test_every_value_a_refusal_repeats_back_is_escaped`: a carriage return in the one value each sentence repeats, including a nested table's parent |
| 324 | The escape of the parser's own words in `LOCAL_UNREADABLE` | No test's parse error held a control byte | `test_the_parsers_own_words_are_escaped` |
| 520 | The escape of git's own words | No test's git said one | `test_gits_own_words_are_escaped_in_the_refusal_and_the_fix` |
| 382, 442, 469 | Escapes of a name that has passed `NAME_RE` or is a built-in's word | Such a name cannot carry a control byte today. Ruling 35 keeps the escape, as it did for survivor `[12]` | `EveryLayerEscapesWhatItRepeats`, with a hand-built name that skipped validation |
| 355 | The `nested and` in `derive` | No test declared a bare `[harness.work]` | `test_a_header_with_nothing_under_it_is_refused_not_skipped`: refused by name, and a bare `[harness.claude]` refuses `claude` (ruling 37) |
| 215 | `if h.cli_name` in `_kinds` | Every harness registered today has a word | `test_a_harness_registered_without_a_cli_name_is_no_kind_and_no_profile` |
| 276 | `LOGIN.get`'s fallback, dropped or reworded | Every kind has a login sentence today | `test_a_kind_registered_without_a_login_sentence_still_gets_one` |
| 268 | `sorted` over the variables, swapped for `list` | No test had two offending variables | `test_a_refusal_names_the_first_offending_variable_by_name`, which also fails for the same `sorted` at 271 |
| 311 | `derive`'s `isinstance(cfg, dict)` | `cfg` is always a table today, and the docstring promises `derive` never raises | `test_a_cfg_that_is_not_a_table_declares_nothing_and_raises_nothing` |
| 470 | `p.source == LOCAL_FILE` in `with_ignore_check` | No test checked that only the local file's profiles are refused | `test_a_built_in_stays_a_profile_and_is_not_also_refused` |
| `util.py` 493, 497, 500 | `proc.stderr or ""` and its `strip` (swapped for `lstrip`), the `else` of the first-line pick, and `proc.stdout or ""` | No test had git fail saying nothing, pad its reason, or return nothing captured | `test_a_git_that_fails_saying_nothing_is_named_by_its_exit`, `test_the_reason_git_gave_is_trimmed_at_both_ends`, `test_a_git_that_prints_nothing_reads_as_tracked_even_with_nothing_captured` |
| `util.py` 508 | `set(code) <= _TRACKED_STATUS` shifted to `<` | No input tells them apart. A two-character code never equals the eight-letter set, and they agree on all 256 codes checked | Not a test: rewritten as `set(code).issubset(_TRACKED_STATUS)`, which says the same thing and has no boundary, in `75900d9` |

**Left as it is:** line 398, the `FileNotFoundError` clause in `_bytes`. The sweep defers it to the platform, and its gate does not count it. Deleting it changes nothing observable, because the `OSError` clause below it would key an absent file by its errno just as distinctly. It would also label an absent file "unreadable", against the function's own docstring.

**Covering set:** across all seven shards, each `profiles.py` mutation ran 2 to 26 test modules, against 347 before ruling 43.

**Evidence for the pins:**
- Each test was run first on the code as it is, then with its line changed by hand. The changes after the full suite started were checked in a scratch copy, so the running suite's child processes never imported a mutant.
- The whole suite on `d38cbfe`'s tree: `Ran 12222 tests in 1245.062s`, `OK (skipped=9)`.
- The whole suite on `75900d9`, the head these commits end at: `Ran 12225 tests in 1157.033s`, `OK (skipped=9)`, with no `RealPlaneRead` in its output.

**CI on `75900d9`, the PR head:** each job was read on its own.
- **tests:** on the push run (34648300776) and the pull_request run (34648305361), test (3.11), (3.12), (3.13) and (3.14) each succeed. The dev-channel install job is skipped on both.
- **CodeQL:** CodeQL, Analyze (actions) and Analyze (python) succeed.
- **deletion sweep** (run 34648305407): 160 mutations over 7 shards, and every shard succeeds. The verdict job is named `no survivors`: 159 pinned and 1 platform-deferred (line 398, above), with nothing unpinned, in a masked cluster, unresolved, out of time or refused. Every pin above holds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
