### PR TITLE
Pin or delete the guards #974's own sweep named

### DIFF
--- a/charter/hooks.py
+++ b/charter/hooks.py
@@ -972,9 +972,11 @@ def _strip_reader_heredocs(cmd: str) -> str:
         body_count = 0
         plan_text = ""
         join = ""                                 # separator carried from the previous stage
-        while i < n:
+        while True:
             # A command line, with any backslash-newline splices folded in first — bash does
             # this before it looks for heredoc bodies, so the bodies follow the folded whole.
+            # No bound of its own: out of lines, the fold below yields "", which opens no
+            # heredoc and continues no pipeline, so this breaks on the next test.
             folded = ""
             while i < n:
                 line = lines[i]
@@ -985,7 +987,7 @@ def _strip_reader_heredocs(cmd: str) -> str:
                     continue
                 folded += line
                 break
-            plan_text = folded if not plan_text else plan_text + join + folded
+            plan_text = plan_text + join + folded      # `join` is "" until a stage continues
             # This command line's heredoc bodies follow, in order; buffer each.
             for m in _HEREDOC_RE.finditer(folded):
                 delim = m.group("delim")
@@ -1007,11 +1009,11 @@ def _strip_reader_heredocs(cmd: str) -> str:
                         (body_line.lstrip("\t") if dash else body_line) == delim)
                     if is_terminator:
                         break
-                    chunks.append((idx,body_line))
+                    chunks.append((idx, body_line))
                     spliced = expands and _ends_in_line_continuation(body_line)
                     i += 1
                 if i < n:                          # the terminator line itself
-                    chunks.append((idx,lines[i]))
+                    chunks.append((idx, lines[i]))
                     i += 1
             if not _pipeline_continues(folded):
                 break

--- a/tests/test_a_heredoc_body_is_read_by_whoever_runs_it.py
+++ b/tests/test_a_heredoc_body_is_read_by_whoever_runs_it.py
@@ -226,6 +226,31 @@ class TheTerminatorMatchesBashExactly(PlaneIso):
         cmd = f"cat <<'A' && bash <<'B'\ndata\\\nA\n{READ}\nB"
         self.assertTrue(self.denies(cmd), cmd)
 
+    def test_a_tab_indented_line_does_not_end_a_plain_heredoc(self):
+        """Only a `<<-` ignores leading tabs. On a plain `<<'A'` a tab-indented `A` is body
+        text, so bash's body — and the read inside it — runs on to the exact `A`. Ending the
+        kept shell body at the tab-indented line would hand that read to `cat <<'B'` to
+        strip."""
+        cmd = f"bash <<'A' && cat <<'B'\necho hi\n\tA\n{READ}\nB\nA\ndata\nB"
+        self.assertTrue(self.denies(cmd), cmd)
+
+    def test_a_dash_heredoc_ends_on_its_tab_indented_terminator(self):
+        """The other direction: `<<-` DOES ignore leading tabs, so the tab-indented `A` ends
+        that body. Failing to see it would run `cat`'s droppable body on over the read meant
+        for `bash <<'B'` and strip it away."""
+        cmd = f"cat <<-'A' && bash <<'B'\n\tdata\n\tA\n{READ}\nB"
+        self.assertTrue(self.denies(cmd), cmd)
+
+    def test_a_command_ending_in_a_continuation_backslash_still_decides(self):
+        """A last line ending in a backslash-newline continues onto a line that is not there.
+        The fold has to stop at the end of the input rather than read past it."""
+        cmd = f"cat <<'EOF'\n{MENTION}\nEOF\necho tail \\"
+        try:
+            decided = self.denies(cmd)
+        except Exception as exc:                       # noqa: BLE001
+            self.fail(f"the leak guard raised instead of deciding: {exc!r}")
+        self.assertFalse(decided, cmd)
+
     def test_a_dash_terminator_still_strips_leading_tabs(self):
         """`<<-` strips leading tabs from body and terminator alike, so a tab-indented
         terminator still ends the body. A quoted reader body naming a path stays data (#258),


### PR DESCRIPTION
Follows #974 (#973): the guards its own sweep named.

#974 merged on the survivor check's READY verdict and green CI at `26d8541`. The deletion
sweep of that head finished after the merge and named guards in the code #974 added —
fallbacks with no test behind them, which is exactly what CONTRIBUTING asks a branch to
close. This is that work, rebased onto the squashed `c48cc5b`.

## The sweep of `26d8541`

**37 mutations applied, 29 pinned, 7 SURVIVED, 1 UNRESOLVED** (baseline: 12,089 tests, OK).
All eight sit in the heredoc walk #974 introduced; none is one of the ten CI had named on
`1acd902`, which #974 already resolved.

## Pinned — red under the mutation, green restored

Each was verified by hand on this base: apply that one mutation, the named test fails;
restore it, the module is green.

| Guard | Mutation the sweep applied | Test |
| --- | --- | --- |
| the `<<-` terminator test | collapse to "always strip leading tabs" | `test_a_tab_indented_line_does_not_end_a_plain_heredoc` |
| the same | collapse to "never strip them" | `test_a_dash_heredoc_ends_on_its_tab_indented_terminator` |
| the same | `lstrip` → `rstrip` | `test_a_dash_heredoc_ends_on_its_tab_indented_terminator` |
| the fold's bound | `i < n` → `i <= n` | `test_a_command_ending_in_a_continuation_backslash_still_decides` |

What each shape is, since a tab is invisible in a diff:

- **A tab-indented line must not end a plain heredoc.** Only `<<-` ignores leading tabs, so on
  `bash <<'A'` a tab-indented `A` is body text and bash runs the body — including the read —
  on to the exact `A`. Ending it early hands that read to the following `cat <<'B'` to strip.
- **A `<<-` heredoc must end on its tab-indented terminator.** The other direction: failing to
  see it runs `cat`'s droppable body over the read meant for `bash <<'B'` and strips it away.
- **A last line ending in a continuation backslash must still decide.** The fold has to stop at
  the end of the input instead of reading past it.

## Deleted — equivalent mutants, with the reason

No input distinguishes these, so no test can pin one; CONTRIBUTING makes that a deletion.

- **The plan-text conditional.** The separator carried from the previous stage is empty until a
  stage continues, so plain concatenation already gives the first stage the same answer.
- **The per-stage loop's own bound.** Out of lines, the fold yields `""`, which opens no heredoc
  and continues no pipeline, so the loop's existing test breaks it. It is now `while True:`.
- **(carried from #974's own resolution, for completeness)** the `kind == "cmd"` half of the emit
  test, the two empty-command filters, and the `len(plan) == body_count` conjunct were deleted
  in #974 itself.

Measured inert: verdicts over the leak rows of `guard_denied_by_main.txt` plus generated
heredoc shapes — 11,489 inputs — are identical to `c48cc5b`, exceptions included.

## The UNRESOLVED one — not pinned, and not claimed to be

The outer walk's bound is the eighth, and it has no verdict. Widening it (`i < n` → `i <= n`)
makes the mutant **non-terminating**: nothing advances the index on an empty tail, so the
suite hangs rather than fails, and the sweep records no verdict. **No test can pin it** — a
test would hang too, not go red.

What I did instead of claiming a pin: the loop beside it, which had the same shape, no longer
has a bound to widen (it is `while True:`, deleted above), and the fold's bound underneath it
is pinned by the backslash test. The outer bound stays as it is, recorded here as unresolved
rather than papered over.

## Verification

- Full suite on this head: **12,154 tests, OK (9 skipped)**.
- Every pin re-verified red/green on `c48cc5b`, not only on the pre-merge base: apply the one
  mutation, the named test fails; restore it, the module is green.
- Deletions measured inert against `c48cc5b` across 11,489 inputs, exceptions included.
- `python3 tools/sweep.py` on this head: **0 mutations applied**, and that is the honest
  reading rather than a green light. The branch's diff against main adds six lines in
  `charter/`, and a branch-scoped sweep only mutates what the branch added — while the guards
  this PR pins were added by #974 and now live in main, so there is nothing here for it to
  mutate. The evidence for those guards is the hand mutation above, not this run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
