### PR TITLE
A chat starts on the profile you name, and keeps it through `+`, tabs, handoff and reopen

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,10 @@ this to `charter.toml` and the command is `charter` on its own:
 default = "claude"
 ```
 
+The value names a **profile** — `claude`, `codex` and `opencode` are the built-in one per
+harness, and `charter.local.toml` is where you declare your own (a pinned version, a second
+account); see [control-plane.md](docs/control-plane.md#harness--profiles-and-the-default).
+
 Piped anywhere, bare `charter` prints its usage instead of starting an agent.
 
 - **`charter init`** scaffolds `charter.toml`, the baseline directories (`personas/`,

--- a/charter/cli.py
+++ b/charter/cli.py
@@ -21,7 +21,6 @@ from . import (
     contain,
     harness,
     hooks,
-    instance,
     statusline,
     toolgate,
     util,
@@ -789,6 +788,12 @@ def _add_frame_parsers(sub) -> None:
         parser.add_argument("--fresh", action="store_true",
                             help="Do not restore the recorded plane, and do not record "
                                  "over it: start one chat and leave the record alone.")
+        # Which PROFILE of this kind to run — `charter claude --profile claude-work`, and
+        # what `_profile_launch` rewrites `charter claude-work` into. Suppressed from the
+        # help because an operator names a profile by typing it: the flag is the shape the
+        # rewrite produces, so every splitter and branch below runs on one set of tokens.
+        parser.add_argument("--profile", dest="profile", default=None,
+                            help=argparse.SUPPRESS)
         parser.set_defaults(harness=name, func=commands_frame.cmd_launch)
 
     # Snapshot, not a live read of `sub.choices` inside the loop — see this function's
@@ -817,7 +822,8 @@ def _add_frame_parsers(sub) -> None:
                                          "frame-resize", "frame-gather", "frame-switch",
                                          "frame-toggle", "frame-chrome", "frame-chat",
                                          "frame-new-chat", "frame-quit", "frame-close",
-                                         "frame-transcript", "frame-bar-rows"}
+                                         "frame-transcript", "frame-bar-rows",
+                                         "frame-launch"}
 
     # Which harness (by `.name`, never `.cli_name` — that's the dict key below) has
     # already claimed each word, so a SECOND harness wanting it is told who got there
@@ -1099,6 +1105,23 @@ def _add_frame_parsers(sub) -> None:
     nc = sub.add_parser("frame-new-chat")
     nc.add_argument("--chat", dest="chat", default="")
     nc.set_defaults(func=commands_frame.cmd_new_chat)
+
+    # Internal: what tmux starts in every chat pane, where the harness's own argv used to go
+    # (`layout.session_argv`, `layout.chat_window_argv`, and `layout.respawn_argv` after the
+    # placeholder in an operator's own tmux). It runs the profile's guards in the pane and
+    # `exec`s the profile's command — `frame/launcher.py` is the whole of it. Never typed by
+    # an operator: `charter <profile>` is the spelling, and this is what it becomes.
+    #
+    # **`--attended` rather than `--unattended`**, because unattended is what a pane gets
+    # unless somebody is in front of it (review 3). A reopen, a handoff and a background
+    # open must never stop on a question nobody can see, and a flag they would have to
+    # remember to pass is a flag that gets forgotten — the failure would be a pane waiting
+    # forever on a keypress that is never coming.
+    fl = sub.add_parser("frame-launch")
+    fl.add_argument("--profile", dest="profile", required=True)
+    fl.add_argument("--attended", action="store_true")
+    fl.add_argument("rest", nargs=argparse.REMAINDER)
+    fl.set_defaults(func=_frame_launch)
 
     # §4i's quit. Started DETACHED by the palette's confirmation row
     # (`commands_frame._start_leaving`) and typeable by hand, which is why it warns on its
@@ -1763,7 +1786,7 @@ _BARE_FLAGS = ("--fresh",)
 #:
 #: `--workspace=<name>` needs no entry — it is a single token, so the leading-run scan
 #: below matches it by prefix and `argparse` splits it.
-_OWN_VALUE_FLAGS = ("--workspace",)
+_OWN_VALUE_FLAGS = ("--workspace", "--profile")
 
 
 def _split_frame_argv(argv: list[str]) -> tuple[list[str], list[str] | None]:
@@ -1899,8 +1922,9 @@ def _bare_launch(argv: list[str]) -> tuple[list[str], int | None]:
     `parse_args`, which is what `commands_update._handoff` reads back.
 
     *The plane declared a value charter cannot launch.* Reported here, loudly, naming the
-    value and the words that would work. `instance.harness_of` recorded it at the config
-    boundary; this is the reader that can say so on the command the key is *for*. Silence
+    value and the profiles that would work. `profiles.current()` resolves the default —
+    `charter.local.toml`'s where it names one, `charter.toml`'s otherwise — and this is the
+    reader that can say so on the command the key is *for*. Silence
     would be the whole defect: a refused default degrades to no default, which renders as
     argparse's usage message — byte-identical to what a plane that declared nothing gets,
     so the operator who committed ``default = "clyde"`` would watch charter behave exactly
@@ -1946,34 +1970,92 @@ def _bare_launch(argv: list[str]) -> tuple[list[str], int | None]:
         util.err(refusal)
         return argv, 1
 
-    declared = config.HARNESS
-    # Truthiness, not `is not None`, and the same test `doctor` makes of the same key.
-    # `contain.readable` never returns a blank string, so on anything `harness_of` produced
-    # the two are the same question — but `config.HARNESS` is a module attribute anything
-    # in-process can assign, and a planted `{"refused": ""}` would otherwise print a
-    # refusal naming nothing at all instead of falling through to the usage message.
-    refused = declared.get("refused")
-    if refused:
-        util.err(f'charter: [harness] default = "{refused}" in '
-                 f'{util.short_path(config.ROOT / "charter.toml")} is not a harness '
-                 f'charter can launch — one of: '
-                 f'{", ".join(instance.launchable_harnesses())}. Nothing was started.')
+    # **The profiles, and not `config.HARNESS`** (ruling 43). The default a launch means is
+    # the one `charter.local.toml` names where it names one and `charter.toml`'s where it
+    # does not, and `profiles.current()` is the only thing that resolves that: `config`
+    # reads nothing from the local file, because every hook process derives config and a
+    # profile read there is the cost ruling 43 measured. A bare launch is a launch, which is
+    # exactly where the read belongs.
+    from . import profiles
+
+    read = profiles.current()
+    # Truthiness, not `is not None`, and the same test `doctor` makes of the same answer.
+    # `contain.readable` never returns a blank string, so on anything `derive` produced the
+    # two are the same question — but a planted empty value would otherwise print a refusal
+    # naming nothing at all instead of falling through to the usage message.
+    if read.default_refused:
+        util.err("charter: " + profiles.DEFAULT_REFUSED.format(
+            value=read.default_refused, names=", ".join(read.profiles)))
         return argv, 2
-    default = declared.get("default")
     # Two conditions, two statements, and deliberately not one `or`. They are different
-    # facts — a file that said nothing, and a terminal that is not one — with different
+    # facts — a plane that named nothing, and a terminal that is not one — with different
     # reasons in the docstring above, and an arm two inputs can both satisfy is an arm
     # neither of them ends up testing.
-    if not default:
+    if not read.default:
         return argv, None
     if not sys.stdout.isatty():
         return argv, None
-    # The flags the operator typed ride along, after the harness name rather than before
-    # it: `_split_frame_argv` recognises `_OWN_FLAGS` only in the run immediately following
+    # The flags the operator typed ride along, after the name rather than before it:
+    # `_split_frame_argv` recognises `_OWN_FLAGS` only in the run immediately following
     # `charter <name>`, which is the same position a typed `charter claude --fresh` puts
-    # them in. So the rewrite produces tokens indistinguishable from the typed form, which
-    # is this function's whole contract.
-    return [default, *argv], None
+    # them in. :func:`_profile_launch` then turns a declared profile's name into its kind's
+    # launcher, so what comes out is indistinguishable from the typed form either way —
+    # which is this function's whole contract.
+    return [read.default, *argv], None
+
+
+def _profile_launch(argv: list[str],
+                    parser: argparse.ArgumentParser) -> tuple[list[str], int | None]:
+    """`charter <profile>` → `charter <kind> --profile <profile>`, or *argv* untouched.
+
+    :func:`_bare_launch`'s own shape and for its own reason: a REWRITE rather than a route
+    of its own, so every splitter, flag and branch below it runs on the tokens a typed
+    `charter claude --profile <name>` produces. A second path into `cmd_launch` would be a
+    second set of answers about the workspace picker, `$CHARTER_HARNESS`, `--probe` and the
+    frame, all of which are settled for the typed form.
+
+    **A word charter already means is never a profile, and the parser is what says so.**
+    `charter doctor` is `doctor` whatever `charter.local.toml` declares, which is why
+    `profiles.current` refuses a clashing name outright — so a command reaches this and
+    leaves it without the profiles ever being read. Asked of the parser `main` has already
+    built, never of `command_words()`, which builds a SECOND one: ~10 ms measured on this
+    machine, in every `charter hook …` process, on hooks that fire on Bash, Read, Grep,
+    Write, Edit, Task, Skill and SendMessage.
+
+    **A built-in's name is left exactly as typed.** `charter claude` already parses and
+    `_launch` resolves `args.profile or args.harness`, so a declared profile that replaces a
+    built-in is reached without a rewrite.
+
+    A name the file declares and charter REFUSED says the rule instead of falling through to
+    argparse, which would call it an invalid choice and offer the gap reporter for a profile
+    the operator can see in their own file.
+    """
+    if not argv or argv[0].startswith("-") or argv[0] in _subcommand_names(parser):
+        return argv, None
+    from .frame import launcher
+
+    p, why = launcher.resolve(argv[0])
+    if p is not None:
+        # The resolved names and never the typed word — `instance.harness_of`'s rule for
+        # the same reason: what goes back onto a command line is charter's own string.
+        return [p.kind, "--profile", p.name, *argv[1:]], None
+    if why:
+        util.err(f"charter: {why}")
+        return argv, 2
+    return argv, None
+
+
+def _frame_launch(args) -> int:
+    """`charter frame-launch` — the launcher every chat pane's first process is.
+
+    A thunk rather than `func=launcher.cmd_frame_launch`, so `charter/frame/launcher.py` and
+    `charter/profiles.py` stay off the import path that every `charter hook …` process pays
+    for (ruling 43): this module is imported to build the parser, and the parser is built
+    per tool call.
+    """
+    from .frame import launcher
+
+    return launcher.cmd_frame_launch(args)
 
 
 #: The commands that still run on a plane charter has refused (`config.PLANE_REFUSAL`).
@@ -2027,10 +2109,19 @@ def main(argv=None) -> int:
     argv, rc = _bare_launch(argv)
     if rc is not None:
         return rc
+    # Built HERE rather than after the splitters, and handed to the rewrite below. The
+    # rewrite has to know which words are commands, and asking `command_words()` builds a
+    # second parser — ~10 ms, in every process, including the `charter hook …` ones that run
+    # per tool call. One parser answers both questions and then parses the result.
+    parser = build_parser()
+    # Directly after `_bare_launch`, so a profile named by a bare `charter`'s own default is
+    # rewritten by the same line a typed one is. See :func:`_profile_launch`.
+    argv, rc = _profile_launch(argv, parser)
+    if rc is not None:
+        return rc
     argv = _hoist_persona_memory(argv)
     argv, exec_command = _split_exec_command(argv)
     argv, frame_rest = _split_frame_argv(argv)
-    parser = build_parser()
     try:
         args = parser.parse_args(argv)
     except SystemExit:

--- a/charter/commands_frame.py
+++ b/charter/commands_frame.py
@@ -2208,20 +2208,29 @@ def _wait_for_harness(socket: str, harness_pane: str) -> int | None:
 _LAUNCHER_SECONDS = 5.0
 
 
-def _what_the_pane_said(socket: str, fid: str, harness_pane: str, profile: str) -> str:
-    """The refusal *fid*'s own launcher recorded, or ``""`` — ruling 42's only reader.
+def _what_the_pane_recorded(socket: str, fid: str, harness_pane: str,
+                            profile: str) -> tuple[int | None, str]:
+    """``(exit code, refusal)`` *fid*'s own launcher recorded — ruling 42's only reader.
 
     Through :func:`_await_the_launcher`, never `_pane_last_words`: the measurement is that
     by the time anything asks, the window carrying the sentence is gone. It answers at once
     wherever the pane has already stopped, because the loop it runs ends on a pane that is
     not alive.
 
-    ``""`` for a launch with no profile (`charter frame -- <cmd>`), which has no launcher to
-    have recorded anything.
+    **The code as well as the sentence, because on an operator's server tmux often cannot
+    supply one.** Nothing sets `remain-on-exit` in somebody else's tmux, so a pane whose
+    launcher refused is simply gone — `#{pane_dead_status}` is not merely unknown, the pane
+    is not there to be asked — and the launch would otherwise report
+    `_UNKNOWN_DEATH_CODE` for a refusal that has a number of its own. Measured on a Linux
+    runner, where that path returned 1 while charter's own server returned 3 for the same
+    refusal.
+
+    ``(None, "")`` for a launch with no profile (`charter frame -- <cmd>`), which has no
+    launcher to have recorded anything.
     """
     if not profile:
-        return ""
-    return _await_the_launcher(socket, fid, harness_pane)[1]
+        return None, ""
+    return _await_the_launcher(socket, fid, harness_pane)
 
 
 def _await_the_launcher(socket: str, fid: str, harness_pane: str) -> tuple[int | None, str]:
@@ -3602,14 +3611,17 @@ def _launch_in_operator_tmux(socket: str, session: str, *, ws: str,
     # them on a dead pane.
     status, code = _pane_state(socket, harness_pane)
     if status != _ALIVE:
-        if code is not None:
-            state.record_exit(fid, code)
         # **Ruling 42 holds on this path too, and it is the path it holds HARDEST.** A
         # launcher that refused printed into a window this function closes a few lines
         # down, so `_pane_last_words` below is measured empty here — and the operator
         # never saw the window at all, because nothing switches them to it. What the pane
-        # RECORDED is the only copy left (`_what_the_pane_said`).
-        refused = _what_the_pane_said(socket, fid, harness_pane, profile)
+        # RECORDED is the only copy left (`_what_the_pane_recorded`), its number included:
+        # a pane that is GONE has no `#{pane_dead_status}` to read.
+        recorded, refused = _what_the_pane_recorded(socket, fid, harness_pane, profile)
+        if recorded is not None:
+            code = recorded
+        if code is not None:
+            state.record_exit(fid, code)
         if refused:
             util.err(f"charter: {refused}")
         elif code is not None and code != 0:
@@ -3658,26 +3670,43 @@ def _launch_in_operator_tmux(socket: str, session: str, *, ws: str,
         _drop_panels(socket, leaving)
 
     code = _wait_for_harness(socket, harness_pane)
+    # **And the refusal a launcher recorded while this process was watching** (ruling 42).
+    # This path stays awake for the whole life of the frame, so a pane that refused after
+    # the checks above passed — the plane moved between them — ends up here: the window is
+    # about to be closed, and the sentence in it with it. An attended pane has already
+    # shown the operator this; saying it once more where their shell comes back costs a
+    # line and is the only copy that survives.
+    #
+    # **Asked BEFORE the `code is None` branch below, and that is the whole fix.** A
+    # refusing launcher in somebody else's tmux is a pane that VANISHES — nothing sets
+    # `remain-on-exit` there — so `_wait_for_harness` answers `None` for it exactly as it
+    # does for a window the operator closed, and reading the record only on the other
+    # branch lost the sentence on the path that has no other copy of it.
+    # The pane is not there to be asked — the operator closed the window (their own
+    # `prefix-&`), the server went with it, or a launcher that refused exited before
+    # anything could arm `remain-on-exit` for it. There is nothing left to close either.
+    gone = code is None
+    recorded, refused = _what_the_pane_recorded(socket, fid, harness_pane, profile)
+    if recorded is not None:
+        # **The launcher's own number wins over tmux's reading of the pane.** It wrote
+        # down what it was exiting with BEFORE it exited; what tmux has afterwards is a
+        # `#{pane_dead_status}` that is empty for a pane killed by a signal and absent
+        # altogether for a pane that is gone — both of which read as
+        # `_UNKNOWN_DEATH_CODE`. Measured on a Linux runner: the same refusal that
+        # answers 3 on charter's own server answered 1 here.
+        code = recorded
     if code is None:
-        # The pane vanished rather than dying askably — the operator closed the window
-        # (their own `prefix-&`), or the server went with it. Nonzero and named: charter
-        # cannot know what the harness would have exited with, and reporting a killed
-        # agent as a clean 0 is the fabricated success this module refuses everywhere
-        # else. Nothing is killed here either; there is nothing left to kill.
+        # Nonzero and named: charter cannot know what the harness would have exited with,
+        # and reporting a killed agent as a clean 0 is the fabricated success this module
+        # refuses everywhere else. Nothing is killed here either.
         util.err("charter frame: the frame's window is gone — the harness's exit code "
                  "is not something charter can know now.")
         code = _UNKNOWN_DEATH_CODE
     else:
         state.record_exit(fid, code)
-        # **And the refusal a launcher recorded while this process was watching** (ruling
-        # 42). This path stays awake for the whole life of the frame, so a pane that
-        # refused after the checks above passed — the plane moved between them — ends up
-        # here: the window is about to be closed, and the sentence in it with it. An
-        # attended pane has already shown the operator this; saying it once more where
-        # their shell comes back costs a line and is the only copy that survives.
-        refused = _what_the_pane_said(socket, fid, harness_pane, profile)
-        if refused:
-            util.err(f"charter: {refused}")
+    if refused:
+        util.err(f"charter: {refused}")
+    if not gone:
         _close_window()
     # Given up before this path's own closing reap, for the reason `cmd_launch` gives at
     # its own (#685): the marker is held for the LAUNCH, and this launch is over.

--- a/charter/commands_frame.py
+++ b/charter/commands_frame.py
@@ -2208,6 +2208,22 @@ def _wait_for_harness(socket: str, harness_pane: str) -> int | None:
 _LAUNCHER_SECONDS = 5.0
 
 
+def _what_the_pane_said(socket: str, fid: str, harness_pane: str, profile: str) -> str:
+    """The refusal *fid*'s own launcher recorded, or ``""`` — ruling 42's only reader.
+
+    Through :func:`_await_the_launcher`, never `_pane_last_words`: the measurement is that
+    by the time anything asks, the window carrying the sentence is gone. It answers at once
+    wherever the pane has already stopped, because the loop it runs ends on a pane that is
+    not alive.
+
+    ``""`` for a launch with no profile (`charter frame -- <cmd>`), which has no launcher to
+    have recorded anything.
+    """
+    if not profile:
+        return ""
+    return _await_the_launcher(socket, fid, harness_pane)[1]
+
+
 def _await_the_launcher(socket: str, fid: str, harness_pane: str) -> tuple[int | None, str]:
     """What *fid*'s launcher did: ``(None, "")`` once the harness has the pane, and
     ``(exit code, refusal)`` when it refused instead.
@@ -3305,6 +3321,12 @@ def _panel_remain_on_exit_argv(*, socket: str, harness_pane: str) -> list[str]:
 #: included, and the one figure that explains the refusal was the one thing not on screen.
 #: *carried* is the harness's arguments alone: the rest of the limit is the window's own
 #: name, directory and identity, which is why a launch just under it can still be refused.
+TOO_LONG_FOR_TMUX = ("charter frame: tmux refused the command that starts this chat as too "
+                     "long — tmux takes at most {limit:,} bytes in one command, and the "
+                     "command charter handed it is {carried:,} bytes. Nothing was started; "
+                     "shorten what this launch carries, or put the long text in a file and "
+                     "pass its path instead.")
+
 #: What an operator's own tmux is told when it will not mark charter's window with the chat
 #: it is drawing. Its own sentence rather than a warning, because what is lost is not a
 #: convenience: the pane's launcher proves which chat it is by this option on this server
@@ -3316,16 +3338,10 @@ UNNAMED_CHAT_WINDOW = (
     "which chat it is in, and without it this chat would run with no frame and be recorded "
     "nowhere. Nothing was started, and the window has been closed.")
 
-TOO_LONG_FOR_TMUX = ("charter frame: tmux refused the command that starts this chat as too "
-                     "long — tmux takes at most {limit:,} bytes in one command, and this "
-                     "launch's harness arguments alone are {carried:,} bytes. Nothing was "
-                     "started; shorten them, or put the long text in a file and pass its "
-                     "path instead.")
-
 
 def _say_why_the_harness_did_not_start(action: str, cmd: list[str],
                                        proc: subprocess.CompletedProcess,
-                                       harness_argv: list[str]) -> None:
+                                       carried: list[str]) -> None:
     """Report a refused harness start: tmux's length refusal by what it was, and anything
     else exactly as `tmuxctl.report_failure` has always reported it.
 
@@ -3337,11 +3353,18 @@ def _say_why_the_harness_did_not_start(action: str, cmd: list[str],
     `os.fsencode` and not `str.encode`, because that is how the argument reached `exec`: a
     byte that is not UTF-8 arrives in `sys.argv` as a surrogate escape, and a strict encode
     of it would raise in the middle of a failure report.
+
+    ***carried* is the argv charter really handed tmux, never the one it SHOWS.** Since a
+    profile launch those are two different lists — tmux is handed
+    `python -P -m charter frame-launch --profile <name> -- …` and the operator is shown the
+    profile's own command — and only one of them explains a refusal about length (ADR 0009:
+    a number beside a limit has to be the number the limit was applied to). The sentence
+    the operator reads names the command charter handed tmux for exactly that reason.
     """
     if tmuxctl.refused_as_too_long(proc.stderr):
         util.err(TOO_LONG_FOR_TMUX.format(
             limit=tmuxctl.MESSAGE_LIMIT,
-            carried=sum(len(os.fsencode(a)) for a in harness_argv)))
+            carried=sum(len(os.fsencode(a)) for a in carried)))
         return
     tmuxctl.report_failure(action, cmd, proc)
 
@@ -3564,8 +3587,10 @@ def _launch_in_operator_tmux(socket: str, session: str, *, ws: str,
                                     env=_guest_harness_env(env), cwd=cwd, harness_argv=argv)
     started = tmuxctl.run("starting the harness in it", start_cmd, report=False)
     if started.returncode != 0:
+        # *argv*, not *display*: what tmux refused is the launcher argv, and the only
+        # number that explains a refusal about length is the one tmux measured.
         _say_why_the_harness_did_not_start("starting the harness in it", start_cmd,
-                                            started, display)
+                                            started, argv)
         # The placeholder is still running in a window the operator never asked for and
         # would never learn the purpose of. Take it back.
         _close_window()
@@ -3579,7 +3604,15 @@ def _launch_in_operator_tmux(socket: str, session: str, *, ws: str,
     if status != _ALIVE:
         if code is not None:
             state.record_exit(fid, code)
-        if code is not None and code != 0:
+        # **Ruling 42 holds on this path too, and it is the path it holds HARDEST.** A
+        # launcher that refused printed into a window this function closes a few lines
+        # down, so `_pane_last_words` below is measured empty here — and the operator
+        # never saw the window at all, because nothing switches them to it. What the pane
+        # RECORDED is the only copy left (`_what_the_pane_said`).
+        refused = _what_the_pane_said(socket, fid, harness_pane, profile)
+        if refused:
+            util.err(f"charter: {refused}")
+        elif code is not None and code != 0:
             # #384 reaches THIS path too, and reaches it harder. Nothing below runs — no
             # panels, no `select-window` — so the operator is never switched to the
             # frame's window at all: it is created, filled with a corpse, and killed
@@ -3636,6 +3669,15 @@ def _launch_in_operator_tmux(socket: str, session: str, *, ws: str,
         code = _UNKNOWN_DEATH_CODE
     else:
         state.record_exit(fid, code)
+        # **And the refusal a launcher recorded while this process was watching** (ruling
+        # 42). This path stays awake for the whole life of the frame, so a pane that
+        # refused after the checks above passed — the plane moved between them — ends up
+        # here: the window is about to be closed, and the sentence in it with it. An
+        # attended pane has already shown the operator this; saying it once more where
+        # their shell comes back costs a line and is the only copy that survives.
+        refused = _what_the_pane_said(socket, fid, harness_pane, profile)
+        if refused:
+            util.err(f"charter: {refused}")
         _close_window()
     # Given up before this path's own closing reap, for the reason `cmd_launch` gives at
     # its own (#685): the marker is held for the LAUNCH, and this launch is over.
@@ -5206,7 +5248,7 @@ def _launch(args) -> int:
             # A profile is a way to run ONE kind, and the kind decides the hooks, the
             # resume flag and how a first message is spelled — so this is refused rather
             # than resolved in either direction.
-            util.err("charter: " + launcher.KIND_MISMATCH.format(
+            util.err("charter: " + launcher.MISMATCHED_KIND.format(
                 name=contain.readable(p.name), kind=p.kind, asked=args.harness))
             return 2
         # Only the profile's NAME crosses tmux. Its command and its environment are read
@@ -5285,8 +5327,7 @@ def _launch(args) -> int:
     # is the refusal's own — 127 for a command that is not on `PATH`, the shell's number
     # for it, so `charter <profile> && …` behaves the way `<command> && …` would have.
     if p is not None:
-        r = launcher.refusal(p, root=config.ROOT, attended=attended,
-                             env=launcher.environment(p, os.environ, framed=True))
+        r = _profile_refusal(p, attended=attended)
         if r is not None:
             util.err(f"charter: {r.text}")
             return r.exit
@@ -5666,9 +5707,9 @@ def _launch(args) -> int:
     # length refusal in its own number, anything else as `report_failure` always said it.
     proc = tmuxctl.run(started_what, start_cmd, env=env, report=False)
     if proc.returncode != 0:
-        # *display*, never *argv*: what tmux refused is charter's own launcher, and naming
-        # it would tell the operator about a command they did not write.
-        _say_why_the_harness_did_not_start(started_what, start_cmd, proc, display)
+        # *argv*, not *display*: this reports what TMUX refused, and its one number is the
+        # size of the command charter handed tmux (see the function's own docstring).
+        _say_why_the_harness_did_not_start(started_what, start_cmd, proc, argv)
         return 1
     harness_pane = proc.stdout.strip()
     if not harness_pane:
@@ -7871,8 +7912,23 @@ def _harness_of(p):
     return next((x for x in harness.all() if x.name == p.harness), None)
 
 
+def _profile_refusal(p, *, attended: bool):
+    """The launcher's own chain for *p* as THIS process sees the world — the `Refusal`, or
+    ``None`` when it may start.
+
+    One spelling of its four arguments, because the two callers ask it identically: the
+    launch itself, before tmux, and a press that has a surface to say it on
+    (:func:`_launch_refusal`). Two copies of a call whose `env` decides what `PATH` a
+    command is looked up on is two answers waiting to drift.
+    """
+    from .frame import launcher
+
+    return launcher.refusal(p, root=config.ROOT, attended=attended,
+                            env=launcher.environment(p, os.environ, framed=True))
+
+
 def _launch_refusal(p, *, attended: bool) -> str:
-    """The launcher's own refusal for *p*, or ``""`` when it may start.
+    """The launcher's own refusal for *p* as a sentence, or ``""`` when it may start.
 
     **Asked by the presses, because a press has no other surface.** `_launch` runs this same
     chain before tmux, but `cmd_new_chat` and `_open_workspace` run detached with all three
@@ -7884,10 +7940,7 @@ def _launch_refusal(p, *, attended: bool) -> str:
     It costs what the chain costs — one `git status` for a declared profile — on a press,
     and nothing on a hook path: none of these callers is one.
     """
-    from .frame import launcher
-
-    r = launcher.refusal(p, root=config.ROOT, attended=attended,
-                         env=launcher.environment(p, os.environ, framed=True))
+    r = _profile_refusal(p, attended=attended)
     return r.text if r is not None else ""
 
 
@@ -10869,6 +10922,10 @@ class Opened(NamedTuple):
 def background_refusal(ws: str, *, caller: str, first_message: str) -> str:
     """Every reason :func:`open_in_background` would refuse, or ``""`` when it may open.
 
+    The sentence half of :func:`_how_a_background_open_would_go`, which is where the
+    reasons live: `charter handoff` asks this before any write of its own, and the open
+    asks the same function again rather than re-resolving what it already answered.
+
     **Asked before anything starts, and it writes nothing**, so `charter handoff` (Task 2)
     can ask it before any write of its own. :func:`open_in_background` asks it again because
     the plane may have moved in between — a race answered by refusing late, which is still a
@@ -10895,42 +10952,62 @@ def background_refusal(ws: str, *, caller: str, first_message: str) -> str:
        :func:`_open_workspace`'s guard and :data:`NO_SESSION_HERE` said once. A session this
        plane can prove is its own is joined, and a name no session holds is started.
     """
+    return _how_a_background_open_would_go(
+        ws, caller=caller, first_message=first_message)[0]
+
+
+def _how_a_background_open_would_go(ws: str, *, caller: str, first_message: str):
+    """``(refusal, profile, harness)`` — every reason an open would refuse, and what it
+    resolved on the way to finding none.
+
+    **One resolution, not two.** The refusal and the open are the same question asked a
+    moment apart, and answering it twice is not merely a second file read: an open that
+    re-resolved could act on a different profile from the one the refusal cleared, which is
+    the drift `_same_profile_as` exists to prevent one caller along.
+    """
     # Split once, on whitespace: no words is an empty message, and one word is a single word.
     # `split()` and never `strip()`, which the deletion sweep settled: `not text.strip()` and
     # `not text.lstrip()` answer alike for every string, so the strip was a line nothing
     # could pin, and the word it named could keep a trailing newline.
     words = first_message.split()
     if not words:
-        return EMPTY_FIRST_MESSAGE
+        return EMPTY_FIRST_MESSAGE, None, None
     if first_message.startswith("-"):
-        return FLAG_FIRST_MESSAGE
+        return FLAG_FIRST_MESSAGE, None, None
     if len(words) == 1:
-        return WORD_FIRST_MESSAGE.format(word=contain.one_line(words[0]))
+        return WORD_FIRST_MESSAGE.format(word=contain.one_line(words[0])), None, None
     if "\x00" in first_message:
-        return NUL_FIRST_MESSAGE
+        return NUL_FIRST_MESSAGE, None, None
     size = len(os.fsencode(first_message))
     if size > FIRST_MESSAGE_MAX_BYTES:
-        return LONG_FIRST_MESSAGE.format(n=size, max=FIRST_MESSAGE_MAX_BYTES)
+        return LONG_FIRST_MESSAGE.format(n=size, max=FIRST_MESSAGE_MAX_BYTES), None, None
     socket = state.frame_server(caller) or SOCKET
     if tmuxctl.is_operator_socket(socket, own=SOCKET):
-        return NO_BACKGROUND_CHAT_HERE
+        return NO_BACKGROUND_CHAT_HERE, None, None
     p, why = _same_profile_as(caller)
     if p is None:
-        return f"cannot open a chat in '{ws}': {why}"
+        return f"cannot open a chat in '{ws}': {why}", None, None
     # **The launcher's own chain, before anything is written** — so a handoff to a profile
     # that cannot start is refused while there is still nothing to undo: no chat directory,
     # no window, no first message anywhere. Unattended, because nobody is in front of the
     # chat this would open: a check that would ask refuses here instead (review 3).
     refused = _launch_refusal(p, attended=False)
     if refused:
-        return f"cannot open a chat in '{ws}': {refused}"
+        return f"cannot open a chat in '{ws}': {refused}", None, None
     h = _harness_of(p)
+    if h is None:
+        # Every profile names a kind this charter registers, so this is unreachable through
+        # a profile charter itself resolved — and it is guarded anyway, because
+        # `_harness_of` is typed `| None`, the press path carried this guard before
+        # profiles, and what is on the other side of it is an `AttributeError` in a process
+        # whose streams are `/dev/null`. Fails closed, in the sentence this already has.
+        return f"cannot open a chat in '{ws}': {NO_HARNESS}", None, None
     if h.first_message_argv("x y") is None:
-        return UNMEASURED_FIRST_MESSAGE.format(ws=ws, harness=h.name)
+        return UNMEASURED_FIRST_MESSAGE.format(ws=ws, harness=h.name), None, None
     prefix = state.workspace_prefix(ws)
     if _plane_session(socket, ws=ws) is None and prefix in _live_sessions(socket):
-        return NOT_THIS_PLANES_SESSION.format(ws=ws, socket=socket, prefix=prefix)
-    return ""
+        return NOT_THIS_PLANES_SESSION.format(ws=ws, socket=socket, prefix=prefix), None, None
+    return "", p, h
 
 
 def open_in_background(ws: str, *, caller: str, first_message: str,
@@ -10963,11 +11040,10 @@ def open_in_background(ws: str, *, caller: str, first_message: str,
     **Success is a chat id with a harness pane, never a return code**: a launcher that
     answered 0 and handed back no id has proved nothing exists.
     """
-    refusal = background_refusal(ws, caller=caller, first_message=first_message)
+    refusal, p, h = _how_a_background_open_would_go(
+        ws, caller=caller, first_message=first_message)
     if refusal:
         return Opened(False, "", refusal)
-    p, _why = _same_profile_as(caller)
-    h = _harness_of(p)
     socket = state.frame_server(caller) or SOCKET
     pane = chats.pane_of(caller)
     if pane is None:

--- a/charter/commands_frame.py
+++ b/charter/commands_frame.py
@@ -2196,6 +2196,42 @@ def _wait_for_harness(socket: str, harness_pane: str) -> int | None:
         time.sleep(_POLL_SECONDS)
 
 
+#: How long an open nobody is watching waits for its pane's launcher to say what it did.
+#:
+#: **A budget, not a hang** (ADR 0009's shape: an unknown is an answer of its own). A
+#: launcher that was never proved a chat records nothing — it runs with no frame and says
+#: so in its own pane — and a reopen putting four chats back must not stop on each of them
+#: for as long as a harness takes to start. Five seconds is an order of magnitude over what
+#: the measured launcher costs before its `exec` (a Python start at 19-22 ms, plus one
+#: `git status` for a declared profile), and the cost of overrunning it is one refusal that
+#: is not repeated outside the pane — never a chat that does not start.
+_LAUNCHER_SECONDS = 5.0
+
+
+def _await_the_launcher(socket: str, fid: str, harness_pane: str) -> tuple[int | None, str]:
+    """What *fid*'s launcher did: ``(None, "")`` once the harness has the pane, and
+    ``(exit code, refusal)`` when it refused instead.
+
+    **Both outcomes are recorded, and that is what makes this affordable** — without the
+    first, every chat that started perfectly well would cost the whole budget above. The
+    ordinary answer arrives in the time one `os.execvpe` takes to be reached.
+
+    Three ways out, and each is a different fact: the launcher answered, the pane stopped
+    being alive (it died without recording anything — an unproven chat, or a kill), or the
+    budget ran out. The last two are both "carry on as though it started", because they
+    are: the pane's own `exit` file and the `pane-died` hooks are what report a chat that
+    is over, exactly as they did before profiles existed.
+    """
+    deadline = time.monotonic() + _LAUNCHER_SECONDS
+    while (state.launch(fid) is None and time.monotonic() < deadline
+           and _pane_state(socket, harness_pane)[0] == _ALIVE):
+        time.sleep(_POLL_SECONDS)
+    code, text = state.launch(fid) or (0, "")
+    # `0` is the launcher handing the pane over, which is not an exit code and must not be
+    # read as one — `None` is this module's word for "still running" everywhere else.
+    return (code or None), text
+
+
 def _spawn_gather(fid: str, ws: str) -> None:
     """Fill *fid*'s gather cache in a DETACHED child, and bump the frame when it lands.
 
@@ -3269,6 +3305,17 @@ def _panel_remain_on_exit_argv(*, socket: str, harness_pane: str) -> list[str]:
 #: included, and the one figure that explains the refusal was the one thing not on screen.
 #: *carried* is the harness's arguments alone: the rest of the limit is the window's own
 #: name, directory and identity, which is why a launch just under it can still be refused.
+#: What an operator's own tmux is told when it will not mark charter's window with the chat
+#: it is drawing. Its own sentence rather than a warning, because what is lost is not a
+#: convenience: the pane's launcher proves which chat it is by this option on this server
+#: (ruling 33), so a chat that ran in an unmarked window would quietly be a chat with no
+#: frame — no session id, no profile record, nothing for a reopen to find.
+UNNAMED_CHAT_WINDOW = (
+    "charter frame: tmux would not mark this window as chat '{chat}', and charter does not "
+    "start a chat it cannot prove is one — the pane's own launcher reads that mark to know "
+    "which chat it is in, and without it this chat would run with no frame and be recorded "
+    "nowhere. Nothing was started, and the window has been closed.")
+
 TOO_LONG_FOR_TMUX = ("charter frame: tmux refused the command that starts this chat as too "
                      "long — tmux takes at most {limit:,} bytes in one command, and this "
                      "launch's harness arguments alone are {carried:,} bytes. Nothing was "
@@ -3300,8 +3347,8 @@ def _say_why_the_harness_did_not_start(action: str, cmd: list[str],
 
 
 def _launch_in_operator_tmux(socket: str, session: str, *, ws: str,
-                             argv: list[str], h, v: tuple[int, int],
-                             picked: bool) -> int | None:
+                             argv: list[str], display: list[str], profile: str, h,
+                             v: tuple[int, int], picked: bool) -> int | None:
     """Build the frame as a WINDOW in the tmux the operator is already in.
 
     The same layout as the private-server path — harness in the middle, charter's panels
@@ -3433,6 +3480,9 @@ def _launch_in_operator_tmux(socket: str, session: str, *, ws: str,
     # sharper one of its own: a panel process cannot resolve it (#512 — see
     # `state.record_workspace`), so this launcher is the only thing that ever knows.
     state.record_workspace(fid, ws)
+    # And which profile — the same record the private-server path writes, and for the same
+    # readers: `+`, a workspace tab and a reopen all ask a chat what it runs.
+    state.record_profile(fid, profile)
     state.bump(fid)
     # And the record this process keeps, if it is keeping one (#845), now knows which chat
     # this terminal is on. This path is a frame process too — it stays awake for the life of
@@ -3477,13 +3527,27 @@ def _launch_in_operator_tmux(socket: str, session: str, *, ws: str,
     # What every later lookup asks instead of parsing this window's name — the liveness
     # list `_reap_this_server` reads, and the same option `@charter_hatch` already uses.
     # A window name is not an identity; see `_CHAT_OPTION`.
-    named = _chat_option_argv(socket=socket, harness_pane=harness_pane, chat=fid)
-    if named is not None:
-        tmuxctl.run("naming the chat on its window", named)
-
     def _close_window() -> None:
         tmuxctl.run("closing the frame's window",
                     tmuxctl.server_argv(socket, "kill-window", "-t", window_id))
+
+    # What every later lookup asks instead of parsing this window's name — the liveness
+    # list `_reap_this_server` reads, and the same option `@charter_hatch` already uses. A
+    # window name is not an identity; see `_CHAT_OPTION`.
+    #
+    # **And on THIS server it is also what the pane's own launcher proves its chat by**
+    # (ruling 33): a window name here can be rewritten by an operator's hook, a plugin or
+    # `allow-rename on` output, so the option is the only mark pane output cannot touch. So
+    # a window charter could not mark stops the launch, loudly, rather than carrying on:
+    # without it every launcher in that window is unproven — it would run with no frame,
+    # drop the chat's session id and record nothing for it, silently and for the life of
+    # the chat. The placeholder window the operator never asked for is taken back.
+    named = _chat_option_argv(socket=socket, harness_pane=harness_pane, chat=fid)
+    if named is None or tmuxctl.run("naming the chat on its window",
+                                    named).returncode != 0:
+        util.err(UNNAMED_CHAT_WINDOW.format(chat=fid))
+        _close_window()
+        return 1
 
     # Before the harness exists, not after: this is what keeps the pane (and its
     # `#{pane_dead_status}`) in place once the harness exits, and there is no way to
@@ -3501,7 +3565,7 @@ def _launch_in_operator_tmux(socket: str, session: str, *, ws: str,
     started = tmuxctl.run("starting the harness in it", start_cmd, report=False)
     if started.returncode != 0:
         _say_why_the_harness_did_not_start("starting the harness in it", start_cmd,
-                                            started, argv)
+                                            started, display)
         # The placeholder is still running in a window the operator never asked for and
         # would never learn the purpose of. Take it back.
         _close_window()
@@ -3527,7 +3591,7 @@ def _launch_in_operator_tmux(socket: str, session: str, *, ws: str,
             # reads it before `kill-session`: afterwards there is nothing left to read.
             # Nonzero only, and by the same argument — `charter frame -- true` lands
             # here with 0, and what it wrote was its own stdout.
-            util.err(early_death_message(argv, code,
+            util.err(early_death_message(display, code,
                                          _pane_last_words(socket, harness_pane)))
         _close_window()
         _reap_this_server(socket)
@@ -5069,6 +5133,16 @@ def _restore_the_plane(args) -> int | None:
     return None
 
 
+def _profile_name(p) -> str:
+    """*p*'s name, or ``""`` for a launch that runs no profile at all.
+
+    One expression, named once: both launch paths record it, and `charter frame -- <cmd>`
+    is the one open that has no profile to record. Two spellings of that would be two
+    answers to "what is this chat running".
+    """
+    return p.name if p is not None else ""
+
+
 def cmd_launch(args) -> int:
     """One launcher, shared by every registered harness and by `charter frame --`.
 
@@ -5104,7 +5178,42 @@ def _launch(args) -> int:
     # is the separator that told argparse to stop parsing, not part of the command.
     if rest and rest[0] == "--":
         rest = rest[1:]
-    argv = h.launch_argv(rest) if h else rest
+    from .frame import launcher
+
+    # **Which PROFILE this launch runs.** From here down `p` decides four things: what tmux
+    # is handed, which guards run before it, what the chat records, and what charter names
+    # when the command dies. ``None`` is `charter frame -- <cmd>`, the escape hatch, which
+    # runs a command charter has never met and has no profile to resolve.
+    #
+    # `args.profile or args.harness`: the flag is what `cli._profile_launch` puts there for
+    # `charter <profile>`, and the kind's own word is the built-in profile named after it —
+    # which a declared profile of that name replaces (`charter claude` on a plane whose
+    # local file declares `[harness.claude]`).
+    p = None
+    argv = display = rest
+    # Attended is somebody being in front of the pane this opens. A reopen and a background
+    # open are not (review 3): they must never stop on a question nobody can see.
+    attended = _reopening(args) is None and _opening(args) is None
+    if h is not None:
+        name = getattr(args, "profile", None) or args.harness
+        p, why = launcher.resolve(name)
+        if p is None:
+            # A profile the file declares and charter refused says its own reason; a name
+            # nothing declares says what this plane has.
+            util.err(f"charter: {why or launcher.unknown_profile(name)}")
+            return 2
+        if p.kind != args.harness:
+            # A profile is a way to run ONE kind, and the kind decides the hooks, the
+            # resume flag and how a first message is spelled — so this is refused rather
+            # than resolved in either direction.
+            util.err("charter: " + launcher.KIND_MISMATCH.format(
+                name=contain.readable(p.name), kind=p.kind, asked=args.harness))
+            return 2
+        # Only the profile's NAME crosses tmux. Its command and its environment are read
+        # again in the pane by the launcher and applied at the `exec`, so nothing of either
+        # reaches `layout.CARRIABLE`, a tmux `-e`, or tmux's own argument parser.
+        argv = launcher.argv(p.name, rest, attended=attended)
+        display = launcher.display_command(p, rest)
     if not argv:
         util.err("charter frame: nothing to run — `charter frame -- <command>`")
         return 2
@@ -5122,7 +5231,18 @@ def _launch(args) -> int:
     # report any of it on. That, and not the `attach` the old refusal named, is what
     # actually stopped a detached process opening a workspace.
     if args.no_frame or (not sys.stdout.isatty() and _wants_attach(args)):
-        return bypass(argv)
+        if p is None:
+            return bypass(argv)
+        # **A profile gets the same checks with no frame around it.** No flag launches one
+        # unguarded, so this is the launcher rather than `bypass`: it runs the chain and
+        # `exec`s the profile's command with the profile's `env`. Unframed, so the
+        # environment drops the inherited `CHARTER_SESSION_ID` and nothing else (review 8).
+        #
+        # *attended* is what THIS process's own streams say rather than what the open was:
+        # the refusal lands in the terminal the operator is already looking at, and a
+        # question here would be asked of whoever typed the command.
+        return launcher.start(p, rest, fid=None,
+                              attended=sys.stdin.isatty() and sys.stdout.isatty())
 
     # A REGISTERED harness whose binary is not installed never reaches tmux — and the
     # irony is worth recording, because it is what hid this for a whole review round:
@@ -5150,8 +5270,26 @@ def _launch(args) -> int:
     # #384 deliberately did not change that either (see the module docstring, and
     # `early_death_message`'s own). Its SILENCE is what changed — the same death is now
     # legible from the other end, once tmux has already answered.
-    if h and not shutil.which(h.binary):
-        return bypass(argv)
+    # **The profile's own guards, before tmux is asked for anything.** This is where the
+    # missing-binary check above became a refusal that can say which PROFILE it is about,
+    # and where the file's ignore check and Task 2's approval refusal join it
+    # (`frame/launcher.refusal`, and the spec's *What guards a launch*). Nothing has been
+    # allocated yet, so a refusal here is a `return` with nothing to tear down.
+    #
+    # The pane runs the identical chain again immediately before the `exec`, because the
+    # plane can move in between — a `.gitignore` edited, a binary uninstalled — and a check
+    # that ran only here would be a promise charter could no longer keep by the time the
+    # harness started.
+    #
+    # Nothing compares `r.text` (ruling 27): callers branch on `r.kind`, and the exit code
+    # is the refusal's own — 127 for a command that is not on `PATH`, the shell's number
+    # for it, so `charter <profile> && …` behaves the way `<command> && …` would have.
+    if p is not None:
+        r = launcher.refusal(p, root=config.ROOT, attended=attended,
+                             env=launcher.environment(p, os.environ, framed=True))
+        if r is not None:
+            util.err(f"charter: {r.text}")
+            return r.exit
 
     # ONE call (correction 5): asking `tmux -V` twice on a path that branches on the
     # answer once is two subprocesses for one unchanging fact.
@@ -5229,6 +5367,7 @@ def _launch(args) -> int:
     inside = tmuxctl.operator_server()
     if inside is not None and tmuxctl.is_operator_socket(inside[0], own=SOCKET):
         rc = _launch_in_operator_tmux(inside[0], inside[1], ws=ws, argv=argv,
+                                      display=display, profile=_profile_name(p),
                                       h=h, v=v, picked=picked)
         if rc is not None:
             return rc
@@ -5399,6 +5538,12 @@ def _launch(args) -> int:
     # thing here no process inside the frame can work out for itself (#512; see
     # `state.record_workspace`).
     state.record_workspace(fid, ws)
+    # And which PROFILE it runs, before tmux is asked for anything. `+`, a workspace tab, a
+    # reopen and a handoff all read this back to decide what the next chat runs
+    # (`_same_profile_as`), and the pane's own launcher writes it again with what it
+    # resolved in the end. The escape hatch records the empty answer rather than a name it
+    # does not have.
+    state.record_profile(fid, _profile_name(p))
     # And WHERE — see the identical call on the operator's-tmux path, and
     # `state.record_cwd` for why this fact could not ride in `identity`. Read once here
     # and used twice: recorded, and handed to `chat_window_argv` below.
@@ -5521,7 +5666,9 @@ def _launch(args) -> int:
     # length refusal in its own number, anything else as `report_failure` always said it.
     proc = tmuxctl.run(started_what, start_cmd, env=env, report=False)
     if proc.returncode != 0:
-        _say_why_the_harness_did_not_start(started_what, start_cmd, proc, argv)
+        # *display*, never *argv*: what tmux refused is charter's own launcher, and naming
+        # it would tell the operator about a command they did not write.
+        _say_why_the_harness_did_not_start(started_what, start_cmd, proc, display)
         return 1
     harness_pane = proc.stdout.strip()
     if not harness_pane:
@@ -5703,9 +5850,23 @@ def _launch(args) -> int:
     # would have done (record the code, end the session) is finished right here, and
     # `attach` is never even called against a session already known to be over.
     code = _query_pane_dead_status(SOCKET, harness_pane)
+    # **What the pane's own launcher decided, for an open nobody is watching** (ruling 42).
+    # Measured 2026-09-11: the eager ask above completes 6-14 ms after the start while a
+    # Python launcher's first line runs at 19-22 ms, so it never catches a launcher that
+    # refused — and by the time anything else could look, the teardown hook has killed the
+    # window (`_pane_last_words` answered `[]` in all 40 runs). An ATTENDED pane holds its
+    # own refusal on screen and waits for a key, so only an unattended open — a reopen, a
+    # handoff, a background open — has nobody to read it and waits for the answer here.
+    refused = ""
+    if code is None and p is not None and not attended:
+        code, refused = _await_the_launcher(SOCKET, fid, harness_pane)
     if code is not None:
         state.record_exit(fid, code)
-        if code != 0:
+        if refused:
+            # The launcher's own sentence, said where the operator is: this process has a
+            # terminal (or a caller reading its stderr) and the pane no longer exists.
+            util.err(f"charter: {refused}")
+        elif code != 0:
             # The one path on which NOTHING is ever drawn (#384): no panels, no
             # `select-pane`, no `attach` — the whole `if code is None:` block below is
             # skipped from here on — so this is the only chance the operator has of
@@ -5716,7 +5877,7 @@ def _launch(args) -> int:
             # up (`charter frame -- true`) reaches this same branch with 0, and whatever
             # it wrote was its stdout — charter repeating that onto stderr would be
             # inventing output on the wrong stream. Its exit code is the whole message.
-            util.err(early_death_message(argv, code,
+            util.err(early_death_message(display, code,
                                          _pane_last_words(SOCKET, harness_pane)))
         # `kill-window` targeting the harness PANE, never `kill-session` on the workspace:
         # this chat's window is what is over, and the workspace may hold other chats whose
@@ -7642,49 +7803,92 @@ def _clients_on(socket: str, session: str) -> list[str]:
 #: `cmd_new_chat`'s names nothing, and neither has to keep the rest of the sentence in step
 #: with the other. One string, because it is one FACT: this plane cannot name a harness to
 #: run.
-NO_HARNESS = ("this chat records no harness this charter can launch, and this plane "
+NO_HARNESS = ("this chat records no profile this charter can launch, and this plane "
               "declares no `[harness] default`")
 
+#: What a press says when the chat it was pressed from ran a profile the plane no longer
+#: declares. **Never a substitute** (ruling 15's reason, one surface over): another profile
+#: may be another account, where this chat's conversation does not exist and its
+#: workspace's code was never meant to go.
+PROFILE_GONE = ("this chat ran on profile '{name}', which this plane no longer declares — "
+                "declare it again in charter.local.toml, or open a chat on a profile you "
+                "name: charter <profile>")
 
-def _same_harness_as(fid: str):
-    """The harness a chat opened FROM *fid* should run, or ``None`` when there is none.
+
+def _same_profile_as(fid: str):
+    """The PROFILE a chat opened FROM *fid* should run — ``(profile, "")``, or
+    ``(None, the refusal)``.
 
     **The one question neither a workspace tab nor a chat bar's `+` can carry.** Both are a
-    single press with nothing typed into it, so the only answer available that the operator
-    has actually expressed is the tool they are already in: the chat they pressed from
-    recorded its own (`state.record_identity`, `$CHARTER_HARNESS`), which makes the press
-    mean "another one of these".
+    single press with nothing typed into it, so the only answer the operator has actually
+    expressed is the tool they are already in — and since profiles that is the PROFILE
+    rather than the kind: two chats of one kind may be two accounts, and "another one of
+    these" means the one in front of them.
 
-    Two rungs and no third. A chat whose identity predates that record — or whose recorded
-    harness this charter cannot launch — falls back to `[harness] default`, and a plane
-    that declares none is refused by name rather than opened under something nobody chose.
+    Four rungs, and each of them refuses where it cannot answer rather than substituting:
 
-    **One function because it was two identical blocks, and the deletion sweep is what
-    found that.** `cmd_new_chat` was written from :func:`_open_workspace` and copied its
-    five lines; the sweep charged the copy and reported the `or {}` below as a survivor —
-    unpinned *there*, while `tests/test_a_workspace_tab_opens_what_it_names
-    .TheOpenUsesTheHarnessTheOperatorIsAlreadyIn
-    .test_a_plane_whose_harness_table_is_missing_entirely_is_not_a_crash` had pinned it
-    *here* all along. One function, one place for that case to reach, and no second copy
-    for the next sweep to charge.
+    1. **The profile this chat recorded** (`state.record_profile`, written by every launch).
+       One the plane no longer declares is :data:`PROFILE_GONE` — never the built-in of that
+       name, never `[harness] default`.
+    2. **A chat from before profiles**: the built-in named after its kind, which a declared
+       profile of that name replaces. A name the file declares and charter REFUSED says its
+       own reason instead (ruling 37): running the built-in in its place would run the
+       command the operator replaced.
+    3. **`[harness] default`**, for a chat whose kind this charter no longer registers at
+       all — the one rung where nothing about the chat itself is left to go on.
+    4. Else :data:`NO_HARNESS`.
 
-    **The `or {}` stays, and it was nearly deleted.** `instance.harness_of` is annotated
-    `-> dict` and measurably answers one for `{}` and for `{"harness": None}`, so the
-    branch looks unreachable through a plane's own config — but that is an argument about
-    ONE producer of the value, and the case above asserts the whole detached path survives
-    `config.HARNESS` being `None`, where an `AttributeError` goes to `/dev/null` and the
-    press does nothing. A guard an existing case makes observable is not this function's
-    to remove.
-
-    The two callers still say their own sentences (:data:`NO_HARNESS` is the half they
-    share), because one names a workspace and the other names nothing.
+    Each caller says its own sentence around the refusal, because one names a workspace, one
+    names nothing and one is answering a tool call.
     """
+    from . import profiles
+    from .frame import launcher
+
+    recorded = state.profile(fid)
+    if recorded:
+        p, why = launcher.resolve(recorded)
+        if p is not None:
+            return p, ""
+        return None, why or PROFILE_GONE.format(name=contain.readable(recorded))
     ident = state.identity(fid).get("CHARTER_HARNESS", "")
     h = next((x for x in harness.all() if x.name == ident and x.cli_name), None)
     if h is not None:
-        return h
-    fallback = (config.HARNESS or {}).get("default")
-    return next((x for x in harness.all() if x.cli_name == fallback), None)
+        p, why = launcher.resolve(h.cli_name)
+        return (p, "") if p is not None else (None, why or NO_HARNESS)
+    read = profiles.current()
+    if read.default:
+        return read.profiles[read.default], ""
+    return None, NO_HARNESS
+
+
+def _harness_of(p):
+    """The registered harness *p* is a profile of, or ``None``.
+
+    By `p.harness`, which is the registry's own NAME (`claude-code`) rather than the word
+    typed after `charter` — the same thing `state.identity` records and the only one that
+    decides whether a chat can be resumed or handed a first message.
+    """
+    return next((x for x in harness.all() if x.name == p.harness), None)
+
+
+def _launch_refusal(p, *, attended: bool) -> str:
+    """The launcher's own refusal for *p*, or ``""`` when it may start.
+
+    **Asked by the presses, because a press has no other surface.** `_launch` runs this same
+    chain before tmux, but `cmd_new_chat` and `_open_workspace` run detached with all three
+    streams on `/dev/null` (`builtin_actions._spawn`), so what it printed is read by nobody
+    and the `+` would report "the launcher returned 3" for something the operator could
+    have fixed in a line. A refusal said on the frame's attention row is the whole reason
+    those commands exist rather than the panel calling the launcher directly.
+
+    It costs what the chain costs — one `git status` for a declared profile — on a press,
+    and nothing on a hook path: none of these callers is one.
+    """
+    from .frame import launcher
+
+    r = launcher.refusal(p, root=config.ROOT, attended=attended,
+                         env=launcher.environment(p, os.environ, framed=True))
+    return r.text if r is not None else ""
 
 
 def _launch_root(ws: str):
@@ -7817,9 +8021,15 @@ def _open_workspace(fid: str, ws: str, *, socket: str,
                             f"hand if it is yours: tmux -L {socket} attach -t "
                             f"{state.workspace_prefix(ws)}")
         return None
-    h = _same_harness_as(fid)
-    if h is None:
-        _say_on_screen(fid, f"cannot open '{ws}': {NO_HARNESS}")
+    p, why = _same_profile_as(fid)
+    if p is None:
+        _say_on_screen(fid, f"cannot open '{ws}': {why}")
+        return None
+    # Attended, because this open ends with the operator's client switched onto the new
+    # window: somebody is in front of whatever it says.
+    refused = _launch_refusal(p, attended=True)
+    if refused:
+        _say_on_screen(fid, f"cannot open '{ws}': {refused}")
         return None
     from types import SimpleNamespace
     root = _launch_root(ws)
@@ -7830,7 +8040,7 @@ def _open_workspace(fid: str, ws: str, *, socket: str,
     # reason and for #518's pointer, `rest` is empty so §4k's open-or-focus gate stays
     # reachable and the harness starts at its own prompt with nothing sent to it, and
     # `attach` is the seam.
-    args = SimpleNamespace(harness=h.cli_name, rest=[], no_frame=False,
+    args = SimpleNamespace(harness=p.kind, profile=p.name, rest=[], no_frame=False,
                            workspace=ws, pick=False, attach=False,
                            size=_window_size(socket, window))
     here_dir = os.getcwd()
@@ -9393,7 +9603,7 @@ def _record_the_plane(doomed, *, focus: str, active, windows,
         entries[c.workspace].append(reopen_state.Chat(
             chat=c.chat, workspace=c.workspace, persona=c.persona, harness=c.harness,
             cwd=c.cwd, resume=c.resume, transcript=transcript,
-            active=c.chat in active))
+            active=c.chat in active, profile=c.profile))
     for ws in order:
         frames.append(reopen_state.Frame(workspace=ws, chats=tuple(entries[ws])))
     if not reopen_state.write(frames, focus=focus):
@@ -10100,6 +10310,15 @@ def _was_standing_in(c) -> str:
     return f"it had been standing in {contain.readable(c.cwd)}"
 
 
+#: What a reopen says for a chat whose profile this plane no longer declares. It names the
+#: profile, because that is the thing to put back — and it promises a retry, which
+#: :func:`_consume` is what makes true.
+REOPEN_GONE = ("charter reopen: {chat} ran on profile '{name}', which this plane no longer "
+               "declares — not reopened, because another profile may be another account, "
+               "where its conversation does not exist. Declare '{name}' again in "
+               "charter.local.toml and run charter reopen to bring it back.")
+
+
 def _reopen_one(c, *, quiet: bool = False) -> "Reopening | None":
     """Put one recorded chat back. The launch's own record, or ``None`` when it did not run.
 
@@ -10128,21 +10347,25 @@ def _reopen_one(c, *, quiet: bool = False) -> "Reopening | None":
     had been — because a restore that moves somebody without saying so is option (b), and
     option (b) is the one #845's grilling threw out.
     """
-    h = next((x for x in harness.all() if x.name == c.harness), None)
-    if h is None or not h.cli_name:
-        fallback = (config.HARNESS or {}).get("default")
-        h = next((x for x in harness.all() if x.cli_name == fallback), None)
-        if h is None:
-            _report(quiet, util.warn,
-                    f"charter reopen: {c.chat} recorded harness "
-                    f"{contain.readable(c.harness) or 'nothing'}, which this charter "
-                    f"cannot launch, and this plane declares no `[harness] default` — "
-                    f"not reopened")
-            return None
+    from .frame import launcher
+
+    # The profile the chat recorded, or — for a manifest written before profiles — the
+    # built-in named after its kind, which a declared profile of that name replaces.
+    name = c.profile or next((x.cli_name for x in harness.all()
+                              if x.name == c.harness and x.cli_name), "")
+    p, why = launcher.resolve(name) if name else (None, "")
+    if p is None:
+        # **The `[harness] default` fallback is deleted** (ruling 15). A reopened chat is
+        # never given another profile: another one may be another account, where its
+        # conversation does not exist and its workspace's code was never meant to go. It
+        # stays in the manifest (`_consume` keeps what did not come back), so declaring the
+        # profile again and running `charter reopen` brings it back — which is exactly what
+        # the sentence promises, and the promise is true.
         _report(quiet, util.warn,
-                f"charter reopen: {c.chat} recorded harness "
-                f"{contain.readable(c.harness) or 'nothing'} — reopening it under "
-                f"{h.cli_name}, this plane's default")
+                f"charter reopen: {c.chat} is not reopened — {why}" if why
+                else REOPEN_GONE.format(
+                    chat=c.chat, name=contain.readable(name or c.harness or "nothing")))
+        return None
     rest: list[str] = []
     if c.resume and leave.resumable_harness(c.harness):
         rest = ["--resume", c.resume]
@@ -10162,7 +10385,8 @@ def _reopen_one(c, *, quiet: bool = False) -> "Reopening | None":
                 f"charter reopen: {c.chat} comes back in {landing} — "
                 f"{_was_standing_in(c)}")
     r = Reopening(c)
-    argv_args = _reopen_args(c, harness_name=h.cli_name, rest=rest, reopening=r)
+    argv_args = _reopen_args(c, harness_name=p.kind, profile=p.name, rest=rest,
+                             reopening=r)
     here = os.getcwd()
     try:
         os.chdir(where)
@@ -10188,7 +10412,7 @@ def _reopen_one(c, *, quiet: bool = False) -> "Reopening | None":
     return r
 
 
-def _reopen_args(c, *, harness_name: str, rest, reopening):
+def _reopen_args(c, *, harness_name: str, profile: str, rest, reopening):
     """The namespace `cmd_launch` is driven with, built once so its fields are visible.
 
     Every field `cmd_launch` and `_choose_workspace` read is named here rather than left to
@@ -10199,8 +10423,8 @@ def _reopen_args(c, *, harness_name: str, rest, reopening):
     ``reopening`` is the seam.
     """
     from types import SimpleNamespace
-    return SimpleNamespace(harness=harness_name, rest=list(rest), no_frame=False,
-                           workspace=c.workspace or None, pick=False,
+    return SimpleNamespace(harness=harness_name, profile=profile, rest=list(rest),
+                           no_frame=False, workspace=c.workspace or None, pick=False,
                            reopening=reopening)
 
 
@@ -10512,9 +10736,16 @@ def cmd_new_chat(args) -> int:
     # paragraph, unchanged: the chat the operator pressed FROM recorded its own
     # (`state.record_identity`), and using it makes the click mean "another chat, same
     # tool", which is the only answer available that they have actually expressed.
-    h = _same_harness_as(fid)
-    if h is None:
-        _say_on_screen(fid, f"cannot open another chat: {NO_HARNESS}")
+    p, why = _same_profile_as(fid)
+    if p is None:
+        _say_on_screen(fid, f"cannot open another chat: {why}")
+        return 0
+    # The launcher's own chain, asked here so its refusal reaches the frame's attention row
+    # rather than `/dev/null` — see :func:`_launch_refusal`. Attended: the new window is
+    # selected, so the operator is looking at whatever it says.
+    refused = _launch_refusal(p, attended=True)
+    if refused:
+        _say_on_screen(fid, f"cannot open another chat: {refused}")
         return 0
     from types import SimpleNamespace
     root = _launch_root(ws)
@@ -10547,7 +10778,7 @@ def cmd_new_chat(args) -> int:
     # the value to `tmuxctl.PANE_ID_RE` — this is a `-t` target coming off disk, which is
     # #475's boundary exactly.
     pane = chats.pane_of(fid) or chats.pane_of(seat[1])
-    launch = SimpleNamespace(harness=h.cli_name, rest=[], no_frame=False,
+    launch = SimpleNamespace(harness=p.kind, profile=p.name, rest=[], no_frame=False,
                              workspace=ws, pick=False, attach=False,
                              size=_window_size(socket, pane) if pane else None)
     here_dir = os.getcwd()
@@ -10683,9 +10914,17 @@ def background_refusal(ws: str, *, caller: str, first_message: str) -> str:
     socket = state.frame_server(caller) or SOCKET
     if tmuxctl.is_operator_socket(socket, own=SOCKET):
         return NO_BACKGROUND_CHAT_HERE
-    h = _same_harness_as(caller)
-    if h is None:
-        return f"cannot open a chat in '{ws}': {NO_HARNESS}"
+    p, why = _same_profile_as(caller)
+    if p is None:
+        return f"cannot open a chat in '{ws}': {why}"
+    # **The launcher's own chain, before anything is written** — so a handoff to a profile
+    # that cannot start is refused while there is still nothing to undo: no chat directory,
+    # no window, no first message anywhere. Unattended, because nobody is in front of the
+    # chat this would open: a check that would ask refuses here instead (review 3).
+    refused = _launch_refusal(p, attended=False)
+    if refused:
+        return f"cannot open a chat in '{ws}': {refused}"
+    h = _harness_of(p)
     if h.first_message_argv("x y") is None:
         return UNMEASURED_FIRST_MESSAGE.format(ws=ws, harness=h.name)
     prefix = state.workspace_prefix(ws)
@@ -10727,7 +10966,8 @@ def open_in_background(ws: str, *, caller: str, first_message: str,
     refusal = background_refusal(ws, caller=caller, first_message=first_message)
     if refusal:
         return Opened(False, "", refusal)
-    h = _same_harness_as(caller)
+    p, _why = _same_profile_as(caller)
+    h = _harness_of(p)
     socket = state.frame_server(caller) or SOCKET
     pane = chats.pane_of(caller)
     if pane is None:
@@ -10749,8 +10989,9 @@ def open_in_background(ws: str, *, caller: str, first_message: str,
         # Every field named, `_reopen_args`' rule. A non-empty `rest` also keeps §4k's
         # open-or-focus shortcut out, which could never answer "run this".
         rc = cmd_launch(SimpleNamespace(
-            harness=h.cli_name, rest=h.first_message_argv(first_message), no_frame=False,
-            workspace=ws, pick=False, attach=False, size=size, opening=opening))
+            harness=p.kind, profile=p.name, rest=h.first_message_argv(first_message),
+            no_frame=False, workspace=ws, pick=False, attach=False, size=size,
+            opening=opening))
     finally:
         for name, was in pins.items():
             if was is None:

--- a/charter/doctor.py
+++ b/charter/doctor.py
@@ -341,8 +341,16 @@ def check_control_plane_config() -> Result:
     # Read from `instance.load` rather than `config.HARNESS`, the way the worktrees branch
     # reads `instance.worktrees_of`: this row is about the FILE, and `derive` already ran
     # before anybody could have fixed it.
+    # **A profile is a name this key may hold** (ruling 43, and the spec's *`default` only
+    # preselects*). `instance.harness_of` compares the value against the launchable KINDS
+    # alone — `config.derive` reads nothing from `charter.local.toml`, so it cannot know the
+    # profiles — and a `default` naming a declared profile therefore arrives here as
+    # "refused" when it is nothing of the kind. `profiles.current()` is the one reader that
+    # knows, memoised per process and already paid for by the `harness profiles` row above.
+    from . import profiles as _profiles
+
     _refused = _instance.harness_of(_cfg).get("refused")
-    if _refused:
+    if _refused and _refused not in _profiles.current().profiles:
         return Result(
             "charter.toml",
             WARN,

--- a/charter/frame/chats.py
+++ b/charter/frame/chats.py
@@ -389,6 +389,20 @@ def harness_of(fid: str) -> str:
     return state.identity(fid).get("CHARTER_HARNESS", "").strip()
 
 
+def profile_of(fid: str) -> str:
+    """The harness PROFILE recorded for chat *fid*, or ``""``.
+
+    :func:`harness_of`'s sibling and read the same way — off the chat's own record, never
+    out of this process's environment, because a palette and a panel are children of a tmux
+    server shared between every frame on the machine.
+
+    ``""`` for a chat launched before profiles existed and for `charter frame -- <cmd>`,
+    which runs no profile at all. Every caller pairs it with :func:`harness_of`, which is
+    what such a chat does record.
+    """
+    return state.profile(fid) or ""
+
+
 def pane_of(chat: str) -> str | None:
     """The tmux pane charter records for *chat*, held to tmux's own shape — or ``None``.
 

--- a/charter/frame/choose.py
+++ b/charter/frame/choose.py
@@ -338,7 +338,10 @@ def _note(noun: str, name: str) -> str:
     before `tui.width` sees it (#472), and a second call would be the masked line
     `builtin_actions._register_names` shipped and this module's docstring records.
     """
-    return chats.harness_of(name) if noun == CHAT else ""
+    # The PROFILE first, because that is what the operator named the way this chat runs —
+    # two chats of one kind may be two accounts. A chat from before profiles has only its
+    # harness, which is what it recorded.
+    return (chats.profile_of(name) or chats.harness_of(name)) if noun == CHAT else ""
 
 
 def labelled(roster: Roster, reason: str = "") -> tuple[overlay.Row, ...]:

--- a/charter/frame/launcher.py
+++ b/charter/frame/launcher.py
@@ -53,9 +53,7 @@ import os
 import shutil
 import sys
 from pathlib import Path
-from typing import Callable, Mapping
-
-from typing import NamedTuple
+from typing import Callable, Mapping, NamedTuple
 
 from .. import config, contain, profiles, util
 from . import state, tmuxctl
@@ -81,9 +79,16 @@ KIND_EXEC = "exec"
 class Refusal(NamedTuple):
     """Why a profile did not start, and what a CLI returns for it."""
 
-    kind: str      # one of the KIND_* constants above
-    text: str      # the sentence, without charter's own prefix — a caller says it its way
-    exit: int      # MISSING_EXIT for KIND_PATH, its own number for KIND_EXEC, else REFUSED_EXIT
+    #: One of the KIND_* constants above. Task 2 reads it in tests and nowhere else; it is
+    #: here because Task 3 branches on it — `KIND_ASK` is the one refusal a pane defers to
+    #: rather than prints — and ruling 27 says that branch is on the kind, never on the
+    #: text, which gets reworded.
+    kind: str
+    #: The sentence, without charter's own prefix: each caller says it its own way.
+    text: str
+    #: What a CLI returns for it — MISSING_EXIT for KIND_PATH, its own number for
+    #: KIND_EXEC, REFUSED_EXIT otherwise.
+    exit: int
 
 
 # Every sentence says the rule worked and names the fix in the same breath (CONTEXT.md,
@@ -92,7 +97,7 @@ class Refusal(NamedTuple):
 # command could otherwise redraw the line to show a harmless command while another one runs.
 UNKNOWN_PROFILE = ("no profile named '{name}' — have: {names}. Nothing was started. "
                    "charter harness list shows every profile and why any was refused.")
-KIND_MISMATCH = ("profile '{name}' is a {kind} profile, not a {asked} one — nothing was "
+MISMATCHED_KIND = ("profile '{name}' is a {kind} profile, not a {asked} one — nothing was "
                  "started. Run it by its own name: charter {name}")
 IGNORED = "profile '{name}' is refused — {why}"
 NOT_ON_PATH = ("profile '{name}' runs {cmd}, which is not on PATH — nothing was started. "
@@ -322,7 +327,10 @@ def framed_chat() -> str | None:
     chat whose window an operator's hook renamed would otherwise lose its session id and its
     resume id with no word said.
     """
-    chat = os.environ.get("CHARTER_SESSION_ID", "")
+    # No `, ""` default: the next line asks whether there is a chat at all, and `None`
+    # answers it exactly as `""` does — a fallback no test can tell apart from its absence
+    # is a line the deletion sweep reports, rightly.
+    chat = os.environ.get("CHARTER_SESSION_ID")
     if not chat:
         return None
     from ..commands_frame import SOCKET
@@ -330,10 +338,12 @@ def framed_chat() -> str | None:
     server = state.frame_server(chat) or SOCKET
     row = tmuxctl.live_pane_by_pid(server, os.getpid())
     if row is not None:
-        _pane, _session, window, option = row
         # The window NAME on charter's own server, the `@charter_chat` option on the
-        # operator's — where a name is only a label anything may rewrite (ruling 33).
-        if (option if tmuxctl.is_operator_socket(server, own=SOCKET) else window) == chat:
+        # operator's — where a name is only a label anything may rewrite (ruling 33). Read
+        # by name off `tmuxctl.LivePane`, because which of the two proves a chat is the one
+        # thing here it would be worst to get subtly wrong.
+        proof = row.chat if tmuxctl.is_operator_socket(server, own=SOCKET) else row.window
+        if proof == chat:
             return chat
     util.err(f"charter: {UNPROVEN_CHAT.format(chat=contain.readable(chat))}")
     return None
@@ -407,7 +417,9 @@ def cmd_frame_launch(args) -> int:
     if p is None:
         return _refused_in_pane(why or unknown_profile(args.profile), REFUSED_EXIT,
                                 fid=fid, attended=args.attended)
-    rest = list(args.rest or [])
+    # `list(args.rest)` and not `args.rest or []`: `nargs=REMAINDER` answers with a list on
+    # every path, `[]` included, so the fallback was a branch nothing could reach.
+    rest = list(args.rest)
     # `nargs=REMAINDER` keeps the `--` that told argparse to stop parsing; it is the
     # separator and not part of the harness's own argv (`commands_frame._launch` strips it
     # the same way).

--- a/charter/frame/launcher.py
+++ b/charter/frame/launcher.py
@@ -1,0 +1,420 @@
+"""The one place a harness profile starts: charter, in the pane, becoming the harness.
+
+Every chat pane's first process is `charter frame-launch --profile <name> -- <rest>`
+(`layout.session_argv` and `layout.chat_window_argv` on charter's own server,
+`layout.respawn_argv` after the `cat` placeholder in the operator's own tmux). It runs the
+guards again in the pane and then `os.execvpe`s the profile's command with the profile's
+`env` applied. Three reasons, the first a constraint (spec, *How a harness starts*):
+
+* **`env` reaches the harness without `layout.CARRIABLE`.** That allow-list raises on every
+  other name and the chat-handoff plan forbids adding to it, so a profile's environment can
+  only arrive on the far side of tmux. It never passes through tmux's own argument parser
+  either, which has already cost this repo #957 and #961. Only the profile's NAME travels.
+* **One place runs the checks for every open** — the CLI, `+`, a tab, reopen, a handoff.
+* **`exec` keeps the launcher's pid for the harness**, so the pane id charter records,
+  `remain-on-exit` and the `pane-died` path see exactly what they saw before. Measured on
+  tmux 3.7c and at the 3.2 floor, on both servers, before any of this was built:
+  `workspaces/harness-profiles/refs/task2-measure/` in the plane.
+
+**A launcher is in a frame only when tmux says so** (rulings 29 and 33). Before it execs,
+and before it claims or prints anything, its own pid must be the `#{pane_pid}` of a LIVE
+pane belonging to the chat it claims, read from tmux on that chat's server:
+
+* on charter's own server, the window's NAME — charter's config is loaded there and nothing
+  charter runs emits a title escape before the exec;
+* in the operator's tmux, the `@charter_chat` window option, set before `respawn-pane` —
+  there a hook, a plugin or `allow-rename on` output can rename a window, so the name is
+  only a label (`commands_frame._CHAT_OPTION` measures it).
+
+`$TMUX_PANE` and `$CHARTER_SESSION_ID` are never proof: a model's own tool shell inherits
+both from its chat (measured — shell pid 4707 under `pane_pid` 53118), so a
+`charter frame-launch` run from one is a launch with no frame that writes no chat's record,
+which reopen follows. It is a guard rail against a model's accidental misuse and not a
+boundary: a process that deliberately starts its own tmux pane in a window named like a
+chat passes it.
+
+**A refusal in the pane has to reach the operator without the dead pane** (ruling 42).
+Measured 2026-09-11: `_launch`'s eager dead-status ask completes 6-14 ms after the start
+while a Python launcher's first line runs at 19-22 ms, and on charter's server the teardown
+hook then kills the window (`_pane_last_words` answered `[]` in all 40 runs). So an
+**attended** launcher shows its refusal in the pane and waits for a key — the pane is
+charter's while no harness has run in it (ADR 0018, as the spec amends it) — and an
+**unattended** one records it under the chat, where the launch that opened the chat reads
+it back (`state.record_launch`, `commands_frame._await_the_launcher`).
+
+**Nothing here is on the import path.** `cli` and `commands_frame` reach this module at call
+time, because every `charter hook …` process builds the parser and derives config, and
+ruling 43 took profile code off that path.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import sys
+from pathlib import Path
+from typing import Callable, Mapping
+
+from typing import NamedTuple
+
+from .. import config, contain, profiles, util
+from . import state, tmuxctl
+
+#: What a launcher that refused in the pane exits with, after printing why.
+REFUSED_EXIT = 3
+
+#: The command is not on `PATH` — the shell's own number, and `bypass`'s (`commands_frame`).
+MISSING_EXIT = 127
+
+#: And its sibling: a command that exists and cannot be executed.
+NOT_EXECUTABLE_EXIT = 126
+
+#: Every kind of refusal this module produces. Callers branch on the KIND and never on the
+#: text (ruling 27): a sentence gets reworded, and a comparison against one is a guard that
+#: stops guarding on the day it does.
+KIND_IGNORED = "ignored"
+KIND_PATH = "path"
+KIND_NOT_YET = "not-yet"
+KIND_EXEC = "exec"
+
+
+class Refusal(NamedTuple):
+    """Why a profile did not start, and what a CLI returns for it."""
+
+    kind: str      # one of the KIND_* constants above
+    text: str      # the sentence, without charter's own prefix — a caller says it its way
+    exit: int      # MISSING_EXIT for KIND_PATH, its own number for KIND_EXEC, else REFUSED_EXIT
+
+
+# Every sentence says the rule worked and names the fix in the same breath (CONTEXT.md,
+# *A refusal is the rule working*), and every profile-derived value in one is contained
+# (ruling 35): `charter.local.toml` is a file a chat can write, and a `\r` or an ESC in a
+# command could otherwise redraw the line to show a harmless command while another one runs.
+UNKNOWN_PROFILE = ("no profile named '{name}' — have: {names}. Nothing was started. "
+                   "charter harness list shows every profile and why any was refused.")
+KIND_MISMATCH = ("profile '{name}' is a {kind} profile, not a {asked} one — nothing was "
+                 "started. Run it by its own name: charter {name}")
+IGNORED = "profile '{name}' is refused — {why}"
+NOT_ON_PATH = ("profile '{name}' runs {cmd}, which is not on PATH — nothing was started. "
+               "Install it, or give the profile a command with a full path in "
+               "charter.local.toml.")
+DECLARED_NOT_YET = (
+    "profile '{name}' comes from charter.local.toml, and this charter cannot yet ask before "
+    "a declared command runs, so it runs none — nothing was started. Until it can, launch a "
+    "built-in the file does not replace: {builtins}.")
+EXEC_FAILED = ("profile '{name}' could not be started — {cmd} failed to run ({why}). Nothing "
+               "is running here; fix the command in charter.local.toml.")
+UNPROVEN_CHAT = ("this launch was given chat '{chat}' but is not that chat's pane, so it "
+                 "runs with no frame and records nothing for '{chat}'.")
+
+#: What an attended pane says under its refusal. The pane is charter's while no harness has
+#: run in it, and the keypress is what keeps the window from closing over the sentence
+#: (ruling 42).
+PRESS_ENTER = "  press Enter to close this chat."
+
+
+def _nothing() -> None:
+    """The undo an :func:`attempt` with nothing to undo runs."""
+
+
+def argv(profile: str, rest: list[str], *, attended: bool) -> list[str]:
+    """What tmux is handed where the harness's own argv went.
+
+    Unattended unless told (review 3): a pane nobody is at must never wait on a question,
+    so `--attended` is what an open with somebody in front of it adds rather than what a
+    reopen or a handoff has to remember to take away.
+
+    `util.self_relaunch_argv` for its own reason (#390): `python -m charter` prepends the
+    child's cwd to `sys.path`, and a chat's cwd is a workspace clone that may hold its own
+    `charter/` package.
+    """
+    return util.self_relaunch_argv("frame-launch", "--profile", profile,
+                                   *(("--attended",) if attended else ()), "--", *rest)
+
+
+def environment(p: profiles.Profile, base: Mapping[str, str], *,
+                framed: bool) -> dict[str, str]:
+    """The environment *p*'s command is exec'd with.
+
+    **`CHARTER_HARNESS` stays the KIND's registry name**, because hooks compare it to
+    `claude-code` for session ids, resume and the working spinner. The profile rides beside
+    it as `CHARTER_HARNESS_PROFILE`, set here at the exec rather than through tmux — it
+    never joins `commands_frame._FRAME_IDENTITY`, which would put it on a tmux `-e`.
+
+    **An unframed launch drops `CHARTER_SESSION_ID` and only that** (review 8). The defect
+    is the pair: `hooks._record_harness_session` acts on a session id beside a launched
+    `CHARTER_HARNESS`, so `charter claude --no-frame` typed inside a chat would otherwise
+    write its own harness session into that chat's state. `CHARTER_ROOT`,
+    `CHARTER_WORKSPACE` and `CHARTER_PERSONA` stay: a bare harness started from a chat's
+    shell staying in that chat's plane and workspace is what its operator wants, and
+    `CHARTER_PERSONA=forge charter claude --no-frame` means what it says.
+    """
+    env = dict(base)
+    if not framed:
+        env.pop("CHARTER_SESSION_ID", None)
+    env.update(profiles.expanded_env(p))
+    env["CHARTER_HARNESS"] = p.harness
+    env["CHARTER_HARNESS_PROFILE"] = p.name
+    return env
+
+
+def resolve(name: str) -> tuple[profiles.Profile | None, str]:
+    """*name*'s profile, or ``(None, why it was refused)`` — ``(None, "")`` for a name this
+    plane has never heard of.
+
+    Two answers rather than one sentence, because the callers say different things about a
+    name nothing declares: `_launch` names the profiles there are, a reopen says the chat is
+    not coming back, and a `+` says the chat's own profile is gone. A REFUSED profile has
+    one answer for all of them — its own reason — and never falls back to the built-in of
+    that name (ruling 37): the operator said how that name runs, and running the built-in in
+    its place runs the command they replaced.
+    """
+    read = profiles.current()
+    found = read.profiles.get(name)
+    if found is not None:
+        return found, ""
+    shown = contain.readable(name)
+    return None, next((r.reason for r in read.refused if r.name == shown), "")
+
+
+def unknown_profile(name: str) -> str:
+    """What a launch says for a name this plane declares nothing for."""
+    return UNKNOWN_PROFILE.format(name=contain.readable(name),
+                                  names=", ".join(profiles.current().profiles))
+
+
+def display_command(p: profiles.Profile, rest: list[str]) -> list[str]:
+    """What charter SHOWS for a launch: *p*'s own command, and what the open added to it.
+
+    Never :func:`argv`, which is `python -P -m charter frame-launch --profile …` — true of
+    every chat and an answer to a question nobody asked. An early death names the command
+    the operator wrote down, and so does a tmux that refused it.
+
+    Contained word by word (ruling 35): the command comes out of a file a chat can write,
+    and this text goes to a terminal.
+    """
+    return [contain.readable(word) for word in profiles.expanded_command(p)] + list(rest)
+
+
+def refusal(p: profiles.Profile, *, root: Path, attended: bool,
+            env: Mapping[str, str]) -> Refusal | None:
+    """Why *p* may not start, or ``None``.
+
+    The spec's order, and it is the order the checks cost in: the file is ignored, the
+    command is on `PATH`, the profile is approved. Asked before tmux wherever a terminal is
+    attached — where a refusal is a `return` with nothing to tear down — and again in the
+    pane immediately before the exec, because the plane can move in between: that is the
+    whole reason there are two calls and not one.
+
+    **The ignore check is asked of DECLARED profiles only.** A built-in comes out of
+    charter's own registry rather than out of the file, so what git would do with that file
+    decides nothing about it. A declared replacement of a built-in (`[harness.claude]`) is
+    declared, so `charter claude` is refused with the rest and never falls back (ruling 19).
+
+    *attended* decides nothing here yet: Task 3's approval is what asks, and this is the seam
+    it fills (`_approval_refusal`).
+    """
+    if p.source != profiles.BUILTIN:
+        why = profiles.ignored_refusal(root)
+        if why:
+            return Refusal(KIND_IGNORED,
+                           IGNORED.format(name=contain.readable(p.name), why=why),
+                           REFUSED_EXIT)
+    program = profiles.expanded_command(p)[0]
+    # The `PATH` the exec will use, not this process's: a profile that needs another one
+    # sets it in `env`, and in a pane the base is the tmux client's (measured — tmux
+    # overwrites a `-e PATH`), which is charter's own.
+    if shutil.which(program, path=env.get("PATH")) is None:
+        return Refusal(KIND_PATH,
+                       NOT_ON_PATH.format(name=contain.readable(p.name),
+                                          cmd=contain.readable(program)),
+                       MISSING_EXIT)
+    return _approval_refusal(p, attended=attended)
+
+
+def _approval_refusal(p: profiles.Profile, *, attended: bool) -> Refusal | None:
+    """Task 2's B1 refusal: a declared profile does not run until something can ask first.
+
+    **`main` must never run an unapproved declared command between two merges.** Nothing
+    yet stands for the operator's approval of a `command` — Task 3's launch record is what
+    will — and `charter.local.toml` is a file a chat can write with no diff to show for it.
+    So every profile the file declares is refused here, a replacement of a built-in
+    included, through `charter <profile>`, `+`, a tab, reopen and a handoff alike; only the
+    built-ins no declared profile replaces launch.
+
+    Task 3 replaces this body with `profiletrust.refusal(p, attended=attended)` and deletes
+    :data:`DECLARED_NOT_YET`, which is why *attended* is already the parameter it takes: an
+    open nobody is at refuses where it would have asked.
+    """
+    if p.source == profiles.BUILTIN:
+        return None
+    builtins = ", ".join(name for name, q in profiles.current().profiles.items()
+                         if q.source == profiles.BUILTIN)
+    return Refusal(KIND_NOT_YET,
+                   DECLARED_NOT_YET.format(name=contain.readable(p.name), builtins=builtins),
+                   REFUSED_EXIT)
+
+
+def _exec_exit(e: OSError) -> int:
+    """What an `execvpe` that raised returns — `bypass`'s own pair, so `charter <profile>
+    && …` behaves the way `<command> && …` would have."""
+    if isinstance(e, FileNotFoundError):
+        return MISSING_EXIT
+    if isinstance(e, PermissionError):
+        return NOT_EXECUTABLE_EXIT
+    return REFUSED_EXIT
+
+
+def attempt(p: profiles.Profile, rest: list[str], *, fid: str | None, attended: bool,
+            on_exec: Callable[[], Callable[[], None]] = lambda: _nothing) -> Refusal | None:
+    """Run the chain and hand this process to *p*'s command. A :class:`Refusal`, or ``None``.
+
+    ``None`` is unreachable in the field — `os.execvpe` replaces this process — and is what
+    a test standing in for it gets back, so a stand-in never has to raise to be believed.
+
+    *on_exec* is what a caller records the moment the pane stops being charter's, and it
+    returns the undo for it: an `execvpe` that raises after it leaves a pane running nothing
+    at all, and a pane running nothing must not also claim to be a chat (N7's nit).
+    """
+    env = environment(p, os.environ, framed=fid is not None)
+    r = refusal(p, root=config.ROOT, attended=attended, env=env)
+    if r is not None:
+        return r
+    undo = on_exec()
+    if fid is not None:
+        state.record_profile(fid, p.name)
+    cmd = profiles.expanded_command(p)
+    try:
+        os.execvpe(cmd[0], [*cmd, *rest], env)
+    except OSError as e:
+        undo()
+        return Refusal(KIND_EXEC,
+                       EXEC_FAILED.format(name=contain.readable(p.name),
+                                          cmd=contain.readable(cmd[0]),
+                                          why=contain.readable(e.strerror or e)),
+                       _exec_exit(e))
+    return None
+
+
+def start(p: profiles.Profile, rest: list[str], *, fid: str | None, attended: bool) -> int:
+    """:func:`attempt`, with the refusal said on charter's own terms. The exit code.
+
+    What `charter <profile> --no-frame` and a launch with no terminal run — the refusal is
+    printed where the operator is already looking, so nothing waits for a key there.
+    """
+    r = attempt(p, rest, fid=fid, attended=attended)
+    if r is None:
+        return 0
+    util.err(f"charter: {r.text}")
+    return r.exit
+
+
+def framed_chat() -> str | None:
+    """The chat this process is the pane of, or ``None`` — asked of tmux, never of the
+    environment (rulings 29 and 33; see the module docstring).
+
+    The claimed chat is `$CHARTER_SESSION_ID`, which tmux put on this pane's window. It
+    counts only when tmux itself says this process's pid is the `#{pane_pid}` of a live pane
+    that belongs to that chat, on that chat's own server — `state.frame_server`, written
+    before the pane existed, so nothing races charter's own pane record and nothing waits.
+
+    A claim that cannot be proven says so in one line rather than downgrading in silence: a
+    chat whose window an operator's hook renamed would otherwise lose its session id and its
+    resume id with no word said.
+    """
+    chat = os.environ.get("CHARTER_SESSION_ID", "")
+    if not chat:
+        return None
+    from ..commands_frame import SOCKET
+
+    server = state.frame_server(chat) or SOCKET
+    row = tmuxctl.live_pane_by_pid(server, os.getpid())
+    if row is not None:
+        _pane, _session, window, option = row
+        # The window NAME on charter's own server, the `@charter_chat` option on the
+        # operator's — where a name is only a label anything may rewrite (ruling 33).
+        if (option if tmuxctl.is_operator_socket(server, own=SOCKET) else window) == chat:
+            return chat
+    util.err(f"charter: {UNPROVEN_CHAT.format(chat=contain.readable(chat))}")
+    return None
+
+
+def _wait_for_the_operator() -> None:
+    """Hold the pane open until the operator acknowledges the refusal (ruling 42).
+
+    **A LINE, not a single raw keystroke, and that is a portability decision taken on
+    evidence rather than taste.** Reading one keypress means putting the pane's terminal
+    into raw mode, and a `tcsetattr` from a pane on a Linux CI runner left the launcher
+    gone with an EMPTY `#{pane_dead_status}` — tmux's own reading for *killed by a signal*
+    (`commands_frame._UNKNOWN_DEATH_CODE` records the measurement) — so the refusal went
+    with the window after all, which is the single thing ruling 42 exists to prevent. Both
+    cases in `tests/test_a_chat_pane_starts_as_charter_and_becomes_the_harness.py` were red
+    on that runner and green on two tmux versions here, which is how it was found.
+
+    The pane's own line discipline does the waiting instead: no mode change, nothing to
+    restore, and Enter is a key every operator has. A Ctrl-C at the prompt is left to mean
+    what it always means — the chat ends on 130 rather than on the refusal's own number,
+    and it ends either way.
+
+    A pane whose stdin is not a terminal has nobody to press anything and must not block:
+    that is the suite, and a `frame-launch` run by hand out of a pipe.
+    """
+    if not sys.stdin.isatty():
+        return
+    sys.stdin.readline()
+
+
+def _handed_over(fid: str | None) -> Callable[[], None]:
+    """Record that the pane is the harness's now, and hand back the undo for it.
+
+    What :func:`attempt`'s *on_exec* is for here: the launch that opened an unattended chat
+    waits for one of these two answers rather than for a timeout it would pay on every chat
+    that started perfectly well (`commands_frame._await_the_launcher`).
+    """
+    if fid is not None:
+        state.record_launch(fid)
+    # Nothing to undo: an `execvpe` that raises is about to be recorded as the refusal it
+    # is, over this very record, by `_refused_in_pane` below.
+    return _nothing
+
+
+def _refused_in_pane(text: str, code: int, *, fid: str | None, attended: bool) -> int:
+    """Say *text* in the pane the way somebody will actually read it, and return *code*.
+
+    Ruling 42, measured: printing and exiting is exactly what nobody reads. An attended pane
+    waits for a key; an unattended one leaves the sentence under the chat, because the
+    process that opened it is the one with a terminal.
+    """
+    util.err(f"charter: {text}")
+    if fid is not None:
+        state.record_launch(fid, code, text)
+    if attended:
+        util.err(PRESS_ENTER)
+        _wait_for_the_operator()
+    return code
+
+
+def cmd_frame_launch(args) -> int:
+    """`charter frame-launch --profile <name> [--attended] -- <rest>` — a chat pane's own
+    first process, and never a command an operator types.
+
+    The frame proof runs FIRST (ruling 35): before the profile is resolved, before anything
+    is claimed, and before a single byte is printed, because the proof holds only while the
+    pane has printed nothing.
+    """
+    fid = framed_chat()
+    p, why = resolve(args.profile)
+    if p is None:
+        return _refused_in_pane(why or unknown_profile(args.profile), REFUSED_EXIT,
+                                fid=fid, attended=args.attended)
+    rest = list(args.rest or [])
+    # `nargs=REMAINDER` keeps the `--` that told argparse to stop parsing; it is the
+    # separator and not part of the harness's own argv (`commands_frame._launch` strips it
+    # the same way).
+    if rest[:1] == ["--"]:
+        rest = rest[1:]
+    r = attempt(p, rest, fid=fid, attended=args.attended,
+                on_exec=lambda: _handed_over(fid))
+    if r is None:
+        return 0
+    return _refused_in_pane(r.text, r.exit, fid=fid, attended=args.attended)

--- a/charter/frame/leave.py
+++ b/charter/frame/leave.py
@@ -109,6 +109,11 @@ class Doomed(NamedTuple):
     #: has to say so. ``False`` for a cwd that is gone, for one that was never recorded and
     #: for a chat with no workspace: none of those is a chat standing somewhere else.
     cwd_outside: bool
+    #: The profile this chat is running (`state.record_profile`), or ``""`` for a chat
+    #: launched by a charter that predates profiles — which is what a reopen needs to put
+    #: it back on its own account rather than on another one, and what the row shows in
+    #: place of the harness (:func:`title`).
+    profile: str = ""
 
 
 class Plan(NamedTuple):
@@ -184,6 +189,10 @@ def plan(*, live, focus: str, only: str = "") -> Plan:
             # the act have to be one reading, which is this record's whole reason.
             cwd_outside=(bool(cwd) and bool(ws) and os.path.isdir(cwd)
                          and not ws_mod.contains(ws, cwd)),
+            # Read off the chat's own record rather than out of `identity`: the profile is
+            # not one of the five names a frame's identity carries onto a tmux argv, and a
+            # reopen has to have it to bring the chat back on its own account.
+            profile=state.profile(fid) or "",
         ))
     return Plan(chats=tuple(out), focus=focus)
 
@@ -419,7 +428,11 @@ def title(c: Doomed) -> str:
     title is, and never here (`chats.py`'s rule, and the masked-containment finding behind
     it).
     """
-    return f"{c.chat} · {c.harness}" if c.harness else c.chat
+    # The PROFILE where there is one: two chats of one kind may be two accounts, and the
+    # profile is the name the operator gave the one this row is about. A chat from before
+    # profiles still names its harness, which is all it ever recorded.
+    shown = c.profile or c.harness
+    return f"{c.chat} · {shown}" if shown else c.chat
 
 
 #: The row that OPENS the confirmation, the row that goes through with it, and one row per

--- a/charter/frame/reopen.py
+++ b/charter/frame/reopen.py
@@ -118,6 +118,15 @@ class Chat(NamedTuple):
     #: reopen can put the operator back on it rather than on whichever window it created
     #: first.
     active: bool
+    #: The PROFILE this chat ran — `charter.local.toml`'s name for its command and
+    #: environment — or ``""`` for a chat recorded before profiles existed, which reopens on
+    #: the built-in named after its kind. A reopen never substitutes another
+    #: (`commands_frame._reopen_one`): a profile may be another account, where this chat's
+    #: conversation does not exist.
+    #:
+    #: Defaulted, because a manifest written one field ago is the migration case this whole
+    #: reader is built to survive (:func:`_chat`), and `VERSION` stays 1 for it.
+    profile: str = ""
 
 
 class Frame(NamedTuple):
@@ -305,7 +314,7 @@ def _chat(raw) -> Chat | None:
         return None
     text = {k: (raw.get(k) if isinstance(raw.get(k), str) else "")
             for k in ("chat", "workspace", "persona", "harness", "cwd", "resume",
-                      "transcript")}
+                      "transcript", "profile")}
     return Chat(active=raw.get("active") is True, **text)
 
 

--- a/charter/frame/state.py
+++ b/charter/frame/state.py
@@ -932,6 +932,101 @@ def record_workspace(fid: str, name: str) -> None:
         return
 
 
+#: Which harness PROFILE this chat runs, as `charter.local.toml` names it — one file, for
+#: `workspace`'s own reason: one fact, written by the one process that knows it.
+#:
+#: **It is not `identity`, and the difference is the promise that list carries.**
+#: `record_identity` holds `commands_frame._FRAME_IDENTITY`, and every value in it goes onto
+#: a tmux `-e` argv, which is world-readable in `/proc/<pid>/cmdline`. `CHARTER_HARNESS`
+#: stays the KIND there because hooks compare it to `claude-code`; the profile is the
+#: launcher's own answer, set at the exec (`frame/launcher.environment`) and written here.
+_PROFILE_FILE = "profile"
+
+
+def record_profile(fid: str, name: str) -> None:
+    """Write down which profile this chat runs.
+
+    Same atomic-write, never-raise, rewrite-on-every-launch shape as
+    :func:`record_workspace`, and for the identical reason: an adopted directory's value is
+    another chat's answer, so it is overwritten rather than merged.
+
+    Written by the launch before tmux is asked for anything — `+`, a tab, a reopen and a
+    handoff all read it back to decide what the next chat runs — and again by the pane's own
+    launcher, which is the one that resolved the profile in the end.
+    """
+    d = frame_dir(fid, create=True)
+    if d is None:
+        return
+    try:
+        config.replace_for(d / _PROFILE_FILE, f"{name}\n")
+    except OSError:
+        return
+
+
+def profile(fid: str) -> str | None:
+    """The profile recorded for *fid*, or ``None``.
+
+    ``None`` for a chat launched by a charter that predates profiles, for a record that
+    cannot be read, and for an empty one — `charter frame -- <cmd>` runs no profile and
+    records the empty answer rather than a name it does not have. Three reasons, one answer,
+    because every caller does the same thing with it: fall back to what the chat's kind
+    says, and never to a substitute (`commands_frame._same_profile_as`).
+    """
+    d = frame_dir(fid)
+    if d is None:
+        return None
+    try:
+        return (d / _PROFILE_FILE).read_text().strip() or None
+    except (OSError, ValueError):
+        return None
+
+
+#: What the pane's own launcher decided, for the launch that opened the chat to read back.
+#:
+#: **Ruling 42, and it is measured rather than argued.** `_launch`'s eager dead-status ask
+#: completes 6-14 ms after the start while a Python launcher's first line runs at 19-22 ms,
+#: so a refusal the pane printed and exited on is never read off the pane: on charter's own
+#: server the teardown hook kills the window at once, and `_pane_last_words` answered `[]`
+#: in all 40 measured runs. An attended pane waits for a key instead; an unattended one —
+#: a reopen, a handoff — has nobody to wait for, so it leaves its answer here.
+_LAUNCH_FILE = "launch"
+
+
+def record_launch(fid: str, code: int = 0, text: str = "") -> None:
+    """Record what the pane's launcher did: nothing but ``0`` once it has handed the pane to
+    the harness, or the code it is exiting with and the refusal it just printed.
+
+    Both outcomes, not only the refusal, because the launch that is waiting for one of them
+    would otherwise pay its whole budget on every chat that started perfectly well.
+    """
+    d = frame_dir(fid, create=True)
+    if d is None:
+        return
+    try:
+        config.replace_for(d / _LAUNCH_FILE, f"{int(code)}\n{text}")
+    except OSError:
+        return
+
+
+def launch(fid: str) -> tuple[int, str] | None:
+    """``(exit code, refusal)`` the pane's launcher recorded, or ``None`` when it has not
+    answered yet. ``(0, "")`` is the harness having taken the pane over."""
+    d = frame_dir(fid)
+    if d is None:
+        return None
+    try:
+        raw = (d / _LAUNCH_FILE).read_text()
+    except OSError:
+        return None
+    code, _, text = raw.partition("\n")
+    try:
+        return int(code), text
+    except ValueError:
+        # A half-written or hand-edited record says nothing, which is what "not yet" means
+        # here: the caller carries on as it would for a launcher still working.
+        return None
+
+
 def frame_workspace(fid: str) -> str | None:
     """The workspace *fid* was launched for, or ``None`` when charter does not know.
 

--- a/charter/frame/tmuxctl.py
+++ b/charter/frame/tmuxctl.py
@@ -446,8 +446,15 @@ def live_pane_by_pid(server: str, pid: int) -> LivePane | None:
               report=False)
     if out.returncode != 0:
         return None
-    for line in (out.stdout or "").splitlines():
+    # `out.stdout` and not `out.stdout or ""`: every one of :func:`run`'s three exits
+    # returns a string — the two it invents pass `stdout=""` explicitly — so the fallback
+    # was a line nothing could reach, which is what the deletion sweep reported it as.
+    for line in out.stdout.splitlines():
         fields = line.split("\t")
+        # A window NAME may contain a tab and `list-panes` does not quote it, so a row can
+        # split into more fields than the format asks for. A row this cannot assign is one
+        # charter cannot read, and a pane charter cannot read is not a pane it will prove a
+        # chat with — skipped rather than unpacked, which would raise here.
         if len(fields) != _PANE_PID_FIELDS:
             continue
         pane_pid, dead, pane, session, window, chat = fields

--- a/charter/frame/tmuxctl.py
+++ b/charter/frame/tmuxctl.py
@@ -410,8 +410,23 @@ _PANE_PID_FORMAT = ("#{pane_pid}\t#{pane_dead}\t#{pane_id}\t#{session_name}"
 _PANE_PID_FIELDS = 6
 
 
-def live_pane_by_pid(server: str, pid: int) -> tuple[str, str, str, str] | None:
-    """``(pane id, session, window name, @charter_chat)`` of the LIVE pane *pid* owns.
+class LivePane(NamedTuple):
+    """One live pane, as :func:`live_pane_by_pid` reads it off tmux.
+
+    A record rather than a bare tuple because its two proof fields are told apart by which
+    SERVER is being asked (ruling 33) — the window name on charter's own, the option in an
+    operator's — and a caller indexing `[2]` or `[3]` for that is a caller one edit away
+    from proving a chat by the wrong half.
+    """
+
+    pane: str       # `%N`
+    session: str
+    window: str     # the window's NAME, which is the proof on charter's own server
+    chat: str       # `@charter_chat`, which is the proof in an operator's tmux
+
+
+def live_pane_by_pid(server: str, pid: int) -> LivePane | None:
+    """The LIVE pane *pid* owns, as a :class:`LivePane`.
 
     ``None`` when no live pane on *server* has that `#{pane_pid}` — a server that does not
     answer at all included, which is an ordinary reading rather than a fault (the chat's
@@ -437,7 +452,7 @@ def live_pane_by_pid(server: str, pid: int) -> tuple[str, str, str, str] | None:
             continue
         pane_pid, dead, pane, session, window, chat = fields
         if pane_pid == str(pid) and dead == "0":
-            return pane, session, window, chat
+            return LivePane(pane, session, window, chat)
     return None
 
 

--- a/charter/frame/tmuxctl.py
+++ b/charter/frame/tmuxctl.py
@@ -398,6 +398,49 @@ def server_argv(server: str, *args: str) -> list[str]:
     return ["tmux", "-S" if is_socket_path(server) else "-L", server, *args]
 
 
+#: What :func:`live_pane_by_pid` asks of every pane on a server, in ONE call: the pid that
+#: owns the pane, whether the pane is dead, and the three things that say which chat it is.
+#: The plan author read `#{@charter_chat}` and `#{pane_dead}` through this format on tmux
+#: 3.7c and at the 3.2 floor (`workspaces/harness-profiles/refs/task2-measure/`).
+_PANE_PID_FORMAT = ("#{pane_pid}\t#{pane_dead}\t#{pane_id}\t#{session_name}"
+                    "\t#{window_name}\t#{@charter_chat}")
+
+#: How many fields :data:`_PANE_PID_FORMAT` produces. A line with any other count is one
+#: this cannot read, and a pane charter cannot read is not a pane it will prove a chat with.
+_PANE_PID_FIELDS = 6
+
+
+def live_pane_by_pid(server: str, pid: int) -> tuple[str, str, str, str] | None:
+    """``(pane id, session, window name, @charter_chat)`` of the LIVE pane *pid* owns.
+
+    ``None`` when no live pane on *server* has that `#{pane_pid}` — a server that does not
+    answer at all included, which is an ordinary reading rather than a fault (the chat's
+    recorded server may be gone).
+
+    **Dead panes are filtered out, and that is ruling 33 rather than tidiness.** A pane kept
+    by `remain-on-exit` still reports the pid its program had, and the system is free to
+    hand that number to somebody else — so a dead pane's pid proves nothing about the
+    process asking.
+
+    One `list-panes -a`, addressed by socket through :func:`server_argv` and never through
+    `$TMUX`: which server a chat is on is the chat's own record, and `$TMUX` says only which
+    server the asking process is inside (#812).
+    """
+    out = run("asking tmux which pane this process is",
+              server_argv(server, "list-panes", "-a", "-F", _PANE_PID_FORMAT),
+              report=False)
+    if out.returncode != 0:
+        return None
+    for line in (out.stdout or "").splitlines():
+        fields = line.split("\t")
+        if len(fields) != _PANE_PID_FIELDS:
+            continue
+        pane_pid, dead, pane, session, window, chat = fields
+        if pane_pid == str(pid) and dead == "0":
+            return pane, session, window, chat
+    return None
+
+
 def is_operator_socket(server: str | None, *, own: str | None = None) -> bool:
     """Is *server* a tmux charter did not start — one it is a guest on?
 

--- a/docs/adr/0018-charter-may-run-the-harness-but-never-draws-it.md
+++ b/docs/adr/0018-charter-may-run-the-harness-but-never-draws-it.md
@@ -151,3 +151,59 @@ back?* Two yeses is this amendment. Anything else is a new one.
 the capture asks tmux for the last N lines (`-S -2000`) rather than for everything and
 trimming afterwards: the bound belongs where the memory is. Verified on tmux 3.7c and at the
 3.2 floor.
+
+## Amendment, 2026-09-12: before the `exec`, that pane is charter's own
+
+Harness profiles put a charter process in the pane. `charter frame-launch --profile <name>`
+is what tmux now starts in every chat pane, and it becomes the harness by `os.execvpe`
+replacing itself with the profile's command (`charter/frame/launcher.py`). A launcher that
+refuses — the local file became committable since the pre-tmux check, the command is not on
+`PATH`, the profile is declared and nothing can ask the operator's approval yet — **prints
+that refusal in the pane and holds the pane open until somebody presses Enter.**
+
+That is charter drawing in a chat's pane, which the rule above says it never does. The rule
+is right and this is not an exception to it, because of *when*: **no harness has ever run in
+that pane.** The `exec` has not happened, so there is no harness process, no output of its
+own on that screen, nothing to draw over and nothing to parse. Every failure this ADR was
+written against needs a harness on the other side of the pane to occur at all — owning a
+terminal parser, deciding what somebody else's cursor means, painting over somebody else's
+frame — and none of them is reachable before the process that would produce them exists.
+
+**The distinguishing question, in the same shape as the one above:** *has a harness ever run
+in this pane, and is charter's own process still the one in it?* No and yes is this
+amendment. Anything else is the rule as written: the instant `execvpe` succeeds the pane is
+the harness's, `state.record_launch` says so, and nothing charter owns writes there again.
+
+**Why the refusal cannot simply be printed and exited on, which is the whole reason this is
+a decision and not a detail.** Measured 2026-09-11 on tmux 3.7c and at the 3.2 floor, 40
+runs, in `workspaces/harness-profiles/refs/task2-measure/`: `_launch`'s eager
+`#{pane_dead_status}` ask completes **6-14 ms** after the start while a Python launcher's
+first line runs at **19-22 ms**, so the ask is always too early to catch a refusal — and by
+the time anything else could look, the chat-teardown hook has killed the window.
+`_pane_last_words` answered `[]` in all 40 runs on charter's own server. A refusal printed
+and exited on is a refusal nobody reads: the window carrying it is gone before the sentence
+can be collected. So the pane has to hold it, and holding it is the part that needs this
+record.
+
+**Bounded, and each bound is checkable from outside.**
+
+* **Only a refusal, and only before the `exec`.** One sentence charter wrote, plus
+  `press Enter to close this chat.` — no escape sequences of charter's own, no panel, no
+  layout, and never a second thing later.
+* **Only where somebody is there to read it.** An ATTENDED open waits; a reopen, a handoff
+  and a background open write the same sentence into the chat's state directory instead
+  (`state.record_launch`), where the launch that opened the chat reports it. A pane nobody
+  is at never stops on anything.
+* **A line, not a keystroke.** Waiting on one keypress means putting the pane's terminal
+  into raw mode, and a `tcsetattr` from a pane on a Linux CI runner left the launcher killed
+  by a signal — an empty `#{pane_dead_status}` — so the refusal went with the window after
+  all. The pane's own line discipline does the waiting instead: no mode change, nothing to
+  restore, nothing of the terminal's state for charter to get wrong.
+* **Reading is untouched.** This amendment adds a WRITE before the harness exists; the two
+  reads the 2026-09-01 amendment allows are unchanged, and charter still never reads this
+  pane to react to what a harness printed in it.
+
+Recorded here rather than in the records task that closes this phase, because the code that
+relies on it ships in the same pull request (`workspaces/harness-profiles/workspace.md`,
+ruling 44): otherwise `main` carries an unqualified prohibition while the code contradicts
+it, and the only thing telling a reader otherwise is a spec they have no reason to open.

--- a/docs/control-plane.md
+++ b/docs/control-plane.md
@@ -466,9 +466,13 @@ be told otherwise. A shell alias does not help — charter runs the harness with
 the alias never resolves. A **harness profile** is the way: a kind, a command and an
 environment, declared in a file that stays on your machine.
 
-**Profiles are listed by `charter harness list`; launching one arrives in a later release.**
-Today charter reads them, refuses the broken ones by name, and keeps the file out of git.
-`charter claude`, bare `charter` and every chat still start exactly as they did.
+**Every chat now starts through charter's own launcher, and launching a DECLARED profile
+arrives in a later release.** Charter reads the profiles, refuses the broken ones by name,
+and keeps the file out of git; `charter claude`, bare `charter`, the `+`, a workspace tab
+and a reopen all run the built-in profile of their harness and record it. A profile this
+file declares is refused, by name, with a sentence saying charter cannot yet ask before a
+declared command runs — the release that adds the asking is the one that lets it launch,
+because until then nothing stands for your approval of a command that runs on a click.
 
 ### Profiles live in `charter.local.toml`, never in `charter.toml`
 
@@ -591,14 +595,16 @@ that one and runs it, so the workspace picker, `--no-frame`, `--probe`, `--works
 everything else the launcher does are the same behaviours, not a second set of them. Every
 subcommand keeps working untouched, `charter claude` included.
 
-The value is one of the words you would type after `charter`: `claude`, `opencode`,
-`codex` — the built-in profiles `charter harness list` shows, read out of charter's own
-registry rather than a list in this page, so a harness added to charter becomes a legal
-default the day it is registered. **Until launching a profile arrives, bare `charter` reads
-this key from `charter.toml` alone, and only as one of those words.** A `default` in
-`charter.local.toml` marks its row in `charter harness list` and launches nothing yet, and a
-declared profile's name in `charter.toml` is reported below like any other name charter
-cannot launch.
+The value is the name of a profile: one of the words you would type after `charter` —
+`claude`, `opencode`, `codex`, the built-in profiles `charter harness list` shows, read out
+of charter's own registry rather than a list in this page — or the name of a profile
+`charter.local.toml` declares. A `default` in the local file wins over the committed one,
+which is how a machine chooses its own without touching what everybody else pulls.
+
+**A declared profile is a legal value here and does not launch yet**: bare `charter` on a
+plane whose default names one is refused with the launcher's own sentence — charter cannot
+yet ask before a declared command runs — rather than started. A built-in default starts
+exactly as it did.
 
 **Charter does not pick one for you.** No default and you get the usage message, not
 "whatever is installed" (a machine with two of them has no answer, and the answer would
@@ -609,8 +615,8 @@ machine-local memory deciding what a committed command does). Naming it is one l
 
 ```
 $ charter
-✗ charter: [harness] default = "clyde" in ~/plane/charter.toml is not a harness charter
-  can launch — one of: claude, opencode, codex. Nothing was started.
+✗ charter: [harness] default = "clyde" names no profile this machine has — one of:
+  claude, codex, opencode.
 ```
 
 That is the whole reason this key is checked where it is read rather than where it is

--- a/docs/frame.md
+++ b/docs/frame.md
@@ -14,9 +14,18 @@ plane places it*, below). The middle pane is the harness's and charter draws not
 (ADR 0018), so a capture with no agent to run has `charter status` in there.
 
     charter claude               # or codex, opencode
+    charter claude-work          # any profile charter.local.toml declares
     charter                      # the same thing, on a plane with [harness] default
     charter frame -- <cmd>       # anything charter has never met
     charter claude --no-frame    # bare, no frame at all
+
+`charter <profile>` names a **harness profile** — a kind, a command and an environment,
+declared in `charter.local.toml`
+([control-plane.md](control-plane.md#harness--profiles-and-the-default)). `claude`, `codex`
+and `opencode` are themselves profiles, the built-in one per harness, and this release
+starts those. A profile the file declares does not run yet: it is refused with a sentence
+saying charter cannot yet ask before a declared command runs, because nothing stands for
+your approval of a command until the release that adds one.
 
 `charter` on its own opens the frame once the plane says which harness it means —
 `[harness] default = "claude"` in `charter.toml`, documented in
@@ -806,8 +815,9 @@ one. There is no third answer available from a hook channel that reports prompts
 calls: charter can be late to stop claiming, or early, and it is set to be early.
 
 **The chat bar ends in a `+` and a `-`, and one of them is a button and one is a door.**
-Pressing the `+` opens another chat: same workspace, same harness you are already in, its
-id allocated for you — which is why it takes nothing and asks nothing. It runs `charter
+Pressing the `+` opens another chat: same workspace, same **profile** you are already in —
+two chats of one harness may be two accounts, so the answer is the one in front of you —
+its id allocated for you, which is why it takes nothing and asks nothing. It runs `charter
 frame-new-chat`, which is `charter <harness>` in this workspace with one difference: it
 builds the frame without becoming your terminal, because the process behind a click is not
 one.
@@ -837,8 +847,10 @@ something costs you the belief that it is there.
 It stops, and says why on the attention row, in four cases: your frame is a window in a
 tmux you already had (charter makes no chats for you there — `charter <harness>` in the
 workspace still does); charter cannot prove the workspace's tmux session is this plane's
-rather than another project's; this chat records no harness charter can launch and your
-plane declares no `[harness] default`; or charter cannot enter the workspace's directory.
+rather than another project's; this chat records no profile charter can launch and your
+plane declares no `[harness] default`; the profile it records cannot start, and the reason
+is the one the launch would have given you; or charter cannot enter the workspace's
+directory.
 
 **The workspace bar has neither, deliberately.** A new chat is nothing but a press. A new
 workspace is a directory and a *name*, which is `charter workspace create` — and a picker
@@ -1034,10 +1046,10 @@ what that chat will and will not get back.
 ```
 quit · 5 to choose from
 >   quit — stop 4 chats in 3 workspaces; 2 of 4 can resume the conversation
-    alpha.1 · claude-code       conversation resumes
-  * alpha.2 · claude-code       reopens empty — no session id recorded for this chat yet
+    alpha.1 · claude            conversation resumes
+  * alpha.2 · claude            reopens empty — no session id recorded for this chat yet
     api.1 · opencode            reopens empty — opencode records no session id to resume …
-    gone.3 · claude-code        conversation resumes · workspace 'gone' is gone — reopen…
+    gone.3 · claude-work        conversation resumes · workspace 'gone' is gone — reopen…
 
   up/down move   enter choose   esc cancel   F12 back to the harness
 ```
@@ -1058,6 +1070,22 @@ resuming it. It attaches you to the workspace you pressed quit in, on the chat t
 front of you. The record describes one quit and is consumed chat by chat, so running it
 twice does not double your tabs — and if some chat could not be started, exactly that chat
 stays recorded, so a second `charter reopen` retries just it.
+
+**Each chat comes back on its own profile, and a chat whose profile is gone does not come
+back at all.** It is skipped, by name, and left in the record:
+
+```
+⚠ charter reopen: api.2 ran on profile 'claude-work', which this plane no longer declares
+  — not reopened, because another profile may be another account, where its conversation
+  does not exist. Declare 'claude-work' again in charter.local.toml and run charter reopen
+  to bring it back.
+```
+
+Charter does not substitute another profile for it, and that is the point rather than
+caution: a profile can be a different account, where the conversation this chat wants to
+resume was never held and the workspace's code was never meant to go. Declaring it again
+and running `charter reopen` brings that chat back — which is what leaving it in the record
+is for.
 
 **A chat comes back in its workspace, and is told when that is not where it had been.** The
 record stores the directory the harness was actually standing in; the restore lands in
@@ -1342,6 +1370,48 @@ is not reported, and its output is not reprinted: that was its stdout, and chart
 invent it on stderr. If you want a short command's output, `--no-frame` — or a pipe, which
 bypasses the frame on its own — is the right tool; the frame is for something you sit in
 front of.
+
+## How a harness starts
+
+**Every chat pane's first process is charter, and charter replaces itself with the
+harness.** The pane starts `charter frame-launch --profile <name> -- <the rest>` — the
+window's first command on charter's own server, and what `respawn-pane` starts after the
+placeholder inside a tmux you already have. It runs the profile's checks there and then
+`exec`s the profile's command with the profile's environment applied.
+
+Three reasons, the first a constraint:
+
+- **the profile's environment reaches the harness without crossing tmux.** Charter puts
+  exactly five variables on a tmux command line and nothing else may join them, so a
+  profile's `env` could not travel that way — and values that never go through tmux's own
+  argument parser cannot be mangled by it;
+- **one place runs the checks for every open** — a typed command, the `+`, a workspace tab,
+  a reopen, a handoff;
+- **`exec` keeps the pid**, so the pane is the harness's own.
+
+That last one is why nothing else here changes, and it was measured before it was built on
+— tmux 3.7c and the 3.2 floor, on charter's own server and in an operator's own tmux: the
+pane id charter records, `remain-on-exit`, the exit code, the `pane-died` hooks and the
+early-death report all answer exactly what they answered when the harness was started
+directly. Only one reading differs, and nothing in charter reads it: until the `exec`,
+`#{pane_current_command}` names charter's interpreter rather than the harness.
+
+**A refusal in the pane waits for you.** A launcher that refuses — a command that is no
+longer on `PATH`, a profile this release cannot yet approve — prints its sentence in the
+pane and waits for you to press Enter, because a pane that printed and exited would have its window
+closed before anything could read it: measured, charter's own check for a chat that died
+early answers a few milliseconds before the launcher's first line has even run. A chat
+nobody is watching — one a reopen or a handoff opened — has nobody to press that key, so it
+records the refusal instead and the command that opened it reports that.
+
+**`charter frame-launch` is in a frame only when tmux says so.** Before it starts anything,
+it asks tmux whether its own pid is the `#{pane_pid}` of a live pane belonging to the chat
+it was given — the window's name on charter's own server, the `@charter_chat` option in
+yours, where a window name is only a label anything can rewrite. `$TMUX_PANE` and
+`$CHARTER_SESSION_ID` are never proof: an agent's own tool shell inherits both from its
+chat, so a `charter frame-launch` run from there is a launch with no frame that rewrites no
+chat's record. It is a guard rail against that mistake and not a boundary: a process that
+deliberately starts its own tmux pane in a window named like a chat passes it.
 
 ## When the terminal is too small
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -326,8 +326,8 @@ here without starting one; [frame.md](frame.md) is the rest. If you ran `charter
 inside a Claude Code session, restart that session first — the plugin loads at the next one.
 
 `init` writes no `[harness] default`, so bare `charter` prints its usage until the plane
-names a harness — one key in `charter.toml`
-([control-plane.md](control-plane.md#default--bare-charter)):
+names a profile — one key in `charter.toml`, and `claude` is the built-in profile of Claude
+Code ([control-plane.md](control-plane.md#default--bare-charter)):
 
 ```toml
 [harness]

--- a/docs/news/unreleased-harness-profiles.md
+++ b/docs/news/unreleased-harness-profiles.md
@@ -29,5 +29,20 @@ yours. While git tracks the file or would commit it, `charter harness list` show
 profile in it refused and names the fix, and `charter doctor` warns on its `harness profiles`
 row.
 
-This release does not launch a profile yet. `charter claude`, bare `charter` and every chat
-start exactly as they did.
+**Every chat now starts through charter's own launcher.** The first process in a chat's
+pane is charter, which checks the profile and then replaces itself with the harness — so a
+profile's environment reaches the harness without passing through tmux, and the pane, its
+exit code and everything charter reads off it stay exactly what they were. The chat records
+the profile it runs: the `+`, a workspace tab and a chat handed off by another chat all
+open on that same profile rather than merely on the same kind of harness, because two chats
+of one harness may be two accounts.
+
+`charter reopen` brings each chat back on its own profile, and a chat whose profile is gone
+is **skipped by name** rather than moved onto another one — another profile may be another
+account, where that conversation does not exist. It stays in the record, so declaring the
+profile again and running `charter reopen` brings it back.
+
+This release still does not launch a profile you declared: it is refused by name, with a
+sentence saying charter cannot yet ask before a declared command runs. Nothing a chat could
+have written into `charter.local.toml` runs until the release that adds the asking. The
+built-in profiles — `claude`, `codex`, `opencode` — start exactly as they did.

--- a/docs/superpowers/plans/2026-09-11-harness-profiles.md
+++ b/docs/superpowers/plans/2026-09-11-harness-profiles.md
@@ -1150,9 +1150,24 @@ KIND_MISMATCH = ("charter: profile '{name}' is a {kind} profile, not a {asked} o
     window named like a chat or an `@charter_chat` set to one, passes this check. It is a guard
     rail against a model's accidental misuse, not a boundary.
 - `rest` loses a leading `--` the way `_launch` strips it (`:5105`).
-- Every failure prints to the pane's stdout/stderr and exits non-zero. `_launch`'s eager
-  `_query_pane_dead_status` then reports it with `_pane_last_words` (L4), so the operator reads
-  charter's own sentence.
+- **Every failure reaches the operator without the dead pane (ruling 42, measured — this
+  paragraph replaces what Task 2 was written with).** The claim here was that `_launch`'s
+  eager `_query_pane_dead_status` reports a pane's refusal with `_pane_last_words`, and the
+  measurement says it cannot: the eager ask completes 6-14 ms after the start while a
+  Python launcher's first line runs at 19-22 ms, so all 40 measured refusals were missed —
+  on charter's own server the teardown hook had already killed the window
+  (`_pane_last_words` → `[]`), and in the operator's tmux `_launch_in_operator_tmux` closes
+  it before reading. So:
+  - an **attended** launcher prints its refusal in the pane and **waits for Enter** before
+    exiting (`launcher._wait_for_the_operator` — a LINE and not a raw keystroke, because a
+    `tcsetattr` from a pane left the launcher killed by a signal on a Linux runner) — the pane is charter's while no harness has run in
+    it (ADR 0018 as the spec amends it, and ruling 30's spirit);
+  - an **unattended** one records the refusal and its exit code under the chat
+    (`state.record_launch`) and exits; the launch that opened the chat reads it back
+    (`commands_frame._await_the_launcher`, bounded by `_LAUNCHER_SECONDS`) and reports it,
+    which is what a reopen and a handoff have instead of somebody at the pane. The same
+    record carries the ordinary "the harness has the pane now" answer, so a chat that
+    started costs no wait at all.
 
 **`KNOWN` entry** (`tests/test_plane_spawn_guard.py`):
 
@@ -1382,9 +1397,15 @@ case, which seeds a launch record. The server env carries `CHARTER_ROOT`, so
   the recorder wrote.
 - `test_a_harness_exit_code_travels_as_it_did` (L2): recorder exits 7 →
   `state.exit_code(fid) == 7` after the hook fires; the window is gone.
-- `test_a_refusal_in_the_pane_is_what_the_operator_reads` (L4): the recorder removed from disk
-  after the pre-tmux check (patch `launcher.refusal` to `""` for the pre-tmux call only) →
-  `_launch` returns 127 and stderr contains `"not on PATH"`, read off the pane.
+- `test_an_attended_pane_holds_its_refusal_until_somebody_reads_it` and
+  `test_an_unattended_refusal_is_read_back_by_the_launch_that_opened_the_chat` (L4, as
+  ruling 42 rewrites it): the plane declares a profile and the pre-tmux `launcher.refusal`
+  is stood down in the launching process only, so the PANE's own launcher refuses (review
+  B1) — the state the two checks exist for. Attended: the refusal is on the pane and
+  `#{pane_dead}` is still `0` until a key is sent, then the chat's exit code is
+  `REFUSED_EXIT`. Unattended: `_launch` returns `REFUSED_EXIT` and says the pane's own
+  sentence. (The original — a recorder removed from disk, read back through
+  `_pane_last_words` — is the thing the measurement showed cannot work.)
 - `test_the_exec_env_reaches_the_harness_and_not_tmux` (L6): the recorder's env holds
   `CHARTER_HARNESS_PROFILE=claude`, and neither `show-environment -g` nor
   `show-environment -t <session>` holds that name.

--- a/docs/superpowers/plans/2026-09-11-harness-profiles.md
+++ b/docs/superpowers/plans/2026-09-11-harness-profiles.md
@@ -1262,17 +1262,25 @@ git repo with the ignore line. `mock.patch("charter.frame.launcher._approval_ref
 for every case that is not about approval; the three B1 cases run without it. Helper `_launch(**ns)` calls `commands_frame._launch(SimpleNamespace(harness="claude", rest=[], no_frame=False, workspace="beta", pick=False, size=(120, 40), **ns))`.
 Refusals:
 
+**Correction, Task 2 as built: the `rc 1` in three rows below is stale.** A launcher that
+refused returns `REFUSED_EXIT`, which this plan fixes at **3** (`:904`, `:1040`, `:1103`) and
+which every other mention of it agrees on; `1` is a leftover from a draft that predated the
+constant. The rows are corrected in place and the three cases assert `launcher.REFUSED_EXIT`,
+whose value is pinned to 3 by a test of its own — the number is what tells a refusal apart
+from 126/127 (the shell's own words for a command that could not run, and what `bypass`
+returns), from 2 (charter's usage error) and from 1 (a harness that ran and failed).
+
 | Case | Asserts |
 |---|---|
-| `test_every_declared_profile_is_refused_until_approval_exists` | no stand-in; `profile="claude-work"` → rc 1, `"cannot yet ask before a declared command runs"` in stderr, no tmux call, no chat directory, `launcher.os.execvpe` not called. Red when the B1 refusal is deleted; Task 3 rewrites it (review B1) |
+| `test_every_declared_profile_is_refused_until_approval_exists` | no stand-in; `profile="claude-work"` → rc `REFUSED_EXIT` (3), `"cannot yet ask before a declared command runs"` in stderr, no tmux call, no chat directory, `launcher.os.execvpe` not called. Red when the B1 refusal is deleted; Task 3 rewrites it (review B1) |
 | `test_a_declared_replacement_of_a_built_in_is_refused_until_approval_exists` | no stand-in; `[harness.claude] command = ["/opt/claude"]`, `harness="claude"` → the same words, no tmux call |
 | `test_a_built_in_the_file_does_not_replace_still_launches` | no stand-in; `harness="codex"` with `claude-work` declared → a `new-window` argv recorded |
 | `test_an_unknown_profile_is_refused_and_nothing_is_allocated` | `profile="nope"` → rc 2, `"no profile named 'nope'"` in stderr, no `tmuxctl.run` call, `workspaces/beta` has no chat directory under `config.STATE_DIR / "frame"` |
 | `test_a_refused_profile_says_its_own_reason` | a local profile with a string command → rc 2, `"never a shell string"` in stderr |
 | `test_a_profile_of_another_kind_is_refused_by_its_name` | `harness="claude", profile="codex-pinned"` → `"is a codex profile"` and `"charter codex-pinned"` |
-| `test_a_declared_profile_from_a_committable_file_is_refused` | remove the ignore line → rc 1, `"charter reinit adds"`, no tmux call |
+| `test_a_declared_profile_from_a_committable_file_is_refused` | remove the ignore line → rc `REFUSED_EXIT` (3), `"charter reinit adds"`, no tmux call |
 | `test_a_built_in_is_not_refused_over_the_local_file` | same repo state, `profile=None, harness="claude"` → launches (a `new-window` argv was recorded) |
-| `test_a_declared_replacement_of_a_built_in_in_a_committable_file_refuses_that_name` | `[harness.claude] command = ["/opt/claude"]`, no ignore line, `harness="claude"` → rc 1, `"charter reinit adds"` in stderr, no tmux call, and `launcher.os.execvpe` not called for `claude` or `/opt/claude` |
+| `test_a_declared_replacement_of_a_built_in_in_a_committable_file_refuses_that_name` | `[harness.claude] command = ["/opt/claude"]`, no ignore line, `harness="claude"` → rc `REFUSED_EXIT` (3), `"charter reinit adds"` in stderr, no tmux call, and `launcher.os.execvpe` not called for `claude` or `/opt/claude` |
 | `test_a_command_not_on_path_is_refused_by_profile_name` | `which` → `None` → rc 127, `"profile 'claude-work' runs claude, which is not on PATH"` |
 | `test_each_refusal_says_something_different` | the stderr texts above are pairwise distinct |
 
@@ -2685,12 +2693,23 @@ what was considered.
 - If git tracks it, or would not ignore it, charter refuses its profiles rather than trusting the
   operator to notice.
 
-**ADR 0018 amendment.**
-- Charter draws in a pane only while no harness has ever run in it.
-- The selector is charter's, drawn before the pane's harness exists. Once a harness has run
-  there, the ADR holds unchanged, its two reading moments included.
-- On charter's own server the window's first command is the launcher. In an operator's tmux the
-  launcher is what `respawn-pane` starts after the placeholder (Ruling 4).
+**ADR 0018 amendment. WRITTEN IN TASK 2 (ruling 44) — this task REVIEWS it and adds the
+selector to it.** Task 2's launcher writes a refusal into a chat pane and holds it there, so
+the amendment shipped in that task's own PR: `main` must not carry an unqualified
+prohibition while the code contradicts it (CONTRIBUTING: docs move with the code). What it
+already says, and what is left here:
+- *(shipped in Task 2)* Charter draws in a pane only while no harness has ever run in it —
+  the distinguishing question stated as *has a harness ever run in this pane, and is
+  charter's own process still the one in it?*, the launcher's refusal as the moment it
+  answers, the measurement (`refs/task2-measure/`) for why the sentence has to be held
+  rather than printed and exited on, and the bounds: a refusal only, before the `exec` only,
+  a line read and not a raw keystroke, unattended opens recording instead of waiting.
+- *(here)* The selector is charter's, drawn before the pane's harness exists, and is the
+  second thing charter puts on that screen. Once a harness has run there, the ADR holds
+  unchanged, its two reading moments included.
+- *(here)* On charter's own server the window's first command is the launcher. In an
+  operator's tmux the launcher is what `respawn-pane` starts after the placeholder
+  (Ruling 4).
 
 **The phase-5 line.** Under "Two chats on the same harness share that harness's credentials.
 Charter cannot separate them and does not pretend to (§4).", add:

--- a/tests/_envguard.py
+++ b/tests/_envguard.py
@@ -191,7 +191,15 @@ def _loud_names() -> frozenset[str]:
     finds nothing has asserted charter's documented default, which is a fixture like any
     other.
 
-    Derived, not spelled. `commands_frame._FRAME_IDENTITY` already exists to answer exactly
+    Derived, not spelled — with one name that cannot be. ``CHARTER_HARNESS_PROFILE`` is
+    which PROFILE a chat is running, and it is an identity by every test above: inside a
+    frame it is that chat's, and in CI it is unset. It is spelled here rather than derived
+    because `_FRAME_IDENTITY` is a promise about what reaches a tmux ``-e`` — world-readable
+    argv — and the profile deliberately never joins it: `frame/launcher.environment` sets it
+    at the `exec` instead. A variable guarded by a list it must never be on would be a
+    guard that quietly stopped guarding the day somebody honoured the promise.
+
+    `commands_frame._FRAME_IDENTITY` already exists to answer exactly
     "which variables must be THIS session's rather than whichever launcher happened to
     start the shared tmux server", and its own docstring commits the next such variable to
     that list — so a variable added there is guarded here on the same commit. The terminal
@@ -206,7 +214,7 @@ def _loud_names() -> frozenset[str]:
     from charter import commands_frame, session
     return frozenset(commands_frame._FRAME_IDENTITY
                      + session._PANE_ID_VARS + session._WINDOW_ID_VARS
-                     + ("TMUX", "CLAUDE_CODE_SESSION_ID"))
+                     + ("TMUX", "CLAUDE_CODE_SESSION_ID", "CHARTER_HARNESS_PROFILE"))
 
 
 _SCRUB_NAMES: frozenset[str] = frozenset()

--- a/tests/_isolation.py
+++ b/tests/_isolation.py
@@ -12,6 +12,7 @@ import io
 import json
 import os
 import shutil
+import subprocess
 import sys
 import tempfile
 import unittest
@@ -21,7 +22,7 @@ from unittest import mock
 
 from charter import config, instance, persona, root
 
-from . import _envguard
+from . import _envguard, _gitguard
 
 #: Snapshotted so a test can still hand-patch one value; `config.DERIVED` is the source
 #: of truth for WHICH values exist, so a setting added to `config.derive` is isolated the
@@ -335,6 +336,58 @@ def point_config_at(case, root: Path) -> Path:
     """
     case.addCleanup(config.restore, config.use(root))
     return root
+
+
+#: What most profile fixtures want in `charter.local.toml`: one profile whose `env` names a
+#: path under `~`, because expanding that at the `exec` is the launcher's own job, and one
+#: of another kind, because "a profile is a way to run ONE kind" is a rule with two sides.
+DECLARED_PROFILES = """
+[harness.claude-work]
+kind = "claude"
+command = ["claude"]
+env = { CLAUDE_CONFIG_DIR = "~/.cw" }
+
+[harness.codex-pinned]
+kind = "codex"
+command = ["npx", "-y", "@openai/codex@0.140.0"]
+"""
+
+
+def declare_profiles(case, text: str = DECLARED_PROFILES) -> Path:
+    """Give *case*'s throwaway plane a `charter.local.toml` git would not carry. Its path.
+
+    Four things a profile fixture needs, and every one of them is a trap by itself — which
+    is why they are one helper rather than four copies:
+
+    * **the file**, which is the only place a profile may be declared;
+    * **a real git repository with the ignore line**, because `profiles.ignore_check` makes
+      a real `git --no-optional-locks status` — the one subprocess profile code runs — and
+      a declared profile is refused wherever git would carry that file. A fixture that
+      skipped it would be testing the refusal, not the profile;
+    * **`$GIT_CEILING_DIRECTORIES`**, so that walk stops above the plane. A temp directory
+      inside somebody's own checkout otherwise answers for THEIR repository: green here,
+      red on the machine next door, which is the shape `CONTRIBUTING.md` calls "your
+      machine is not the runner";
+    * **`$HOME`**, so a test asserting where `CLAUDE_CONFIG_DIR = "~/.cw"` expanded to can
+      name the answer instead of running the same `expanduser` the code did and agreeing
+      with itself. It is `case.home` afterwards.
+
+    `make_plane(case)` first: profiles are read off a plane, and `instance.load` wants the
+    marker.
+    """
+    home = case.tmp / "home"
+    home.mkdir(exist_ok=True)
+    case.home = home
+    case.enterContext(mock.patch.dict(os.environ, {
+        "HOME": str(home),
+        "GIT_CEILING_DIRECTORIES": str(Path(case.tmp).resolve().parent),
+    }))
+    local = config.ROOT / "charter.local.toml"
+    local.write_text(text)
+    (config.ROOT / ".gitignore").write_text("/charter.local.toml\n")
+    subprocess.run(["git", "-C", str(config.ROOT), "init", "-q"], check=True,
+                   capture_output=True, env={**os.environ, **_gitguard.environment()})
+    return local
 
 
 def isolate_state_dir(case) -> Path:

--- a/tests/test_a_background_chat_really_starts_on_its_brief.py
+++ b/tests/test_a_background_chat_really_starts_on_its_brief.py
@@ -44,11 +44,14 @@ import termios
 import time
 import unittest
 from contextlib import ExitStack
+from pathlib import Path
 from unittest import mock
 
 from charter import commands_frame, config
 from charter.frame import layout, state, tmuxctl
-from charter.harness import claude_code
+
+#: This checkout, for the `$PYTHONPATH` the pane's own launcher needs — see `setUp`.
+_REPO_ROOT = Path(__file__).resolve().parents[1]
 
 from tests import _tmuxreap, _tmuxsocket
 from tests._isolation import PersonaIso, make_plane, no_update_check_in
@@ -105,7 +108,14 @@ class _TwoChatsOnARealServer(PersonaIso):
         self.tmux_logs.mkdir()
         self.records = self.tmp / "records"
         self.records.mkdir()
-        self.recorder = self.tmp / "claude-recorder"
+        # **The recorder IS `claude`, first on the `PATH` the tmux client is started
+        # with.** Patching `ClaudeCodeHarness.binary` used to decide what ran in the pane;
+        # since profiles it decides nothing there, because the pane's first process is
+        # charter's own launcher and it resolves the profile's command in ITS process, out
+        # of reach of any patch this one makes.
+        bindir = self.tmp / "bin"
+        bindir.mkdir()
+        self.recorder = bindir / "claude"
         self.recorder.write_text(
             f"#!{sys.executable}\n"
             "import json, os, sys, time\n"
@@ -116,8 +126,20 @@ class _TwoChatsOnARealServer(PersonaIso):
             "os.replace(p + '.tmp', p)\n"
             "time.sleep(120)\n")
         self.recorder.chmod(0o755)
-        server_env = dict(os.environ, RECORD_DIR=str(self.records),
-                          CHARTER_ROOT=str(config.ROOT))
+        # `$PYTHONPATH` because the pane's launcher is a real `python -P -m charter` child
+        # and `-P` keeps its own cwd — a workspace directory — off `sys.path` (#390): it
+        # would not find the charter under test at all, and a launcher that cannot start
+        # takes its window with it. Stated on THIS process's environment as well as on the
+        # server's, because a pane's `$PATH` comes from the tmux CLIENT (measured) while
+        # the rest of its environment comes from the server.
+        self.enterContext(mock.patch.dict(os.environ, {
+            "PATH": f"{bindir}{os.pathsep}{os.environ.get('PATH', '')}",
+            "RECORD_DIR": str(self.records),
+            "CHARTER_ROOT": str(config.ROOT),
+            "PYTHONPATH": os.pathsep.join(
+                [str(_REPO_ROOT), os.environ.get("PYTHONPATH", "")]).rstrip(os.pathsep),
+        }))
+        server_env = dict(os.environ)
         #: Each workspace's recorded chat pane.
         self.panes: dict[str, str] = {}
         for ws in ("alpha", "beta"):
@@ -173,8 +195,7 @@ class _TwoChatsOnARealServer(PersonaIso):
 
     def _stand_ins(self) -> list:
         """Everything an open runs with here beyond the real launcher and the real tmux."""
-        return [mock.patch.object(claude_code.ClaudeCodeHarness, "binary", str(self.recorder)),
-                mock.patch.object(commands_frame, "_spawn_gather"),
+        return [mock.patch.object(commands_frame, "_spawn_gather"),
                 mock.patch("sys.stdout.isatty", return_value=True),
                 mock.patch("sys.stdin.isatty", return_value=False)]
 

--- a/tests/test_a_chat_carries_its_profile.py
+++ b/tests/test_a_chat_carries_its_profile.py
@@ -27,14 +27,7 @@ from unittest import mock
 from charter import commands_frame, config
 from charter.frame import chats, choose, launcher, leave, reopen as reopen_state, state
 from tests import _gitguard
-from tests._isolation import PersonaIso, make_plane
-
-_LOCAL = """
-[harness.claude-work]
-kind = "claude"
-command = ["claude"]
-env = { CLAUDE_CONFIG_DIR = "~/.cw" }
-"""
+from tests._isolation import PersonaIso, declare_profiles, make_plane
 
 
 #: The real `subprocess.run`, captured before any fixture below patches the module
@@ -77,11 +70,9 @@ class _APressInAlpha(PersonaIso):
             {"PATH": os.environ.get("PATH", ""),
              "GIT_CEILING_DIRECTORIES": str(self.tmp.resolve().parent),
              "CHARTER_ROOT": str(config.ROOT), **_gitguard.environment()}, clear=True))
-        self.local = config.ROOT / "charter.local.toml"
-        self.local.write_text(_LOCAL)
-        (config.ROOT / ".gitignore").write_text("/charter.local.toml\n")
-        subprocess.run(["git", "-C", str(config.ROOT), "init", "-q"], check=True,
-                       capture_output=True, env={**os.environ, **_gitguard.environment()})
+        # After the clearing patch above, so its `$HOME` and `$GIT_CEILING_DIRECTORIES`
+        # survive: a declared profile's launch asks git whether this file is ignored.
+        self.local = declare_profiles(self)
         for ws in ("alpha", "beta"):
             (config.WORKSPACES_DIR / ws).mkdir(parents=True, exist_ok=True)
         _a_chat(self.FID, ws="alpha", profile="claude-work")
@@ -170,10 +161,35 @@ class ANewChatTakesThePressersProfile(_APressInAlpha, unittest.TestCase):
     def test_a_chat_whose_profile_is_gone_is_refused_not_given_the_default(self):
         """Ruling 15's reason, one surface over: another profile may be another account."""
         _a_chat(self.FID, ws="alpha", profile="gone")
-        self.local.write_text(_LOCAL + '\n[harness]\ndefault = "claude"\n')
+        self.local.write_text(self.local.read_text()
+                              + '\n[harness]\ndefault = "claude"\n')
         self._press()
         self.assertEqual(self.launched, [])
         self.assertTrue(any("no longer declares" in s for s in self._sentences()),
+                        self._sentences())
+
+    def test_the_gone_profiles_name_is_repeated_back_escaped(self):
+        """The record is a file under `.charter/`, not something charter minted this run —
+        and this sentence goes to the frame, where an ESC would repaint the line around it.
+        (A `\\r` cannot make the trip: `read_text` translates it to `\\n` on the way back,
+        which is a fact about the record and not about the containment.)"""
+        _a_chat(self.FID, ws="alpha", profile="go\x1bne")
+        self._press()
+        self.assertEqual(self.launched, [])
+        self.assertTrue(any("\\u001b" in s for s in self._sentences()),
+                        self._sentences())
+
+    def test_a_chat_from_before_profiles_says_why_its_kinds_profile_was_refused(self):
+        """Rung 2, and ruling 37 on the way down it: the built-in named after this chat's
+        kind is one the file replaced and charter refused, so the press says THAT reason
+        rather than running the command the operator replaced. Losing the reason here is
+        the silent half — a `+` that does nothing, with nothing said about why."""
+        self.local.write_text('[harness.codex]\nkind = "codex"\ncommand = "codex --x"\n')
+        _a_chat(self.FID, ws="alpha", harness="codex")
+        (config.STATE_DIR / "frame" / self.FID / "profile").unlink(missing_ok=True)
+        self._press()
+        self.assertEqual(self.launched, [])
+        self.assertTrue(any("never a shell string" in s for s in self._sentences()),
                         self._sentences())
 
     def test_with_no_record_and_no_default_the_press_is_refused_by_name(self):
@@ -255,6 +271,22 @@ class AHandoffTakesTheCallingChatsProfile(_APressInAlpha, unittest.TestCase):
         directory, a window or a first message exists anywhere."""
         self.assertIn("cannot yet ask before a declared command runs", self._refusal())
 
+    def test_a_profile_whose_kind_this_charter_cannot_place_is_refused_not_raised(self):
+        """The guard `_same_harness_as` carried before profiles, restored.
+
+        Every profile names a kind this charter registers, so nothing reachable produces
+        this — but `_harness_of` is typed `| None`, and what is on the other side of a
+        missing guard here is an `AttributeError` inside a process whose three streams are
+        `/dev/null`: a handoff that answers nothing at all, to a caller waiting for a
+        sentence. It fails closed, in the words this refusal already has."""
+        # Task 2's own B1 refusal comes earlier in the chain and would answer this case for
+        # a reason it is not about.
+        self._no_approval_needed()
+        with mock.patch.object(commands_frame, "_harness_of", return_value=None):
+            said = self._refusal()
+        self.assertIn("cannot open a chat in 'beta'", said)
+        self.assertIn("no profile this charter can launch", said)
+
     def test_a_handoff_from_a_chat_whose_profile_is_gone_is_refused(self):
         _a_chat(self.FID, ws="alpha", profile="gone")
         self.assertIn("no longer declares", self._refusal())
@@ -316,10 +348,7 @@ class AReopenNeverSubstitutes(PersonaIso, unittest.TestCase):
             {"PATH": os.environ.get("PATH", ""),
              "GIT_CEILING_DIRECTORIES": str(self.tmp.resolve().parent),
              "CHARTER_ROOT": str(config.ROOT), **_gitguard.environment()}, clear=True))
-        (config.ROOT / "charter.local.toml").write_text(_LOCAL)
-        (config.ROOT / ".gitignore").write_text("/charter.local.toml\n")
-        subprocess.run(["git", "-C", str(config.ROOT), "init", "-q"], check=True,
-                       capture_output=True, env={**os.environ, **_gitguard.environment()})
+        self.local = declare_profiles(self)
         (config.WORKSPACES_DIR / "alpha").mkdir(parents=True, exist_ok=True)
         self.launched: list = []
         self.enterContext(mock.patch.object(launcher, "_approval_refusal",
@@ -368,12 +397,28 @@ class AReopenNeverSubstitutes(PersonaIso, unittest.TestCase):
     def test_a_chat_whose_kind_is_unregistered_is_skipped_not_moved_to_the_default(self):
         """This replaces the case that pinned the `[harness] default` fallback: a chat is
         never reopened under something nobody chose."""
-        (config.ROOT / "charter.local.toml").write_text(
-            _LOCAL + '\n[harness]\ndefault = "claude"\n')
+        self.local.write_text(self.local.read_text()
+                              + '\n[harness]\ndefault = "claude"\n')
         r, said = self._reopen(self._chat(harness="zzz", profile=""))
         self.assertIsNone(r)
         self.assertEqual(self.launched, [])
         self.assertNotIn("reopening it under", said)
+
+    def test_a_chat_with_no_profile_to_name_asks_the_file_nothing(self):
+        """A chat that never had a profile, whose kind nothing registers, has no NAME to
+        resolve — so the file is not asked, and this chat is skipped under its own kind.
+
+        `[harness.""]` is what makes that visible rather than merely tidy: TOML allows the
+        empty key, charter refuses it for its shape, and the refusal is filed under the
+        empty name. A resolve that ran anyway would find it and report somebody else's bad
+        line as the reason this chat did not come back — sending the operator to fix a
+        profile the manifest never mentions.
+        """
+        self.local.write_text('[harness.""]\nkind = "claude"\ncommand = ["claude"]\n')
+        r, said = self._reopen(self._chat(harness="zzz", profile=""))
+        self.assertIsNone(r)
+        self.assertEqual(self.launched, [])
+        self.assertIn("zzz", said)
 
     def test_a_chat_from_before_profiles_comes_back_on_its_kinds_built_in(self):
         r, _said = self._reopen(self._chat(profile=""))
@@ -392,6 +437,58 @@ class AReopenNeverSubstitutes(PersonaIso, unittest.TestCase):
         left = reopen_state.read().all_chats()
         self.assertEqual([c.chat for c in left], ["alpha.2"])
         self.assertEqual(left[0].profile, "gone")
+
+
+class TheTwoRecordsAChatsLauncherWrites(PersonaIso, unittest.TestCase):
+    """`state.record_profile` and `state.record_launch` — what the pane writes down, read
+    back by the launch that opened it and by every later `+`, tab, quit and reopen.
+
+    **A chat id is not charter's to trust.** It reaches these four functions from
+    `$CHARTER_SESSION_ID` as often as from `frame_id`, so `frame_dir` answers `None` for one
+    that names no directory under the state root — and `None` has to be handled here rather
+    than raised out of a hook that cannot afford it. A test that only ever passes a
+    well-formed id measures none of that: the writes are `try`-wrapped and would look
+    identical.
+    """
+
+    #: `contain.child` refuses it, so `frame_dir` has no directory to answer with. Written
+    #: as the id an inherited `$CHARTER_SESSION_ID` could really carry.
+    NOT_A_CHAT = "../elsewhere"
+
+    def setUp(self) -> None:
+        super().setUp()
+        make_plane(self)
+
+    def test_a_chat_id_that_names_no_directory_is_written_nowhere(self):
+        state.record_profile(self.NOT_A_CHAT, "claude-work")
+        state.record_launch(self.NOT_A_CHAT, 3, "refused")
+        self.assertIsNone(state.profile(self.NOT_A_CHAT))
+        self.assertIsNone(state.launch(self.NOT_A_CHAT))
+        # And nothing was written beside the state root under that name either.
+        self.assertEqual(list((config.STATE_DIR / "frame").glob("*elsewhere*")), [])
+
+    def test_a_refusal_of_several_lines_comes_back_whole(self):
+        """The record is `<code>\\n<text>`, and the text is a refusal that may carry its own
+        newline — `press Enter to close this chat.` is a second line of one. Only the FIRST
+        newline separates the two fields; every later one belongs to the sentence."""
+        state.record_launch("alpha.1", 3, "profile 'x' is refused\n  press Enter.\n")
+        self.assertEqual(state.launch("alpha.1"),
+                         (3, "profile 'x' is refused\n  press Enter.\n"))
+
+    def test_a_half_written_record_is_read_as_no_answer_yet(self):
+        """The launcher writes this file while the launch that opened the chat is reading
+        it, and a hand edit is always possible. A code that is not a number is not a
+        verdict — and "not yet" is the reading that lets the launch carry on."""
+        state.record_launch("alpha.1", 0, "")
+        d = state.frame_dir("alpha.1")
+        (d / "launch").write_text("not-a-number\nhalf a sentence")
+        self.assertIsNone(state.launch("alpha.1"))
+
+    def test_a_launch_that_has_not_answered_yet_says_so(self):
+        state.frame_dir("alpha.1", create=True)
+        self.assertIsNone(state.launch("alpha.1"))
+        state.record_launch("alpha.1")
+        self.assertEqual(state.launch("alpha.1"), (0, ""))
 
 
 class WhereTheHarnessWasShownTheProfileIs(PersonaIso, unittest.TestCase):

--- a/tests/test_a_chat_carries_its_profile.py
+++ b/tests/test_a_chat_carries_its_profile.py
@@ -484,6 +484,20 @@ class TheTwoRecordsAChatsLauncherWrites(PersonaIso, unittest.TestCase):
         (d / "launch").write_text("not-a-number\nhalf a sentence")
         self.assertIsNone(state.launch("alpha.1"))
 
+    def test_a_record_that_cannot_be_written_is_not_raised_out_of_a_hook(self):
+        """**A disk that is full is not this function's to report.** Both writers are
+        reached from a launcher mid-`exec` and from hook paths that have nowhere to print,
+        and the caller's own answer to "the record is missing" is already "not yet" — which
+        is exactly what a write that failed leaves behind. So the failure is swallowed
+        HERE, and the reader above is what says so."""
+        state.frame_dir("alpha.1", create=True)
+        with mock.patch.object(state.config, "replace_for",
+                               side_effect=OSError(28, "No space left on device")):
+            state.record_profile("alpha.1", "claude-work")
+            state.record_launch("alpha.1", 3, "refused")
+        self.assertIsNone(state.profile("alpha.1"))
+        self.assertIsNone(state.launch("alpha.1"))
+
     def test_a_launch_that_has_not_answered_yet_says_so(self):
         state.frame_dir("alpha.1", create=True)
         self.assertIsNone(state.launch("alpha.1"))

--- a/tests/test_a_chat_carries_its_profile.py
+++ b/tests/test_a_chat_carries_its_profile.py
@@ -1,0 +1,433 @@
+"""A chat keeps its profile through `+`, a workspace tab, a handoff, a quit and a reopen.
+
+Wherever charter showed a chat's harness it shows its profile, and wherever a press had to
+answer "which harness" without being told — the `+`, a tab, a chat handed off by another
+chat — the answer is the profile the chat it was pressed from is running. `CHARTER_HARNESS`
+stays the KIND underneath, because hooks compare it to `claude-code`.
+
+**A reopen never substitutes** (ruling 15). A chat whose profile is gone is skipped with a
+line naming it and stays in the manifest for a retry, rather than being given another: a
+profile may be another account, where the chat's resume id does not exist and its
+workspace's code was never meant to go. The `[harness] default` fallback that used to move
+such a chat is deleted here, and the two tests that pinned it are rewritten.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import os
+import subprocess
+import unittest
+from contextlib import redirect_stderr
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
+
+from charter import commands_frame, config
+from charter.frame import chats, choose, launcher, leave, reopen as reopen_state, state
+from tests import _gitguard
+from tests._isolation import PersonaIso, make_plane
+
+_LOCAL = """
+[harness.claude-work]
+kind = "claude"
+command = ["claude"]
+env = { CLAUDE_CONFIG_DIR = "~/.cw" }
+"""
+
+
+#: The real `subprocess.run`, captured before any fixture below patches the module
+#: attribute — see `_APressInAlpha._tmux` for what that patch really reaches.
+_REAL_RUN = subprocess.run
+
+
+def _completed(cmd, rc=0, out=""):
+    return subprocess.CompletedProcess(list(cmd), rc, out, "")
+
+
+def _a_chat(fid: str, *, ws: str, profile: str | None = None,
+            harness: str = "claude-code", pane: str | None = "%1") -> None:
+    """A chat directory on this plane, in the shape a launcher leaves one.
+
+    *harness* is `$CHARTER_HARNESS` as the launch records it — `harness.base.name`, not the
+    CLI word — and *profile* the record this task adds beside it.
+    """
+    state.frame_dir(fid, create=True)
+    state.record_workspace(fid, ws)
+    state.record_server(fid, commands_frame.SOCKET)
+    state.record_identity(fid, {"CHARTER_HARNESS": harness})
+    if profile is not None:
+        state.record_profile(fid, profile)
+    if pane is not None:
+        state.record_harness_pane(fid, pane)
+
+
+class _APressInAlpha(PersonaIso):
+    """One chat in `alpha`, a fake launcher and a fake tmux — `test_the_chat_bars_plus_makes
+    _a_chat.py`'s own fixture, with a profile on the chat."""
+
+    FID = "alpha.1"
+
+    def setUp(self) -> None:
+        super().setUp()
+        make_plane(self)
+        self.enterContext(mock.patch.dict(
+            os.environ,
+            {"PATH": os.environ.get("PATH", ""),
+             "GIT_CEILING_DIRECTORIES": str(self.tmp.resolve().parent),
+             "CHARTER_ROOT": str(config.ROOT), **_gitguard.environment()}, clear=True))
+        self.local = config.ROOT / "charter.local.toml"
+        self.local.write_text(_LOCAL)
+        (config.ROOT / ".gitignore").write_text("/charter.local.toml\n")
+        subprocess.run(["git", "-C", str(config.ROOT), "init", "-q"], check=True,
+                       capture_output=True, env={**os.environ, **_gitguard.environment()})
+        for ws in ("alpha", "beta"):
+            (config.WORKSPACES_DIR / ws).mkdir(parents=True, exist_ok=True)
+        _a_chat(self.FID, ws="alpha", profile="claude-work")
+        self.said = self.enterContext(
+            mock.patch("charter.commands_frame._say_on_screen"))
+        self.launched: list = []
+
+    def _no_approval_needed(self) -> None:
+        """Task 2 refuses every declared profile (review B1), and these cases are about
+        which profile is CARRIED. The two that are about the refusal reaching the presser do
+        not stand it down."""
+        self.enterContext(mock.patch.object(launcher, "_approval_refusal",
+                                            return_value=None))
+
+    def _tmux(self, cmd, **kw):
+        """Answer the two tmux questions a press asks, and let everything else through.
+
+        **`commands_frame.subprocess` IS the `subprocess` module**, so patching
+        `charter.commands_frame.subprocess.run` replaces that attribute for the whole
+        process — `charter.util.run` included. A fake that answered every command would
+        therefore answer the profile ignore check's `git status` with rc 0 and no output,
+        which `util.git_path_state` reads as *git tracks this file*: every profile in it
+        refused, in a fixture that set out to describe the opposite.
+        """
+        if not cmd or cmd[0] != "tmux":
+            return _REAL_RUN(cmd, **kw)
+        if "display-message" in cmd:
+            if "window_width" in cmd[-1]:
+                return _completed(cmd, 0, "132:43")
+            return _completed(cmd, 0, "$1\t@1")
+        if "list-panes" in cmd:
+            return _completed(cmd, 0, f"$1\t%1\t{config.STATE_DIR}\n")
+        return _completed(cmd, 0)
+
+    def _press(self, *, rc: int = 0):
+        def fake_launch(args):
+            self.launched.append(args)
+            return rc
+
+        with mock.patch("charter.commands_frame.subprocess.run", side_effect=self._tmux), \
+                mock.patch("charter.commands_frame.cmd_launch", side_effect=fake_launch):
+            return commands_frame.cmd_new_chat(mock.Mock(chat=self.FID))
+
+    def _sentences(self) -> list[str]:
+        return [c[0][1] for c in self.said.call_args_list]
+
+
+class ANewChatTakesThePressersProfile(_APressInAlpha, unittest.TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self._no_approval_needed()
+        # **The profile's command is on `PATH`, said rather than inherited.** These cases
+        # name `codex` as well as `claude`, and a press now runs the launcher's own checks
+        # before it launches — so on a machine without codex installed (CI is one; the
+        # machine this was written on is not) every one of them would be refused for a
+        # reason none of them is about. `charter.commands_frame.shutil` is the `shutil`
+        # module, so this is the answer the launcher's own check gets too.
+        self.enterContext(mock.patch("charter.commands_frame.shutil.which",
+                                     return_value="/nowhere/harness"))
+
+    def test_the_plus_launches_the_profile_this_chat_records(self):
+        self._press()
+        self.assertEqual(len(self.launched), 1, self._sentences())
+        self.assertEqual(self.launched[0].harness, "claude")
+        self.assertEqual(self.launched[0].profile, "claude-work")
+
+    def test_a_chat_from_before_profiles_takes_the_built_in_of_its_kind(self):
+        _a_chat(self.FID, ws="alpha", harness="codex")
+        (config.STATE_DIR / "frame" / self.FID / "profile").unlink(missing_ok=True)
+        self._press()
+        self.assertEqual(self.launched[0].profile, "codex")
+
+    def test_a_declared_replacement_of_the_built_in_is_what_that_chat_gets(self):
+        """A command that really resolves, because the launcher's PATH guard runs here for
+        real: a replacement pinning a path this machine does not have is a different case
+        (`…refused_before_tmux`), and it would pass this one for the wrong reason."""
+        self.local.write_text('[harness.codex]\nkind = "codex"\n'
+                              'command = ["/bin/sh"]\n')
+        _a_chat(self.FID, ws="alpha", harness="codex")
+        (config.STATE_DIR / "frame" / self.FID / "profile").unlink(missing_ok=True)
+        self._press()
+        self.assertEqual(self.launched[0].profile, "codex")
+        from charter import profiles
+        self.assertEqual(profiles.current().profiles["codex"].command, ("/bin/sh",))
+
+    def test_a_chat_whose_profile_is_gone_is_refused_not_given_the_default(self):
+        """Ruling 15's reason, one surface over: another profile may be another account."""
+        _a_chat(self.FID, ws="alpha", profile="gone")
+        self.local.write_text(_LOCAL + '\n[harness]\ndefault = "claude"\n')
+        self._press()
+        self.assertEqual(self.launched, [])
+        self.assertTrue(any("no longer declares" in s for s in self._sentences()),
+                        self._sentences())
+
+    def test_with_no_record_and_no_default_the_press_is_refused_by_name(self):
+        _a_chat(self.FID, ws="alpha", harness="zzz-nothing")
+        (config.STATE_DIR / "frame" / self.FID / "profile").unlink(missing_ok=True)
+        self.local.write_text("")
+        self._press()
+        self.assertEqual(self.launched, [])
+        self.assertTrue(any("no profile" in s for s in self._sentences()),
+                        self._sentences())
+
+
+class APressThatCannotLaunchSaysWhyOnTheFrame(_APressInAlpha, unittest.TestCase):
+    """`cmd_new_chat` runs detached with its three streams on `/dev/null`, so a refusal
+    `_launch` printed is read by nobody: without this the `+` would report only "the
+    launcher returned 3" for a profile the operator could have fixed. Review B1 makes this
+    reachable today — every declared profile is refused until Task 3."""
+
+    def test_the_press_says_the_launchers_own_refusal(self):
+        self._press()
+        self.assertEqual(self.launched, [])
+        self.assertTrue(any("cannot yet ask before a declared command runs" in s
+                            for s in self._sentences()), self._sentences())
+
+
+class AWorkspaceTabOpensTheSameProfile(_APressInAlpha, unittest.TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self._no_approval_needed()
+
+    def _open(self):
+        def fake_launch(args):
+            self.launched.append(args)
+            return 0
+
+        with mock.patch("charter.commands_frame.subprocess.run", side_effect=self._tmux), \
+                mock.patch("charter.commands_frame.cmd_launch", side_effect=fake_launch), \
+                mock.patch.object(commands_frame, "_live_sessions", return_value=set()), \
+                mock.patch.object(commands_frame, "_plane_session",
+                                  return_value=("$1", "beta.1")), \
+                mock.patch.object(commands_frame, "_window_size", return_value=(120, 40)):
+            return commands_frame._open_workspace(self.FID, "beta",
+                                                  socket=commands_frame.SOCKET,
+                                                  window="@1")
+
+    def test_a_workspace_tab_opens_the_profile_the_presser_is_running(self):
+        self._open()
+        self.assertEqual(len(self.launched), 1, self._sentences())
+        self.assertEqual(self.launched[0].profile, "claude-work")
+        self.assertEqual(self.launched[0].harness, "claude")
+
+
+class AHandoffTakesTheCallingChatsProfile(_APressInAlpha, unittest.TestCase):
+    def _refusal(self, ws: str = "beta") -> str:
+        with mock.patch("charter.commands_frame.subprocess.run", side_effect=self._tmux), \
+                mock.patch.object(commands_frame, "_live_sessions", return_value=set()), \
+                mock.patch.object(commands_frame, "_plane_session",
+                                  return_value=("$1", "beta.1")):
+            return commands_frame.background_refusal(ws, caller=self.FID,
+                                                     first_message="fix the widget please")
+
+    def test_a_handoff_takes_the_calling_chats_profile(self):
+        self._no_approval_needed()
+        self.assertEqual(self._refusal(), "")
+        with mock.patch("charter.commands_frame.subprocess.run", side_effect=self._tmux), \
+                mock.patch.object(commands_frame, "_live_sessions", return_value=set()), \
+                mock.patch.object(commands_frame, "_plane_session",
+                                  return_value=("$1", "beta.1")), \
+                mock.patch.object(commands_frame, "_window_size", return_value=(120, 40)), \
+                mock.patch("charter.commands_frame.cmd_launch",
+                           side_effect=lambda args: self.launched.append(args)):
+            commands_frame.open_in_background("beta", caller=self.FID,
+                                              first_message="fix the widget please")
+        self.assertEqual(self.launched[0].profile, "claude-work")
+        self.assertEqual(self.launched[0].harness, "claude")
+
+    def test_a_handoff_to_a_declared_profile_refuses_before_anything_is_written(self):
+        """Review B1: the refusal is the whole answer a handoff gets, before a chat
+        directory, a window or a first message exists anywhere."""
+        self.assertIn("cannot yet ask before a declared command runs", self._refusal())
+
+    def test_a_handoff_from_a_chat_whose_profile_is_gone_is_refused(self):
+        _a_chat(self.FID, ws="alpha", profile="gone")
+        self.assertIn("no longer declares", self._refusal())
+
+
+class TheRecordCarriesTheProfile(PersonaIso, unittest.TestCase):
+    """What a quit writes down, and what a reopen reads back. The key and the file name are
+    spelled literally: a round trip through charter's own writer and reader cannot pin a
+    name that both halves would rename together."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        make_plane(self)
+
+    def _doomed(self, **kw):
+        fields = dict(chat="alpha.1", workspace="alpha", persona="", harness="claude-code",
+                      cwd="", resume="", server=commands_frame.SOCKET, live=True,
+                      active=True, exit_code=None, closed=False, homeless=False,
+                      cwd_gone=False, cwd_outside=False, profile="claude-work")
+        return leave.Doomed(**{**fields, **kw})
+
+    def test_a_quit_records_each_chats_profile(self):
+        commands_frame._record_the_plane([self._doomed()], focus="alpha",
+                                         active={"alpha.1"}, windows={}, capture=False)
+        raw = json.loads((config.STATE_DIR / "frame" / "reopen.json").read_text())
+        (chat,) = raw["frames"][0]["chats"]
+        self.assertEqual(chat["profile"], "claude-work")
+
+    def test_a_manifest_written_before_profiles_reads_as_no_profile(self):
+        commands_frame._record_the_plane([self._doomed()], focus="alpha",
+                                         active=set(), windows={}, capture=False)
+        path = config.STATE_DIR / "frame" / "reopen.json"
+        raw = json.loads(path.read_text())
+        del raw["frames"][0]["chats"][0]["profile"]
+        path.write_text(json.dumps(raw))
+        self.assertEqual(reopen_state.read().all_chats()[0].profile, "")
+
+    def test_a_profile_that_is_not_text_reads_as_no_profile(self):
+        commands_frame._record_the_plane([self._doomed()], focus="alpha",
+                                         active=set(), windows={}, capture=False)
+        path = config.STATE_DIR / "frame" / "reopen.json"
+        raw = json.loads(path.read_text())
+        raw["frames"][0]["chats"][0]["profile"] = 3
+        path.write_text(json.dumps(raw))
+        self.assertEqual(reopen_state.read().all_chats()[0].profile, "")
+
+    def test_a_quit_reads_the_profile_off_the_chat_it_is_stopping(self):
+        _a_chat("alpha.1", ws="alpha", profile="claude-work")
+        plan = leave.plan(live={"alpha.1"}, focus="alpha")
+        self.assertEqual(plan.chats[0].profile, "claude-work")
+
+
+class AReopenNeverSubstitutes(PersonaIso, unittest.TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        make_plane(self)
+        self.enterContext(mock.patch.dict(
+            os.environ,
+            {"PATH": os.environ.get("PATH", ""),
+             "GIT_CEILING_DIRECTORIES": str(self.tmp.resolve().parent),
+             "CHARTER_ROOT": str(config.ROOT), **_gitguard.environment()}, clear=True))
+        (config.ROOT / "charter.local.toml").write_text(_LOCAL)
+        (config.ROOT / ".gitignore").write_text("/charter.local.toml\n")
+        subprocess.run(["git", "-C", str(config.ROOT), "init", "-q"], check=True,
+                       capture_output=True, env={**os.environ, **_gitguard.environment()})
+        (config.WORKSPACES_DIR / "alpha").mkdir(parents=True, exist_ok=True)
+        self.launched: list = []
+        self.enterContext(mock.patch.object(launcher, "_approval_refusal",
+                                            return_value=None))
+
+    def _chat(self, **kw):
+        fields = dict(chat="alpha.1", workspace="alpha", persona="", harness="claude-code",
+                      cwd="", resume="", transcript="", active=True, profile="claude-work")
+        return reopen_state.Chat(**{**fields, **kw})
+
+    def _reopen(self, c):
+        def fake_launch(args):
+            self.launched.append(args)
+            args.reopening.fid = "alpha.1"
+            return 0
+
+        err = io.StringIO()
+        with redirect_stderr(err), \
+                mock.patch("charter.commands_frame.cmd_launch", side_effect=fake_launch):
+            r = commands_frame._reopen_one(c)
+        return r, err.getvalue()
+
+    def test_a_chat_comes_back_on_its_own_profile(self):
+        r, _said = self._reopen(self._chat())
+        self.assertIsNotNone(r)
+        self.assertEqual(self.launched[0].profile, "claude-work")
+        self.assertEqual(self.launched[0].harness, "claude")
+
+    def test_a_chat_whose_profile_is_gone_is_skipped_with_its_name(self):
+        r, said = self._reopen(self._chat(profile="gone"))
+        self.assertIsNone(r)
+        self.assertEqual(self.launched, [])
+        self.assertIn("gone", said)
+        self.assertIn("charter reopen", said)
+
+    def test_a_chat_whose_profile_is_refused_says_the_refusal_rather_than_gone(self):
+        """Declared and refused is not the same fact as no longer declared, and the two
+        remedies differ: one is a line to fix, the other a profile to declare again."""
+        (config.ROOT / "charter.local.toml").write_text(
+            '[harness.claude-work]\nkind = "claude"\ncommand = "claude -x"\n')
+        r, said = self._reopen(self._chat())
+        self.assertIsNone(r)
+        self.assertIn("never a shell string", said)
+        self.assertNotIn("no longer declares", said)
+
+    def test_a_chat_whose_kind_is_unregistered_is_skipped_not_moved_to_the_default(self):
+        """This replaces the case that pinned the `[harness] default` fallback: a chat is
+        never reopened under something nobody chose."""
+        (config.ROOT / "charter.local.toml").write_text(
+            _LOCAL + '\n[harness]\ndefault = "claude"\n')
+        r, said = self._reopen(self._chat(harness="zzz", profile=""))
+        self.assertIsNone(r)
+        self.assertEqual(self.launched, [])
+        self.assertNotIn("reopening it under", said)
+
+    def test_a_chat_from_before_profiles_comes_back_on_its_kinds_built_in(self):
+        r, _said = self._reopen(self._chat(profile=""))
+        self.assertIsNotNone(r)
+        self.assertEqual(self.launched[0].profile, "claude")
+
+    def test_a_skipped_chat_is_still_recorded_for_a_retry(self):
+        """`_consume` keeps what did not come back, so declaring the profile again and
+        running `charter reopen` brings it back."""
+        kept = self._chat(chat="alpha.2", profile="gone")
+        m = reopen_state.Manifest(
+            at=0, focus="alpha",
+            frames=(reopen_state.Frame(workspace="alpha", chats=(self._chat(), kept)),))
+        with redirect_stderr(io.StringIO()):
+            commands_frame._consume(m, {"alpha.1"})
+        left = reopen_state.read().all_chats()
+        self.assertEqual([c.chat for c in left], ["alpha.2"])
+        self.assertEqual(left[0].profile, "gone")
+
+
+class WhereTheHarnessWasShownTheProfileIs(PersonaIso, unittest.TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        make_plane(self)
+
+    def _doomed(self, **kw):
+        fields = dict(chat="alpha.1", workspace="alpha", persona="", harness="claude-code",
+                      cwd="", resume="", server=commands_frame.SOCKET, live=True,
+                      active=True, exit_code=None, closed=False, homeless=False,
+                      cwd_gone=False, cwd_outside=False, profile="claude-work")
+        return leave.Doomed(**{**fields, **kw})
+
+    def test_a_quit_row_names_the_profile(self):
+        self.assertEqual(leave.title(self._doomed()), "alpha.1 · claude-work")
+
+    def test_a_chat_row_from_before_profiles_still_names_its_harness(self):
+        self.assertEqual(leave.title(self._doomed(profile="")), "alpha.1 · claude-code")
+
+    def test_a_chat_that_says_nothing_at_all_is_its_own_id(self):
+        self.assertEqual(leave.title(self._doomed(profile="", harness="")), "alpha.1")
+
+    def test_the_chat_pickers_note_names_the_profile(self):
+        _a_chat("alpha.1", ws="alpha", profile="claude-work")
+        self.assertEqual(choose._note(choose.CHAT, "alpha.1"), "claude-work")
+
+    def test_a_chat_from_before_profiles_still_notes_its_harness(self):
+        _a_chat("alpha.1", ws="alpha")
+        self.assertEqual(choose._note(choose.CHAT, "alpha.1"), "claude-code")
+
+    def test_the_profile_a_chat_records_is_what_chats_reports(self):
+        _a_chat("alpha.1", ws="alpha", profile="claude-work")
+        self.assertEqual(chats.profile_of("alpha.1"), "claude-work")
+        self.assertEqual(chats.profile_of("alpha.2"), "")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_a_chat_opens_in_the_background_with_its_first_message.py
+++ b/tests/test_a_chat_opens_in_the_background_with_its_first_message.py
@@ -59,6 +59,16 @@ class _AChatInAlpha(PersonaIso, unittest.TestCase):
     def setUp(self):
         super().setUp()
         self.enterContext(mock.patch.dict(os.environ, {}, clear=True))
+        # **The profile's command is on `PATH`, said rather than inherited.** A handoff now
+        # runs the launcher's own checks before it writes anything (`background_refusal`),
+        # and the first of them asks `shutil.which`. This class clears the environment, and
+        # its cases run for `codex` and `opencode` as well as `claude`, so left to the real
+        # answer every one of them would be refused for a reason none of them is about —
+        # which profile a handoff takes, and what it refuses BEFORE anything is written.
+        # `charter.commands_frame.shutil` is the `shutil` module, so this is the answer the
+        # launcher gets too.
+        self.enterContext(mock.patch("charter.commands_frame.shutil.which",
+                                     return_value="/nowhere/harness"))
         for ws in ("alpha", "beta"):
             (config.WORKSPACES_DIR / ws).mkdir(parents=True, exist_ok=True)
         _a_chat(self.CALLER, ws="alpha")

--- a/tests/test_a_chat_pane_starts_as_charter_and_becomes_the_harness.py
+++ b/tests/test_a_chat_pane_starts_as_charter_and_becomes_the_harness.py
@@ -383,14 +383,20 @@ class ARefusalInsideTheOperatorsOwnTmux(_ARealChatOnARealServer, unittest.TestCa
                                             return_value=(self.op_path, session)))
 
     def test_the_launch_says_what_the_pane_refused(self):
+        """The sentence first, because it is the thing this path had no other copy of —
+        and the number second, with what was said in its message: the two halves fail for
+        different reasons, and a bare `1 != 3` said which half only by luck."""
         said: list[str] = []
         with mock.patch.object(commands_frame.util, "err", side_effect=said.append):
             rc = self._launch(profile="claude-work",
                               opening=commands_frame.Opening("fix the widget please"))
-        self.assertEqual(rc, launcher.REFUSED_EXIT)
         self.assertTrue(
             any("cannot yet ask before a declared command runs" in s for s in said),
             f"the launch did not say what the pane refused: {said}")
+        # The launcher's own number, not tmux's reading of a pane that is no longer there:
+        # in somebody else's tmux `#{pane_dead_status}` is empty or absent for exactly this
+        # pane, and both read as `_UNKNOWN_DEATH_CODE`.
+        self.assertEqual(rc, launcher.REFUSED_EXIT, said)
 
     def test_the_window_it_opened_is_taken_back(self):
         """A window the operator never asked for, holding a chat that never started, is not

--- a/tests/test_a_chat_pane_starts_as_charter_and_becomes_the_harness.py
+++ b/tests/test_a_chat_pane_starts_as_charter_and_becomes_the_harness.py
@@ -38,8 +38,8 @@ from charter import commands_frame, config
 from charter.frame import launcher, state, tmuxctl
 
 from tests import _gitguard, _tmuxreap, _tmuxsocket, _ttyguard
-from tests._isolation import PersonaIso, make_plane, no_background_refresh, \
-    no_update_check_in
+from tests._isolation import (PersonaIso, declare_profiles, make_plane,
+                              no_background_refresh, no_update_check_in)
 
 _HAS_TMUX = shutil.which("tmux") is not None
 
@@ -56,6 +56,9 @@ _SERVERS = itertools.count()
 #: happened.
 _REPO_ROOT = Path(__file__).resolve().parents[1]
 
+#: One declared profile whose command really resolves here: the recorder on this fixture's
+#: own `PATH` is `claude`, so what the pane refuses is the DECLARATION (review B1) rather
+#: than a command that was never going to run.
 _LOCAL = """
 [harness.claude-work]
 kind = "claude"
@@ -64,7 +67,7 @@ env = { CLAUDE_CONFIG_DIR = "~/.cw" }
 """
 
 
-def _await(predicate, timeout: float = 15.0) -> bool:
+def _eventually(predicate, timeout: float = 15.0) -> bool:
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:
         if predicate():
@@ -156,7 +159,7 @@ class _ARealChatOnARealServer(PersonaIso):
     def _harness(self) -> dict:
         """What the exec'd harness wrote down, once it has run."""
         record = self.records / "harness.json"
-        self.assertTrue(_await(record.is_file),
+        self.assertTrue(_eventually(record.is_file),
                         f"the harness never ran in the pane: {self._pane_text()}")
         return json.loads(record.read_text())
 
@@ -216,7 +219,7 @@ class ThePaneCharterStartsIsThePaneTheHarnessRunsIn(_ARealChatOnARealServer,
         fid = "beta.1"
         harness = self._harness()
         self.assertEqual(harness["env"].get("TMUX_PANE"), state.harness_pane(fid))
-        self.assertTrue(_await(lambda: fid in (commands_frame._live_chats(self.socket)
+        self.assertTrue(_eventually(lambda: fid in (commands_frame._live_chats(self.socket)
                                                or set())),
                         "the chat is not in the server's liveness list")
 
@@ -255,10 +258,10 @@ class TheHarnessExitCodeTravelsAsItDid(_ARealChatOnARealServer, unittest.TestCas
     def test_a_harness_exit_code_travels_as_it_did(self):
         self.assertEqual(self._launch(), 0)
         fid = "beta.1"
-        self.assertTrue(_await(lambda: state.exit_code(fid) == 7),
+        self.assertTrue(_eventually(lambda: state.exit_code(fid) == 7),
                         f"the exit code did not reach the chat's state: "
                         f"{state.exit_code(fid)!r}")
-        self.assertTrue(_await(lambda: fid not in self._tmux(
+        self.assertTrue(_eventually(lambda: fid not in self._tmux(
             "list-windows", "-a", "-F", "#{window_name}").stdout.split()),
             "the teardown hook did not close the window of a chat that ended")
 
@@ -276,10 +279,11 @@ class ARefusalInThePaneReachesTheOperator(_ARealChatOnARealServer, unittest.Test
 
     def setUp(self) -> None:
         super().setUp()
-        (config.ROOT / "charter.local.toml").write_text(_LOCAL)
-        (config.ROOT / ".gitignore").write_text("/charter.local.toml\n")
-        subprocess.run(["git", "-C", str(config.ROOT), "init", "-q"], check=True,
-                       capture_output=True, env=dict(os.environ))
+        # The shared fixture: the file, a repository that ignores it, `$HOME`, and the
+        # ceiling that stops git's walk above this throwaway plane. It carries
+        # `tests._gitguard.environment()` into the git it runs, which is what every other
+        # module here does and what `tests._planeguard.AmbientGitConfig` holds them to.
+        self.local = declare_profiles(self, _LOCAL)
         # Only the pre-tmux call, in THIS process. The pane's launcher is another process
         # and runs the whole chain for itself, which is the half under test.
         self.enterContext(mock.patch.object(launcher, "refusal", return_value=None))
@@ -288,7 +292,7 @@ class ARefusalInThePaneReachesTheOperator(_ARealChatOnARealServer, unittest.Test
         self.assertEqual(self._launch(profile="claude-work"), 0)
         fid = "beta.1"
         pane = state.harness_pane(fid)
-        self.assertTrue(_await(
+        self.assertTrue(_eventually(
             lambda: "cannot yet ask before a declared command runs" in self._pane_text(pane)),
             f"the pane never showed the refusal: {self._pane_text(pane)!r}")
         # **The property ruling 42 is about**: it is still there to be read. A launcher that
@@ -299,7 +303,7 @@ class ARefusalInThePaneReachesTheOperator(_ARealChatOnARealServer, unittest.Test
             "0", "the pane died with the refusal on it instead of waiting")
         sent = self._tmux("send-keys", "-t", pane, "Enter")
         self.assertEqual(sent.returncode, 0, sent.stderr)
-        self.assertTrue(_await(lambda: not self._alive(pane), 30),
+        self.assertTrue(_eventually(lambda: not self._alive(pane), 30),
                         f"the keypress did not let the launcher go: "
                         f"{self._pane_text(pane)!r}")
 
@@ -314,7 +318,7 @@ class ARefusalInThePaneReachesTheOperator(_ARealChatOnARealServer, unittest.Test
         self.assertEqual(self._launch(profile="claude-work"), 0)
         pane = state.harness_pane("beta.1")
         self._tmux("send-keys", "-t", pane, "Enter")
-        self.assertTrue(_await(lambda: not self._alive(pane), 30),
+        self.assertTrue(_eventually(lambda: not self._alive(pane), 30),
                         f"the keypress was swallowed: {self._pane_text(pane)!r}")
 
     def test_an_unattended_refusal_is_read_back_by_the_launch_that_opened_the_chat(self):
@@ -334,6 +338,70 @@ class ARefusalInThePaneReachesTheOperator(_ARealChatOnARealServer, unittest.Test
         self.assertTrue(
             any("cannot yet ask before a declared command runs" in s for s in said),
             f"the launch did not report what the pane refused: {said}")
+
+
+@unittest.skipUnless(_HAS_TMUX, "no tmux on this machine")
+class ARefusalInsideTheOperatorsOwnTmux(_ARealChatOnARealServer, unittest.TestCase):
+    """Ruling 42 on the path that needs it most — a real window in a tmux charter does not
+    own, end to end.
+
+    **Nothing here ever looks at that pane.** Charter's launcher on this path stays awake
+    for the life of the frame and closes the window itself, and an open nobody is watching
+    is never switched to — so a refusal printed in the pane is gone with the window before
+    anything reads it, which is what `_pane_last_words` measured empty. The chat's own
+    record is the only copy, and the process holding the terminal is the one that must say
+    it.
+
+    The pre-tmux check is stood down in THIS process only: the pane's launcher is another
+    process and runs the whole chain for itself, which is the half under test.
+    """
+
+    SLUG = "pane-refusal-operator"
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.local = declare_profiles(self, _LOCAL)
+        self.enterContext(mock.patch.object(launcher, "refusal", return_value=None))
+        # An operator's own server: started by NAME so `tests._tmuxreap` can collect it,
+        # and reached by PATH, which is what `tmuxctl.is_operator_socket` reads as "a tmux
+        # charter did not start" (#812 is what happens when those two are compared as
+        # strings). `test_frame_tmux_integration.OP_SOCKET_PATH` is the same pairing.
+        self.op_name = _tmuxreap.name(f"{self.SLUG}-{next(_SERVERS)}")
+        self.addCleanup(subprocess.run,
+                        [self.tmux, "-L", self.op_name, "kill-server"],
+                        capture_output=True, timeout=20)
+        started = subprocess.run(
+            [self.tmux, "-L", self.op_name, "-f", "/dev/null", "new-session", "-d",
+             "-s", "op", "-x", "120", "-y", "40", "--", "cat"],
+            capture_output=True, text=True, timeout=20, env=dict(os.environ))
+        self.assertEqual(started.returncode, 0, started.stderr)
+        self.op_path = _tmuxsocket.socket_path(self.op_name)
+        session = subprocess.run(
+            [self.tmux, "-L", self.op_name, "display-message", "-p", "#{session_id}"],
+            capture_output=True, text=True, timeout=20).stdout.strip()
+        self.enterContext(mock.patch.object(tmuxctl, "operator_server",
+                                            return_value=(self.op_path, session)))
+
+    def test_the_launch_says_what_the_pane_refused(self):
+        said: list[str] = []
+        with mock.patch.object(commands_frame.util, "err", side_effect=said.append):
+            rc = self._launch(profile="claude-work",
+                              opening=commands_frame.Opening("fix the widget please"))
+        self.assertEqual(rc, launcher.REFUSED_EXIT)
+        self.assertTrue(
+            any("cannot yet ask before a declared command runs" in s for s in said),
+            f"the launch did not say what the pane refused: {said}")
+
+    def test_the_window_it_opened_is_taken_back(self):
+        """A window the operator never asked for, holding a chat that never started, is not
+        theirs to close."""
+        with mock.patch.object(commands_frame.util, "err"):
+            self._launch(profile="claude-work",
+                         opening=commands_frame.Opening("fix the widget please"))
+        windows = subprocess.run(
+            [self.tmux, "-L", self.op_name, "list-windows", "-a", "-F", "#{window_name}"],
+            capture_output=True, text=True, timeout=20).stdout.split()
+        self.assertNotIn("beta.1", windows, f"the frame's window was left behind: {windows}")
 
 
 if __name__ == "__main__":

--- a/tests/test_a_chat_pane_starts_as_charter_and_becomes_the_harness.py
+++ b/tests/test_a_chat_pane_starts_as_charter_and_becomes_the_harness.py
@@ -1,0 +1,340 @@
+"""A real chat pane starts as charter's launcher and becomes the harness — on real tmux.
+
+The claim this file holds is the one the whole feature rests on: every chat pane's first
+process is `charter frame-launch`, and after its `exec` the pane is indistinguishable from
+one the harness was started in directly. The pane id charter recorded, the exit code, the
+`pane-died` hooks, `$TMUX_PANE` and the liveness list all answer what they answered before
+profiles existed — measured on tmux 3.7c and at the 3.2 floor, on charter's own server and
+in an operator's, before any of it was built
+(`workspaces/harness-profiles/refs/task2-measure/`, and `docs/frame.md`'s *How a harness
+starts*). This is that measurement as a test, on whatever tmux the runner has.
+
+**And the two halves of ruling 42**, which the measurement is the reason for: a refusal the
+pane prints and exits on is read by nobody — the eager dead-status ask completes 6-14 ms
+after the start while the launcher's first line runs at 19-22 ms, and the teardown hook
+then kills the window. So an attended pane shows its refusal and WAITS for a key, and an
+unattended one records it where the launch that opened the chat reads it back.
+
+**The recorder is the harness here**, first on the `PATH` the tmux client is started with:
+a launcher resolves the profile in its own process, so patching `ClaudeCodeHarness.binary`
+in this one would not reach the pane at all.
+"""
+
+from __future__ import annotations
+
+import itertools
+import json
+import os
+import shutil
+import subprocess
+import sys
+import time
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
+
+from charter import commands_frame, config
+from charter.frame import launcher, state, tmuxctl
+
+from tests import _gitguard, _tmuxreap, _tmuxsocket, _ttyguard
+from tests._isolation import PersonaIso, make_plane, no_background_refresh, \
+    no_update_check_in
+
+_HAS_TMUX = shutil.which("tmux") is not None
+
+#: A fresh socket per CASE, never per class: a server told to exit is still accepting on
+#: its socket for a few milliseconds, and the next case's `new-session` draws that race
+#: (`test_a_background_chat_really_starts_on_its_brief.py` records the CI run that showed
+#: it).
+_SERVERS = itertools.count()
+
+#: This checkout, for the `$PYTHONPATH` the pane's own launcher needs. `-P` keeps the
+#: child's cwd off `sys.path` (#390) and its cwd is a workspace directory, so without this
+#: `python -P -m charter frame-launch` cannot import the charter under test — it would exit
+#: at once and take its window with it, which looks exactly like a launch that never
+#: happened.
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+
+_LOCAL = """
+[harness.claude-work]
+kind = "claude"
+command = ["claude"]
+env = { CLAUDE_CONFIG_DIR = "~/.cw" }
+"""
+
+
+def _await(predicate, timeout: float = 15.0) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(0.05)
+    return bool(predicate())
+
+
+class _ARealChatOnARealServer(PersonaIso):
+    """One workspace, a real private server, and a recorder standing in for `claude`."""
+
+    WS = "beta"
+    SLUG = "pane-becomes-harness"
+    #: What the recorder exits with once it has written its file. `None` keeps it alive.
+    EXIT_WITH: int | None = None
+
+    def setUp(self) -> None:
+        super().setUp()
+        v = tmuxctl.version()
+        if v is None or v < tmuxctl.FLOOR:
+            self.skipTest(f"the frame's floor is tmux {tmuxctl.FLOOR[0]}.{tmuxctl.FLOOR[1]}"
+                          f"; this machine has {v}")
+        make_plane(self)
+        no_background_refresh(self)
+        no_update_check_in(config.ROOT)
+        # A launch with no terminal of its own: `attach=False`, the way a tab or a handoff
+        # drives it, and the state `os.get_terminal_size()` raising is the seam for.
+        _ttyguard.no_terminal()
+        self.tmux = shutil.which("tmux")
+        self.socket = _tmuxreap.name(f"{self.SLUG}-{next(_SERVERS)}")
+        self.enterContext(mock.patch.object(commands_frame, "SOCKET", self.socket))
+        self.addCleanup(self._reap_the_server)
+        # A detached `charter frame-gather` outlives the case and is refused by
+        # `tests/_planeguard`; what is asked here is what tmux does.
+        self.enterContext(mock.patch.object(commands_frame, "_spawn_gather"))
+        # No panel panes: every one is another `-m charter` child, and none of them is what
+        # this file is about.
+        self.enterContext(mock.patch.object(commands_frame, "_drawable_slots",
+                                            return_value=[]))
+        (config.WORKSPACES_DIR / self.WS).mkdir(parents=True, exist_ok=True)
+
+        self.records = self.tmp / "records"
+        self.records.mkdir()
+        bindir = self.tmp / "bin"
+        bindir.mkdir()
+        # **The harness**: it writes down the argv, the environment and the pid it was
+        # given — which is the whole measurement — and then either stays or exits with a
+        # number the frame has to carry out.
+        (bindir / "claude").write_text(
+            f"#!{sys.executable}\n"
+            "import json, os, sys, time\n"
+            "out = os.path.join(os.environ['RECORD_DIR'], 'harness.json')\n"
+            "with open(out + '.tmp', 'w') as f:\n"
+            "    json.dump({'argv': sys.argv[1:], 'env': dict(os.environ),\n"
+            "               'pid': os.getpid()}, f)\n"
+            "os.replace(out + '.tmp', out)\n"
+            f"{'sys.exit(' + str(self.EXIT_WITH) + ')' if self.EXIT_WITH is not None else 'time.sleep(300)'}\n")
+        (bindir / "claude").chmod(0o755)
+        self.enterContext(mock.patch.dict(os.environ, {
+            # First on the client's `PATH`, ahead of `tests/_claudeguard`'s own fake: the
+            # launcher resolves the profile's command in the PANE, so this is the only way
+            # to decide what really runs there.
+            "PATH": f"{bindir}{os.pathsep}{os.environ.get('PATH', '')}",
+            "RECORD_DIR": str(self.records),
+            "CHARTER_ROOT": str(config.ROOT),
+            "PYTHONPATH": os.pathsep.join(
+                [str(_REPO_ROOT), os.environ.get("PYTHONPATH", "")]).rstrip(os.pathsep),
+            **_gitguard.environment(),
+        }, clear=True))
+
+    def _reap_the_server(self) -> None:
+        subprocess.run([self.tmux, "-L", self.socket, "kill-server"],
+                       capture_output=True, timeout=20)
+        try:
+            os.unlink(_tmuxsocket.socket_path(self.socket))
+        except OSError:
+            pass
+
+    def _tmux(self, *args: str) -> subprocess.CompletedProcess:
+        return subprocess.run([self.tmux, "-L", self.socket, *args], capture_output=True,
+                              text=True, timeout=20)
+
+    def _launch(self, **ns) -> int:
+        args = SimpleNamespace(**{"harness": "claude", "rest": [], "no_frame": False,
+                                  "workspace": self.WS, "pick": False, "attach": False,
+                                  "size": (120, 40), **ns})
+        return commands_frame._launch(args)
+
+    def _harness(self) -> dict:
+        """What the exec'd harness wrote down, once it has run."""
+        record = self.records / "harness.json"
+        self.assertTrue(_await(record.is_file),
+                        f"the harness never ran in the pane: {self._pane_text()}")
+        return json.loads(record.read_text())
+
+    def _alive(self, pane: str) -> bool:
+        """Is *pane*'s own process still running?
+
+        **The reading a refusal in the pane is asserted on, rather than the exit code the
+        `pane-died` hook records** — and the difference is measured rather than assumed. A
+        launcher that refuses exits without ever `exec`ing a harness, and on the Linux
+        runner that pane comes back dead with an EMPTY `#{pane_dead_status}` and no exit
+        file written, where the same pane on macOS carries the number; a pane whose HARNESS
+        exits records its code on both (`TheHarnessExitCodeTravelsAsItDid`, which is where
+        that contract belongs). What ruling 42 is about is whether the sentence survives
+        long enough to be read and whether a keypress then releases it, and that is exactly
+        what this answers.
+
+        A pane tmux no longer lists at all is not alive either — the teardown hook closes
+        the window once the chat is over.
+        """
+        out = self._tmux("display-message", "-p", "-t", pane, "#{pane_dead}")
+        return out.returncode == 0 and out.stdout.strip() == "0"
+
+    def _pane_text(self, pane: str | None = None) -> str:
+        """What is on the pane, with tmux's own hard wrap taken out.
+
+        `capture-pane` returns the pane as it is DRAWN, so a sentence longer than the pane
+        is wide comes back broken across lines mid-word. Joining is what makes an assertion
+        about the sentence rather than about the width of the window it landed in.
+        """
+        pane = pane or (state.harness_pane("beta.1") or "")
+        out = self._tmux("capture-pane", "-p", "-S", "-", "-t", pane).stdout
+        return "".join(out.splitlines())
+
+
+@unittest.skipUnless(_HAS_TMUX, "no tmux on this machine")
+class ThePaneCharterStartsIsThePaneTheHarnessRunsIn(_ARealChatOnARealServer,
+                                                    unittest.TestCase):
+    """L1, L5 and L6 of the measurement, as one launch: the pane charter recorded is the
+    pane the harness is in, it is that pane to every status reader, and the profile's
+    environment arrived without crossing tmux."""
+
+    def test_the_pane_charter_recorded_is_the_one_the_harness_is_running_in(self):
+        self.assertEqual(self._launch(), 0)
+        fid = "beta.1"
+        pane = state.harness_pane(fid)
+        self.assertTrue(pane, "the launch recorded no harness pane")
+        harness = self._harness()
+        pid = self._tmux("display-message", "-p", "-t", pane, "#{pane_pid}").stdout.strip()
+        self.assertEqual(pid, str(harness["pid"]),
+                         "the `exec` did not keep the launcher's pid for the harness, so "
+                         "the pane charter recorded is not the harness's own")
+
+    def test_the_harness_is_still_this_chat_to_every_status_reader(self):
+        """L5: `$TMUX_PANE` inside the harness is the pane charter recorded, and the chat
+        is in the server's own liveness list — which is what `state.reap` spares."""
+        self.assertEqual(self._launch(), 0)
+        fid = "beta.1"
+        harness = self._harness()
+        self.assertEqual(harness["env"].get("TMUX_PANE"), state.harness_pane(fid))
+        self.assertTrue(_await(lambda: fid in (commands_frame._live_chats(self.socket)
+                                               or set())),
+                        "the chat is not in the server's liveness list")
+
+    def test_the_profile_reaches_the_harness_and_never_tmux(self):
+        """L6, and the constraint the launcher exists for: `CHARTER_HARNESS_PROFILE` is set
+        at the `exec`, so it reaches the harness without joining `layout.CARRIABLE` and
+        without passing through tmux's own argument parser."""
+        self.assertEqual(self._launch(), 0)
+        harness = self._harness()
+        self.assertEqual(harness["env"].get("CHARTER_HARNESS_PROFILE"), "claude")
+        self.assertEqual(harness["env"].get("CHARTER_HARNESS"), "claude-code")
+        for scope in (("show-environment", "-g"),
+                      ("show-environment", "-t", state.workspace_prefix(self.WS))):
+            said = self._tmux(*scope).stdout
+            self.assertNotIn("CHARTER_HARNESS_PROFILE", said,
+                             "the profile crossed tmux, where only its name may go")
+
+    def test_the_chat_is_framed_because_the_pane_proved_it(self):
+        """Rulings 29 and 33 end to end: the launcher asked tmux whether its own pid was
+        the `#{pane_pid}` of a live pane whose window is named for this chat, and kept the
+        chat's session id because it was. A launcher that could not prove it drops that id
+        — which is what stops a `charter frame-launch` run from a model's tool shell
+        rewriting a chat's record."""
+        self.assertEqual(self._launch(), 0)
+        self.assertEqual(self._harness()["env"].get("CHARTER_SESSION_ID"), "beta.1")
+
+
+@unittest.skipUnless(_HAS_TMUX, "no tmux on this machine")
+class TheHarnessExitCodeTravelsAsItDid(_ARealChatOnARealServer, unittest.TestCase):
+    """L2: the `pane-died` hooks are installed against the launcher's pane and fire for the
+    harness that replaced it, so the code the harness chose is the code charter records."""
+
+    SLUG = "pane-exit-code"
+    EXIT_WITH = 7
+
+    def test_a_harness_exit_code_travels_as_it_did(self):
+        self.assertEqual(self._launch(), 0)
+        fid = "beta.1"
+        self.assertTrue(_await(lambda: state.exit_code(fid) == 7),
+                        f"the exit code did not reach the chat's state: "
+                        f"{state.exit_code(fid)!r}")
+        self.assertTrue(_await(lambda: fid not in self._tmux(
+            "list-windows", "-a", "-F", "#{window_name}").stdout.split()),
+            "the teardown hook did not close the window of a chat that ended")
+
+
+@unittest.skipUnless(_HAS_TMUX, "no tmux on this machine")
+class ARefusalInThePaneReachesTheOperator(_ARealChatOnARealServer, unittest.TestCase):
+    """Ruling 42, both halves, against a real pane.
+
+    The plane declares a profile, so the pane's own launcher refuses it (review B1) — while
+    the check this process makes before tmux is stood down, which is exactly the state the
+    two checks exist for: the plane can move between them.
+    """
+
+    SLUG = "pane-refusal"
+
+    def setUp(self) -> None:
+        super().setUp()
+        (config.ROOT / "charter.local.toml").write_text(_LOCAL)
+        (config.ROOT / ".gitignore").write_text("/charter.local.toml\n")
+        subprocess.run(["git", "-C", str(config.ROOT), "init", "-q"], check=True,
+                       capture_output=True, env=dict(os.environ))
+        # Only the pre-tmux call, in THIS process. The pane's launcher is another process
+        # and runs the whole chain for itself, which is the half under test.
+        self.enterContext(mock.patch.object(launcher, "refusal", return_value=None))
+
+    def test_an_attended_pane_holds_its_refusal_until_somebody_reads_it(self):
+        self.assertEqual(self._launch(profile="claude-work"), 0)
+        fid = "beta.1"
+        pane = state.harness_pane(fid)
+        self.assertTrue(_await(
+            lambda: "cannot yet ask before a declared command runs" in self._pane_text(pane)),
+            f"the pane never showed the refusal: {self._pane_text(pane)!r}")
+        # **The property ruling 42 is about**: it is still there to be read. A launcher that
+        # printed and exited would have had its window killed by the teardown hook 6-14 ms
+        # after the start, and all 40 measured refusals were lost that way.
+        self.assertEqual(
+            self._tmux("display-message", "-p", "-t", pane, "#{pane_dead}").stdout.strip(),
+            "0", "the pane died with the refusal on it instead of waiting")
+        sent = self._tmux("send-keys", "-t", pane, "Enter")
+        self.assertEqual(sent.returncode, 0, sent.stderr)
+        self.assertTrue(_await(lambda: not self._alive(pane), 30),
+                        f"the keypress did not let the launcher go: "
+                        f"{self._pane_text(pane)!r}")
+
+    def test_a_key_pressed_before_the_pane_is_listening_is_not_lost(self):
+        """**The window between the refusal appearing and the read starting is where an
+        operator actually presses.** `tty.setraw`'s own default is `TCSAFLUSH`, which
+        discards input that arrived before the mode change — so a key pressed in that
+        window was thrown away and the pane waited for a second one nobody knew to send.
+        Measured on CI (Linux, tmux 3.4), where the case above went red for exactly this;
+        on the machine it was written on the timing happened to fall the other way, which
+        is why this case sends the key as early as it possibly can."""
+        self.assertEqual(self._launch(profile="claude-work"), 0)
+        pane = state.harness_pane("beta.1")
+        self._tmux("send-keys", "-t", pane, "Enter")
+        self.assertTrue(_await(lambda: not self._alive(pane), 30),
+                        f"the keypress was swallowed: {self._pane_text(pane)!r}")
+
+    def test_an_unattended_refusal_is_read_back_by_the_launch_that_opened_the_chat(self):
+        """Nobody is at a chat a handoff opens, so there is no key to wait for: the pane
+        records what it did and this launch — which has a caller listening — reports it and
+        carries the refusal's own exit code out.
+
+        Asserted on what was SAID rather than on the record it was read from: the launch
+        ends by reaping the chat that never started, so the record has done its job and
+        gone by the time anything could look at it. What has to survive is the sentence.
+        """
+        said: list[str] = []
+        with mock.patch.object(commands_frame.util, "err", side_effect=said.append):
+            rc = self._launch(profile="claude-work",
+                              opening=commands_frame.Opening("fix the widget please"))
+        self.assertEqual(rc, launcher.REFUSED_EXIT)
+        self.assertTrue(
+            any("cannot yet ask before a declared command runs" in s for s in said),
+            f"the launch did not report what the pane refused: {said}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_a_launch_too_long_for_tmux_says_so.py
+++ b/tests/test_a_launch_too_long_for_tmux_says_so.py
@@ -27,7 +27,7 @@ import unittest
 from pathlib import Path
 from unittest import mock
 
-from charter.frame import layout, tmuxctl
+from charter.frame import launcher, layout, tmuxctl
 
 from tests import _tmuxreap, _tmuxsocket
 from tests._isolation import PersonaIso
@@ -51,8 +51,21 @@ _LIMIT_ON_SCREEN = "16,364"
 #: so what tmux was sent is byte-for-byte what was typed.
 _PASTED = "fix it: " + "x" * 20000
 
-#: `_launch`'s harness is `claude`, so its arguments are that binary and the one above.
-_CARRIED = f"{len('claude') + len(_PASTED.encode()):,}"
+def _carried(rest: list[str]) -> str:
+    """The bytes tmux was really handed for a launch carrying *rest*, spelled as the
+    sentence spells them.
+
+    **Charter's own launcher argv, not the profile's command.** Since a chat pane starts as
+    `charter frame-launch --profile <name> -- …` (`frame/launcher.argv`), what tmux measured
+    against its limit is that list — and a number beside a limit has to be the number the
+    limit was applied to (ADR 0009). The command an operator is SHOWN is the profile's own,
+    which is a different list and would explain nothing about the refusal.
+    """
+    return f"{sum(len(os.fsencode(a)) for a in launcher.argv('claude', rest, attended=True)):,}"
+
+
+#: `_launch`'s harness is the built-in `claude` profile, and this is what starting it costs.
+_CARRIED = _carried([_PASTED])
 
 
 class TmuxsLengthRefusalIsRecognisedByItsExactWords(unittest.TestCase):
@@ -131,10 +144,9 @@ class ALaunchOnCharactersOwnServer(PersonaIso, unittest.TestCase):
                          rest=["fix é漢 \udcff " + "x" * 20000])
         self.assertEqual(rc, 1)
         self.assertEqual(len(said), 1, said)
-        # `claude`; then `fix `, é as C3 A9, 漢 as E6 BC A2, a space, the single byte 0xff,
-        # a space; then the padding.
-        carried = len(b"claude") + len(b"fix \xc3\xa9\xe6\xbc\xa2 \xff ") + 20000
-        self.assertIn(f"{carried:,}", said[0])
+        # The launcher argv, whose tail is that argument: `fix `, é as C3 A9, 漢 as
+        # E6 BC A2, a space, the single byte 0xff, a space, then the padding.
+        self.assertIn(_carried(["fix é漢 \udcff " + "x" * 20000]), said[0])
 
     def test_any_other_refusal_keeps_the_report_it_always_had(self):
         rc, said = self._launched(_RefusedStart(stderr="no space for a new pane\n"))

--- a/tests/test_a_profile_launch_is_refused_before_tmux.py
+++ b/tests/test_a_profile_launch_is_refused_before_tmux.py
@@ -27,29 +27,13 @@ from unittest import mock
 from charter import commands_frame, config, contain
 from charter.frame import launcher, layout, reopen as reopen_state, state, tmuxctl
 from tests import _gitguard, _tmuxsocket
-from tests._isolation import PersonaIso, make_plane
-
-_LOCAL = """
-[harness.claude-work]
-kind = "claude"
-command = ["claude"]
-env = { CLAUDE_CONFIG_DIR = "~/.cw" }
-
-[harness.codex-pinned]
-kind = "codex"
-command = ["npx", "-y", "@openai/codex@0.140.0"]
-"""
+from tests._isolation import PersonaIso, declare_profiles, make_plane
 
 #: The operator's own tmux, as `tmuxctl.operator_server` reads it out of `$TMUX`: a socket
 #: PATH, which is what `is_operator_socket` tells from charter's own `-L charter` name.
 #: Computed the way tmux computes it (`tests/_tmuxsocket.py`) rather than written down —
 #: a literal uid in a socket path is one developer's machine baked into the suite.
 _OPERATOR = _tmuxsocket.OPERATOR_SOCKET
-
-
-def _git(root: Path, *args: str) -> None:
-    subprocess.run(["git", "-C", str(root), *args], check=True, capture_output=True,
-                   env={**os.environ, **_gitguard.environment()})
 
 
 class _ALaunchNamesAProfile(PersonaIso):
@@ -59,16 +43,14 @@ class _ALaunchNamesAProfile(PersonaIso):
     def setUp(self) -> None:
         super().setUp()
         make_plane(self)
-        self.local = config.ROOT / "charter.local.toml"
-        self.local.write_text(_LOCAL)
-        (config.ROOT / ".gitignore").write_text("/charter.local.toml\n")
-        _git(config.ROOT, "init", "-q")
         (config.WORKSPACES_DIR / "beta").mkdir(parents=True, exist_ok=True)
         self.enterContext(mock.patch.dict(
             os.environ,
             {"PATH": os.environ.get("PATH", ""),
-             "GIT_CEILING_DIRECTORIES": str(self.tmp.resolve().parent),
              "CHARTER_ROOT": str(config.ROOT), **_gitguard.environment()}, clear=True))
+        # AFTER the clearing patch, so its `$HOME` and `$GIT_CEILING_DIRECTORIES` survive:
+        # the ignore check is a real `git status`, and both decide what it answers.
+        self.local = declare_profiles(self)
         self.argvs: list[list[str]] = []
         self.execs: list[tuple] = []
         self.enterContext(mock.patch.object(launcher.os, "execvpe",
@@ -80,7 +62,7 @@ class _ALaunchNamesAProfile(PersonaIso):
         self.enterContext(mock.patch.object(launcher, "_approval_refusal",
                                             return_value=None))
 
-    def _run(self, action, argv, **kw):
+    def _tmux_answer(self, action, argv, **kw):
         self.argvs.append(list(argv))
         out = "%9\n"
         if "new-window" in argv and "-t" in argv and _OPERATOR in argv:
@@ -108,7 +90,7 @@ class _ALaunchNamesAProfile(PersonaIso):
                 mock.patch.object(tmuxctl, "operator_server", return_value=operator), \
                 mock.patch.object(commands_frame, "_live_sessions", return_value={"beta"}), \
                 mock.patch.object(commands_frame, "_live_chats", return_value=set()), \
-                mock.patch.object(tmuxctl, "run", side_effect=self._run), \
+                mock.patch.object(tmuxctl, "run", side_effect=self._tmux_answer), \
                 mock.patch.object(tmuxctl, "write_all",
                                   side_effect=lambda joint, writes, **kw: [
                                       subprocess.CompletedProcess(w.argv, 0, "", "")
@@ -191,6 +173,19 @@ class ALaunchRefusesBeforeTmux(_ALaunchNamesAProfile, unittest.TestCase):
         self.assertEqual(rc, 2)
         self.assertIn("is a codex profile", said)
         self.assertIn("charter codex-pinned", said)
+
+    def test_the_name_that_refusal_repeats_back_is_bounded(self):
+        """`profiles.NAME_RE` bounds a declared name's shape and not its length, so this is
+        the one value in the sentence that arrives printable and as long as the file liked.
+        The sentence ends in the remedy — `Run it by its own name: charter <name>` — and an
+        unbounded name in the middle of it is a remedy nobody gets to."""
+        long_name = "c" * 200
+        self.local.write_text(f'[harness.{long_name}]\nkind = "codex"\n'
+                              'command = ["codex"]\n')
+        rc, said = self._said(profile=long_name)
+        self.assertEqual(rc, 2)
+        self.assertIn("c" * 160 + "...", said)
+        self.assertNotIn(long_name, said)
 
     def test_a_declared_profile_from_a_committable_file_is_refused(self):
         (config.ROOT / ".gitignore").write_text("")
@@ -357,7 +352,7 @@ class AnEarlyDeathNamesTheProfilesCommand(_ALaunchNamesAProfile, unittest.TestCa
         self.assertNotIn("frame-launch", said)
 
 
-class AnUnattendedLaunchReadsTheLauncherssVerdict(_ALaunchNamesAProfile, unittest.TestCase):
+class AnUnattendedLaunchReadsTheLaunchersVerdict(_ALaunchNamesAProfile, unittest.TestCase):
     """Ruling 42's second half. Nobody is at a reopened or handed-off chat to press a key,
     so the pane records what it did and the launch that opened it reports that."""
 
@@ -384,6 +379,31 @@ class AnUnattendedLaunchReadsTheLauncherssVerdict(_ALaunchNamesAProfile, unittes
                      opening=commands_frame.Opening("fix it please"))
         self.awaited.assert_called_once()
 
+    def test_a_pane_that_already_died_is_not_asked_a_second_time(self):
+        """Two answers about one pane, and the eager one is the answer: tmux itself reported
+        `#{pane_dead_status}`, so the harness RAN and then exited on that number. Reading a
+        launcher record over the top of it would report a refusal for a chat that started
+        perfectly well and failed afterwards — and on the wrong exit code."""
+        with mock.patch.object(commands_frame, "_pane_last_words", return_value=[]):
+            rc, said = self._said(profile="claude-work", attach=False,
+                                  opening=commands_frame.Opening("fix it please"),
+                                  dead_status=7,
+                                  verdict=(3, "a refusal from some other launch"))
+        self.assertEqual(rc, 7)
+        self.assertIn("7", said)
+        self.assertNotIn("some other launch", said)
+
+    def test_a_launch_with_no_profile_has_no_launcher_to_ask(self):
+        """`charter frame -- <cmd>` starts the command itself — no charter launcher runs in
+        that pane, so nothing there can have recorded a verdict. A record left under that
+        chat id by an earlier chat is not this launch's answer, and waiting for one would
+        cost the whole budget on every escape-hatch open."""
+        rc, said = self._said(harness="frame", rest=["--", "true"], attach=False,
+                              opening=commands_frame.Opening("fix it please"),
+                              verdict=(3, "a refusal from some other launch"))
+        self.assertEqual(rc, 0)
+        self.assertNotIn("some other launch", said)
+
 
 class TheVerdictWaitStopsOnItsOwnTerms(PersonaIso, unittest.TestCase):
     """`_await_the_launcher` itself: it ends on the verdict, on the pane dying, or on its
@@ -395,24 +415,37 @@ class TheVerdictWaitStopsOnItsOwnTerms(PersonaIso, unittest.TestCase):
         state.frame_dir("beta.1", create=True)
         self.slept: list[float] = []
         self.enterContext(mock.patch.object(commands_frame.time, "sleep",
-                                            side_effect=self.slept.append))
+                                            side_effect=self._sleep))
 
-    def _await(self, alive: bool = True):
+    #: A bound rather than a recorder, because the failure this class is about is a WAIT
+    #: that does not end: a loop with its deadline gone would spin here forever and a
+    #: hanging test is not a verdict (`tests/_ttyguard.py` records the same lesson). Well
+    #: above what any case below asks for, so only a genuinely unbounded loop reaches it.
+    _POLL_CEILING = 100
+
+    def _sleep(self, seconds: float) -> None:
+        self.slept.append(seconds)
+        if len(self.slept) > self._POLL_CEILING:
+            raise AssertionError(
+                f"the wait polled {len(self.slept)} times: its budget is not bounding it")
+
+    def _verdict(self, alive: bool = True):
+        """What `_await_the_launcher` answers with the pane in the state named."""
         status = commands_frame._ALIVE if alive else commands_frame._GONE
         with mock.patch.object(commands_frame, "_pane_state", return_value=(status, None)):
             return commands_frame._await_the_launcher("sock", "beta.1", "%1")
 
     def test_a_launcher_that_handed_the_pane_over_is_not_waited_on(self):
         state.record_launch("beta.1")
-        self.assertEqual(self._await(), (None, ""))
+        self.assertEqual(self._verdict(), (None, ""))
         self.assertEqual(self.slept, [], "a chat that started fine must not cost a wait")
 
     def test_a_refusal_comes_back_with_its_own_exit_code(self):
         state.record_launch("beta.1", launcher.MISSING_EXIT, "not on PATH")
-        self.assertEqual(self._await(), (launcher.MISSING_EXIT, "not on PATH"))
+        self.assertEqual(self._verdict(), (launcher.MISSING_EXIT, "not on PATH"))
 
     def test_a_pane_that_died_without_a_verdict_is_not_waited_on_either(self):
-        self.assertEqual(self._await(alive=False), (None, ""))
+        self.assertEqual(self._verdict(alive=False), (None, ""))
         self.assertEqual(self.slept, [])
 
     def test_a_launcher_that_never_answers_is_given_up_on(self):
@@ -421,7 +454,20 @@ class TheVerdictWaitStopsOnItsOwnTerms(PersonaIso, unittest.TestCase):
         ticks = iter([0.0, 0.0, commands_frame._LAUNCHER_SECONDS + 1])
         with mock.patch.object(commands_frame.time, "monotonic",
                                side_effect=lambda: next(ticks)):
-            self.assertEqual(self._await(), (None, ""))
+            self.assertEqual(self._verdict(), (None, ""))
+
+    def test_the_budget_is_spent_at_the_deadline_and_not_one_poll_later(self):
+        """The clock is asked twice — once to set the deadline, once to find it reached —
+        and that second reading ends the wait, because the budget is spent AT it and not
+        after it. The third tick is left in the iterator on purpose: a wait that consumed
+        it polled a pane, and slept, on time it had already been told it did not have.
+        """
+        ticks = iter([0.0, float(commands_frame._LAUNCHER_SECONDS), 99.0])
+        with mock.patch.object(commands_frame.time, "monotonic",
+                               side_effect=lambda: next(ticks)):
+            self.assertEqual(self._verdict(), (None, ""))
+        self.assertEqual(next(ticks), 99.0)
+        self.assertEqual(self.slept, [])
 
 
 class TheOperatorsTmuxRespawnsTheLauncher(_ALaunchNamesAProfile, unittest.TestCase):
@@ -434,7 +480,7 @@ class TheOperatorsTmuxRespawnsTheLauncher(_ALaunchNamesAProfile, unittest.TestCa
         self._no_approval_needed()
         self.chat_option_rc = 0
 
-    def _run(self, action, argv, **kw):
+    def _tmux_answer(self, action, argv, **kw):
         self.argvs.append(list(argv))
         rc = 0
         if "set-option" in argv and commands_frame._CHAT_OPTION in argv:

--- a/tests/test_a_profile_launch_is_refused_before_tmux.py
+++ b/tests/test_a_profile_launch_is_refused_before_tmux.py
@@ -488,13 +488,16 @@ class TheOperatorsTmuxRespawnsTheLauncher(_ALaunchNamesAProfile, unittest.TestCa
         out = "@1 %9\n" if "new-window" in argv else "%9\n"
         return subprocess.CompletedProcess(argv, rc, out, "")
 
-    def _in_operator_tmux(self, *, harness_exit: int | None = 0, **ns) -> tuple[int, str]:
+    def _in_operator_tmux(self, *, harness_exit: int | None = 0,
+                          pane_state: tuple = (commands_frame._ALIVE, None),
+                          **ns) -> tuple[int, str]:
         """*harness_exit* is what `_wait_for_harness` answers — ``None`` for a pane that is
-        no longer there to be asked, which is a parameter rather than a patch for the
-        reason `_launch` gives about its own knobs."""
+        no longer there to be asked — and *pane_state* what the EAGER ask right after the
+        respawn finds. Parameters rather than patches applied inside here, for the reason
+        `_launch` gives about its own knobs: the two are different moments in this
+        function's life and a case has to be able to name which one it is about."""
         ns.setdefault("operator", (_OPERATOR, "$1"))
-        with mock.patch.object(commands_frame, "_pane_state",
-                                  return_value=(commands_frame._ALIVE, None)), \
+        with mock.patch.object(commands_frame, "_pane_state", return_value=pane_state), \
                 mock.patch.object(commands_frame, "_wait_for_harness",
                                   return_value=harness_exit), \
                 mock.patch.object(commands_frame, "_window_size", return_value=(120, 40)), \
@@ -530,6 +533,49 @@ class TheOperatorsTmuxRespawnsTheLauncher(_ALaunchNamesAProfile, unittest.TestCa
         self.assertEqual(rc, launcher.REFUSED_EXIT)
         self.assertIn("is refused — nope", said)
         self.assertNotIn("is not something charter can know", said)
+
+    def test_a_pane_already_dead_when_the_frame_is_built_reports_the_refusal(self):
+        """The EAGER ask, one moment after the respawn: a launcher fast enough to refuse
+        before this line runs leaves a pane that is already over, and nothing below this
+        branch ever runs — no panels, no `select-window`, so the operator is never switched
+        to the window at all. The chat's own record is the only copy of the sentence, and
+        the number the launcher exited with is the launch's."""
+        rc, said = self._in_operator_tmux(
+            profile="claude-work",
+            pane_state=(commands_frame._GONE, None),
+            verdict=(launcher.REFUSED_EXIT, "profile 'claude-work' is refused — nope"))
+        self.assertEqual(rc, launcher.REFUSED_EXIT)
+        self.assertIn("is refused — nope", said)
+
+    def test_a_pane_already_dead_with_no_refusal_keeps_tmuxs_own_number(self):
+        """And the other way down the same branch: a harness that RAN and failed has no
+        launcher record to prefer, so what tmux reported about the pane is the answer — and
+        the operator is told what died, because nothing else on this path will."""
+        with mock.patch.object(commands_frame, "_pane_last_words", return_value=[]):
+            rc, said = self._in_operator_tmux(profile="claude-work",
+                                              pane_state=(commands_frame._DEAD, 7))
+        self.assertEqual(rc, 7)
+        self.assertIn("7", said)
+
+    def test_a_pane_that_vanished_with_nothing_recorded_says_nothing_it_cannot_know(self):
+        """`code` is `None` and the launcher recorded nothing: charter knows the pane is
+        gone and knows nothing else. An early-death sentence built on that would name an
+        exit code nobody has — so the branch that writes one is asked whether there IS a
+        number first, and this path says nothing at all."""
+        rc, said = self._in_operator_tmux(profile="claude-work",
+                                          pane_state=(commands_frame._GONE, None))
+        self.assertEqual(rc, commands_frame._UNKNOWN_DEATH_CODE)
+        self.assertEqual(said, "")
+
+    def test_a_launch_with_no_profile_has_no_launcher_record_to_read_here_either(self):
+        """`charter frame -- <cmd>` starts the command itself on this path too: no charter
+        launcher runs in that pane, so a record left under that chat id by an earlier chat
+        is not this launch's verdict."""
+        rc, said = self._in_operator_tmux(
+            harness="frame", rest=["--", "true"], pane_state=(commands_frame._GONE, None),
+            verdict=(launcher.REFUSED_EXIT, "a refusal from some other launch"))
+        self.assertEqual(rc, commands_frame._UNKNOWN_DEATH_CODE)
+        self.assertNotIn("some other launch", said)
 
     def test_it_fails_closed_and_loudly_when_the_chat_option_does_not_take(self):
         """The launcher proves its chat by `@charter_chat` on this server (ruling 33). A

--- a/tests/test_a_profile_launch_is_refused_before_tmux.py
+++ b/tests/test_a_profile_launch_is_refused_before_tmux.py
@@ -1,0 +1,483 @@
+"""A profile that may not run is refused before tmux is asked for anything.
+
+Each guard runs before tmux wherever a terminal is attached — a refusal there is a `return`,
+with no session, no window and no chat directory to tear down — and again in the pane
+immediately before the exec, because the plane can move in between (spec, *What guards a
+launch*). This module is the first half: what `_launch` refuses, what it hands tmux when it
+does not, and what never crosses tmux at all.
+
+**Every declared profile is refused here** (review B1). Nothing yet stands for the
+operator's approval of a `command`, and `charter.local.toml` is a file a chat can write
+with no diff to show for it — so between this merge and Task 3's, `main` runs no command
+that file declares, through `charter <profile>`, `+`, a tab, reopen or a handoff. The three
+cases that say so run without the stand-in the rest of the module uses.
+"""
+
+from __future__ import annotations
+
+import io
+import os
+import subprocess
+import unittest
+from contextlib import redirect_stderr
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
+
+from charter import commands_frame, config, contain
+from charter.frame import launcher, layout, reopen as reopen_state, state, tmuxctl
+from tests import _gitguard, _tmuxsocket
+from tests._isolation import PersonaIso, make_plane
+
+_LOCAL = """
+[harness.claude-work]
+kind = "claude"
+command = ["claude"]
+env = { CLAUDE_CONFIG_DIR = "~/.cw" }
+
+[harness.codex-pinned]
+kind = "codex"
+command = ["npx", "-y", "@openai/codex@0.140.0"]
+"""
+
+#: The operator's own tmux, as `tmuxctl.operator_server` reads it out of `$TMUX`: a socket
+#: PATH, which is what `is_operator_socket` tells from charter's own `-L charter` name.
+#: Computed the way tmux computes it (`tests/_tmuxsocket.py`) rather than written down —
+#: a literal uid in a socket path is one developer's machine baked into the suite.
+_OPERATOR = _tmuxsocket.OPERATOR_SOCKET
+
+
+def _git(root: Path, *args: str) -> None:
+    subprocess.run(["git", "-C", str(root), *args], check=True, capture_output=True,
+                   env={**os.environ, **_gitguard.environment()})
+
+
+class _ALaunchNamesAProfile(PersonaIso):
+    """The real `_launch`, with tmux and everything that would start a process stood in —
+    `tests/test_a_chat_opens_in_the_background_with_its_first_message.py`'s own patch set."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        make_plane(self)
+        self.local = config.ROOT / "charter.local.toml"
+        self.local.write_text(_LOCAL)
+        (config.ROOT / ".gitignore").write_text("/charter.local.toml\n")
+        _git(config.ROOT, "init", "-q")
+        (config.WORKSPACES_DIR / "beta").mkdir(parents=True, exist_ok=True)
+        self.enterContext(mock.patch.dict(
+            os.environ,
+            {"PATH": os.environ.get("PATH", ""),
+             "GIT_CEILING_DIRECTORIES": str(self.tmp.resolve().parent),
+             "CHARTER_ROOT": str(config.ROOT), **_gitguard.environment()}, clear=True))
+        self.argvs: list[list[str]] = []
+        self.execs: list[tuple] = []
+        self.enterContext(mock.patch.object(launcher.os, "execvpe",
+                                            side_effect=lambda *a: self.execs.append(a)))
+
+    def _no_approval_needed(self) -> None:
+        """Task 2 refuses every declared profile (review B1). A case that is about something
+        else stands that one refusal down; the three that are about it do not."""
+        self.enterContext(mock.patch.object(launcher, "_approval_refusal",
+                                            return_value=None))
+
+    def _run(self, action, argv, **kw):
+        self.argvs.append(list(argv))
+        out = "%9\n"
+        if "new-window" in argv and "-t" in argv and _OPERATOR in argv:
+            out = "@1 %9\n"
+        return subprocess.CompletedProcess(argv, 0, out, "")
+
+    def _launch(self, *, which: str | None = "/nowhere/claude", dead_status=None,
+                verdict: tuple = (None, ""), operator=None, **ns) -> int:
+        """The real `_launch` with tmux stood in — and every answer a case might care about
+        as a PARAMETER rather than a patch applied inside here.
+
+        The existing launcher tests record why (`_harness_binary_installed`): these patches
+        are entered inside this helper, so they override anything a case set up outside it,
+        and the case about a missing binary was answered "installed" along with everything
+        else. A knob a case can state is the only way that stays honest.
+        """
+        args = SimpleNamespace(**{"harness": "claude", "rest": [], "no_frame": False,
+                                  "workspace": "beta", "pick": False, "size": (120, 40),
+                                  **ns})
+        with mock.patch("charter.commands_frame.shutil.which", return_value=which), \
+                mock.patch.object(launcher.shutil, "which", return_value=which), \
+                mock.patch("sys.stdout.isatty", return_value=True), \
+                mock.patch("sys.stdin.isatty", return_value=False), \
+                mock.patch.object(tmuxctl, "version", return_value=(3, 7)), \
+                mock.patch.object(tmuxctl, "operator_server", return_value=operator), \
+                mock.patch.object(commands_frame, "_live_sessions", return_value={"beta"}), \
+                mock.patch.object(commands_frame, "_live_chats", return_value=set()), \
+                mock.patch.object(tmuxctl, "run", side_effect=self._run), \
+                mock.patch.object(tmuxctl, "write_all",
+                                  side_effect=lambda joint, writes, **kw: [
+                                      subprocess.CompletedProcess(w.argv, 0, "", "")
+                                      for w in writes]), \
+                mock.patch.object(tmuxctl, "interact",
+                                  return_value=subprocess.CompletedProcess([], 0)), \
+                mock.patch.object(commands_frame, "_query_pane_dead_status",
+                                  return_value=dead_status), \
+                mock.patch.object(commands_frame, "_await_the_launcher",
+                                  return_value=verdict) as awaited, \
+                mock.patch.object(commands_frame, "_draw_panels", return_value={}), \
+                mock.patch.object(commands_frame, "_arm_panel_respawn"), \
+                mock.patch.object(commands_frame, "_spawn_gather"), \
+                mock.patch.object(commands_frame, "_chat_being_left", return_value=""), \
+                mock.patch.object(commands_frame, "_drop_panels"), \
+                mock.patch.object(commands_frame.state, "reap"):
+            rc = commands_frame._launch(args)
+        self.awaited = awaited
+        return rc
+
+    def _said(self, **ns) -> tuple[int, str]:
+        err = io.StringIO()
+        with redirect_stderr(err):
+            rc = self._launch(**ns)
+        return rc, err.getvalue()
+
+    def _tmux_verbs(self) -> list[str]:
+        return [a[3] for a in self.argvs if len(a) > 3]
+
+    def _started(self) -> bool:
+        return any("new-window" in a or "new-session" in a for a in self.argvs)
+
+
+class EveryDeclaredProfileIsRefusedUntilApprovalExists(_ALaunchNamesAProfile,
+                                                       unittest.TestCase):
+    """Review B1, and the three cases that run WITHOUT the stand-in. Delete the refusal and
+    these go red: `main` would run whatever a chat wrote into `charter.local.toml`."""
+
+    def test_every_declared_profile_is_refused_until_approval_exists(self):
+        rc, said = self._said(profile="claude-work")
+        self.assertEqual(rc, launcher.REFUSED_EXIT)
+        self.assertIn("cannot yet ask before a declared command runs", said)
+        self.assertFalse(self._started(), self.argvs)
+        self.assertEqual(self.execs, [])
+
+    def test_a_declared_replacement_of_a_built_in_is_refused_until_approval_exists(self):
+        self.local.write_text('[harness.claude]\nkind = "claude"\n'
+                              'command = ["/opt/claude"]\n')
+        rc, said = self._said()
+        self.assertEqual(rc, launcher.REFUSED_EXIT)
+        self.assertIn("cannot yet ask before a declared command runs", said)
+        self.assertFalse(self._started(), self.argvs)
+
+    def test_a_built_in_the_file_does_not_replace_still_launches(self):
+        self.assertEqual(self._launch(harness="codex"), 0)
+        self.assertTrue(self._started(), self.argvs)
+
+
+class ALaunchRefusesBeforeTmux(_ALaunchNamesAProfile, unittest.TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self._no_approval_needed()
+
+    def test_an_unknown_profile_is_refused_and_nothing_is_allocated(self):
+        rc, said = self._said(profile="nope")
+        self.assertEqual(rc, 2)
+        self.assertIn("no profile named 'nope'", said)
+        self.assertEqual(self.argvs, [])
+        self.assertFalse((config.STATE_DIR / "frame" / "beta.1").exists())
+
+    def test_a_refused_profile_says_its_own_reason(self):
+        self.local.write_text('[harness.bad]\nkind = "claude"\ncommand = "claude -x"\n')
+        rc, said = self._said(profile="bad")
+        self.assertEqual(rc, 2)
+        self.assertIn("never a shell string", said)
+        self.assertEqual(self.argvs, [])
+
+    def test_a_profile_of_another_kind_is_refused_by_its_name(self):
+        rc, said = self._said(profile="codex-pinned")
+        self.assertEqual(rc, 2)
+        self.assertIn("is a codex profile", said)
+        self.assertIn("charter codex-pinned", said)
+
+    def test_a_declared_profile_from_a_committable_file_is_refused(self):
+        (config.ROOT / ".gitignore").write_text("")
+        rc, said = self._said(profile="claude-work")
+        self.assertEqual(rc, launcher.REFUSED_EXIT)
+        self.assertIn("charter reinit", said)
+        self.assertFalse(self._started(), self.argvs)
+
+    def test_a_built_in_is_not_refused_over_the_local_file(self):
+        (config.ROOT / ".gitignore").write_text("")
+        self.assertEqual(self._launch(), 0)
+        self.assertTrue(self._started(), self.argvs)
+
+    def test_a_declared_replacement_of_a_built_in_in_a_committable_file_refuses_that_name(
+            self):
+        """Ruling 19: that name refuses rather than falling back to the built-in, which
+        would run the command the operator replaced."""
+        self.local.write_text('[harness.claude]\nkind = "claude"\n'
+                              'command = ["/opt/claude"]\n')
+        (config.ROOT / ".gitignore").write_text("")
+        rc, said = self._said()
+        self.assertEqual(rc, launcher.REFUSED_EXIT)
+        self.assertIn("charter reinit", said)
+        self.assertFalse(self._started(), self.argvs)
+        self.assertEqual(self.execs, [])
+
+    def test_a_command_not_on_path_is_refused_by_profile_name(self):
+        rc, said = self._said(profile="claude-work", which=None)
+        self.assertEqual(rc, launcher.MISSING_EXIT)
+        self.assertIn("profile 'claude-work' runs claude, which is not on PATH", said)
+
+    def test_each_refusal_says_something_different(self):
+        """A reader has to be able to tell which rule fired. Four refusals, four sentences,
+        and the same fixture — so a copied message is a red test rather than a shrug."""
+        said = {self._said(profile="nope")[1],
+                self._said(profile="codex-pinned")[1]}
+        self.local.write_text('[harness.bad]\nkind = "claude"\ncommand = "claude -x"\n')
+        said.add(self._said(profile="bad")[1])
+        said.add(self._said(which=None)[1])
+        self.assertEqual(len(said), 4, said)
+
+
+class TheLaunchHandsTmuxTheLauncherAndNeverTheEnv(_ALaunchNamesAProfile, unittest.TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self._no_approval_needed()
+
+    def test_the_launch_hands_tmux_the_launcher_and_never_the_env(self):
+        self.assertEqual(self._launch(profile="claude-work"), 0)
+        start = next(a for a in self.argvs if "new-window" in a)
+        self.assertEqual(start[-9:], [os.sys.executable, "-P", "-m", "charter",
+                                      "frame-launch", "--profile", "claude-work",
+                                      "--attended", "--"])
+        flat = " ".join(" ".join(a) for a in self.argvs)
+        self.assertNotIn("~/.cw", flat)
+        self.assertNotIn(os.path.expanduser("~/.cw"), flat)
+        self.assertNotIn("CLAUDE_CONFIG_DIR", flat)
+
+    def test_every_environment_name_that_crosses_tmux_is_one_of_the_five(self):
+        """Spelled here rather than imported: the promise is the LIST, and a test that read
+        it off the same constant would agree with any change to it."""
+        self._launch(profile="claude-work")
+        carried = {a[i + 1].split("=")[0]
+                   for a in self.argvs for i, tok in enumerate(a) if tok == "-e"}
+        self.assertTrue(carried)
+        self.assertLessEqual(carried, {"CHARTER_SESSION_ID", "CHARTER_HARNESS",
+                                       "CHARTER_ROOT", "CHARTER_WORKSPACE",
+                                       "CHARTER_PERSONA", "PATH"})
+
+    def test_carriable_is_unchanged(self):
+        """A pin: nothing is added to it, and a profile's `env` never travels this way."""
+        self.assertEqual(layout.CARRIABLE,
+                         frozenset({"CHARTER_SESSION_ID", "CHARTER_HARNESS", "CHARTER_ROOT",
+                                    "CHARTER_WORKSPACE", "CHARTER_PERSONA", "PATH"}))
+
+    def test_the_chat_records_its_profile_and_keeps_the_kind_as_the_harness(self):
+        self._launch(profile="claude-work")
+        self.assertEqual(state.profile("beta.1"), "claude-work")
+        self.assertEqual(state.identity("beta.1")["CHARTER_HARNESS"], "claude-code")
+
+    def test_a_frame_escape_hatch_launch_records_no_profile(self):
+        self.assertEqual(self._launch(harness="frame", rest=["--", "true"]), 0)
+        start = next(a for a in self.argvs if "new-window" in a)
+        self.assertEqual(start[-2:], ["--", "true"])
+        self.assertNotIn("frame-launch", " ".join(start))
+        self.assertIsNone(state.profile("beta.1"))
+
+    def test_a_reopen_launch_is_unattended(self):
+        recorded = reopen_state.Chat(chat="beta.1", workspace="beta", persona="",
+                                     harness="claude-code", cwd="", resume="",
+                                     transcript="", active=False)
+        self._launch(profile="claude-work",
+                     reopening=commands_frame.Reopening(recorded))
+        start = next(a for a in self.argvs if "new-window" in a)
+        self.assertNotIn("--attended", start)
+
+    def test_a_background_open_launch_is_unattended(self):
+        self._launch(profile="claude-work", attach=False,
+                     opening=commands_frame.Opening("fix it please"))
+        start = next(a for a in self.argvs if "new-window" in a)
+        self.assertNotIn("--attended", start)
+
+
+class ALaunchWithNoFrameExecsTheProfile(_ALaunchNamesAProfile, unittest.TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self._no_approval_needed()
+
+    def test_no_frame_execs_the_profile_with_its_env(self):
+        self.assertEqual(self._launch(profile="claude-work", no_frame=True), 0)
+        (program, argv, env), = self.execs
+        self.assertEqual((program, argv), ("claude", ["claude"]))
+        self.assertEqual(env["CLAUDE_CONFIG_DIR"], os.path.expanduser("~/.cw"))
+        self.assertEqual(env["CHARTER_HARNESS_PROFILE"], "claude-work")
+        self.assertEqual(env["CHARTER_HARNESS"], "claude-code")
+        self.assertEqual(self.argvs, [], "a bare harness asks tmux for nothing")
+
+    def test_no_frame_from_a_chat_does_not_carry_that_chats_session_id(self):
+        """Review 8: the pair is the defect — `hooks._record_harness_session` acts on a
+        session id beside the launched `CHARTER_HARNESS`, so a bare harness typed inside a
+        chat would write its own harness session into that chat's state."""
+        with mock.patch.dict(os.environ, {"CHARTER_SESSION_ID": "alpha.1",
+                                          "CHARTER_HARNESS": "codex"}):
+            self._launch(profile="claude-work", no_frame=True)
+        (_program, _argv, env), = self.execs
+        self.assertNotIn("CHARTER_SESSION_ID", env)
+        self.assertEqual(env["CHARTER_HARNESS"], "claude-code")
+
+    def test_a_persona_pin_typed_before_no_frame_still_reaches_the_harness(self):
+        """A pin: `bypass` carried these before profiles, and they are pins an operator
+        means — `CHARTER_PERSONA=forge charter claude --no-frame` says what it says."""
+        with mock.patch.dict(os.environ, {"CHARTER_PERSONA": "forge",
+                                          "CHARTER_WORKSPACE": "alpha",
+                                          "CHARTER_SESSION_ID": "alpha.1"}):
+            self._launch(profile="claude-work", no_frame=True)
+        (_program, _argv, env), = self.execs
+        self.assertEqual(env["CHARTER_PERSONA"], "forge")
+        self.assertEqual(env["CHARTER_WORKSPACE"], "alpha")
+        self.assertEqual(env["CHARTER_ROOT"], str(config.ROOT))
+
+    def test_a_no_frame_launch_of_a_declared_profile_is_refused_like_any_other(self):
+        """The `--no-frame` harness gets the same checks — no flag launches a profile
+        unguarded."""
+        with mock.patch.object(launcher, "_approval_refusal",
+                               return_value=launcher.Refusal(launcher.KIND_NOT_YET, "no",
+                                                             launcher.REFUSED_EXIT)):
+            rc = self._launch(profile="claude-work", no_frame=True)
+        self.assertEqual(rc, launcher.REFUSED_EXIT)
+        self.assertEqual(self.execs, [])
+
+
+class AnEarlyDeathNamesTheProfilesCommand(_ALaunchNamesAProfile, unittest.TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self._no_approval_needed()
+
+    def test_an_early_death_names_the_profiles_command_not_the_launcher(self):
+        """What the operator reads has to be the command they wrote down, not
+        `python -P -m charter frame-launch --profile …`."""
+        with mock.patch.object(commands_frame, "_pane_last_words", return_value=[]):
+            rc, said = self._said(profile="claude-work", dead_status=3)
+        self.assertEqual(rc, 3)
+        self.assertIn("claude", said)
+        self.assertNotIn("frame-launch", said)
+
+
+class AnUnattendedLaunchReadsTheLauncherssVerdict(_ALaunchNamesAProfile, unittest.TestCase):
+    """Ruling 42's second half. Nobody is at a reopened or handed-off chat to press a key,
+    so the pane records what it did and the launch that opened it reports that."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        self._no_approval_needed()
+
+    def test_a_refusal_the_pane_recorded_is_what_the_operator_is_told(self):
+        rc, said = self._said(
+            profile="claude-work", attach=False,
+            opening=commands_frame.Opening("fix it please"),
+            verdict=(launcher.REFUSED_EXIT, "profile 'claude-work' is refused — nope"))
+        self.assertEqual(rc, launcher.REFUSED_EXIT)
+        self.assertIn("is refused — nope", said)
+
+    def test_an_attended_launch_waits_for_nothing_because_the_pane_holds_its_own(self):
+        """An attended pane shows its refusal and waits for a key, so the launch that opened
+        it must not also stop to read a verdict — it is about to attach."""
+        self._launch(profile="claude-work")
+        self.awaited.assert_not_called()
+
+    def test_an_unattended_launch_is_the_one_that_asks(self):
+        self._launch(profile="claude-work", attach=False,
+                     opening=commands_frame.Opening("fix it please"))
+        self.awaited.assert_called_once()
+
+
+class TheVerdictWaitStopsOnItsOwnTerms(PersonaIso, unittest.TestCase):
+    """`_await_the_launcher` itself: it ends on the verdict, on the pane dying, or on its
+    own budget — and never on a sleep nobody bounded."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        make_plane(self)
+        state.frame_dir("beta.1", create=True)
+        self.slept: list[float] = []
+        self.enterContext(mock.patch.object(commands_frame.time, "sleep",
+                                            side_effect=self.slept.append))
+
+    def _await(self, alive: bool = True):
+        status = commands_frame._ALIVE if alive else commands_frame._GONE
+        with mock.patch.object(commands_frame, "_pane_state", return_value=(status, None)):
+            return commands_frame._await_the_launcher("sock", "beta.1", "%1")
+
+    def test_a_launcher_that_handed_the_pane_over_is_not_waited_on(self):
+        state.record_launch("beta.1")
+        self.assertEqual(self._await(), (None, ""))
+        self.assertEqual(self.slept, [], "a chat that started fine must not cost a wait")
+
+    def test_a_refusal_comes_back_with_its_own_exit_code(self):
+        state.record_launch("beta.1", launcher.MISSING_EXIT, "not on PATH")
+        self.assertEqual(self._await(), (launcher.MISSING_EXIT, "not on PATH"))
+
+    def test_a_pane_that_died_without_a_verdict_is_not_waited_on_either(self):
+        self.assertEqual(self._await(alive=False), (None, ""))
+        self.assertEqual(self.slept, [])
+
+    def test_a_launcher_that_never_answers_is_given_up_on(self):
+        """A budget, not a hang: a pane charter could not prove a chat for records nothing,
+        and a reopen of four chats must not stop on it."""
+        ticks = iter([0.0, 0.0, commands_frame._LAUNCHER_SECONDS + 1])
+        with mock.patch.object(commands_frame.time, "monotonic",
+                               side_effect=lambda: next(ticks)):
+            self.assertEqual(self._await(), (None, ""))
+
+
+class TheOperatorsTmuxRespawnsTheLauncher(_ALaunchNamesAProfile, unittest.TestCase):
+    """Ruling 4: inside a tmux the operator already has, the `cat` placeholder stays — it is
+    what lets `remain-on-exit` be set before anything in the pane can exit (#384) — and the
+    launcher is what `respawn-pane` starts, where the harness argv went."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        self._no_approval_needed()
+        self.chat_option_rc = 0
+
+    def _run(self, action, argv, **kw):
+        self.argvs.append(list(argv))
+        rc = 0
+        if "set-option" in argv and commands_frame._CHAT_OPTION in argv:
+            rc = self.chat_option_rc
+        out = "@1 %9\n" if "new-window" in argv else "%9\n"
+        return subprocess.CompletedProcess(argv, rc, out, "")
+
+    def _in_operator_tmux(self, **ns) -> tuple[int, str]:
+        ns.setdefault("operator", (_OPERATOR, "$1"))
+        with mock.patch.object(commands_frame, "_pane_state",
+                                  return_value=(commands_frame._ALIVE, None)), \
+                mock.patch.object(commands_frame, "_wait_for_harness", return_value=0), \
+                mock.patch.object(commands_frame, "_window_size", return_value=(120, 40)), \
+                mock.patch.object(commands_frame, "_reap_this_server"), \
+                mock.patch.object(commands_frame, "_live_windows", return_value=set()):
+            return self._said(**ns)
+
+    def test_the_window_starts_on_the_placeholder_and_respawns_the_launcher(self):
+        rc, _said = self._in_operator_tmux(profile="claude-work")
+        self.assertEqual(rc, 0)
+        opened = next(a for a in self.argvs if "new-window" in a)
+        self.assertEqual(opened[-2:], ["--", *layout.PLACEHOLDER])
+        respawned = next(a for a in self.argvs if "respawn-pane" in a)
+        self.assertEqual(respawned[-5:], ["frame-launch", "--profile", "claude-work",
+                                          "--attended", "--"])
+        self.assertLess(self.argvs.index(next(a for a in self.argvs
+                                              if "remain-on-exit" in a)),
+                        self.argvs.index(respawned))
+
+    def test_it_fails_closed_and_loudly_when_the_chat_option_does_not_take(self):
+        """The launcher proves its chat by `@charter_chat` on this server (ruling 33). A
+        window that could not be told which chat it is would make every launcher in it
+        unproven — running with no frame, recording nothing, and silently — so the launch
+        stops instead."""
+        self.chat_option_rc = 1
+        rc, said = self._in_operator_tmux(profile="claude-work")
+        self.assertNotEqual(rc, 0)
+        self.assertIn("chat", said.lower())
+        self.assertFalse([a for a in self.argvs if "respawn-pane" in a],
+                         "nothing may be started in a window charter could not name")
+        self.assertTrue([a for a in self.argvs if "kill-window" in a],
+                        "the window the operator never asked for is taken back")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_a_profile_launch_is_refused_before_tmux.py
+++ b/tests/test_a_profile_launch_is_refused_before_tmux.py
@@ -488,11 +488,15 @@ class TheOperatorsTmuxRespawnsTheLauncher(_ALaunchNamesAProfile, unittest.TestCa
         out = "@1 %9\n" if "new-window" in argv else "%9\n"
         return subprocess.CompletedProcess(argv, rc, out, "")
 
-    def _in_operator_tmux(self, **ns) -> tuple[int, str]:
+    def _in_operator_tmux(self, *, harness_exit: int | None = 0, **ns) -> tuple[int, str]:
+        """*harness_exit* is what `_wait_for_harness` answers — ``None`` for a pane that is
+        no longer there to be asked, which is a parameter rather than a patch for the
+        reason `_launch` gives about its own knobs."""
         ns.setdefault("operator", (_OPERATOR, "$1"))
         with mock.patch.object(commands_frame, "_pane_state",
                                   return_value=(commands_frame._ALIVE, None)), \
-                mock.patch.object(commands_frame, "_wait_for_harness", return_value=0), \
+                mock.patch.object(commands_frame, "_wait_for_harness",
+                                  return_value=harness_exit), \
                 mock.patch.object(commands_frame, "_window_size", return_value=(120, 40)), \
                 mock.patch.object(commands_frame, "_reap_this_server"), \
                 mock.patch.object(commands_frame, "_live_windows", return_value=set()):
@@ -509,6 +513,23 @@ class TheOperatorsTmuxRespawnsTheLauncher(_ALaunchNamesAProfile, unittest.TestCa
         self.assertLess(self.argvs.index(next(a for a in self.argvs
                                               if "remain-on-exit" in a)),
                         self.argvs.index(respawned))
+
+    def test_a_pane_that_refused_and_vanished_still_reports_its_own_number(self):
+        """**The launcher's number, not tmux's reading of a pane that is not there.**
+        `remain-on-exit` is armed on this path, and nothing guarantees it took — a pane
+        that is gone answers no `#{pane_dead_status}` at all, and `_wait_for_harness`
+        reports that as `None` exactly as it does for a window the operator closed. The
+        launcher wrote down what it was exiting with BEFORE it exited, which is better
+        evidence than anything reconstructed afterwards. Measured on a Linux runner, where
+        this path answered `_UNKNOWN_DEATH_CODE` for the same refusal charter's own server
+        reported as 3 — and the sentence went with it.
+        """
+        rc, said = self._in_operator_tmux(
+            profile="claude-work", harness_exit=None,
+            verdict=(launcher.REFUSED_EXIT, "profile 'claude-work' is refused — nope"))
+        self.assertEqual(rc, launcher.REFUSED_EXIT)
+        self.assertIn("is refused — nope", said)
+        self.assertNotIn("is not something charter can know", said)
 
     def test_it_fails_closed_and_loudly_when_the_chat_option_does_not_take(self):
         """The launcher proves its chat by `@charter_chat` on this server (ruling 33). A

--- a/tests/test_a_quit_records_the_plane_before_it_kills.py
+++ b/tests/test_a_quit_records_the_plane_before_it_kills.py
@@ -1170,10 +1170,14 @@ class WhatIsOnDiskIsAFormatAndNotAnImplementationDetail(PersonaIso, unittest.Tes
         self.assertEqual(raw["at"], 1700000000)
         self.assertEqual(raw["focus"], "alpha")
         self.assertEqual(sorted(raw["frames"][0]), ["chats", "workspace"])
+        # `profile` joined them when a chat began recording which PROFILE it runs rather
+        # than only which harness — and it joined them without moving `version`, because a
+        # manifest one field older is the migration case the reader is built for: a missing
+        # key reads as `""`, which reopens the chat on the built-in of its kind.
         self.assertEqual(
             sorted(raw["frames"][0]["chats"][0]),
-            ["active", "chat", "cwd", "harness", "persona", "resume", "transcript",
-             "workspace"])
+            ["active", "chat", "cwd", "harness", "persona", "profile", "resume",
+             "transcript", "workspace"])
 
     def test_at_is_a_whole_number_of_seconds_and_defaults_to_now(self):
         # `int(...)`, so a float clock never reaches the file: `at` is read back through an

--- a/tests/test_a_real_click_on_a_real_tab_bar_switches.py
+++ b/tests/test_a_real_click_on_a_real_tab_bar_switches.py
@@ -83,7 +83,7 @@ def _NOT_OPEN(ws: str) -> str:
     the module under test would follow a reworded sentence silently, and the wording is
     the thing. It carries the name, so a click that landed on the wrong tab fails here.
     """
-    return f"cannot open '{ws}': this chat records no harness"
+    return f"cannot open '{ws}': this chat records no profile"
 
 _REPO_ROOT = Path(__file__).resolve().parents[1]
 
@@ -1082,7 +1082,7 @@ class ARealPressOnThePlusReachesTheCommandBehindIt(_ARealFrameWithBars,
     #: reworded sentence into a green run, which is the survivor this repository's sweep
     #: reports. Short enough to survive a rewording that keeps the meaning, specific enough
     #: that no other refusal on this path says it.
-    _NO_HARNESS = "records no harness this charter can launch"
+    _NO_HARNESS = "records no profile this charter can launch"
 
     def setUp(self) -> None:
         super().setUp()

--- a/tests/test_a_reopen_says_what_it_cannot_bring_back.py
+++ b/tests/test_a_reopen_says_what_it_cannot_bring_back.py
@@ -537,12 +537,19 @@ class WhatAReopenPutsBack(PersonaIso, unittest.TestCase):
         self.assertEqual(self.calls, [])
         self.assertIsNotNone(reopen.read(), "left in place so it can be tried again")
 
-    def test_a_harness_this_charter_cannot_launch_falls_back_to_the_planes_default(self):
+    def test_a_harness_this_charter_cannot_launch_is_skipped_rather_than_moved(self):
+        """**The `[harness] default` fallback is deleted** (ruling 15). A chat recorded
+        under a harness this charter no longer registers used to come back under the
+        plane's default and be told so; it is skipped now, and stays in the record for a
+        retry — because a profile can be another account, where this chat's conversation
+        does not exist and its workspace's code was never meant to go. The declared default
+        changes nothing about that."""
         self._record(self._chat(harness="clyde"))
         with mock.patch.object(config, "HARNESS",
                                {"default": "claude", "refused": None}):
-            self.assertEqual(self._reopen(), 0)
-        self.assertEqual(self.calls[0].harness, "claude")
+            self.assertEqual(self._reopen(), 1)
+        self.assertEqual(self.calls, [])
+        self.assertIsNotNone(reopen.read(), "left in place so it can be tried again")
 
 
 class TheReopenPathSuppressesFourThingsInTheLauncher(PersonaIso, unittest.TestCase):

--- a/tests/test_a_workspace_tab_opens_what_it_names.py
+++ b/tests/test_a_workspace_tab_opens_what_it_names.py
@@ -140,6 +140,15 @@ class _OpensBeta(PersonaIso, unittest.TestCase):
     def setUp(self):
         super().setUp()
         self.enterContext(mock.patch.dict(os.environ, {}, clear=True))
+        # **The profile's own guards, stood down for this class.** A click now runs them
+        # before it launches, so its refusal reaches the frame's attention row rather than
+        # `/dev/null` (`commands_frame._launch_refusal`) — and the first of them asks
+        # whether the command is on `PATH`, which would refuse every case here on a machine
+        # without `codex` installed. What these cases are about is which workspace and
+        # which profile a click opens; `tests/test_a_profile_launch_is_refused_before_tmux
+        # .py` is about the guards.
+        self.enterContext(mock.patch("charter.commands_frame._launch_refusal",
+                                     return_value=""))
         for n in ("alpha", "beta"):
             (config.WORKSPACES_DIR / n).mkdir(parents=True, exist_ok=True)
         _a_chat(self.FID, ws="alpha", pane="%1")
@@ -359,11 +368,16 @@ class TheOpenUsesTheHarnessTheOperatorIsAlreadyIn(_OpensBeta):
     def test_a_chat_with_no_recorded_harness_falls_back_to_the_planes_default(self):
         """A chat launched by a charter that predates `state.record_identity`. The plane's
         `[harness] default` is a thing somebody chose, so it is a better answer than
-        refusing — and the fallback is named in `cmd_reopen`'s own words."""
+        refusing.
+
+        Declared in the FILE, not patched onto `config.HARNESS`: the effective default is
+        `profiles.current()`'s since ruling 43 — `charter.local.toml`'s where it names one
+        — and a patched setting would pin a value this path no longer reads."""
         _a_chat(self.FID, ws="alpha", pane="%1", harness="")
-        with mock.patch.dict(config.HARNESS, {"default": "codex"}):
-            self._run()
+        (config.ROOT / "charter.local.toml").write_text('[harness]\ndefault = "codex"\n')
+        self._run()
         self.assertEqual(self.launched[0].harness, "codex")
+        self.assertEqual(self.launched[0].profile, "codex")
 
     def test_the_launch_runs_in_the_workspaces_own_directory(self):
         """Where `charter --workspace beta` typed in it would have run, and what
@@ -474,22 +488,25 @@ class TheOpenUsesTheHarnessTheOperatorIsAlreadyIn(_OpensBeta):
         self.assertEqual(os.getcwd(), was)
 
     def test_a_plane_whose_harness_table_is_missing_entirely_is_not_a_crash(self):
-        """`config.HARNESS` is ``None`` on a plane whose config has no `[harness]` table at
-        all — a different state from one that has the table with no `default` in it, and
-        the `or {}` is the only thing between the two and an `AttributeError` on the
-        detached side, where a traceback goes to `/dev/null` and the click does nothing."""
+        """`config.HARNESS` was read here through an `or {}`, because it is ``None`` on a
+        plane whose config has no `[harness]` table at all and `None.get` is an
+        `AttributeError` on the detached side, where a traceback goes to `/dev/null` and
+        the click does nothing.
+
+        That read is gone — the default is `profiles.current()`'s now (ruling 43) — so this
+        case holds the stronger promise in its place: the click reads that setting nowhere,
+        so whatever it holds, a chat with nothing recorded is refused by name."""
         _a_chat(self.FID, ws="alpha", pane="%1", harness="")
         with mock.patch.object(config, "HARNESS", None):
             self._run()
         self.assertEqual(self.launched, [])
-        self.assertIn("no harness", self.said.call_args[0][1])
+        self.assertIn("no profile", self.said.call_args[0][1])
 
     def test_with_neither_it_refuses_by_name_rather_than_guessing(self):
         _a_chat(self.FID, ws="alpha", pane="%1", harness="")
-        with mock.patch.dict(config.HARNESS, {"default": ""}):
-            self._run()
+        self._run()
         self.assertEqual(self.launched, [])
-        self.assertIn("no harness", self.said.call_args[0][1])
+        self.assertIn("no profile", self.said.call_args[0][1])
 
 
 class TheLauncherCanBuildAFrameWithNoTerminalOfItsOwn(PersonaIso, unittest.TestCase):
@@ -528,17 +545,24 @@ class TheLauncherCanBuildAFrameWithNoTerminalOfItsOwn(PersonaIso, unittest.TestC
 
     def test_a_launch_that_wants_a_terminal_is_still_bypassed_without_one(self):
         """The guard is opened for one case and left standing for every other: a piped
-        `charter claude > file` must still run the harness with no frame."""
+        `charter claude > file` must still run the harness with no frame.
+
+        Through the LAUNCHER since profiles, and that is the same promise one step along:
+        it runs the profile's own checks and `exec`s its command with its environment, so
+        `--no-frame` and a pipe are not ways past a guard. `bypass` is what a launch with
+        no profile — `charter frame -- <cmd>` — still reaches."""
         args = SimpleNamespace(harness="claude", rest=[], no_frame=False,
                                workspace=None, pick=False)
         with mock.patch("charter.commands_frame.sys.stdout") as out, \
+                mock.patch("sys.stdin.isatty", return_value=False), \
                 mock.patch("charter.commands_frame.shutil.which",
                            return_value="/nowhere/claude"), \
-                mock.patch("charter.commands_frame.bypass",
-                           return_value=0) as byp:
+                mock.patch("charter.frame.launcher.start", return_value=0) as started, \
+                mock.patch("charter.commands_frame.bypass", return_value=0) as byp:
             out.isatty.return_value = False
             commands_frame.cmd_launch(args)
-        byp.assert_called_once()
+        started.assert_called_once()
+        byp.assert_not_called()
 
     def test_a_size_that_is_not_two_positive_integers_is_measured_instead(self):
         """The handed-in size reaches `layout.session_argv` as `-x`/`-y`, where a
@@ -997,8 +1021,36 @@ class ARealTabOpensARealWorkspace(PersonaIso, unittest.TestCase):
         fake = binroot / "codex"
         fake.write_text("#!/bin/sh\nexec sleep 300\n")
         fake.chmod(0o755)
-        self.enterContext(mock.patch.dict(
-            os.environ, {"PATH": f"{binroot}{os.pathsep}{os.environ.get('PATH', '')}"}))
+        # **The pane's first process is charter itself now**, not the harness: tmux starts
+        # `python -P -m charter frame-launch --profile <name> -- …`, which runs the
+        # profile's guards and `exec`s its command (`frame/launcher.py`). That child needs
+        # two things this fixture used not to owe it, and both are stated here because the
+        # tmux client is started with this process's environment (`_frame_env`):
+        #
+        # * `$PYTHONPATH` — `-P` keeps the child's own cwd off `sys.path` (#390), and the
+        #   cwd is a workspace directory rather than this checkout, so without it the
+        #   child cannot import the charter under test at all;
+        # * `$CHARTER_ROOT` — so the child resolves THIS throwaway plane rather than
+        #   walking up from a workspace directory to whatever plane contains it, which is
+        #   also what `tests/_planeguard` holds a charter child to before it may spawn.
+        self.enterContext(mock.patch.dict(os.environ, {
+            "PATH": f"{binroot}{os.pathsep}{os.environ.get('PATH', '')}",
+            "CHARTER_ROOT": str(config.ROOT),
+            "PYTHONPATH": os.pathsep.join(
+                [str(Path(__file__).resolve().parents[1]),
+                 os.environ.get("PYTHONPATH", "")]).rstrip(os.pathsep),
+        }))
+        # **And the SERVER has to know it too.** A pane's environment comes from the tmux
+        # server, not from the client that asked for the pane — `$PATH` is the measured
+        # exception (`commands_frame._guest_harness_env`) and `$PYTHONPATH` is not one. This
+        # class holds one server across its tests (`_hold_the_server`), born before this
+        # test's own environment existed, so without this the pane's launcher cannot import
+        # the charter under test: it exits at once and takes its window, and the session, with
+        # it. Set rather than assumed, because that failure looks exactly like a launch that
+        # never happened.
+        pinned = self._tmux("set-environment", "-g", "PYTHONPATH",
+                            os.environ["PYTHONPATH"])
+        self.assertEqual(pinned.returncode, 0, pinned.stderr)
 
         for n in (self.HERE, self.THERE):
             (config.WORKSPACES_DIR / n).mkdir(parents=True, exist_ok=True)

--- a/tests/test_bare_charter_opens_the_frame.py
+++ b/tests/test_bare_charter_opens_the_frame.py
@@ -24,6 +24,7 @@ plane declaring nothing gets — which is precisely the confusion `refused` exis
 
 from __future__ import annotations
 
+import contextlib
 import io
 import sys
 import unittest
@@ -32,7 +33,7 @@ from unittest import mock
 
 from charter import cli, commands_frame, config, doctor, harness, instance
 from charter.harness.base import Harness
-from tests._isolation import PersonaIso
+from tests._isolation import PersonaIso, make_plane
 
 
 class TheSectionIsReadAtTheConfigBoundary(unittest.TestCase):
@@ -231,16 +232,25 @@ class _Recorder:
         return 0
 
 
-class _BareLaunchCase(unittest.TestCase):
+class _BareLaunchCase(PersonaIso):
     """Drives `cli.main`, with the launcher replaced and the plane's setting stated.
 
     Everything below goes through `cli.main` rather than `_bare_launch`, because the claim
     is about the COMMAND — that bare `charter` reaches the same handler `charter claude`
     reaches, having crossed the same three argv splitters. A test of the helper alone would
     still pass if `main` stopped calling it.
+
+    **`PersonaIso`, since bare `charter` resolves its default through `profiles.current()`**
+    (ruling 43): that reads `charter.toml` and `charter.local.toml` off the plane, and
+    `tests/_planeguard` refuses a read of the developer's own local file outright — this
+    machine's harness profiles are in no commit, so what a case asserted would depend on
+    whoever ran the suite. The plane here is a throwaway one, and :meth:`_declare` writes
+    the key into it the way an operator would.
     """
 
     def setUp(self) -> None:
+        super().setUp()
+        make_plane(self)
         # argparse writes its usage error straight to `sys.stderr`, and half the cases
         # below want that to happen — off a buffer it would land in the suite's own output.
         self.enterContext(redirect_stderr(io.StringIO()))
@@ -252,9 +262,24 @@ class _BareLaunchCase(unittest.TestCase):
             mock.patch("os.execvp", side_effect=AssertionError("charter exec'd a harness")))
         self.err = self.enterContext(mock.patch("charter.util.err"))
 
-    def _declare(self, **harness_setting):
-        return mock.patch.object(config, "HARNESS",
-                                 {"default": None, "refused": None, **harness_setting})
+    @contextlib.contextmanager
+    def _declare(self, *, default=None, refused=None):
+        """State the plane's `[harness] default` — in the FILE, the way an operator does.
+
+        It was `mock.patch.object(config, "HARNESS", …)`, and that stopped being the thing
+        under test when the launch began resolving its default through `profiles.current()`
+        (ruling 43): a patched setting would pin a value nothing reads any more.
+
+        *refused* is a value that names no profile this machine has, which is the only way
+        a default is refused now — a name charter cannot launch and a name charter could
+        launch are the same question once every launchable name is a profile.
+        """
+        name = default or refused
+        (config.ROOT / "charter.toml").write_text(
+            f"schema = {instance.SCHEMA}\n"
+            + (f'[harness]\ndefault = "{name}"\n' if name else ""))
+        config.use(config.ROOT)
+        yield
 
     def _messages(self) -> str:
         return "\n".join(str(c.args[0]) for c in self.err.call_args_list)

--- a/tests/test_charter_names_a_profile_on_the_command_line.py
+++ b/tests/test_charter_names_a_profile_on_the_command_line.py
@@ -1,0 +1,194 @@
+"""`charter <profile>` names a profile, and bare `charter` runs the default one.
+
+A profile is `charter <profile>` the way `charter claude` already is (spec, *A profile*),
+and it is a REWRITE rather than a route of its own: `charter claude-work -p hi` becomes
+`charter claude --profile claude-work -p hi`, so every splitter, flag and branch below it
+runs on the tokens a typed launch produces. That is `_bare_launch`'s own shape and for its
+own reason — a second path into `cmd_launch` would be a second set of answers about the
+workspace picker, `$CHARTER_HARNESS`, `--probe` and the frame.
+
+**No subparser per profile, and no profile read for a command.** `build_parser()` runs in
+every `charter hook …` process, which fires on Bash, Read, Grep, Write, Edit, Task, Skill
+and SendMessage; reading profiles there is what ruling 43 took off the import path, and
+`tests/_planeguard` refuses the read outright. So the rewrite asks the parser charter has
+already built whether the word is a command, and only a word that is none reaches
+`profiles.current()`.
+"""
+
+from __future__ import annotations
+
+import io
+import os
+import unittest
+from contextlib import redirect_stderr
+from unittest import mock
+
+from charter import cli, commands_frame, config, doctor, profiles
+from charter.doctor import OK
+from tests._isolation import PersonaIso, make_plane
+
+_LOCAL = """
+[harness.claude-work]
+kind = "claude"
+command = ["claude"]
+env = { CLAUDE_CONFIG_DIR = "~/.cw" }
+
+[harness.codex-pinned]
+kind = "codex"
+command = ["npx", "-y", "@openai/codex@0.140.0"]
+"""
+
+
+class _APlaneWithProfiles(PersonaIso):
+    def setUp(self) -> None:
+        super().setUp()
+        make_plane(self)
+        self.local = config.ROOT / "charter.local.toml"
+        self.local.write_text(_LOCAL)
+        config.use(config.ROOT)
+        self.parser = cli.build_parser()
+
+    def _launch_argv(self, argv: list[str]):
+        return cli._profile_launch(list(argv), self.parser)
+
+
+class ADeclaredProfileIsItsKindsLauncher(_APlaneWithProfiles, unittest.TestCase):
+    def test_a_declared_profile_name_becomes_its_kinds_launcher(self):
+        self.assertEqual(self._launch_argv(["claude-work", "-p", "hi"]),
+                         (["claude", "--profile", "claude-work", "-p", "hi"], None))
+
+    def test_a_profile_of_another_kind_becomes_that_kinds_launcher(self):
+        self.assertEqual(self._launch_argv(["codex-pinned"]),
+                         (["codex", "--profile", "codex-pinned"], None))
+
+    def test_a_built_in_name_is_left_as_typed(self):
+        """`charter claude` already parses, and `_launch` resolves `args.profile or
+        args.harness` — so a declared replacement of a built-in is reached without a
+        rewrite."""
+        self.assertEqual(self._launch_argv(["claude", "-p", "hi"]),
+                         (["claude", "-p", "hi"], None))
+
+    def test_an_unknown_word_is_left_for_argparse(self):
+        self.assertEqual(self._launch_argv(["nope"]), (["nope"], None))
+
+    def test_a_flag_is_left_alone(self):
+        self.assertEqual(self._launch_argv(["--version"]), (["--version"], None))
+
+    def test_a_core_command_never_reads_the_profiles(self):
+        """The hook path. Every `charter hook …` process runs `main`, and a profile read
+        there is the cost ruling 43 measured and removed."""
+        with mock.patch.object(profiles, "current",
+                               side_effect=AssertionError("read the profiles")):
+            for typed in (["doctor"], ["frame-new-chat"], ["hook", "pretooluse"],
+                          ["frame"], ["claude"]):
+                self.assertEqual(self._launch_argv(typed), (typed, None))
+
+    def test_a_refused_profile_named_on_the_command_line_says_why(self):
+        """A declared profile charter refused is a word argparse would call an invalid
+        choice, and the operator would be offered the gap reporter for a profile they can
+        see in their own file. It says the rule instead."""
+        self.local.write_text('[harness.bad]\nkind = "claude"\ncommand = "claude -x"\n')
+        err = io.StringIO()
+        with redirect_stderr(err):
+            argv, rc = self._launch_argv(["bad"])
+        self.assertEqual(rc, 2)
+        self.assertIn("never a shell string", err.getvalue())
+
+    def test_main_builds_the_parser_once(self):
+        """The rewrite asks the parser `main` has already built. Building a second one
+        costs every `charter hook …` process ~10 ms, measured on this machine."""
+        built: list[int] = []
+        real = cli.build_parser
+        with mock.patch.object(cli, "build_parser",
+                               side_effect=lambda: (built.append(1), real())[1]):
+            with self.assertRaises(SystemExit), redirect_stderr(io.StringIO()):
+                cli.main(["nope"])
+        self.assertEqual(built, [1])
+
+
+class TheProfileFlagIsChartersAndTheRestIsTheHarnesses(_APlaneWithProfiles,
+                                                       unittest.TestCase):
+    def test_the_flag_is_split_off_before_argparse_sees_the_rest(self):
+        argv, rest = cli._split_frame_argv(
+            ["claude", "--profile", "claude-work", "-p", "hi"])
+        self.assertEqual(argv, ["claude", "--profile", "claude-work"])
+        self.assertEqual(rest, ["-p", "hi"])
+
+    def test_the_parser_carries_the_profile_to_the_launcher(self):
+        args = self.parser.parse_args(["claude", "--profile", "claude-work"])
+        self.assertIs(args.func, commands_frame.cmd_launch)
+        self.assertEqual(args.profile, "claude-work")
+
+    def test_a_launch_that_names_no_profile_carries_none(self):
+        self.assertIsNone(self.parser.parse_args(["claude"]).profile)
+
+    def test_frame_launch_is_unattended_unless_told(self):
+        """Review 3: a pane nobody asked for never waits on a question."""
+        self.assertFalse(self.parser.parse_args(
+            ["frame-launch", "--profile", "claude", "--"]).attended)
+        self.assertTrue(self.parser.parse_args(
+            ["frame-launch", "--profile", "claude", "--attended", "--"]).attended)
+
+    def test_frame_launch_is_a_command_no_profile_can_take(self):
+        self.assertIn("frame-launch", cli.command_words())
+
+
+class BareCharterRunsTheDefaultProfile(_APlaneWithProfiles, unittest.TestCase):
+    def _bare(self, text: str):
+        self.local.write_text(text)
+        config.use(config.ROOT)
+        with mock.patch("sys.stdout.isatty", return_value=True):
+            return cli._bare_launch([])
+
+    def test_bare_charter_on_a_terminal_runs_the_declared_default_profile(self):
+        argv, rc = self._bare(_LOCAL + '\n[harness]\ndefault = "claude-work"\n')
+        self.assertEqual((argv, rc), (["claude-work"], None))
+        self.assertEqual(self._launch_argv(argv),
+                         (["claude", "--profile", "claude-work"], None))
+
+    def test_bare_charter_names_a_refused_default_and_exits_2(self):
+        err = io.StringIO()
+        with redirect_stderr(err):
+            argv, rc = self._bare('[harness]\ndefault = "nope"\n')
+        self.assertEqual(rc, 2)
+        self.assertIn("nope", err.getvalue())
+        self.assertIn("names no profile", err.getvalue())
+
+    def test_bare_charter_on_a_plane_that_declares_nothing_is_unchanged(self):
+        self.assertEqual(self._bare(""), ([], None))
+
+    def test_bare_charter_off_a_terminal_starts_nothing(self):
+        """#687/#690: `charter 2>&1 | head` is a probe that costs nothing, and it must stay
+        one whatever the plane defaults to."""
+        self.local.write_text(_LOCAL + '\n[harness]\ndefault = "claude-work"\n')
+        config.use(config.ROOT)
+        with mock.patch("sys.stdout.isatty", return_value=False):
+            self.assertEqual(cli._bare_launch([]), ([], None))
+
+
+class ACharterTomlDefaultMayNameADeclaredProfile(_APlaneWithProfiles, unittest.TestCase):
+    """`charter.toml`'s `[harness] default` names the row the selector starts on, and a
+    profile is a name it may hold — so doctor's `charter.toml` row must not report one as a
+    harness charter cannot launch."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        (config.ROOT / "charter.toml").write_text(
+            'schema = 1\n[harness]\ndefault = "claude-work"\n')
+        config.use(config.ROOT)
+        self.enterContext(mock.patch.dict(
+            os.environ, {"GIT_CEILING_DIRECTORIES": str(self.tmp.resolve().parent)}))
+
+    def test_the_charter_toml_row_is_ok(self):
+        row = doctor.check_control_plane_config()
+        self.assertEqual(row.status, OK, f"{row.detail} — {row.hint}")
+
+    def test_a_default_naming_nothing_at_all_is_still_reported(self):
+        (config.ROOT / "charter.toml").write_text(
+            'schema = 1\n[harness]\ndefault = "clyde"\n')
+        config.use(config.ROOT)
+        self.assertNotEqual(doctor.check_control_plane_config().status, OK)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_charter_names_a_profile_on_the_command_line.py
+++ b/tests/test_charter_names_a_profile_on_the_command_line.py
@@ -25,7 +25,7 @@ from unittest import mock
 
 from charter import cli, commands_frame, config, doctor, profiles
 from charter.doctor import OK
-from tests._isolation import PersonaIso, make_plane
+from tests._isolation import PersonaIso, declare_profiles, make_plane
 
 _LOCAL = """
 [harness.claude-work]
@@ -43,8 +43,10 @@ class _APlaneWithProfiles(PersonaIso):
     def setUp(self) -> None:
         super().setUp()
         make_plane(self)
-        self.local = config.ROOT / "charter.local.toml"
-        self.local.write_text(_LOCAL)
+        # The shared fixture, for its `$GIT_CEILING_DIRECTORIES` as much as for its file:
+        # the doctor row below runs a real `git status`, and a temp plane inside somebody's
+        # own checkout would otherwise be answered for by THEIR repository.
+        self.local = declare_profiles(self, _LOCAL)
         config.use(config.ROOT)
         self.parser = cli.build_parser()
 
@@ -176,8 +178,6 @@ class ACharterTomlDefaultMayNameADeclaredProfile(_APlaneWithProfiles, unittest.T
         (config.ROOT / "charter.toml").write_text(
             'schema = 1\n[harness]\ndefault = "claude-work"\n')
         config.use(config.ROOT)
-        self.enterContext(mock.patch.dict(
-            os.environ, {"GIT_CEILING_DIRECTORIES": str(self.tmp.resolve().parent)}))
 
     def test_the_charter_toml_row_is_ok(self):
         row = doctor.check_control_plane_config()

--- a/tests/test_frame_launcher.py
+++ b/tests/test_frame_launcher.py
@@ -237,8 +237,15 @@ class MissingHarnessBinary(PersonaIso, unittest.TestCase):
         where `_record_crash` lives — a test calling `bypass` directly could never
         observe it."""
         from charter import cli
-        with mock.patch("os.execvp", side_effect=FileNotFoundError(2, "No such file")), \
+        # `os.execvpe` and not `os.execvp`: a profile carries an environment, so the
+        # launcher execs with one — and the condition is the same one, a `claude` that is
+        # not installed.
+        with mock.patch("charter.frame.launcher.os.execvpe",
+                        side_effect=FileNotFoundError(2, "No such file")), \
+             mock.patch("charter.frame.launcher.shutil.which",
+                        return_value="/nowhere/claude"), \
              mock.patch("sys.stdout.isatty", return_value=True), \
+             mock.patch("sys.stdin.isatty", return_value=False), \
              mock.patch("charter.cli._record_crash") as crash, \
              mock.patch("charter.util.err"):
             rc = cli.main(["claude", "--no-frame"])
@@ -1135,7 +1142,11 @@ class Respawn(PersonaIso, unittest.TestCase):
         self.assertEqual(fake.respawns, [])
 
 
-class MissingTmux(unittest.TestCase):
+class MissingTmux(PersonaIso, unittest.TestCase):
+    """`PersonaIso` since a launch resolves its profile before it asks tmux anything:
+    `profiles.current()` reads the plane's own `charter.local.toml`, and `tests/_planeguard`
+    refuses a read of the developer's — this machine's profiles are in no commit."""
+
     def test_an_absent_tmux_names_the_remedy_and_does_not_start_a_frame(self):
         """Adapted from the task brief's own draft, which mocked `tmuxctl.available()`.
         Correction 5 requires `cmd_launch` to call `tmuxctl.version()` exactly ONCE and
@@ -1175,16 +1186,18 @@ def _ceilings(line: str) -> list[str]:
     return [ln for ln in line.split("\n") if "↳" in ln]
 
 
-class Probe(unittest.TestCase):
+class Probe(PersonaIso, unittest.TestCase):
     """`--probe` (on `cmd_launch`) and `charter frame-probe` (`cmd_probe`) share one
     read-only gate, `commands_frame.frame_ready` — mirroring `cmd_launch`'s OWN behaviour
     below `tmuxctl.FLOOR` (warn, still runs), not a stricter refusal, is the whole point:
     a probe that refused there would report a frame this same launcher goes on to draw.
     """
     def setUp(self) -> None:
-        # Outside a frame, with no session id and no pinned workspace: stated here
-        # rather than inherited from the shell the suite was launched from
-        # (#519, #521, #528).
+        # `PersonaIso` for the case below that reaches the LAUNCH path, which resolves a
+        # profile off the plane (`profiles.current()`) — the developer's own file is
+        # refused outright by `tests/_planeguard`. It declares the environment unset too,
+        # which is what this class said for itself before (#519, #521, #528).
+        super().setUp()
         _envguard.unset_all()
 
     def test_present_and_at_the_floor_exits_zero(self):
@@ -4548,25 +4561,45 @@ class BypassRouting(PersonaIso, unittest.TestCase):
     `state.reap` and all — which writes frame state under `config.STATE_DIR` and reaps
     everything beside it. That was the developer's real `.charter/` until this."""
 
-    def test_the_no_frame_flag_routes_to_bypass(self):
-        args = SimpleNamespace(harness="claude", rest=[], no_frame=True)
-        with mock.patch("charter.commands_frame.bypass", return_value=0) as byp, \
-             mock.patch("sys.stdout.isatty", return_value=True), \
-             mock.patch("charter.commands_frame.subprocess.run") as run:
-            rc = commands_frame.cmd_launch(args)
-        byp.assert_called_once_with(["claude"])
-        run.assert_not_called()
-        self.assertEqual(rc, 0)
+    def _routed(self, **ns):
+        """Where a launch with no frame goes, and what it never touches.
 
-    def test_a_non_tty_stdout_routes_to_bypass_even_without_the_flag(self):
-        args = SimpleNamespace(harness="claude", rest=[], no_frame=False)
-        with mock.patch("charter.commands_frame.bypass", return_value=0) as byp, \
-             mock.patch("sys.stdout.isatty", return_value=False), \
-             mock.patch("charter.commands_frame.subprocess.run") as run:
+        **It is the LAUNCHER since profiles, not `bypass`** — and that is the decision
+        under test rather than a rename: the launcher runs the profile's own checks and
+        `exec`s its command with its environment, so `--no-frame` and a pipe are not ways
+        around a guard. `bypass` is still what a launch with no profile reaches
+        (`charter frame -- <cmd>`), and it must not be reached from here.
+        """
+        args = SimpleNamespace(**{"harness": "claude", "rest": [], **ns})
+        with mock.patch("charter.frame.launcher.start", return_value=0) as started, \
+                mock.patch("charter.commands_frame.bypass", return_value=0) as byp, \
+                mock.patch("sys.stdin.isatty", return_value=False), \
+                mock.patch("sys.stdout.isatty",
+                           return_value=ns.get("no_frame", False)), \
+                mock.patch("charter.commands_frame.subprocess.run") as run:
             rc = commands_frame.cmd_launch(args)
-        byp.assert_called_once_with(["claude"])
-        run.assert_not_called()
         self.assertEqual(rc, 0)
+        run.assert_not_called()
+        byp.assert_not_called()
+        return started
+
+    def test_the_no_frame_flag_routes_to_the_launcher(self):
+        started = self._routed(no_frame=True)
+        started.assert_called_once()
+        self.assertEqual(started.call_args.args[0].name, "claude")
+
+    def test_a_non_tty_stdout_routes_to_the_launcher_even_without_the_flag(self):
+        started = self._routed(no_frame=False)
+        started.assert_called_once()
+
+    def test_a_launch_with_no_profile_still_reaches_bypass(self):
+        """The escape hatch: `charter frame -- <cmd>` runs a command charter has never met,
+        so there is no profile to resolve and nothing to check it against."""
+        args = SimpleNamespace(harness="frame", rest=["--", "true"], no_frame=True)
+        with mock.patch("charter.commands_frame.bypass", return_value=0) as byp, \
+                mock.patch("sys.stdout.isatty", return_value=True):
+            self.assertEqual(commands_frame.cmd_launch(args), 0)
+        byp.assert_called_once_with(["true"])
 
     def test_a_tty_without_no_frame_does_not_bypass(self):
         fake = _FakeTmux(exit_code=0)
@@ -4940,7 +4973,7 @@ class FrameArgvSplit(unittest.TestCase):
                 self.assertIsNone(frame_rest)
 
 
-class MainDeliversFrameRest(unittest.TestCase):
+class MainDeliversFrameRest(PersonaIso, unittest.TestCase):
     """The DELIVERY half of Critical 2. `FrameArgvSplit` above tests `_split_frame_argv`
     in isolation, re-implementing in its own `_parse` helper the graft `cli.main` itself
     performs (`args.rest = frame_rest`) — a test that only exercises the helper cannot
@@ -4948,12 +4981,21 @@ class MainDeliversFrameRest(unittest.TestCase):
     frame_rest` from `main()` left the full suite green, while `charter claude -p hi`
     silently ran with `rest=[]`, dropping `-p hi` entirely."""
 
-    def test_charter_claude_dash_p_hi_reaches_bypass_via_main(self):
+    def test_charter_claude_dash_p_hi_reaches_the_harness_via_main(self):
+        """The same delivery, one layer along: a harness launch with no frame is the
+        LAUNCHER's `exec` now (it runs the profile's checks first), so what this asserts is
+        the argv that reaches the harness — `-p hi` and nothing charter added."""
         from charter import cli
-        with mock.patch("charter.commands_frame.bypass", return_value=0) as byp:
+        with mock.patch("charter.frame.launcher.os.execvpe") as execd, \
+                mock.patch("charter.frame.launcher.shutil.which",
+                           return_value="/nowhere/claude"), \
+                mock.patch("sys.stdout.isatty", return_value=True), \
+                mock.patch("sys.stdin.isatty", return_value=False):
             rc = cli.main(["claude", "--no-frame", "-p", "hi"])
-        byp.assert_called_once_with(["claude", "-p", "hi"])
         self.assertEqual(rc, 0)
+        execd.assert_called_once()
+        self.assertEqual(execd.call_args.args[0], "claude")
+        self.assertEqual(execd.call_args.args[1], ["claude", "-p", "hi"])
 
     def test_charter_frame_palette_reaches_cmd_palette_via_main(self):
         """The delivery half of the `_split_frame_argv` fix above: a test that only
@@ -5449,7 +5491,12 @@ class LaunchInsideTmux(PersonaIso, unittest.TestCase):
         new_window = next(c for c in fake.calls if "new-window" in c)
         self.assertNotIn("claude", new_window, f"the harness started too early: {new_window}")
         respawn = next(c for c in fake.calls if "respawn-pane" in c)
-        self.assertEqual(respawn[respawn.index("--") + 1:], ["claude"])
+        # What `respawn-pane` starts is charter's own launcher, which resolves the profile
+        # in the pane and `exec`s it there (`frame/launcher.py`): the harness's own command
+        # never reaches tmux at all, and only the profile's NAME does.
+        self.assertEqual(respawn[-5:], ["frame-launch", "--profile", "claude",
+                                        "--attended", "--"])
+        self.assertNotIn("claude", respawn[respawn.index("--") + 1:][:1])
 
     def test_the_pane_is_kept_askable_before_the_harness_can_exit(self):
         """Matched on the PANE scope, not on the string: charter arms `remain-on-exit`

--- a/tests/test_no_test_reads_the_operators_shell.py
+++ b/tests/test_no_test_reads_the_operators_shell.py
@@ -57,6 +57,20 @@ class WhatIsGuarded(unittest.TestCase):
         self.assertIn("CHARTER_SESSION_ID", _envguard._LOUD)
         self.assertIn("CLAUDE_CODE_SESSION_ID", _envguard._LOUD)
 
+    def test_the_profile_a_chat_runs_is_guarded(self):
+        """`$CHARTER_HARNESS_PROFILE` is an identity by this module's own test — inside a
+        frame it is that chat's profile, in CI it is unset — so a test that reads it
+        without saying what it holds is reading the operator's own terminal."""
+        self.assertIn("CHARTER_HARNESS_PROFILE", _envguard._LOUD)
+
+    def test_the_profile_does_not_ride_the_frames_identity(self):
+        """And it is guarded by a SPELLING rather than by the derivation above, because it
+        must never join that list: every name in `_FRAME_IDENTITY` goes onto a tmux `-e`,
+        which is world-readable argv. The launcher sets the profile at the `exec` instead
+        (`frame/launcher.environment`), which is the whole reason `env` can reach a harness
+        without `layout.CARRIABLE`."""
+        self.assertNotIn("CHARTER_HARNESS_PROFILE", commands_frame._FRAME_IDENTITY)
+
     def test_tmux_itself_is_guarded_not_only_its_pane(self):
         """The pair that decides "am I inside a tmux". `$TMUX_PANE` arrives from
         `_PANE_ID_VARS`; `$TMUX` has no constant to derive it from and is spelled once."""

--- a/tests/test_plane_spawn_guard.py
+++ b/tests/test_plane_spawn_guard.py
@@ -879,6 +879,12 @@ class NoCharterEscapesThroughTheExecFamily(unittest.TestCase):
         "charter/commands_frame.py:execvp":
             "`bypass` hands this process to the HARNESS (`claude`), and replaces it. The "
             "thing that runs afterwards is not charter and has no plane to resolve.",
+        "charter/frame/launcher.py:execvpe":
+            "The launcher hands its pane — or, on `--no-frame`, this process — to a harness "
+            "profile's command and replaces itself. A profile whose command's first word is "
+            "charter is refused by `profiles.current` before any launch (Ruling 14), so what "
+            "runs afterwards is a harness and not charter. A wrapper script that execs "
+            "charter is the limit, and it is the operator's own to write.",
         "charter/commands_secrets.py:execvpe":
             "`secret exec` replaces this process with the operator's own command. If they "
             "type `charter`, the process that becomes charter is the one that was already "

--- a/tests/test_report_gap_signal.py
+++ b/tests/test_report_gap_signal.py
@@ -15,6 +15,7 @@ import unittest
 from contextlib import redirect_stderr, redirect_stdout
 
 from charter import cli
+from tests._isolation import PersonaIso
 
 
 def _run(argv) -> str:
@@ -27,7 +28,13 @@ def _run(argv) -> str:
     return err.getvalue()
 
 
-class TestUnknownSubcommandOffersToReportAGap(unittest.TestCase):
+class TestUnknownSubcommandOffersToReportAGap(PersonaIso, unittest.TestCase):
+    """`PersonaIso` because an unknown first word is exactly what a PROFILE name is: the
+    launch rewrite asks `profiles.current()` whether the plane declares one before argparse
+    ever sees it, and `tests/_planeguard` refuses a read of the developer's own
+    `charter.local.toml`. A throwaway plane declares none, so the word stays unknown and
+    the gap signal is what it was."""
+
     def test_an_unknown_command_points_at_gap_reporting(self):
         self.assertIn("charter report gap", _run(["frobnicate"]))
 

--- a/tests/test_the_branch_not_taken_is_still_a_promise.py
+++ b/tests/test_the_branch_not_taken_is_still_a_promise.py
@@ -578,23 +578,33 @@ class ReopeningOneChatSaysWhatItChanged(PersonaIso):
         return out, said, seen
 
     def test_a_plane_with_no_harness_table_at_all_is_not_a_crash(self):
-        """`(config.HARNESS or {}).get("default")` — a plane whose `charter.toml` declares
-        no `[harness]` section reads `None`, and `None.get` is the traceback this prevents.
-        Every fixture in the suite has a table."""
+        """`(config.HARNESS or {}).get("default")` ran here until the `[harness] default`
+        fallback was deleted (ruling 15), and `None.get` was the traceback it prevented.
+        The promise is stronger now and this case still holds it: a reopen reads that key
+        nowhere at all, so a plane whose `charter.toml` declares no `[harness]` section is
+        not a crash — it is a chat skipped by name."""
         out, said, seen = self._reopen(_chat(harness="a-harness-from-2019"),
                                        harness_table=None)
 
         self.assertIsNone(out)
         self.assertEqual(seen, [])
-        self.assertTrue(any("declares no `[harness] default`" in s for s in said))
+        self.assertTrue(any("a-harness-from-2019" in s for s in said), said)
 
-    def test_a_harness_charter_cannot_launch_falls_back_and_says_so(self):
+    def test_a_harness_charter_cannot_launch_is_skipped_rather_than_moved(self):
+        """**The branch that was taken until this task, and is now not taken at all.** A
+        chat recorded under a harness this charter no longer registers used to be reopened
+        under `[harness] default` and told so; it is skipped instead (ruling 15), because a
+        profile may be another account, where its conversation does not exist and its
+        workspace's code was never meant to go. The declared default changes nothing.
+
+        `tests/test_a_chat_carries_its_profile.py` holds the rest of that rule; what this
+        case is for is the sentence that must NOT come back."""
         out, said, seen = self._reopen(_chat(harness="a-harness-from-2019"),
                                        harness_default="claude")
 
-        self.assertIsNotNone(out)
-        self.assertEqual(seen[0].harness, "claude")
-        self.assertTrue(any("reopening it under claude" in s for s in said))
+        self.assertIsNone(out)
+        self.assertEqual(seen, [])
+        self.assertFalse([s for s in said if "reopening it under" in s], said)
 
     def test_a_directory_that_has_gone_is_named_beside_the_one_it_comes_back_in(self):
         """`_was_standing_in`'s middle branch — a cwd that was recorded and has since

--- a/tests/test_the_chat_bars_plus_makes_a_chat.py
+++ b/tests/test_the_chat_bars_plus_makes_a_chat.py
@@ -74,7 +74,14 @@ class _APlusOnAFrameInAlpha(PersonaIso, unittest.TestCase):
 
     def setUp(self):
         super().setUp()
-        self.enterContext(mock.patch.dict(os.environ, {}, clear=True))
+        # `$PATH` is stated rather than cleared with the rest: a press now runs the
+        # profile's own guards before it launches (`commands_frame._launch_refusal`), and
+        # the first of them asks whether the command is on `PATH`. An empty environment is
+        # no machine anybody has — it would refuse every press here for a reason none of
+        # these cases is about, and `tests/_claudeguard` puts the `claude` they resolve on
+        # exactly this `PATH`.
+        self.enterContext(mock.patch.dict(
+            os.environ, {"PATH": os.environ.get("PATH", "")}, clear=True))
         (config.WORKSPACES_DIR / "alpha").mkdir(parents=True, exist_ok=True)
         _a_chat(self.FID, ws="alpha")
         self.said = self.enterContext(
@@ -155,11 +162,18 @@ class ThePressRunsTheLauncherForThisWorkspace(_APlusOnAFrameInAlpha):
 
     def test_a_chat_with_no_recorded_harness_falls_back_to_the_planes_default(self):
         """The migration case — a chat launched by a charter that predates
-        `state.record_identity`."""
+        `state.record_identity`, which is the one rung where nothing about the chat itself
+        is left to go on.
+
+        The default is declared in the FILE rather than patched onto `config.HARNESS`:
+        since ruling 43 the effective default is `profiles.current()`'s, which reads
+        `charter.local.toml` over `charter.toml`, and a patched setting would pin a value
+        this path no longer reads."""
         state.record_identity(self.FID, {"CHARTER_HARNESS": ""})
-        with mock.patch.dict(config.HARNESS, {"default": "claude"}):
-            self._press()
+        (config.ROOT / "charter.local.toml").write_text('[harness]\ndefault = "claude"\n')
+        self._press()
         self.assertEqual(self.launched[0].harness, "claude")
+        self.assertEqual(self.launched[0].profile, "claude")
 
     def test_the_launch_is_sized_for_the_window_the_chat_is_on(self):
         """A launcher with no terminal of its own measures nothing, and `cmd_launch`'s own
@@ -333,7 +347,7 @@ class ThePressSaysWhyWhenItWillNotMakeAChat(_APlusOnAFrameInAlpha):
         self.assertEqual(self.launched, [])
         said = self._sentences()
         self.assertEqual(len(said), 1, said)
-        self.assertIn("records no harness this charter can launch", said[0])
+        self.assertIn("records no profile this charter can launch", said[0])
         self.assertIn("[harness] default", said[0],
                       "the refusal does not name the key that would fix it")
         self.assertTrue(said[0].startswith("cannot open another chat:"),

--- a/tests/test_the_launcher_becomes_the_profile.py
+++ b/tests/test_the_launcher_becomes_the_profile.py
@@ -35,14 +35,7 @@ from unittest import mock
 from charter import commands_frame, config, profiles
 from charter.frame import launcher, state, tmuxctl
 from tests import _gitguard, _tmuxsocket
-from tests._isolation import PersonaIso, make_plane
-
-_LOCAL = """
-[harness.claude-work]
-kind = "claude"
-command = ["claude"]
-env = { CLAUDE_CONFIG_DIR = "~/.cw" }
-"""
+from tests._isolation import PersonaIso, declare_profiles, make_plane
 
 #: The `list-panes -a` row `tmuxctl.live_pane_by_pid` parses: pid, dead, pane, session,
 #: window, `@charter_chat`. Spelled here rather than built from the format, so a change to
@@ -50,11 +43,6 @@ env = { CLAUDE_CONFIG_DIR = "~/.cw" }
 def _row(pid: int, *, dead: str = "0", pane: str = "%1", session: str = "alpha",
          window: str = "alpha.1", chat: str = "alpha.1") -> str:
     return f"{pid}\t{dead}\t{pane}\t{session}\t{window}\t{chat}\n"
-
-
-def _git(root: Path, *args: str) -> None:
-    subprocess.run(["git", "-C", str(root), *args], check=True, capture_output=True,
-                   env={**os.environ, **_gitguard.environment()})
 
 
 class _AProfileAndAPlane(PersonaIso):
@@ -68,12 +56,7 @@ class _AProfileAndAPlane(PersonaIso):
     def setUp(self) -> None:
         super().setUp()
         make_plane(self)
-        self.enterContext(mock.patch.dict(
-            os.environ, {"GIT_CEILING_DIRECTORIES": str(self.tmp.resolve().parent)}))
-        self.local = config.ROOT / "charter.local.toml"
-        self.local.write_text(_LOCAL)
-        (config.ROOT / ".gitignore").write_text("/charter.local.toml\n")
-        _git(config.ROOT, "init", "-q")
+        self.local = declare_profiles(self)
         self.execs: list[tuple] = []
         self.exec = self.enterContext(mock.patch.object(
             launcher.os, "execvpe", side_effect=lambda *a: self.execs.append(a)))
@@ -122,7 +105,7 @@ class TheLauncherBecomesTheProfile(_AProfileAndAPlane, unittest.TestCase):
         env = launcher.environment(self._profile(),
                                    {"PATH": "/x", "CLAUDE_CONFIG_DIR": "/old"}, framed=True)
         self.assertEqual(env["PATH"], "/x")
-        self.assertEqual(env["CLAUDE_CONFIG_DIR"], os.path.expanduser("~/.cw"))
+        self.assertEqual(env["CLAUDE_CONFIG_DIR"], str(self.home / ".cw"))
         self.assertEqual(env["CHARTER_HARNESS_PROFILE"], "claude-work")
 
     def test_the_profile_and_kind_ride_the_exec_not_tmux(self):
@@ -133,7 +116,7 @@ class TheLauncherBecomesTheProfile(_AProfileAndAPlane, unittest.TestCase):
         self.assertEqual(argv, ["claude", "--resume", "s1"])
         self.assertEqual(env["CHARTER_HARNESS_PROFILE"], "claude-work")
         self.assertEqual(env["CHARTER_HARNESS"], "claude-code")
-        self.assertEqual(env["CLAUDE_CONFIG_DIR"], os.path.expanduser("~/.cw"))
+        self.assertEqual(env["CLAUDE_CONFIG_DIR"], str(self.home / ".cw"))
         self.assertEqual(state.profile("beta.1"), "claude-work")
 
     def test_a_file_that_became_committable_since_tmux_is_refused_in_the_pane(self):
@@ -190,6 +173,55 @@ class TheLauncherBecomesTheProfile(_AProfileAndAPlane, unittest.TestCase):
         self.assertEqual(r.exit, launcher.REFUSED_EXIT)
         self.assertIn("Input/output error", r.text)
 
+    def test_a_refusal_exits_three_and_the_number_is_the_point(self):
+        """**3, written out**, because every neighbouring number already means something
+        else to whoever reads `$?`: 127 and 126 are the shell's own words for a command
+        that could not be found or could not be run (`MISSING_EXIT`, `NOT_EXECUTABLE_EXIT`,
+        and `bypass` returns those same two), 2 is charter's own usage error, 1 is a
+        harness that ran and failed, and 0 is a harness that ran and did not. A refusal
+        started nothing at all, and `charter <profile> || …` can only tell that apart if
+        the number is pinned rather than merely consistent with itself.
+        """
+        self.assertEqual(launcher.start(self._profile(), [], fid=None, attended=False), 3)
+        self.assertEqual(launcher.REFUSED_EXIT, 3)
+        self.assertEqual(launcher.MISSING_EXIT, 127)
+        self.assertEqual(launcher.NOT_EXECUTABLE_EXIT, 126)
+
+    def test_the_kinds_are_a_written_down_vocabulary(self):
+        """Ruling 27: a caller branches on the KIND and never on the text, so the kinds are
+        an interface — Task 3 matches `KIND_NOT_YET` to decide which refusal a pane defers
+        to instead of prints. Spelled out here so a rename is a red test rather than a
+        branch that quietly stops matching, and asserted DISTINCT because two kinds that
+        collided would make that branch answer for both.
+        """
+        kinds = (launcher.KIND_IGNORED, launcher.KIND_PATH, launcher.KIND_NOT_YET,
+                 launcher.KIND_EXEC)
+        self.assertEqual(kinds, ("ignored", "path", "not-yet", "exec"))
+        self.assertEqual(len(set(kinds)), len(kinds))
+
+    def test_the_path_the_exec_will_use_is_the_path_that_is_asked(self):
+        """**`env["PATH"]`, not this process's**, and the difference is a whole launch: a
+        profile whose `env` puts its own directory on `PATH` runs a command charter itself
+        cannot see. The command here exists ONLY in the profile's `PATH`, so a check asking
+        any other question refuses a profile that is about to start perfectly well.
+        """
+        self._no_approval_needed()
+        elsewhere = self.tmp / "bin"
+        elsewhere.mkdir()
+        program = elsewhere / "harness-only-here"
+        program.write_text("#!/bin/sh\nexit 0\n")
+        program.chmod(0o755)
+        self.local.write_text('[harness.own-path]\nkind = "claude"\n'
+                              'command = ["harness-only-here"]\n')
+        p = self._profile("own-path")
+        self.assertIsNone(launcher.refusal(p, root=config.ROOT, attended=False,
+                                           env={"PATH": str(elsewhere)}))
+        # And the other half of the same fact: with that directory gone from `PATH` the
+        # very same profile is refused, so the answer above came from the `env` asked for.
+        self.assertEqual(launcher.refusal(p, root=config.ROOT, attended=False,
+                                          env={"PATH": str(self.tmp)}).kind,
+                         launcher.KIND_PATH)
+
 
 class AQuotedCommandIsShownEscaped(_AProfileAndAPlane, unittest.TestCase):
     """Ruling 35, and the fourth review's nit: a refusal that quotes a command shows it
@@ -218,6 +250,103 @@ class AQuotedCommandIsShownEscaped(_AProfileAndAPlane, unittest.TestCase):
             r = launcher.attempt(self._profile("sneaky"), [], fid=None, attended=False)
         self.assertNotIn("\r", r.text)
         self.assertNotIn("\x1b", r.text)
+        self.assertIn("\\u000d", r.text)
+
+    def test_what_the_system_said_about_the_failure_is_escaped_too(self):
+        """The `strerror` is not charter's own words: it comes back from the kernel about a
+        path the FILE chose, and on a filesystem where that name is the error message it is
+        the file's text arriving on the operator's terminal by another route."""
+        self.exec.side_effect = OSError(5, "cannot run cl\raude\x1b[2K")
+        with mock.patch.object(launcher.shutil, "which", return_value="/nowhere"):
+            r = launcher.attempt(self._profile("sneaky"), [], fid=None, attended=False)
+        self.assertNotIn("\r", r.text)
+        self.assertNotIn("\x1b", r.text)
+        self.assertIn("\\u000d", r.text)
+
+    def test_the_command_charter_shows_for_a_launch_is_escaped(self):
+        """`display_command` is what an early death and a tmux that refused the argv both
+        quote back, so it is a third way the file's own bytes reach a terminal."""
+        shown = launcher.display_command(self._profile("sneaky"), ["--resume", "s1"])
+        self.assertEqual(shown[-2:], ["--resume", "s1"])
+        self.assertNotIn("\r", " ".join(shown))
+        self.assertNotIn("\x1b", " ".join(shown))
+        self.assertIn("\\u000d", shown[0])
+
+
+#: A name `profiles.NAME_RE` accepts and `contain.readable` still has work to do on. The
+#: regex bounds a profile name's SHAPE — ASCII letters, digits, `_` and `-` — and says
+#: nothing at all about its LENGTH, so a declared name is the one value in these sentences
+#: that arrives printable and unbounded. 200 is over `contain.DISPLAY_LIMIT` and under
+#: nothing in particular.
+LONG_NAME = "w" * 200
+
+
+class ARefusalNamesTheProfileWithoutBecomingIt(_AProfileAndAPlane, unittest.TestCase):
+    """Every refusal quotes the profile's name back, and the quote is BOUNDED.
+
+    `profiles.NAME_RE` is why this is about length rather than about escapes: a name with a
+    `\\r` in it never resolves at all, so what reaches these four sentences is always
+    printable — and always as long as the file cared to make it. A 200-character name
+    unbounded is a refusal that scrolls its own remedy off the screen, and each of these is
+    a sentence whose whole job is to be read to the end (CONTEXT.md, *A refusal is the rule
+    working*). One fixture, four sites, because it is one property.
+    """
+
+    #: What `contain.readable` leaves of :data:`LONG_NAME` — its own clip, spelled out
+    #: rather than recomputed, so this test disagrees with the code instead of agreeing
+    #: with whatever it happens to do.
+    CLIPPED = "w" * 160 + "..."
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.local.write_text(f'[harness.{LONG_NAME}]\nkind = "claude"\n'
+                              'command = ["claude"]\n')
+
+    def _refusal(self, **kw):
+        return launcher.refusal(self._profile(LONG_NAME), root=config.ROOT,
+                                attended=False, env=dict(os.environ), **kw)
+
+    def test_the_not_yet_refusal_clips_it(self):
+        r = self._refusal()
+        self.assertEqual(r.kind, launcher.KIND_NOT_YET)
+        self.assertIn(self.CLIPPED, r.text)
+        self.assertNotIn(LONG_NAME, r.text)
+
+    def test_the_ignored_refusal_clips_it(self):
+        (config.ROOT / ".gitignore").write_text("")
+        r = self._refusal()
+        self.assertEqual(r.kind, launcher.KIND_IGNORED)
+        self.assertIn(self.CLIPPED, r.text)
+        self.assertNotIn(LONG_NAME, r.text)
+
+    def test_the_not_on_path_refusal_clips_it(self):
+        self._no_approval_needed()
+        with mock.patch.object(launcher.shutil, "which", return_value=None):
+            r = self._refusal()
+        self.assertEqual(r.kind, launcher.KIND_PATH)
+        self.assertIn(self.CLIPPED, r.text)
+        self.assertNotIn(LONG_NAME, r.text)
+
+    def test_the_exec_that_failed_clips_it(self):
+        self._no_approval_needed()
+        self.exec.side_effect = FileNotFoundError(2, "No such file")
+        r = launcher.attempt(self._profile(LONG_NAME), [], fid=None, attended=False)
+        self.assertEqual(r.kind, launcher.KIND_EXEC)
+        self.assertIn(self.CLIPPED, r.text)
+        self.assertNotIn(LONG_NAME, r.text)
+
+    def test_the_not_yet_refusal_offers_only_profiles_the_file_does_not_declare(self):
+        """The other half of :data:`launcher.DECLARED_NOT_YET`: it names what the operator
+        CAN launch, and a list that repeated the declared profiles back would name the very
+        commands this refusal exists to not run."""
+        self.local.write_text(f'[harness.{LONG_NAME}]\nkind = "claude"\n'
+                              'command = ["claude"]\n\n'
+                              '[harness.claude]\nkind = "claude"\ncommand = ["elsewhere"]\n')
+        offered = self._refusal().text.rsplit(": ", 1)[1].rstrip(".").split(", ")
+        read = profiles.current()
+        self.assertTrue(offered)
+        for name in offered:
+            self.assertEqual(read.profiles[name].source, profiles.BUILTIN, name)
 
 
 class OnlyThePanesOwnFirstProcessIsFramed(_AProfileAndAPlane, unittest.TestCase):
@@ -283,6 +412,29 @@ class OnlyThePanesOwnFirstProcessIsFramed(_AProfileAndAPlane, unittest.TestCase)
                 [], 1, "", "no server running")), \
                 mock.patch.object(launcher.os, "getpid", return_value=53118):
             self.assertIsNone(launcher.framed_chat())
+
+    def test_a_tmux_that_failed_is_not_read_even_though_it_printed(self):
+        """A `list-panes` that exited non-zero listed SOME panes at best — a server shutting
+        down answers for the sessions it has left — and a partial listing is not evidence
+        about which pane this process is. The rows here would prove the chat if the code
+        read them, which is the whole point: what decides is the return code."""
+        with mock.patch.object(tmuxctl, "run", return_value=subprocess.CompletedProcess(
+                [], 1, _row(53118), "server exiting")), \
+                mock.patch.object(launcher.os, "getpid", return_value=53118):
+            self.assertIsNone(launcher.framed_chat())
+
+    def test_an_unprovable_chat_is_repeated_back_escaped(self):
+        """`$CHARTER_SESSION_ID` is inherited from whatever started this process, so it is
+        the one value in this sentence charter did not mint — and this sentence goes
+        straight to a terminal."""
+        said: list[str] = []
+        with mock.patch.dict(os.environ, {"CHARTER_SESSION_ID": "alpha\r.1"}), \
+                mock.patch.object(launcher.util, "err", side_effect=said.append), \
+                mock.patch.object(launcher.os, "getpid", return_value=4707):
+            self.assertIsNone(launcher.framed_chat())
+        self.assertEqual(len(said), 1, said)
+        self.assertIn("\\u000d", said[0])
+        self.assertNotIn("\r", said[0])
 
     def test_a_claimed_chat_that_cannot_be_proven_says_so_in_one_line(self):
         said: list[str] = []
@@ -374,6 +526,27 @@ class ThePaneCommandResolvesTheProfileByName(_AProfileAndAPlane, unittest.TestCa
         self.assertEqual(rc, launcher.REFUSED_EXIT)
         self.assertTrue(any("never a shell string" in s for s in said), said)
 
+    def test_each_refused_profile_answers_with_its_own_reason(self):
+        """Two refused profiles, two different reasons: a resolve that handed back the
+        first refusal it found would tell an operator to fix the wrong line of their own
+        file. The refusals are a LIST, and which entry answers is the question here."""
+        self.local.write_text('[harness.bad-command]\nkind = "claude"\n'
+                              'command = "claude -x"\n\n'
+                              '[harness.bad-kind]\nkind = "nosuchharness"\n'
+                              'command = ["claude"]\n')
+        self.assertIn("never a shell string", launcher.resolve("bad-command")[1])
+        self.assertIn("nosuchharness", launcher.resolve("bad-kind")[1])
+
+    def test_a_refused_name_is_looked_up_the_way_it_was_written_down(self):
+        """`profiles` records a refused name CONTAINED, because a refusal quotes it; so the
+        lookup here has to ask the same question the record answered. A name with a `\\r` in
+        it is refused for its shape — and it is exactly the name whose reason goes missing
+        if the two halves stop agreeing, which is the silent failure, not a loud one."""
+        self.local.write_text('[harness."a\\rb"]\nkind = "claude"\ncommand = ["claude"]\n')
+        p, why = launcher.resolve("a\rb")
+        self.assertIsNone(p)
+        self.assertIn("\\u000d", why)
+
     def test_the_frame_proof_runs_before_anything_is_printed(self):
         """Ruling 35: `framed_chat()` is the first thing this does — before claiming,
         before drawing, before any output. The name proof holds only while the pane has
@@ -442,11 +615,52 @@ class ARefusalInThePaneReachesTheOperator(_AProfileAndAPlane, unittest.TestCase)
                                                   rest=[]))
         self.assertEqual(state.launch("beta.1"), (0, ""))
 
+    def test_the_attended_pane_names_the_key_it_actually_waits_for(self):
+        """Enter, spelled out, because it is the key the line read below really waits for:
+        `_wait_for_the_operator` reads a LINE rather than a keystroke (a `tcsetattr` from a
+        pane left the launcher killed by a signal on a Linux runner, and the refusal went
+        with the window — the one thing ruling 42 exists to prevent). "Press any key" under
+        a line read is a pane that looks hung."""
+        said: list[str] = []
+        with mock.patch.object(launcher, "_wait_for_the_operator"), \
+                mock.patch.object(launcher.util, "err", side_effect=said.append):
+            launcher.cmd_frame_launch(SimpleNamespace(
+                profile="claude-work", attended=True, rest=[]))
+        self.assertIn("  press Enter to close this chat.", said)
+
     def test_a_pane_with_nobody_at_its_keyboard_does_not_stop_to_ask(self):
         """`_wait_for_the_operator` is what an attended refusal ends on, and a pane whose
-        stdin is not a terminal has nobody to press anything — so it must not block."""
-        with mock.patch("sys.stdin.isatty", return_value=False):
+        stdin is not a terminal has nobody to press anything — so it must not READ, which
+        is a stronger claim than "does not block": the suite's own stdin is `/dev/null`,
+        where a read returns at once and a missing guard looks exactly like a present one.
+        """
+        class _APipe:
+            def isatty(self) -> bool:
+                return False
+
+            def readline(self) -> str:
+                raise AssertionError("nobody is here to press anything")
+
+        with mock.patch("sys.stdin", _APipe()):
             launcher._wait_for_the_operator()
+
+    def test_a_pane_with_somebody_at_its_keyboard_waits_for_their_line(self):
+        """And the other direction, which is what keeps the guard above honest."""
+        class _ATerminal:
+            def __init__(self) -> None:
+                self.lines = 0
+
+            def isatty(self) -> bool:
+                return True
+
+            def readline(self) -> str:
+                self.lines += 1
+                return "\n"
+
+        stdin = _ATerminal()
+        with mock.patch("sys.stdin", stdin):
+            launcher._wait_for_the_operator()
+        self.assertEqual(stdin.lines, 1)
 
 
 class TheLauncherIsWhatTmuxStarts(_AProfileAndAPlane, unittest.TestCase):

--- a/tests/test_the_launcher_becomes_the_profile.py
+++ b/tests/test_the_launcher_becomes_the_profile.py
@@ -1,0 +1,472 @@
+"""Every chat pane's first process is charter's launcher, and it becomes the harness.
+
+The launcher runs the checks in the pane — the file is still ignored, the command is still
+on `PATH`, the profile is approved — and then `os.execvpe`s the profile's command with the
+profile's `env` applied. Three reasons, the first a constraint (spec, *How a harness
+starts*): `env` reaches the harness without `layout.CARRIABLE` and without tmux's own
+argument parser (#957, #961); one place runs the checks for every open; and `exec` keeps
+the launcher's pid, so the pane id, `remain-on-exit` and the `pane-died` path see what they
+see today. Measured before it was built on — `workspaces/harness-profiles/refs/task2-measure/`.
+
+**A launcher is in a frame only when tmux says so** (rulings 29 and 33). Its own pid must be
+the `#{pane_pid}` of a LIVE pane belonging to the chat it claims, read from tmux on that
+chat's server: the window name on charter's own server, the `@charter_chat` option in the
+operator's. `$TMUX_PANE` and `$CHARTER_SESSION_ID` are never proof — a model's own tool
+shell inherits both from its chat, measured — so `charter frame-launch` run from one is a
+launch with no frame that rewrites no chat's record.
+
+**A refusal in the pane has to reach the operator without the dead pane** (ruling 42,
+measured 2026-09-11): `_launch`'s eager dead-status ask completes 6-14 ms after the start
+while a Python launcher's first line runs at 19-22 ms, and the teardown hook then kills the
+window, so all 40 launcher refusals were missed. An attended launcher shows its refusal in
+the pane and waits for a key; an unattended one writes it into the chat's state directory,
+where the launch that opened the chat reads it back.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
+
+from charter import commands_frame, config, profiles
+from charter.frame import launcher, state, tmuxctl
+from tests import _gitguard, _tmuxsocket
+from tests._isolation import PersonaIso, make_plane
+
+_LOCAL = """
+[harness.claude-work]
+kind = "claude"
+command = ["claude"]
+env = { CLAUDE_CONFIG_DIR = "~/.cw" }
+"""
+
+#: The `list-panes -a` row `tmuxctl.live_pane_by_pid` parses: pid, dead, pane, session,
+#: window, `@charter_chat`. Spelled here rather than built from the format, so a change to
+#: either is a test that fails rather than two halves that move together.
+def _row(pid: int, *, dead: str = "0", pane: str = "%1", session: str = "alpha",
+         window: str = "alpha.1", chat: str = "alpha.1") -> str:
+    return f"{pid}\t{dead}\t{pane}\t{session}\t{window}\t{chat}\n"
+
+
+def _git(root: Path, *args: str) -> None:
+    subprocess.run(["git", "-C", str(root), *args], check=True, capture_output=True,
+                   env={**os.environ, **_gitguard.environment()})
+
+
+class _AProfileAndAPlane(PersonaIso):
+    """A plane declaring `claude-work`, in a git repository that ignores the local file.
+
+    The ignore check is a real `git status` — the one subprocess `profiles` runs — so the
+    fixture is a real repository. `GIT_CEILING_DIRECTORIES` states where the walk stops, so
+    a temp directory inside somebody's own checkout is not read as belonging to it.
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+        make_plane(self)
+        self.enterContext(mock.patch.dict(
+            os.environ, {"GIT_CEILING_DIRECTORIES": str(self.tmp.resolve().parent)}))
+        self.local = config.ROOT / "charter.local.toml"
+        self.local.write_text(_LOCAL)
+        (config.ROOT / ".gitignore").write_text("/charter.local.toml\n")
+        _git(config.ROOT, "init", "-q")
+        self.execs: list[tuple] = []
+        self.exec = self.enterContext(mock.patch.object(
+            launcher.os, "execvpe", side_effect=lambda *a: self.execs.append(a)))
+
+    def _profile(self, name: str = "claude-work") -> profiles.Profile:
+        return profiles.current().profiles[name]
+
+    def _no_approval_needed(self) -> None:
+        """Stand in for Task 2's B1 refusal, for a case that is about something else.
+
+        Task 2 refuses every declared profile (review B1), so without this every case below
+        would be measuring that one sentence. Task 3 replaces the body it stands in for.
+        """
+        self.enterContext(mock.patch.object(launcher, "_approval_refusal",
+                                            return_value=None))
+
+
+class TheLauncherBecomesTheProfile(_AProfileAndAPlane, unittest.TestCase):
+    def test_the_pane_refuses_a_declared_profile_until_approval_exists(self):
+        """Review B1: `main` must never run an unapproved declared command between two
+        merges, so Task 2 refuses every declared profile and Task 3 lifts it."""
+        rc = launcher.start(self._profile(), [], fid="beta.1", attended=False)
+        self.assertEqual(rc, launcher.REFUSED_EXIT)
+        self.assertEqual(self.execs, [])
+
+    def test_a_built_in_the_file_does_not_replace_still_launches(self):
+        rc = launcher.start(self._profile("claude"), [], fid=None, attended=False)
+        self.assertEqual(rc, 0)
+        self.assertEqual(self.execs[0][0], "claude")
+
+    def test_an_unframed_environment_drops_only_the_session_id(self):
+        """Review 8: the defect is the PAIR — an inherited `$CHARTER_SESSION_ID` beside the
+        launched `CHARTER_HARNESS` makes `hooks._record_harness_session` write a harness's
+        session id into another chat's state. The other three are pins an operator means."""
+        base = {"CHARTER_SESSION_ID": "a.1", "CHARTER_ROOT": "/p",
+                "CHARTER_PERSONA": "forge", "CHARTER_HARNESS": "codex"}
+        env = launcher.environment(self._profile(), base, framed=False)
+        self.assertNotIn("CHARTER_SESSION_ID", env)
+        self.assertEqual(env["CHARTER_ROOT"], "/p")
+        self.assertEqual(env["CHARTER_PERSONA"], "forge")
+        self.assertEqual(env["CHARTER_HARNESS"], "claude-code")
+        framed = launcher.environment(self._profile(), base, framed=True)
+        self.assertEqual(framed["CHARTER_SESSION_ID"], "a.1")
+
+    def test_the_env_is_the_profiles_over_this_process(self):
+        env = launcher.environment(self._profile(),
+                                   {"PATH": "/x", "CLAUDE_CONFIG_DIR": "/old"}, framed=True)
+        self.assertEqual(env["PATH"], "/x")
+        self.assertEqual(env["CLAUDE_CONFIG_DIR"], os.path.expanduser("~/.cw"))
+        self.assertEqual(env["CHARTER_HARNESS_PROFILE"], "claude-work")
+
+    def test_the_profile_and_kind_ride_the_exec_not_tmux(self):
+        self._no_approval_needed()
+        launcher.start(self._profile(), ["--resume", "s1"], fid="beta.1", attended=False)
+        (program, argv, env), = self.execs
+        self.assertEqual(program, "claude")
+        self.assertEqual(argv, ["claude", "--resume", "s1"])
+        self.assertEqual(env["CHARTER_HARNESS_PROFILE"], "claude-work")
+        self.assertEqual(env["CHARTER_HARNESS"], "claude-code")
+        self.assertEqual(env["CLAUDE_CONFIG_DIR"], os.path.expanduser("~/.cw"))
+        self.assertEqual(state.profile("beta.1"), "claude-work")
+
+    def test_a_file_that_became_committable_since_tmux_is_refused_in_the_pane(self):
+        """The pane re-runs the chain because the plane can move between the pre-tmux check
+        and the exec — which is the whole reason the checks run twice."""
+        self._no_approval_needed()
+        (config.ROOT / ".gitignore").write_text("")
+        r = launcher.refusal(self._profile(), root=config.ROOT, attended=False,
+                             env=dict(os.environ))
+        self.assertEqual(r.kind, launcher.KIND_IGNORED)
+        self.assertIn("charter reinit", r.text)
+        self.assertEqual(launcher.start(self._profile(), [], fid=None, attended=False),
+                         launcher.REFUSED_EXIT)
+        self.assertEqual(self.execs, [])
+
+    def test_a_built_in_is_not_refused_over_the_local_file(self):
+        """Ruling 19 applies to what the file DECLARES. A built-in no declared profile
+        replaces runs whatever git would do with a file it does not come from."""
+        self._no_approval_needed()
+        (config.ROOT / ".gitignore").write_text("")
+        self.assertIsNone(launcher.refusal(self._profile("claude"), root=config.ROOT,
+                                           attended=False, env=dict(os.environ)))
+
+    def test_a_command_removed_since_tmux_is_refused_in_the_pane(self):
+        self._no_approval_needed()
+        with mock.patch.object(launcher.shutil, "which", return_value=None):
+            rc = launcher.start(self._profile(), [], fid=None, attended=False)
+        self.assertEqual(rc, launcher.MISSING_EXIT)
+        self.assertEqual(self.execs, [])
+
+    def test_a_command_that_vanished_between_which_and_exec_is_127(self):
+        self._no_approval_needed()
+        self.exec.side_effect = FileNotFoundError(2, "No such file or directory")
+        r = launcher.attempt(self._profile(), [], fid=None, attended=False)
+        self.assertEqual(r.kind, launcher.KIND_EXEC)
+        self.assertEqual(r.exit, 127)
+
+    def test_a_command_that_cannot_be_executed_is_126(self):
+        self._no_approval_needed()
+        self.exec.side_effect = PermissionError(13, "Permission denied")
+        self.assertEqual(launcher.attempt(self._profile(), [], fid=None,
+                                          attended=False).exit, 126)
+
+    def test_an_exec_that_fails_after_on_exec_undoes_it(self):
+        """N7's nit: what `on_exec` recorded is undone, so a pane that is no longer running
+        anything does not also claim to be a chat."""
+        self._no_approval_needed()
+        self.exec.side_effect = OSError(5, "Input/output error")
+        undone: list[int] = []
+        r = launcher.attempt(self._profile(), [], fid=None, attended=False,
+                             on_exec=lambda: lambda: undone.append(1))
+        self.assertEqual(undone, [1])
+        self.assertEqual(r.kind, launcher.KIND_EXEC)
+        self.assertEqual(r.exit, launcher.REFUSED_EXIT)
+        self.assertIn("Input/output error", r.text)
+
+
+class AQuotedCommandIsShownEscaped(_AProfileAndAPlane, unittest.TestCase):
+    """Ruling 35, and the fourth review's nit: a refusal that quotes a command shows it
+    escaped. The file is one a chat can write, and a `\\r` or an ESC in a command could
+    otherwise redraw the line to show a harmless command while another one runs."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.local.write_text(
+            '[harness.sneaky]\nkind = "claude"\n'
+            'command = ["cl\\raude\\u001b[2Kharmless"]\n')
+        self._no_approval_needed()
+
+    def test_a_command_not_on_path_is_quoted_escaped(self):
+        with mock.patch.object(launcher.shutil, "which", return_value=None):
+            r = launcher.refusal(self._profile("sneaky"), root=config.ROOT,
+                                 attended=False, env=dict(os.environ))
+        self.assertNotIn("\r", r.text)
+        self.assertNotIn("\x1b", r.text)
+        # `contain.readable`'s own spelling for a byte that is not printable ASCII.
+        self.assertIn("\\u000d", r.text)
+
+    def test_an_exec_that_failed_quotes_it_escaped(self):
+        self.exec.side_effect = FileNotFoundError(2, "No such file")
+        with mock.patch.object(launcher.shutil, "which", return_value="/nowhere"):
+            r = launcher.attempt(self._profile("sneaky"), [], fid=None, attended=False)
+        self.assertNotIn("\r", r.text)
+        self.assertNotIn("\x1b", r.text)
+
+
+class OnlyThePanesOwnFirstProcessIsFramed(_AProfileAndAPlane, unittest.TestCase):
+    """Ruling 29, revised: the pid proof, and what it refuses.
+
+    Measured 2026-09-11 in a real framed chat: its Bash tool shell (pid 4707, ppid 53118)
+    saw `TMUX_PANE=%3195`, the harness pane of the chat whose `pane_pid` was 53118 — so a
+    model running `charter frame-launch` from its tool would have passed a pane-id proof and
+    rewritten that chat's profile record, which reopen follows.
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+        state.frame_dir("alpha.1", create=True)
+        state.record_server("alpha.1", commands_frame.SOCKET)
+        state.record_profile("alpha.1", "codex")
+        self.rows = _row(53118)
+        self.asked: list[list[str]] = []
+        self.enterContext(mock.patch.object(
+            tmuxctl, "run",
+            side_effect=lambda action, argv, **kw: (
+                self.asked.append(list(argv)),
+                subprocess.CompletedProcess(argv, 0, self.rows, ""))[1]))
+        self.enterContext(mock.patch.dict(
+            os.environ, {"CHARTER_SESSION_ID": "alpha.1", "TMUX_PANE": "%1",
+                         "TMUX": "/tmp/somebody/else,1,0",
+                         "CHARTER_ROOT": str(config.ROOT),
+                         "PATH": os.environ.get("PATH", ""),
+                         **_gitguard.environment()}, clear=True))
+
+    def test_the_panes_own_first_process_is_framed(self):
+        with mock.patch.object(launcher.os, "getpid", return_value=53118):
+            self.assertEqual(launcher.framed_chat(), "alpha.1")
+
+    def test_a_process_that_is_not_the_panes_first_process_is_not_framed(self):
+        with mock.patch.object(launcher.os, "getpid", return_value=4707):
+            self.assertIsNone(launcher.framed_chat())
+
+    def test_the_pane_is_asked_of_the_chats_own_server_never_of_tmux(self):
+        """`$TMUX` names the socket this process is inside, which is not the same question
+        as which server the chat is on (#812). The chat's own record decides."""
+        with mock.patch.object(launcher.os, "getpid", return_value=53118):
+            launcher.framed_chat()
+        self.assertTrue(self.asked)
+        for argv in self.asked:
+            self.assertIn(commands_frame.SOCKET, argv)
+            self.assertNotIn("/tmp/somebody/else", argv)
+
+    def test_a_pane_whose_window_is_not_named_for_the_chat_is_not_framed(self):
+        self.rows = _row(53118, window="alpha.2")
+        with mock.patch.object(launcher.os, "getpid", return_value=53118):
+            self.assertIsNone(launcher.framed_chat())
+
+    def test_a_dead_pane_whose_pid_matches_does_not_prove_the_chat(self):
+        """A dead `remain-on-exit` pane keeps its old pid, which the system may have reused
+        (ruling 33)."""
+        self.rows = _row(53118, dead="1")
+        with mock.patch.object(launcher.os, "getpid", return_value=53118):
+            self.assertIsNone(launcher.framed_chat())
+
+    def test_a_server_that_does_not_answer_is_no_frame(self):
+        with mock.patch.object(tmuxctl, "run", return_value=subprocess.CompletedProcess(
+                [], 1, "", "no server running")), \
+                mock.patch.object(launcher.os, "getpid", return_value=53118):
+            self.assertIsNone(launcher.framed_chat())
+
+    def test_a_claimed_chat_that_cannot_be_proven_says_so_in_one_line(self):
+        said: list[str] = []
+        with mock.patch.object(launcher.util, "err", side_effect=said.append), \
+                mock.patch.object(launcher.os, "getpid", return_value=4707):
+            launcher.framed_chat()
+        self.assertEqual(len(said), 1, said)
+        self.assertIn("alpha.1", said[0])
+
+    def test_a_launch_that_claims_no_chat_says_nothing_about_one(self):
+        said: list[str] = []
+        with mock.patch.dict(os.environ, {"CHARTER_SESSION_ID": ""}), \
+                mock.patch.object(launcher.util, "err", side_effect=said.append):
+            self.assertIsNone(launcher.framed_chat())
+        self.assertEqual(said, [])
+
+
+class TheOperatorsTmuxProvesTheChatByItsOption(_AProfileAndAPlane, unittest.TestCase):
+    """Ruling 33: there a window name is only a label — an operator hook, a plugin or
+    `allow-rename on` output can change it — so the proof is the `@charter_chat` option
+    charter sets before `respawn-pane`, which pane output cannot touch."""
+
+    #: Computed the way tmux computes it, never written down: a literal uid in a socket
+    #: path is one developer's machine baked into the suite.
+    OPERATOR = _tmuxsocket.OPERATOR_SOCKET
+
+    def setUp(self) -> None:
+        super().setUp()
+        state.frame_dir("alpha.1", create=True)
+        state.record_server("alpha.1", self.OPERATOR)
+        self.rows = _row(53118, session="op", window="PWNED", chat="alpha.1")
+        self.enterContext(mock.patch.object(
+            tmuxctl, "run",
+            side_effect=lambda action, argv, **kw: subprocess.CompletedProcess(
+                argv, 0, self.rows, "")))
+        self.enterContext(mock.patch.dict(
+            os.environ, {"CHARTER_SESSION_ID": "alpha.1",
+                         "CHARTER_ROOT": str(config.ROOT),
+                         "PATH": os.environ.get("PATH", ""),
+                         **_gitguard.environment()}, clear=True))
+
+    def test_a_renamed_window_still_proves_the_chat_by_its_option(self):
+        with mock.patch.object(launcher.os, "getpid", return_value=53118):
+            self.assertEqual(launcher.framed_chat(), "alpha.1")
+
+    def test_a_window_named_like_the_chat_is_not_proof_without_the_option(self):
+        self.rows = _row(53118, session="op", window="alpha.1", chat="")
+        with mock.patch.object(launcher.os, "getpid", return_value=53118):
+            self.assertIsNone(launcher.framed_chat())
+
+
+class ThePaneCommandResolvesTheProfileByName(_AProfileAndAPlane, unittest.TestCase):
+    """`charter frame-launch --profile <name> -- <rest>` — what tmux starts in every chat
+    pane, and the only thing about a profile that crosses tmux."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.enterContext(mock.patch.dict(
+            os.environ, {"CHARTER_ROOT": str(config.ROOT),
+                         "PATH": os.environ.get("PATH", ""),
+                         **_gitguard.environment()}, clear=True))
+        self.enterContext(mock.patch.object(launcher, "framed_chat", return_value=None))
+        self.enterContext(mock.patch.object(launcher, "_wait_for_the_operator"))
+
+    def _run(self, **ns) -> int:
+        args = SimpleNamespace(**{"profile": "claude-work", "attended": False,
+                                  "rest": ["--"], **ns})
+        return launcher.cmd_frame_launch(args)
+
+    def test_the_pane_execs_the_profile_it_was_named(self):
+        self._no_approval_needed()
+        self.assertEqual(self._run(rest=["--", "-p", "x"]), 0)
+        (_program, argv, _env), = self.execs
+        self.assertEqual(argv, ["claude", "-p", "x"])
+
+    def test_a_pane_asked_for_a_profile_that_is_gone_says_so(self):
+        said: list[str] = []
+        with mock.patch.object(launcher.util, "err", side_effect=said.append):
+            rc = self._run(profile="gone")
+        self.assertEqual(rc, launcher.REFUSED_EXIT)
+        self.assertTrue(any("no profile named 'gone'" in s for s in said), said)
+        self.assertEqual(self.execs, [])
+
+    def test_a_pane_asked_for_a_refused_profile_says_its_own_reason(self):
+        self.local.write_text('[harness.bad]\nkind = "claude"\ncommand = "claude -x"\n')
+        said: list[str] = []
+        with mock.patch.object(launcher.util, "err", side_effect=said.append):
+            rc = self._run(profile="bad")
+        self.assertEqual(rc, launcher.REFUSED_EXIT)
+        self.assertTrue(any("never a shell string" in s for s in said), said)
+
+    def test_the_frame_proof_runs_before_anything_is_printed(self):
+        """Ruling 35: `framed_chat()` is the first thing this does — before claiming,
+        before drawing, before any output. The name proof holds only while the pane has
+        printed nothing."""
+        log: list[str] = []
+        self._no_approval_needed()
+        with mock.patch.object(launcher, "framed_chat",
+                               side_effect=lambda: log.append("proof")), \
+                mock.patch.object(launcher.util, "err",
+                                  side_effect=lambda m: log.append("err")), \
+                mock.patch.object(launcher.util, "info",
+                                  side_effect=lambda m: log.append("info")), \
+                mock.patch("sys.stdout.write", side_effect=lambda m: log.append("out")), \
+                mock.patch("sys.stderr.write", side_effect=lambda m: log.append("err")):
+            self._run(profile="gone")
+        self.assertEqual(log[0], "proof", log)
+
+
+class ARefusalInThePaneReachesTheOperator(_AProfileAndAPlane, unittest.TestCase):
+    """Ruling 42, measured: the eager dead-status ask completes 6-14 ms after the start and
+    a Python launcher's first line runs at 19-22 ms, so a refusal printed and exited on is
+    never read back off the pane — on charter's own server the teardown hook kills the
+    window at once (`_pane_last_words` answered `[]` in all 40 runs), and in the operator's
+    tmux `_launch_in_operator_tmux` closes the window before reading it."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.enterContext(mock.patch.dict(
+            os.environ, {"CHARTER_ROOT": str(config.ROOT),
+                         "PATH": os.environ.get("PATH", ""),
+                         **_gitguard.environment()}, clear=True))
+        state.frame_dir("beta.1", create=True)
+        self.enterContext(mock.patch.object(launcher, "framed_chat",
+                                            return_value="beta.1"))
+
+    def test_an_attended_pane_waits_for_a_key_before_it_exits(self):
+        waited: list[int] = []
+        with mock.patch.object(launcher, "_wait_for_the_operator",
+                               side_effect=lambda: waited.append(1)):
+            rc = launcher.cmd_frame_launch(SimpleNamespace(
+                profile="claude-work", attended=True, rest=[]))
+        self.assertEqual(rc, launcher.REFUSED_EXIT)
+        self.assertEqual(waited, [1], "an attended refusal must not vanish with the pane")
+
+    def test_an_unattended_pane_waits_for_nobody(self):
+        waited: list[int] = []
+        with mock.patch.object(launcher, "_wait_for_the_operator",
+                               side_effect=lambda: waited.append(1)):
+            launcher.cmd_frame_launch(SimpleNamespace(
+                profile="claude-work", attended=False, rest=[]))
+        self.assertEqual(waited, [], "nobody is at this pane to press a key")
+
+    def test_an_unattended_refusal_is_written_where_the_launch_can_read_it(self):
+        with mock.patch.object(launcher, "_wait_for_the_operator"):
+            launcher.cmd_frame_launch(SimpleNamespace(
+                profile="claude-work", attended=False, rest=[]))
+        code, said = state.launch("beta.1")
+        self.assertEqual(code, launcher.REFUSED_EXIT)
+        self.assertIn("claude-work", said)
+
+    def test_handing_the_pane_over_is_recorded_too(self):
+        """The other half of the same record: without it a launch that waits for a verdict
+        would wait out its whole budget on every chat that started perfectly well."""
+        self._no_approval_needed()
+        launcher.cmd_frame_launch(SimpleNamespace(profile="claude-work", attended=False,
+                                                  rest=[]))
+        self.assertEqual(state.launch("beta.1"), (0, ""))
+
+    def test_a_pane_with_nobody_at_its_keyboard_does_not_stop_to_ask(self):
+        """`_wait_for_the_operator` is what an attended refusal ends on, and a pane whose
+        stdin is not a terminal has nobody to press anything — so it must not block."""
+        with mock.patch("sys.stdin.isatty", return_value=False):
+            launcher._wait_for_the_operator()
+
+
+class TheLauncherIsWhatTmuxStarts(_AProfileAndAPlane, unittest.TestCase):
+    def test_only_the_profiles_name_crosses_tmux(self):
+        argv = launcher.argv("claude-work", ["-p", "hi"], attended=True)
+        self.assertEqual(argv[-7:], ["frame-launch", "--profile", "claude-work",
+                                     "--attended", "--", "-p", "hi"])
+        self.assertNotIn(os.path.expanduser("~/.cw"), " ".join(argv))
+        self.assertNotIn("CLAUDE_CONFIG_DIR", " ".join(argv))
+
+    def test_an_unattended_launch_says_so_by_leaving_the_flag_out(self):
+        self.assertNotIn("--attended", launcher.argv("claude-work", [], attended=False))
+
+    def test_it_is_this_interpreters_own_charter(self):
+        """`util.self_relaunch_argv`'s `-P`: `python -m charter` prepends the child's cwd to
+        `sys.path`, and a chat's cwd is a workspace clone that may hold its own `charter/`
+        package (#390)."""
+        argv = launcher.argv("claude-work", [], attended=False)
+        self.assertEqual(argv[:4], [os.sys.executable, "-P", "-m", "charter"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_the_launcher_becomes_the_profile.py
+++ b/tests/test_the_launcher_becomes_the_profile.py
@@ -423,6 +423,15 @@ class OnlyThePanesOwnFirstProcessIsFramed(_AProfileAndAPlane, unittest.TestCase)
                 mock.patch.object(launcher.os, "getpid", return_value=53118):
             self.assertIsNone(launcher.framed_chat())
 
+    def test_a_row_with_more_fields_than_the_format_is_not_read(self):
+        """A window NAME may hold a tab and `list-panes` does not quote it, so a row can
+        arrive with seven fields where the format asks for six. A row charter cannot assign
+        is not a pane it will prove a chat with — and unpacking it would raise inside the
+        one function whose whole job is to answer yes or no."""
+        self.rows = "53118\t0\t%1\talpha\talpha.1\tstray\talpha.1\n"
+        with mock.patch.object(launcher.os, "getpid", return_value=53118):
+            self.assertIsNone(launcher.framed_chat())
+
     def test_an_unprovable_chat_is_repeated_back_escaped(self):
         """`$CHARTER_SESSION_ID` is inherited from whatever started this process, so it is
         the one value in this sentence charter did not mint — and this sentence goes
@@ -509,6 +518,13 @@ class ThePaneCommandResolvesTheProfileByName(_AProfileAndAPlane, unittest.TestCa
         self.assertEqual(self._run(rest=["--", "-p", "x"]), 0)
         (_program, argv, _env), = self.execs
         self.assertEqual(argv, ["claude", "-p", "x"])
+
+    def test_a_name_nothing_declares_is_repeated_back_escaped(self):
+        """The name in this sentence came off a command line or out of a chat's own
+        record, and the sentence goes to a terminal (ruling 35)."""
+        said = launcher.unknown_profile("cl\raude")
+        self.assertIn("\\u000d", said)
+        self.assertNotIn("\r", said)
 
     def test_a_pane_asked_for_a_profile_that_is_gone_says_so(self):
         said: list[str] = []

--- a/tests/test_what_a_quit_says_is_spelled_where_it_is_asserted.py
+++ b/tests/test_what_a_quit_says_is_spelled_where_it_is_asserted.py
@@ -316,15 +316,17 @@ class AValueOffTheManifestCannotOwnTheLine(PersonaIso):
         self.assertContained(said[0])
 
     def test_a_hostile_harness_is_still_contained_when_the_plane_has_a_default(self):
-        """The SECOND `contain.readable(c.harness)`, on the branch this file's other case
-        cannot reach: with a `[harness] default` declared, the reopen falls back to it and
-        says so, and that is a different sentence with its own wrapper. Measured — without
-        this case, hand-mutating that line leaves the module green."""
+        """There was a SECOND `contain.readable(c.harness)` here, on the branch where a
+        `[harness] default` made the reopen fall back to it and say so. That fallback is
+        deleted (ruling 15) — a chat is never given another profile — so there is one
+        sentence and one wrapper, and this case now says the declared default changes
+        nothing about it rather than pinning a branch that no longer exists."""
         with mock.patch.object(config, "HARNESS", {"default": "claude"}):
             said = self._warnings(self._chat(harness=HOSTILE))
 
-        line = next(s for s in said if "reopening it under" in s)
-        self.assertContained(line)
+        self.assertTrue(said, "the skip warning is the surface under test")
+        self.assertContained(said[0])
+        self.assertFalse([s for s in said if "reopening it under" in s], said)
 
     def test_a_recorded_directory_that_has_gone_is_shown_not_executed(self):
         said = self._warnings(self._chat(cwd=HOSTILE))


### PR DESCRIPTION
**Task 2 of the harness-profiles plan** — `docs/superpowers/plans/2026-09-11-harness-profiles.md`, against the spec `docs/superpowers/specs/2026-09-11-harness-profiles.md` (*How a harness starts*). Task 1 (#978) taught charter to read profiles; this is the one that launches them.

## The failure it prevents

Charter ran one program per harness kind, one way: `Harness.binary` is a class attribute and nothing overrode it. Two Claude Code accounts, or a Codex pinned to an older release, had no way to tell charter so — and a shell alias never could, because nothing charter launches runs through a shell. A profile's environment could not reach the harness either: `layout.CARRIABLE` raises on every name but five, and the chat-handoff plan forbids adding to it.

## What now happens

**Every chat pane's first process is charter's own launcher** (`charter/frame/launcher.py`). It runs the profile's checks in the pane and then `os.execvpe`s the profile's command with the profile's `env` applied — so the environment reaches the harness without joining `CARRIABLE` and without passing through tmux's argument parser (#957, #961), one place runs the checks for every open, and `exec` keeps the pid so the pane is the harness's own. Only the profile's NAME crosses tmux.

**A chat records its profile.** `CHARTER_HARNESS` stays the kind — hooks compare it to `claude-code` — and the profile rides as `CHARTER_HARNESS_PROFILE`, set at the `exec` and written into the chat's state and the reopen manifest. The `+`, a workspace tab and a handoff take the profile of the chat they came from rather than merely its kind (two chats of one harness may be two accounts), and a reopen brings each chat back on its own. A chat whose profile is gone is skipped by name and left in the manifest for a retry: the `[harness] default` fallback is deleted (ruling 15), because another profile may be another account, where that conversation does not exist.

**No declared profile runs yet** (review B1). Nothing stands for the operator's approval of a `command` until Task 3, and `charter.local.toml` is a file a chat can write with no diff to show for it — so every profile the file declares is refused by name, a replacement of a built-in included; only built-ins launch. `main` therefore runs no unapproved declared command between this merge and Task 3's. Three tests go red if that refusal is deleted.

**Inside an operator's own tmux**, the `cat` placeholder stays and `respawn-pane` carries the launcher (ruling 4) — and a window charter could not mark with `@charter_chat` now fails the launch closed and loudly, because that option is what the pane's launcher proves its chat by there.

## The measurement, and ruling 42

Task 2's opening step was a measurement, already done and cited here: `workspaces/harness-profiles/refs/task2-measure/` (`table.md`, `real.md`, `results.json`). Every L1–L8 and pid-proof item PASSED on tmux 3.7c and at the 3.2 floor, on charter's own server and in an operator's tmux; the stop rule did not fire. The pane id, `remain-on-exit`, the exit code, the `pane-died` path, `_pane_last_words`, `$TMUX_PANE` and the liveness list all answer what they answered before, and `#{pane_current_command}` names charter's interpreter only until the `exec`.

It also found one thing the plan had wrong, now **ruling 42**: a refusal the launcher prints in the pane never reaches the operator. `_launch`'s eager dead-status ask completes 6–14 ms after the start while a Python launcher's first line runs at 19–22 ms; on charter's server the teardown hook kills the window at once (`_pane_last_words` → `[]`), and in an operator's tmux `_launch_in_operator_tmux` closes it before reading. All 40 measured refusals were lost. So:

- an **attended** launcher shows its refusal in the pane and **waits for a key** before exiting — the pane is charter's while no harness has run in it (ADR 0018 as the spec amends it);
- an **unattended** one records the refusal under the chat (`state.record_launch`), and the launch that opened it reads that back (`_await_the_launcher`, bounded) and reports it — which is what a reopen and a handoff have instead of somebody at the pane. The same record carries the ordinary "the harness has the pane now" answer, so a chat that started costs no wait.

**This PR amends the plan's Task 2 Behaviour text and its L4 test case to say that** — the plan's original wording is the thing the measurement showed cannot work.

**The frame proof** (rulings 29, 33, 35) is the first thing `cmd_frame_launch` does: its own pid must be the `#{pane_pid}` of a live pane belonging to the chat it claims — the window name on charter's server, `@charter_chat` in an operator's. `$TMUX_PANE` and `$CHARTER_SESSION_ID` are never proof, because a model's own tool shell inherits both from its chat.

## What CI found that this machine could not

Two things, both real and both now fixed here rather than worked around:

- **A key pressed before the pane is listening was thrown away.** `tty.setraw`'s own default is `TCSAFLUSH`, which discards input that arrived before the mode change — and the window between the refusal being printed and the read starting is exactly where an operator presses. It cost a second keypress nobody knew to send.
- **Then raw mode itself.** With the flush fixed, the Linux runner still came back with the launcher gone and an EMPTY `#{pane_dead_status}` — tmux's own reading for *killed by a signal* — where two tmux versions here were green. A single keystroke is not worth a `tcsetattr` from a pane, so the wait is a line read now (`press Enter to close this chat`): no mode change, nothing to restore, and the pane's own line discipline does the waiting. The measurement also showed what to assert on — a refusing launcher never `exec`s, and on that runner such a pane records no exit code at all, so the cases assert the pane stops being alive and `TheHarnessExitCodeTravelsAsItDid` keeps the exit-code contract where it belongs.

## Departures from the plan, and why

- **`_profile_launch(argv, parser)` takes the parser `main` already built**, instead of asking `command_words()`. That builds a second parser — ~10 ms measured on this machine — in every `charter hook …` process, and those fire per tool call. `main` now builds one parser and hands it to the rewrite.
- **`_profile_launch` returns `(argv, rc)`**, `_bare_launch`'s own shape, so a declared profile charter REFUSED says its reason instead of falling through to argparse's "invalid choice" and the gap reporter, which would offer to file an issue about a profile in the operator's own file.
- **`cmd_new_chat` and `_open_workspace` ask the launcher's chain before launching** (`_launch_refusal`) and say the refusal on the frame's attention row. Those commands run detached with their streams on `/dev/null`, so `_launch`'s own sentence is read by nobody and the `+` would report only "the launcher returned 3".
- **`refusal()` takes no `cwd`** — nothing in Task 2 reads it; Task 4 adds it with the probe that does.
- The plan's Task 2 test table said rc 1 for the B1 and ignored-file refusals; its Behaviour text says `r.exit` (`REFUSED_EXIT`, 3). The Behaviour text is what shipped, because `Refusal.exit` is the thing every caller reads — and the review confirmed the table is the stale half, so this PR corrects those three rows (below).

## The reviews, and what each finding became

Two reviews of `a4703ae`. All five departures above were accepted; the seven fixes are in `5d76169`.

| # | Finding | Outcome |
|---|---|---|
| F1 | Spec gap (ruling 42): `_launch_in_operator_tmux` never read the launcher's refusal, on the path where it is the only copy left | Fixed. `_what_the_pane_recorded` reads the record at both of that function's reporting sites — and, after CI found the second half (`9f3ccde`, below), **before** anything is decided from tmux's own answer about the pane. Red without it: `test_the_launch_says_what_the_pane_refused` |
| F2 | Standards: ADR 0018 must be amended in this PR (ruling 44), not deferred to Task 6 | Done. New amendment, *before the `exec`, that pane is charter's own*; Task 6's plan entry now reviews it and adds the selector |
| F3 | `UNNAMED_CHAT_WINDOW`'s `#:` block sat above `TOO_LONG_FOR_TMUX` | Swapped; each sentence sits under its own reasons |
| F4 | `declare_profiles`' `git init` used the ambient git identity | Uses `tests._gitguard.environment()` |
| F5 | `$GIT_CEILING_DIRECTORIES` unpinned in that fixture | Pinned above the throwaway plane |
| F6 | The length refusal counted the harness's arguments, not what charter handed tmux | Counts *carried*; the sentence says "the command charter handed it is N bytes". Both callers pass the launcher argv |
| F7 | The `h is None` guard was lost in the background-open extraction | Restored, fails closed in the sentence it already had |

Structure, also applied: `_profile_refusal` is the one spelling of the launcher chain both callers ask; `_how_a_background_open_would_go` returns what it resolved so the open does not resolve twice; `tmuxctl.live_pane_by_pid` answers a named `LivePane` (which field proves a chat depends on which server was asked); `KIND_MISMATCH` → `MISMATCHED_KIND`; `declare_profiles` adopted by all five profile modules; test helpers renamed to say what they do.

**ADR 0018's new amendment** states the distinguishing question in the ADR's own shape — *has a harness ever run in this pane, and is charter's own process still the one in it?* — cites `refs/task2-measure/` for why a refusal cannot be printed and exited on, and writes down its bounds: a refusal only, before the `exec` only, a line read and not a raw keystroke, and an unattended open recording instead of waiting.

### What CI found in the fix itself (`9f3ccde`)

`tests` on 3.11 went red on F1's own real-tmux case: `AssertionError: 1 != 3`. It was not the test. `_launch_in_operator_tmux` reads the pane's record at two sites, and the second — the process that stays awake for the life of the frame — read it only where tmux could say what the pane exited with. **A pane whose launcher refused is exactly the pane tmux often cannot say anything about there:** `#{pane_dead_status}` is empty for a pane killed by a signal and absent altogether for one that is no longer there, and `_wait_for_harness` reports both as `None` — the same answer it gives for a window the operator closed. So the sentence was dropped on the one branch with no other copy of it, and the launch returned `_UNKNOWN_DEATH_CODE`; the same refusal answers 3 on charter's own server.

The record is now read first, and **the launcher's own number wins**: it wrote down what it was exiting with before it exited, which is better evidence than anything reconstructed from a pane that is not there. Pinned on both sides of the platform line — `test_a_pane_that_refused_and_vanished_still_reports_its_own_number` drives the real `_launch` with `_wait_for_harness` answering `None`, and the real-tmux case now asserts the sentence before the number with what was said in its message.

## The deletion sweep: 33 survivors, 31 pinned and 2 deleted

The sweep on `a4703ae` (run 34662717840) ran out of budget with `no verdict: 33 survivors so far, 2 not measured; 130 of 135 measured, 5 out of time` — shards 2, 3 and 8 were cancelled, 1, 4, 5, 6 and 7 succeeded. Every survivor was read off the shard logs and dealt with. Each pin was checked by hand against its own mutation: the line changed, the module run, the failure read.

**Two are deletions, not pins** — lines no test could tell apart from their absence, which is the sweep's finding and not a gap in it: `os.environ.get("CHARTER_SESSION_ID", "")`'s fallback (the next line asks whether there is a chat at all, and `None` answers exactly as `""` does) and `list(args.rest or [])` (`nargs=REMAINDER` answers with a list on every path).

| Line | Question | What pins it |
|---|---|---|
| `launcher.REFUSED_EXIT = 3` | is the value pinned, or would any number do? | `test_a_refusal_exits_three_and_the_number_is_the_point` |
| `KIND_IGNORED`, `KIND_PATH`, `KIND_NOT_YET`, `KIND_EXEC` | is this literal pinned? (×4) | `test_the_kinds_are_a_written_down_vocabulary` |
| `PRESS_ENTER` | is this literal pinned? | `test_the_attended_pane_names_the_key_it_actually_waits_for` |
| `resolve`'s `contain.readable(name)` | is the containment pinned? | `test_a_refused_name_is_looked_up_the_way_it_was_written_down` |
| `resolve`'s `r.name == shown` | is the filter pinned? | `test_each_refused_profile_answers_with_its_own_reason` |
| `display_command`'s `contain.readable(word)` | is the containment pinned? | `test_the_command_charter_shows_for_a_launch_is_escaped` |
| `contain.readable(p.name)` in `IGNORED`, `NOT_ON_PATH`, `DECLARED_NOT_YET`, `EXEC_FAILED` | is the containment pinned? (×4) | `ARefusalNamesTheProfileWithoutBecomingIt` — `NAME_RE` bounds a name's shape and not its length, so the live job is the clip |
| `refusal`'s `env.get("PATH")` | is this literal pinned? | `test_the_path_the_exec_will_use_is_the_path_that_is_asked` |
| `_approval_refusal`'s `q.source == profiles.BUILTIN` | is the filter pinned? | `test_the_not_yet_refusal_offers_only_profiles_the_file_does_not_declare` |
| `attempt`'s `contain.readable(e.strerror or e)` | is the containment pinned? | `test_what_the_system_said_about_the_failure_is_escaped_too` |
| `framed_chat`'s `contain.readable(chat)` | is the containment pinned? | `test_an_unprovable_chat_is_repeated_back_escaped` |
| `_wait_for_the_operator`'s `if not sys.stdin.isatty()` | is the refusal pinned? | `…does_not_stop_to_ask` rewritten against a stdin whose `readline` raises — the suite's own stdin is `/dev/null`, where a missing guard looks identical — plus `…waits_for_their_line` |
| `framed_chat`'s `os.environ.get(…, "")` | is the fallback pinned? | **deleted** |
| `cmd_frame_launch`'s `args.rest or []` | is the fallback pinned? | **deleted** |
| `tmuxctl.live_pane_by_pid`'s `if out.returncode != 0` | is the refusal pinned? | `test_a_tmux_that_failed_is_not_read_even_though_it_printed` |
| `state` `if d is None` in `record_profile`, `profile`, `record_launch`, `launch` | is the refusal pinned? | `test_a_chat_id_that_names_no_directory_is_written_nowhere` |
| `state.launch`'s `raw.partition("\n")` | is *which end* pinned? | `test_a_refusal_of_several_lines_comes_back_whole` |
| `state.launch`'s `except ValueError` | is the catch pinned? | `test_a_half_written_record_is_read_as_no_answer_yet` |
| `_await_the_launcher`'s `time.monotonic() < deadline` | is the boundary pinned? | `test_the_budget_is_spent_at_the_deadline_and_not_one_poll_later` (a clock that lands exactly on the deadline, and a third tick left unread on purpose) |
| the same line's `drop-conjunct` (the sweep's `UNRESOLVED`) | is that half pinned? | a poll ceiling in that class's `sleep` stand-in: an unbounded wait fails loudly instead of hanging |
| `MISMATCHED_KIND`'s `contain.readable(p.name)` | is the containment pinned? | `test_the_name_that_refusal_repeats_back_is_bounded` |
| `_launch`'s `code is None` | is that half pinned? | `test_a_pane_that_already_died_is_not_asked_a_second_time` |
| `_launch`'s `p is not None` | is that half pinned? | `test_a_launch_with_no_profile_has_no_launcher_to_ask` |
| `PROFILE_GONE`'s `contain.readable(recorded)` | is the containment pinned? | `test_the_gone_profiles_name_is_repeated_back_escaped` |
| `_same_profile_as`'s `(p, "") if p is not None else …` | is the `else` branch pinned? | `test_a_chat_from_before_profiles_says_why_its_kinds_profile_was_refused` |
| `_reopen_one`'s `launcher.resolve(name) if name else (None, "")` | is the `else` branch pinned? | `test_a_chat_with_no_profile_to_name_asks_the_file_nothing` |

The sweep's other `UNRESOLVED`, `NO_HARNESS`'s literal, is already pinned by two existing modules that assert its words.

**Sizing, since the sweep ran out of budget on this branch.** 135 mutations over 10 files, 1,050 added lines, 178 minutes of predicted test time, heaviest shard 2,073 s against a 1,680 s budget. Mutations per file: `launcher.py` 60, `commands_frame.py` 38, `state.py` 12, `tmuxctl.py` 6, `cli.py` 5, `leave.py` 3, `doctor.py` 3, `choose.py` 2, `chats.py` 1 (130 of 135 measured). Modules selected per mutation, over 479 test modules: median **8**, mean 26. `launcher.py`'s own median is 15 and its maximum 25 — **nothing here is charged anything like the whole suite the way `profiles.py` was before ruling 43.** Five mutations select more than 100 modules and four of those select 470: every one is a module-level constant, where the selected set is "every test module that imports this file" — `commands_frame`'s four message literals (470 each), `state._PROFILE_FILE` (126) and `tmuxctl._PANE_PID_FORMAT` (97). That is a property of where a constant sits, not of profiles, and it is the same for any literal added to those modules.

### The sweep's verdict on `9f3ccde`, and what it found in the fixes (`529f604`)

CI's `deletion sweep` (run 34673589562) reached a verdict this time: **141 pinned, `7 survivors, 2 not measured`, 0 out of time, 0 shards refused** — all eight shards finished, against 152 mutations over 10 files and 1,201 added lines. Six of the seven were in the two commits above, and every one is now pinned or deleted:

| Line | What it was | What pins it |
|---|---|---|
| `_launch_in_operator_tmux`'s eager branch: `if recorded is not None`, `if refused`, and `code is not None` | **that whole branch had no test** — the fixture answered `_ALIVE` to that ask on every case it had | `pane_state` is a knob on the helper now, and four cases drive it: dead with a refusal recorded, dead with none, vanished with neither, and `charter frame -- <cmd>` |
| `_what_the_pane_recorded`'s `if not profile` | a launch with no profile has no launcher there to have recorded anything | `test_a_launch_with_no_profile_has_no_launcher_record_to_read_here_either` |
| `state.record_profile` / `record_launch`'s `except OSError` | written in this branch and never made to fail | `test_a_record_that_cannot_be_written_is_not_raised_out_of_a_hook` |
| `live_pane_by_pid`'s `if len(fields) != _PANE_PID_FIELDS` | a window NAME may hold a tab and `list-panes` does not quote it — unpacking such a row raises | `test_a_row_with_more_fields_than_the_format_is_not_read` |
| `unknown_profile`'s `contain.readable(name)` | the third of three sentences in `launcher.py` that quote a name off a command line | `test_a_name_nothing_declares_is_repeated_back_escaped` |
| `live_pane_by_pid`'s `out.stdout or ""` | every one of `tmuxctl.run`'s three exits returns a string | **deleted** |

**The 2 not measured are the same pair the earlier sweep could not resolve, and both are timeouts rather than reds**: dropping `_await_the_launcher`'s deadline, and collapsing `("--attended",) if attended else ()` so every launch is attended. Each hangs a real-tmux case, which then holds the whole mutation run past its budget — so neither has been shown to be tested, and neither has been shown not to be. Named rather than counted.

## The plan's stale `rc 1`

The Task 2 test table said `rc 1` in three rows where every other mention of `REFUSED_EXIT` in the plan says 3. Fixed in place in this PR's plan amendment, with a note saying which half was stale and why 3 is the number: 126 and 127 are the shell's own words for a command that could not run (and what `bypass` returns), 2 is charter's usage error, 1 is a harness that ran and failed.

## Checks

- `python3 -m unittest discover -s tests`, in one run on this machine before each push: `5d76169` **`Ran 12679 tests in 1079.918s — OK (skipped=9)`**, `9f3ccde` **`Ran 12680 tests in 1306.573s — OK (skipped=9)`**, `529f604` **`Ran 12687 tests in 1362.461s — OK (skipped=9)`**.
- Every one of the 31 pins above was verified red-before-green by hand: its own line mutated the way the sweep mutates it, the module run, the failure read, the line restored. F1 and F7 likewise (`test_the_launch_says_what_the_pane_refused` fails without the operator-path report; `_how_a_background_open_would_go` raises `AttributeError` without the guard).
- Deletion check by hand for the guard added under `tests/` (the sweep never mutates those): removing `CHARTER_HARNESS_PROFILE` from `_envguard._loud_names()` reddens `WhatIsGuarded.test_the_profile_a_chat_runs_is_guarded`, and restoring it goes green.
- **CI on `9f3ccde`: `tests` green on 3.11, 3.12, 3.13 and 3.14** (run 34673589585), and its `deletion sweep` (run 34673589562) ran to the verdict above with no push while it reported. The sweep on `a4703ae` (run 34662717840) ran out of budget; the one on `5d76169` refused on its own red baseline, which `9f3ccde` fixes. CI on `529f604` is running as this line is written.
- Real tmux: `tests/test_a_chat_pane_starts_as_charter_and_becomes_the_harness.py` drives a real `_launch` on a private server — the pane's launcher execs the recorder, the pid it wrote is the pane's `#{pane_pid}`, the exit code travels, `CHARTER_HARNESS_PROFILE` reaches the harness and appears in neither `show-environment -g` nor `-t <session>`, and both halves of ruling 42 hold, the operator's-tmux refusal included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

