### PR TITLE
The ask rule reaches the chat that runs the handoff, and a stale workspace is sent to reinit (chat handoff, task 4, phase 2)

### DIFF
--- a/charter/doctor.py
+++ b/charter/doctor.py
@@ -1943,42 +1943,72 @@ def check_ask_rules() -> Result:
                        "want — this names it so the prompts are not a mystery.")
 
 
-def _stale_layer_clause() -> str:
-    """The clause that turns "add the rule" into "refresh this directory" — or ``""``.
+def _reinit_target(root: Path) -> str | None:
+    """The workspace `charter workspace reinit` would repair to fix *root*'s layer — or
+    ``None`` when no `reinit` writes this directory at all.
+
+    `reinit(name)` writes `workspaces/<name>` and each guest checkout inside it
+    (`workspace.wire_harnesses`), and nothing else. So a session in `docs/`, in
+    `personas/<p>/`, at the plane root, or in a deep directory *inside* a checkout is one
+    `reinit` cannot help — Claude Code reads settings from the session's own directory
+    (#855), and `reinit` does not write that directory. Naming the command there sends the
+    operator to run something that provably cannot clear the row.
+
+    This subsumes the plane-root case rather than guarding it separately: the plane root is
+    not a workspace directory, so it answers ``None`` by the same rule as every other
+    directory `reinit` does not write.
+    """
+    from . import workspace as _workspace
+
+    for name in _workspace.list_workspaces():
+        try:
+            if root == _workspace.workspace_dir(name).resolve():
+                return name
+            if any(root == tree.resolve() for tree in _workspace.guest_trees(name)):
+                return name
+        except OSError:
+            continue
+    return None
+
+
+def _stale_layer_clause(missing: list, plane: dict) -> tuple[str, str]:
+    """``(command, sentence)`` naming `charter workspace reinit` when that is the command
+    that fixes this row — or ``("", "")``.
 
     A session standing in `workspaces/<ws>/` reads that directory's settings and nowhere else
     (#855), so the gate can be missing there while the plane holds it. That is not a plane
-    with no rule: nothing needs adding, the layer here is simply behind, and the command that
-    fixes it is `charter workspace reinit`. Telling that operator to `charter guard ask` would
-    have them write a rule the plane already has.
+    with no rule: nothing needs adding, the layer here is behind, and telling the operator to
+    `charter guard ask` would have them write a rule the plane already has.
 
-    **Whether the plane holds it is #948's answer** — `Harness.restrictive_rules`, the same
-    surface `workspace layer` counts (task 4 ruling 5). Read out of `.claude/settings.json`
-    here it would be a second notion of "the plane's policy", and which of the plane's policy
-    travels is a fact about a harness's own config format, not about this file.
+    Three things must all hold, because each one on its own names a command that does not
+    work (#982 review round 1):
 
-    Empty at the plane root, where there is no layer to refresh, and empty when no harness
-    holds the rule, where `reinit` would copy nothing. A harness that cannot answer costs the
-    clause and never the row — narrow, per :func:`_mirrored_restrictions`.
+    * `reinit` must write THIS directory — :func:`_reinit_target`;
+    * the harness actually MISSING the rule must be one whose layer `reinit` carries here. A
+      harness that generates no workspace files is one `reinit` copies nothing for, so with
+      only opencode lacking the rule the answer is silence, not a command that cannot help;
+    * the plane must hold the rule **by the row's own test** — `apply_ask_rule` against
+      `config.ROOT`, the same reading, one root over. `restrictive_rules` was a second
+      predicate over `ask`+`deny` flattened, and it disagreed: a plane that DENIES
+      `charter handoff` held no ask rule and the clause fired anyway.
+
+    *plane* is that reading, taken in the row's own `try` so ONE `OSError` handler covers both
+    roots. There is deliberately no handler of its own here: a harness whose settings raise
+    takes the whole row to not-checked before this is reached, and the `except` that used to
+    sit here was measured dead — every harness answers `unsupported` or a status for an
+    unreadable or malformed file rather than raising (#982 review round 1).
     """
-    from . import config as _config
-    from .commands import HANDOFF_ASK_PATTERN
-    from .harness import registry as _harness
-
-    try:
-        if session_root().resolve() == _config.ROOT.resolve():
-            return ""
-    except OSError:
-        return ""
-    for h in _harness.all():
-        try:
-            rules = h.restrictive_rules() or {}
-        except (OSError, ValueError):
+    target = _reinit_target(session_root())
+    if target is None:
+        return "", ""
+    for h in missing:
+        if not h.workspace_files():
             continue
-        if any(HANDOFF_ASK_PATTERN in rule for held in rules.values() for rule in held):
-            return (" — the plane already holds it, so this session's directory carries a "
-                    "stale layer: charter workspace reinit")
-    return ""
+        if plane.get(h.name) == "present":
+            return (f"charter workspace reinit {target}",
+                    f"The plane already holds it for {h.name}, so this directory's layer is "
+                    f"behind — nothing to add, only to refresh")
+    return "", ""
 
 
 def check_handoff_gate() -> Result:
@@ -2008,10 +2038,17 @@ def check_handoff_gate() -> Result:
 
     name = "handoff gate"
     rows = []
+    plane: dict[str, str] = {}
     for h in _harness.all():
         root = session_root() if h.name == _harness.CLAUDE_CODE else _config.ROOT
         try:
             status, detail = h.apply_ask_rule(root, HANDOFF_ASK_PATTERN, dry_run=True)
+            # The same reading one root over, for the stale-layer clause. Taken HERE so a
+            # single `except OSError` covers both roots: a second handler around a second
+            # call was measured dead, because every harness answers rather than raising for
+            # an unreadable or malformed file (#982 review round 1).
+            plane[h.name] = h.apply_ask_rule(
+                _config.ROOT, HANDOFF_ASK_PATTERN, dry_run=True)[0]
         except OSError as e:
             # The settings loaders test `Path.exists` outside their own `try`, and on a file
             # under a directory charter may not enter that raises on Python 3.11-3.13 (3.14
@@ -2028,16 +2065,22 @@ def check_handoff_gate() -> Result:
                       detail=f"{broken} is not valid — charter cannot tell whether "
                              f"`charter handoff` asks first",
                       hint=_NOT_CHECKED_HINT)
-    missing = [h.name for h, status, _detail in rows if status == "added"]
+    missing = [h for h, status, _detail in rows if status == "added"]
     if missing:
+        command, why = _stale_layer_clause(missing, plane)
+        # `reinit` INSTEAD of `guard ask`, never both: one sentence telling the operator to
+        # add a rule and then that they already have it is a sentence that cannot be acted
+        # on (#982 review round 1).
+        how = (f"{why}: {command}" if command
+               else "Add it: charter guard ask 'charter handoff *'")
         return Result(name, WARN,
-                      detail=f"no ask rule for `charter handoff` under {', '.join(missing)}",
+                      detail="no ask rule for `charter handoff` under "
+                             f"{', '.join(h.name for h in missing)}",
                       hint="A handoff's brief becomes a new chat's first message and runs with "
                            "your authority; this rule is the prompt that asks you first, and "
-                           "on Claude Code it asks under bypassPermissions too. Add it: charter "
-                           f"guard ask 'charter handoff *'{_stale_layer_clause()}. Removing it "
-                           "is your choice — this row says so, and charter does not put it "
-                           "back.")
+                           f"on Claude Code it asks under bypassPermissions too. {how}. "
+                           "Removing it is your choice — this row says so, and charter does "
+                           "not put it back.")
     present = [h.name for h, status, _detail in rows if status == "present"]
     gaps = [f"        ↳ {h.name}: {d.detail}" for h, _status, _detail in rows
             for d in h.deficits if d.key == "handoff-gate"]

--- a/charter/doctor.py
+++ b/charter/doctor.py
@@ -1971,9 +1971,46 @@ def _reinit_target(root: Path) -> str | None:
     return None
 
 
-def _stale_layer_clause(missing: list, plane: dict) -> tuple[str, str]:
-    """``(command, sentence)`` naming `charter workspace reinit` when that is the command
-    that fixes this row — or ``("", "")``.
+def _how_to_fix(missing: list, plane: dict) -> str:
+    """The middle sentence of this row's hint: what would actually put the rule in force for a
+    chat rooted here. One of three, and the third names no command at all.
+
+    Charter writes these settings in exactly two kinds of place — the plane root, and a
+    workspace's or checkout's own root — while Claude Code reads them from the session's
+    EXACT directory (#855). So for a chat rooted anywhere else (`docs/`, `personas/<p>/`, a
+    deep directory inside a checkout) there is no command that puts the rule in force, and
+    `charter guard ask` is as inert there as `charter workspace reinit` was before round 1
+    stopped naming it: measured, all three rows unchanged after running it. The row is still
+    right to warn — the rule genuinely is not in force for that chat, which is what this row
+    exists to surface — so what changes is the advice. **A hint with no command beats a hint
+    with a command that does nothing** (#982 review round 2).
+
+    Charter is deliberately NOT made to write settings into arbitrary directories to rescue
+    the old advice: that is scope creep into directories charter does not manage.
+    """
+    from . import config as _config
+
+    root = session_root()
+    stale = _stale_layer_clause(missing, plane)
+    if stale:
+        return stale
+    try:
+        wired = root == _config.ROOT.resolve() or _reinit_target(root) is not None
+    except OSError:
+        wired = True                           # unreadable: keep the advice that can work
+    if wired:
+        return "Add it: charter guard ask 'charter handoff *'"
+    return ("It cannot be put in force for a chat rooted in this directory: charter writes "
+            "these settings at the plane root and at a workspace's or checkout's own root, and "
+            "a chat reads them from the directory it starts in. `charter guard ask` reaches "
+            "workspaces by mirroring into each one, not by writing where you are standing — so "
+            "start the chat in the plane root, a workspace, or a checkout, and it is gated "
+            "there")
+
+
+def _stale_layer_clause(missing: list, plane: dict) -> str:
+    """The sentence naming `charter workspace reinit` when that is the command that fixes this
+    row — or ``""``.
 
     A session standing in `workspaces/<ws>/` reads that directory's settings and nowhere else
     (#855), so the gate can be missing there while the plane holds it. That is not a plane
@@ -2010,15 +2047,15 @@ def _stale_layer_clause(missing: list, plane: dict) -> tuple[str, str]:
     """
     target = _reinit_target(session_root())
     if target is None:
-        return "", ""
+        return ""
     for h in missing:
         if not h.workspace_files():
             continue
         if plane.get(h.name) == "present":
-            return (f"charter workspace reinit {target}",
-                    f"The plane already holds it for {h.name}, so this directory's layer is "
-                    f"behind — nothing to add, only to refresh")
-    return "", ""
+            return (f"The plane already holds it for {h.name}, so this directory's layer is "
+                    f"behind — nothing to add, only to refresh: charter workspace "
+                    f"reinit {target}")
+    return ""
 
 
 def check_handoff_gate() -> Result:
@@ -2077,12 +2114,11 @@ def check_handoff_gate() -> Result:
                       hint=_NOT_CHECKED_HINT)
     missing = [h for h, status, _detail in rows if status == "added"]
     if missing:
-        command, why = _stale_layer_clause(missing, plane)
         # `reinit` INSTEAD of `guard ask`, never both: one sentence telling the operator to
-        # add a rule and then that they already have it is a sentence that cannot be acted
-        # on (#982 review round 1).
-        how = (f"{why}: {command}" if command
-               else "Add it: charter guard ask 'charter handoff *'")
+        # add a rule and then that they already have it is a sentence that cannot be acted on
+        # (#982 review round 1). And in a directory charter does not wire, neither — see
+        # :func:`_how_to_fix`.
+        how = _how_to_fix(missing, plane)
         return Result(name, WARN,
                       detail="no ask rule for `charter handoff` under "
                              f"{', '.join(h.name for h in missing)}",

--- a/charter/doctor.py
+++ b/charter/doctor.py
@@ -1960,7 +1960,14 @@ def _reinit_target(root: Path) -> str | None:
     """
     from . import workspace as _workspace
 
-    for name in _workspace.list_workspaces():
+    try:
+        names = _workspace.list_workspaces()
+    except OSError:
+        # The LISTING, guarded separately from each entry below. Its `try` sits inside the
+        # loop, so an unreadable `workspaces/` raised straight past it, out of this function
+        # and out of `charter doctor` — the whole command, not one row (#982 review round 2b).
+        return None
+    for name in names:
         try:
             if root == _workspace.workspace_dir(name).resolve():
                 return name
@@ -1991,21 +1998,43 @@ def _how_to_fix(missing: list, plane: dict) -> str:
     from . import config as _config
 
     root = session_root()
+    # The plane root is settled FIRST, and without reading `workspaces/` at all: `guard ask`
+    # writes here, so the answer cannot depend on whether some other directory is readable.
+    # Asked after the stale clause, an unreadable `workspaces/` decided it (#982 round 2b).
+    try:
+        at_plane_root = root == _config.ROOT.resolve()
+    except OSError:
+        # Cannot tell where this chat is standing, so take the answer that can only be
+        # USELESS and never WRONG. `guard ask` is the right advice at the plane root and
+        # merely inert elsewhere; the no-command sentence is false at the plane root, where
+        # `guard ask` works — and a false sentence is believed, while an inert one costs a
+        # minute (#982 review rounds 2 and 2b).
+        at_plane_root = True
+    if at_plane_root:
+        return "Add it: charter guard ask 'charter handoff *'"
     stale = _stale_layer_clause(missing, plane)
     if stale:
         return stale
-    try:
-        wired = root == _config.ROOT.resolve() or _reinit_target(root) is not None
-    except OSError:
-        wired = True                           # unreadable: keep the advice that can work
-    if wired:
+    if _reinit_target(root) is not None:
         return "Add it: charter guard ask 'charter handoff *'"
-    return ("It cannot be put in force for a chat rooted in this directory: charter writes "
-            "these settings at the plane root and at a workspace's or checkout's own root, and "
-            "a chat reads them from the directory it starts in. `charter guard ask` reaches "
-            "workspaces by mirroring into each one, not by writing where you are standing — so "
-            "start the chat in the plane root, a workspace, or a checkout, and it is gated "
-            "there")
+    # Unwired, and the two states read differently. A sentence here makes a claim about a
+    # DIFFERENT directory, so it may only say what is true in every state it can be read from
+    # — including a workspace whose own layer is behind, which is the state this whole row
+    # exists to surface (#982 review round 2). Hence no enumerated guarantee: from here
+    # charter cannot see which workspaces are current.
+    where = ("charter writes these settings at the plane root and at a workspace's or "
+             "checkout's own root, and a chat reads them from the directory it starts in")
+    if any(plane.get(h.name) == "present" for h in missing):
+        return ("It cannot be put in force for a chat rooted in this directory: " + where +
+                ". A chat started in the plane root is gated; charter gates a workspace or a "
+                "checkout once it has written the rule there, and this row says so in any "
+                "whose layer is behind")
+    # `guard ask` is NOT inert here: run from anywhere inside the plane it writes the plane's
+    # own settings, and the plane root and every workspace go clean afterwards — measured. It
+    # simply cannot gate a chat rooted HERE, which is what the second half says.
+    return ("Add it: charter guard ask 'charter handoff *' — that gates a chat started in the "
+            "plane root, and reaches workspaces and checkouts by mirroring into them. It "
+            "cannot gate a chat rooted in this directory: " + where)
 
 
 def _stale_layer_clause(missing: list, plane: dict) -> str:

--- a/charter/doctor.py
+++ b/charter/doctor.py
@@ -1943,6 +1943,44 @@ def check_ask_rules() -> Result:
                        "want — this names it so the prompts are not a mystery.")
 
 
+def _stale_layer_clause() -> str:
+    """The clause that turns "add the rule" into "refresh this directory" — or ``""``.
+
+    A session standing in `workspaces/<ws>/` reads that directory's settings and nowhere else
+    (#855), so the gate can be missing there while the plane holds it. That is not a plane
+    with no rule: nothing needs adding, the layer here is simply behind, and the command that
+    fixes it is `charter workspace reinit`. Telling that operator to `charter guard ask` would
+    have them write a rule the plane already has.
+
+    **Whether the plane holds it is #948's answer** — `Harness.restrictive_rules`, the same
+    surface `workspace layer` counts (task 4 ruling 5). Read out of `.claude/settings.json`
+    here it would be a second notion of "the plane's policy", and which of the plane's policy
+    travels is a fact about a harness's own config format, not about this file.
+
+    Empty at the plane root, where there is no layer to refresh, and empty when no harness
+    holds the rule, where `reinit` would copy nothing. A harness that cannot answer costs the
+    clause and never the row — narrow, per :func:`_mirrored_restrictions`.
+    """
+    from . import config as _config
+    from .commands import HANDOFF_ASK_PATTERN
+    from .harness import registry as _harness
+
+    try:
+        if session_root().resolve() == _config.ROOT.resolve():
+            return ""
+    except OSError:
+        return ""
+    for h in _harness.all():
+        try:
+            rules = h.restrictive_rules() or {}
+        except (OSError, ValueError):
+            continue
+        if any(HANDOFF_ASK_PATTERN in rule for held in rules.values() for rule in held):
+            return (" — the plane already holds it, so this session's directory carries a "
+                    "stale layer: charter workspace reinit")
+    return ""
+
+
 def check_handoff_gate() -> Result:
     """Does a `charter handoff` wait for the operator's yes here? (chat handoff)
 
@@ -1997,8 +2035,9 @@ def check_handoff_gate() -> Result:
                       hint="A handoff's brief becomes a new chat's first message and runs with "
                            "your authority; this rule is the prompt that asks you first, and "
                            "on Claude Code it asks under bypassPermissions too. Add it: charter "
-                           "guard ask 'charter handoff *'. Removing it is your choice — this "
-                           "row says so, and charter does not put it back.")
+                           f"guard ask 'charter handoff *'{_stale_layer_clause()}. Removing it "
+                           "is your choice — this row says so, and charter does not put it "
+                           "back.")
     present = [h.name for h, status, _detail in rows if status == "present"]
     gaps = [f"        ↳ {h.name}: {d.detail}" for h, _status, _detail in rows
             for d in h.deficits if d.key == "handoff-gate"]

--- a/charter/doctor.py
+++ b/charter/doctor.py
@@ -1986,7 +1986,17 @@ def _stale_layer_clause(missing: list, plane: dict) -> tuple[str, str]:
     * `reinit` must write THIS directory — :func:`_reinit_target`;
     * the harness actually MISSING the rule must be one whose layer `reinit` carries here. A
       harness that generates no workspace files is one `reinit` copies nothing for, so with
-      only opencode lacking the rule the answer is silence, not a command that cannot help;
+      only opencode lacking the rule the answer is silence, not a command that cannot help.
+
+      **No real plane reaches that branch today, and it is kept deliberately.** Every harness
+      but Claude Code is judged against `config.ROOT`, so "missing here" already implies
+      "missing at the plane" and the `present` test below has already said no. It is the code
+      form of the defect this round fixed — naming a command that does nothing for the harness
+      that is actually stale — and the day another harness generates workspace files, deleting
+      it turns the clause back into advice that cannot work with nobody left to remember why.
+      Its test reaches it with a CONSTRUCTED shape (a patched `workspace_files`), so a passing
+      test here is not evidence that any plane exercises it: read it as a fail-safe, not as
+      coverage, and do not let a deletion sweep nominate it (#982 review round 1);
     * the plane must hold the rule **by the row's own test** — `apply_ask_rule` against
       `config.ROOT`, the same reading, one root over. `restrictive_rules` was a second
       predicate over `ask`+`deny` flattened, and it disagreed: a plane that DENIES

--- a/docs/handoff.md
+++ b/docs/handoff.md
@@ -100,11 +100,21 @@ over, so the two halves of this row cannot disagree.
 **Where charter writes these settings, and where it does not.** The plane root, a workspace
 directory, and a checkout's own root — nowhere else. `charter guard ask` reaches workspaces by
 mirroring into each one, not by writing where you happen to be standing. So for a chat rooted
-in `docs/`, in `personas/<p>/`, or in a deep directory inside a checkout, **no command puts the
-rule in force**, and the row says exactly that rather than naming one: running `guard ask` from
-there leaves the row warning, measured. The warning itself is right — the rule really is not in
-force for that chat — and the answer is to start the chat in the plane root, a workspace or a
-checkout, where it is gated.
+in `docs/`, in `personas/<p>/`, or in a deep directory inside a checkout, **nothing puts the
+rule in force for that chat**, and the row says so rather than pretending otherwise. The warning
+itself is right: the rule really is not in force there.
+
+What the row offers depends on whether the rule exists at all, because the two are different
+problems. If the plane already holds it, there is no command to give — a chat started in the
+plane root is gated, and charter gates a workspace or a checkout once it has written the rule
+there, which this row reports in any whose layer is behind. If nothing holds it yet, `charter
+guard ask 'charter handoff *'` is still worth running from where you are: it writes the plane's
+own settings wherever inside the plane you run it, and the plane root and every workspace are
+gated afterwards — measured. It simply cannot gate the chat you are in.
+
+A workspace whose layer is behind is *not* gated, which is why neither sentence promises that a
+chat started in "a workspace" is gated: from `docs/` charter cannot see which workspaces are
+current, and a hint must only claim what is true from everywhere it can be read.
 
 ## What charter refuses that the prompt cannot cover
 

--- a/docs/handoff.md
+++ b/docs/handoff.md
@@ -94,9 +94,17 @@ When the rule is missing in a chat whose plane *does* hold it, the row's hint na
 `charter workspace reinit <workspace>` instead of `charter guard ask`: nothing needs adding,
 the layer in that directory is behind. It says that only where `reinit` is the command that
 fixes it — in a workspace directory or a checkout inside one, for a harness whose layer
-`reinit` carries there. Anywhere else, and for a harness `reinit` writes nothing for, the hint
-says "add it" and names no command that cannot help. Whether the plane holds the rule is the
-row's own reading one directory over, so the two halves of this row cannot disagree.
+`reinit` carries there. Whether the plane holds the rule is the row's own reading one directory
+over, so the two halves of this row cannot disagree.
+
+**Where charter writes these settings, and where it does not.** The plane root, a workspace
+directory, and a checkout's own root — nowhere else. `charter guard ask` reaches workspaces by
+mirroring into each one, not by writing where you happen to be standing. So for a chat rooted
+in `docs/`, in `personas/<p>/`, or in a deep directory inside a checkout, **no command puts the
+rule in force**, and the row says exactly that rather than naming one: running `guard ask` from
+there leaves the row warning, measured. The warning itself is right — the rule really is not in
+force for that chat — and the answer is to start the chat in the plane root, a workspace or a
+checkout, where it is gated.
 
 ## What charter refuses that the prompt cannot cover
 

--- a/docs/handoff.md
+++ b/docs/handoff.md
@@ -84,6 +84,17 @@ workspace's own file, it asked there too. A chat a frame opens stands in its wor
 directory, so that directory's file is the one that has to carry the rule. `charter doctor` run
 from such a chat reads that file, and its `handoff gate` row warns when the rule is not there.
 
+**How it gets there.** The plane's `ask` rules ride into every workspace's generated
+`.claude/settings.json` ([#942](https://github.com/diazoxide/charter/pull/948)), so the gate is
+in force in a workspace chat without anyone copying it by hand, and a workspace that already
+existed picks up a newly added rule the next time it is launched. An `allow` rule never travels
+— widening what a chat may do is the plane's own business.
+
+When the rule is missing in a chat whose plane *does* hold it, the row's hint names
+`charter workspace reinit` instead of `charter guard ask`: nothing needs adding, the layer in
+that directory is simply behind. Whether the plane holds it is read from the same place
+`doctor`'s `workspace layer` row reads it, so the two rows cannot disagree.
+
 ## What charter refuses that the prompt cannot cover
 
 Inside a control plane, charter's Bash hook refuses a `charter handoff` in four situations the

--- a/docs/handoff.md
+++ b/docs/handoff.md
@@ -85,15 +85,18 @@ directory, so that directory's file is the one that has to carry the rule. `char
 from such a chat reads that file, and its `handoff gate` row warns when the rule is not there.
 
 **How it gets there.** The plane's `ask` rules ride into every workspace's generated
-`.claude/settings.json` ([#942](https://github.com/diazoxide/charter/pull/948)), so the gate is
+`.claude/settings.json` ([#948](https://github.com/diazoxide/charter/pull/948)), so the gate is
 in force in a workspace chat without anyone copying it by hand, and a workspace that already
 existed picks up a newly added rule the next time it is launched. An `allow` rule never travels
 — widening what a chat may do is the plane's own business.
 
 When the rule is missing in a chat whose plane *does* hold it, the row's hint names
-`charter workspace reinit` instead of `charter guard ask`: nothing needs adding, the layer in
-that directory is simply behind. Whether the plane holds it is read from the same place
-`doctor`'s `workspace layer` row reads it, so the two rows cannot disagree.
+`charter workspace reinit <workspace>` instead of `charter guard ask`: nothing needs adding,
+the layer in that directory is behind. It says that only where `reinit` is the command that
+fixes it — in a workspace directory or a checkout inside one, for a harness whose layer
+`reinit` carries there. Anywhere else, and for a harness `reinit` writes nothing for, the hint
+says "add it" and names no command that cannot help. Whether the plane holds the rule is the
+row's own reading one directory over, so the two halves of this row cannot disagree.
 
 ## What charter refuses that the prompt cannot cover
 

--- a/docs/news/unreleased-a-handoff-waits-for-your-yes.md
+++ b/docs/news/unreleased-a-handoff-waits-for-your-yes.md
@@ -18,6 +18,13 @@ Code 2.1.268, that rule asks before `charter handoff … <<'BRIEF'` under `manua
 `charter update` writes nothing, because removing the rule is your choice, and
 `charter doctor`'s new `handoff gate` row names it when it is missing.
 
+The rule reaches the chat that runs the command. A chat launched in `workspaces/<ws>/` reads
+that directory's settings and nowhere else, so the gate is in force there because the plane's
+`ask` rules ride into each workspace's generated settings — and a workspace that already existed
+picks the rule up the next time it is launched. When the row finds the gate missing in a chat
+whose plane *does* hold it, it says so and names `charter workspace reinit` rather than telling
+you to add a rule you already have.
+
 ## What charter refuses that the prompt cannot cover
 
 Inside a control plane, charter's Bash hook refuses a `charter handoff`:

--- a/docs/news/unreleased-a-handoff-waits-for-your-yes.md
+++ b/docs/news/unreleased-a-handoff-waits-for-your-yes.md
@@ -22,8 +22,9 @@ The rule reaches the chat that runs the command. A chat launched in `workspaces/
 that directory's settings and nowhere else, so the gate is in force there because the plane's
 `ask` rules ride into each workspace's generated settings — and a workspace that already existed
 picks the rule up the next time it is launched. When the row finds the gate missing in a chat
-whose plane *does* hold it, it says so and names `charter workspace reinit` rather than telling
-you to add a rule you already have.
+whose plane *does* hold it, and `charter workspace reinit` is the command that would fix that
+chat, the row names it rather than telling you to add a rule you already have — and where
+`reinit` would not help, it does not name it.
 
 ## What charter refuses that the prompt cannot cover
 

--- a/docs/superpowers/plans/2026-09-10-chat-handoff.md
+++ b/docs/superpowers/plans/2026-09-10-chat-handoff.md
@@ -1068,9 +1068,11 @@ stays out. First draft, for the record: the plane's `.claude/settings.json` hold
   The original said `permissions == {"ask": ["Bash(charter handoff *)"]}`, which is false on main:
   #948 mirrors the plane's `deny` as well, so equality fails on any plane that has one, and it
   would break again whenever a neighbouring feature legitimately adds a key.
-- `test_an_allow_rule_never_travels_into_a_workspace` — no `"allow"` anywhere in any generated
-  document, from `.claude/settings.json` **and** `.claude/settings.local.json`. The security
-  invariant, asserted from the angle equality cannot reach.
+- `test_an_allow_rule_never_travels_into_a_workspace` — no `"allow"` anywhere in the generated
+  documents, reading `workspace_files()` **and** `checkout_files()`, since the plane's local
+  file rides only in the second. The security invariant from the angle equality cannot reach;
+  the local half is pinned for every plane by #948's own
+  `test_a_local_grant_does_not_travel_either`, and this holds the handoff-shaped plane to it.
 - ~~`test_a_deny_rule_does_not_travel_either`~~ — **dropped in Phase 2.** #948 mirrors `deny`
   deliberately, so this asserted the opposite of shipped behaviour; task 4 ruling 4 already said
   Task 4 "asserts nothing about `deny`, which #942 carries", and two suites pinning one behaviour

--- a/docs/superpowers/plans/2026-09-10-chat-handoff.md
+++ b/docs/superpowers/plans/2026-09-10-chat-handoff.md
@@ -87,6 +87,14 @@ carries the rulings that touch it.
   `charter 'handoff'` — which Claude Code 2.1.268 runs with no prompt — is refused along with every
   other variant. Phase 2 (ruling 4's #948-path tests, ruling 5's `{stale}` hint) is split into a
   follow-up PR after #948 merges; Task 4's PR merges as Phase 1.
+- **Task 4 Phase 2 (2026-09-12), measured against #948 on main.** The `#948-path` test list above
+  predated #948 and disagreed with it on `deny`: #948 mirrors the plane's `ask` **and** `deny`
+  into every workspace document, and only `allow` never travels. Ruling 4 already governs — Task 4
+  "asserts nothing about `deny`" — so the deny test is dropped and the first test asserts the ask
+  rule's presence plus the absence of `allow` rather than equality on the whole `permissions`
+  object. The entries themselves are corrected below rather than left for the next reader to
+  re-derive. `{stale}` consumes `Harness.restrictive_rules` (#948's own surface), so "does the
+  plane hold this rule" has one answer, not two.
 - **Task 4 review round 2 (2026-09-11).** A7 guards a good-faith chat's spelling mistakes and
   names what it cannot see; it is not a shell parser, and it does not refuse every command that
   merely mentions a handoff. R2b: exactly one ASCII space after `handoff` too, or the end of the
@@ -1055,9 +1063,18 @@ a launch refreshing a workspace after the plane gains the rule, with no assertio
 stays out. First draft, for the record: the plane's `.claude/settings.json` holds
 `{"enabledPlugins": {"charter@charter": true}, "permissions": {"ask": ["Bash(charter handoff *)"], "allow": ["Bash(ls *)"], "deny": ["Bash(rm *)"]}}`.
 
-- `test_a_workspace_settings_document_carries_the_planes_asks` — `json.loads(ClaudeCodeHarness().workspace_files()[".claude/settings.json"])["permissions"] == {"ask": ["Bash(charter handoff *)"]}`.
-- `test_an_allow_rule_never_travels_into_a_workspace` — no `"allow"` anywhere in that document.
-- `test_a_deny_rule_does_not_travel_either` — no `"deny"`.
+- `test_a_workspace_settings_document_carries_the_planes_asks` — **corrected in Phase 2, measured
+  against #948 on main:** `"Bash(charter handoff *)" in permissions["ask"]` and no `"allow"` key.
+  The original said `permissions == {"ask": ["Bash(charter handoff *)"]}`, which is false on main:
+  #948 mirrors the plane's `deny` as well, so equality fails on any plane that has one, and it
+  would break again whenever a neighbouring feature legitimately adds a key.
+- `test_an_allow_rule_never_travels_into_a_workspace` — no `"allow"` anywhere in any generated
+  document, from `.claude/settings.json` **and** `.claude/settings.local.json`. The security
+  invariant, asserted from the angle equality cannot reach.
+- ~~`test_a_deny_rule_does_not_travel_either`~~ — **dropped in Phase 2.** #948 mirrors `deny`
+  deliberately, so this asserted the opposite of shipped behaviour; task 4 ruling 4 already said
+  Task 4 "asserts nothing about `deny`, which #942 carries", and two suites pinning one behaviour
+  from different angles is how a guard ends up half-pinned.
 - `test_an_ask_bucket_of_the_wrong_shape_travels_as_nothing` — `"ask": "Bash(x)"` → no `"permissions"` key.
 - `test_a_rule_that_is_not_a_string_is_dropped` — `"ask": ["Bash(a *)", 3]` → `["Bash(a *)"]`.
 - `test_the_layer_row_still_judges_by_charters_own_keys` — `claude_code.WORKSPACE_KEYS == ("enabledPlugins", "env")`.

--- a/tests/test_a_handoff_waits_for_a_yes.py
+++ b/tests/test_a_handoff_waits_for_a_yes.py
@@ -1355,6 +1355,42 @@ class DoctorNamesTheGate(SessionRootCase):
         self.rooted_at(self.workspace)
         self.assertEqual(doctor.check_handoff_gate().status, OK)
 
+    def test_a_session_rooted_in_a_stale_workspace_is_sent_to_reinit(self):
+        """The plane HOLDS the rule and this directory does not, which is a different problem
+        from never having written one: nothing needs adding, the layer here is simply behind.
+        So the hint names `charter workspace reinit` — the command that copies what the plane
+        already has — rather than sending the operator to add a rule twice.
+
+        Whether the plane holds it is #948's answer (`Harness.restrictive_rules`), not a
+        second reading of `.claude/settings.json` from in here."""
+        self._claude_rule(config.ROOT)
+        self._opencode_rule()
+        self.rooted_at(self.workspace)
+        r = doctor.check_handoff_gate()
+        self.assertEqual(r.status, WARN, r)
+        self.assertIn("charter workspace reinit", r.hint)
+        self.assertIn("stale", r.hint)
+
+    def test_a_plane_that_never_had_the_rule_is_not_sent_to_reinit(self):
+        """The other side of that clause, and the reason it is conditional: with no rule in
+        the plane either, `reinit` would copy nothing. The hint has to say "add it" and stop.
+        """
+        self._opencode_rule()
+        self.rooted_at(self.workspace)
+        r = doctor.check_handoff_gate()
+        self.assertEqual(r.status, WARN, r)
+        self.assertIn("charter guard ask 'charter handoff *'", r.hint)
+        self.assertNotIn("reinit", r.hint)
+
+    def test_a_session_at_the_plane_itself_is_never_sent_to_reinit(self):
+        """`reinit` refreshes a workspace's layer. A session standing at the plane root has no
+        layer to refresh, so the clause must not appear there however the rule is missing."""
+        self._opencode_rule()
+        self.rooted_at(config.ROOT)
+        r = doctor.check_handoff_gate()
+        self.assertEqual(r.status, WARN, r)
+        self.assertNotIn("reinit", r.hint)
+
     def test_a_malformed_settings_file_is_not_read_as_a_missing_rule(self):
         p = config.ROOT / ".claude" / "settings.json"
         p.parent.mkdir(parents=True, exist_ok=True)
@@ -1393,6 +1429,93 @@ class DoctorNamesTheGate(SessionRootCase):
 
     def test_the_row_is_in_the_preflight(self):
         self.assertIn("handoff gate", doctor.check_names())
+
+
+class TheAskRuleReachesAWorkspaceChat(PlaneIso):
+    """The gate's other half, which Phase 1 could only assert indirectly (chat handoff, task 4,
+    phase 2).
+
+    A chat launched in `workspaces/<ws>/` reads that directory's settings and nowhere else, so
+    the plane's `ask` rule is in force there only if it rides into the generated document. #942
+    (PR #948) built that path; these are the tests that the HANDOFF rule travels it — #948's own
+    suite never names `charter handoff`, so this is coverage rather than a second opinion.
+
+    What #948 mirrors is its business, and `deny` is asserted here nowhere: two suites pinning
+    one behaviour from different angles is how a guard ends up half-pinned.
+    """
+
+    PLUGINS = {"charter@charter": True}
+
+    def _plane(self, permissions: dict) -> dict:
+        """The plane's settings, as `charter init` leaves them plus *permissions*; returns the
+        generated workspace document."""
+        p = config.ROOT / ".claude"
+        p.mkdir(parents=True, exist_ok=True)
+        p.joinpath("settings.json").write_text(
+            json.dumps({"enabledPlugins": self.PLUGINS, "permissions": permissions}))
+        files = registry.get(registry.CLAUDE_CODE).workspace_files()
+        return json.loads(files[".claude/settings.json"]) if ".claude/settings.json" in files \
+            else {}
+
+    def test_a_workspace_settings_document_carries_the_planes_asks(self):
+        """The rule reaches the chat that runs the command. Asserted as membership plus the
+        `allow` invariant rather than equality on the whole `permissions` object: equality
+        breaks the moment a neighbouring feature legitimately adds a key, and this test should
+        fail only when the handoff gate stops travelling."""
+        perms = self._plane({"ask": [RULE], "allow": ["Bash(ls *)"]})["permissions"]
+        self.assertIn(RULE, perms["ask"])
+        self.assertNotIn("allow", perms)
+
+    def test_an_allow_rule_never_travels_into_a_workspace(self):
+        """The security invariant, from the angle the test above cannot reach: a permissive
+        rule must not appear ANYWHERE in the generated text, whichever plane file it came
+        from. `ask` and `deny` restrict; `allow` widens, and widening is the plane's own
+        business."""
+        p = config.ROOT / ".claude"
+        p.mkdir(parents=True, exist_ok=True)
+        p.joinpath("settings.json").write_text(json.dumps(
+            {"enabledPlugins": self.PLUGINS,
+             "permissions": {"ask": [RULE], "allow": ["Bash(ls *)"]}}))
+        p.joinpath("settings.local.json").write_text(json.dumps(
+            {"permissions": {"allow": ["Bash(curl *)"]}}))
+        for rel, text in registry.get(registry.CLAUDE_CODE).workspace_files().items():
+            with self.subTest(generated=rel):
+                self.assertNotIn("Bash(ls *)", text)
+                self.assertNotIn("Bash(curl *)", text)
+                self.assertNotIn('"allow"', text)
+
+    def test_an_ask_bucket_of_the_wrong_shape_travels_as_nothing(self):
+        """A string where a list belongs is a plane that declares no rules charter can read —
+        not a plane declaring one rule spelled oddly. Nothing travels, and the document is
+        still written for what it does carry."""
+        self.assertNotIn("permissions", self._plane({"ask": "Bash(x)"}))
+
+    def test_a_rule_that_is_not_a_string_is_dropped(self):
+        """One unusable entry costs itself, not the rules beside it: a handoff gate that
+        travels only when every neighbouring rule is well-formed is a gate that stops being
+        in force because of someone else's typo."""
+        self.assertEqual(["Bash(a *)"],
+                         self._plane({"ask": ["Bash(a *)", 3]})["permissions"]["ask"])
+
+    def test_the_layer_row_still_judges_by_charters_own_keys(self):
+        """`doctor`'s `workspace layer` row compares the keys charter authors. The rules ride
+        in the same document but are the plane's, not charter's, so they must not be added to
+        that list — a plane that changes an unrelated `ask` would otherwise read as charter's
+        layer having gone stale."""
+        from charter.harness import claude_code
+        self.assertEqual(("enabledPlugins", "env"), claude_code.WORKSPACE_KEYS)
+
+    def test_a_launch_refreshes_a_workspace_the_plane_gave_a_new_ask(self):
+        """The rule has to reach workspaces that already exist. A plane that adds the gate
+        after a workspace was made would otherwise leave that chat ungated until someone
+        happened to run `reinit`."""
+        self._plane({})
+        workspace.ensure("w")
+        settings = config.ROOT / "workspaces" / "w" / ".claude" / "settings.json"
+        self.assertNotIn("permissions", json.loads(settings.read_text()))
+        self._plane({"ask": [RULE]})
+        workspace.ensure("w")
+        self.assertIn(RULE, json.loads(settings.read_text())["permissions"]["ask"])
 
 
 class EveryHarnessSaysHowAHandoffIsGated(unittest.TestCase):

--- a/tests/test_a_handoff_waits_for_a_yes.py
+++ b/tests/test_a_handoff_waits_for_a_yes.py
@@ -1355,41 +1355,101 @@ class DoctorNamesTheGate(SessionRootCase):
         self.rooted_at(self.workspace)
         self.assertEqual(doctor.check_handoff_gate().status, OK)
 
+    #: The two hints this row can give, asserted WHOLE. A fragment (`"reinit" in hint`) passes
+    #: while the sentence around it says something false — which is what it did: the hint told
+    #: the operator to add a rule and then that they already had it, in one breath.
+    ADD = ("A handoff's brief becomes a new chat's first message and runs with your authority; "
+           "this rule is the prompt that asks you first, and on Claude Code it asks under "
+           "bypassPermissions too. Add it: charter guard ask 'charter handoff *'. Removing it "
+           "is your choice — this row says so, and charter does not put it back.")
+    REFRESH = ("A handoff's brief becomes a new chat's first message and runs with your "
+               "authority; this rule is the prompt that asks you first, and on Claude Code it "
+               "asks under bypassPermissions too. The plane already holds it for claude-code, "
+               "so this directory's layer is behind — nothing to add, only to refresh: charter "
+               "workspace reinit fleet. Removing it is your choice — this row says so, and "
+               "charter does not put it back.")
+
     def test_a_session_rooted_in_a_stale_workspace_is_sent_to_reinit(self):
         """The plane HOLDS the rule and this directory does not, which is a different problem
-        from never having written one: nothing needs adding, the layer here is simply behind.
-        So the hint names `charter workspace reinit` — the command that copies what the plane
-        already has — rather than sending the operator to add a rule twice.
-
-        Whether the plane holds it is #948's answer (`Harness.restrictive_rules`), not a
-        second reading of `.claude/settings.json` from in here."""
+        from never having written one: nothing needs adding, the layer here is behind. So the
+        hint names `charter workspace reinit` INSTEAD of `charter guard ask` — asserted whole,
+        because printed together the two halves contradict each other."""
         self._claude_rule(config.ROOT)
         self._opencode_rule()
         self.rooted_at(self.workspace)
         r = doctor.check_handoff_gate()
         self.assertEqual(r.status, WARN, r)
-        self.assertIn("charter workspace reinit", r.hint)
-        self.assertIn("stale", r.hint)
+        self.assertEqual(self.REFRESH, r.hint)
 
-    def test_a_plane_that_never_had_the_rule_is_not_sent_to_reinit(self):
-        """The other side of that clause, and the reason it is conditional: with no rule in
-        the plane either, `reinit` would copy nothing. The hint has to say "add it" and stop.
-        """
+    def test_a_plane_that_never_had_the_rule_is_told_to_add_it(self):
+        """The other side, and the reason the clause is conditional: with no rule in the plane
+        either, `reinit` would copy nothing."""
         self._opencode_rule()
         self.rooted_at(self.workspace)
         r = doctor.check_handoff_gate()
         self.assertEqual(r.status, WARN, r)
-        self.assertIn("charter guard ask 'charter handoff *'", r.hint)
-        self.assertNotIn("reinit", r.hint)
+        self.assertEqual(self.ADD, r.hint)
 
-    def test_a_session_at_the_plane_itself_is_never_sent_to_reinit(self):
-        """`reinit` refreshes a workspace's layer. A session standing at the plane root has no
-        layer to refresh, so the clause must not appear there however the rule is missing."""
+    def test_only_a_directory_reinit_writes_is_sent_to_reinit(self):
+        """`reinit(name)` writes `workspaces/<name>` and the checkouts inside it, and nothing
+        else. Everywhere else it cannot clear this row, so naming it would send the operator to
+        run something that provably does not work — the plane root included, which needs no
+        guard of its own once the question is asked this way."""
+        self._claude_rule(config.ROOT)
         self._opencode_rule()
-        self.rooted_at(config.ROOT)
+        deep = self.workspace / "repo" / "src" / "deep"
+        for name, where in (("the plane root", config.ROOT),
+                            ("docs/", config.ROOT / "docs"),
+                            ("a persona directory", config.ROOT / "personas" / "x"),
+                            ("a deep directory inside a checkout", deep)):
+            with self.subTest(rooted_in=name):
+                where.mkdir(parents=True, exist_ok=True)
+                self.rooted_at(where.resolve())
+                r = doctor.check_handoff_gate()
+                if r.status == WARN:
+                    self.assertEqual(self.ADD, r.hint)
+
+    def test_the_harness_that_is_missing_the_rule_is_the_one_named(self):
+        """With only opencode lacking the rule, `reinit` copies nothing — opencode generates no
+        workspace files at all. Blaming a stale Claude Code layer there names a command that
+        cannot help, however true the row's WARN is."""
+        self._claude_rule(config.ROOT)
+        self._claude_rule(self.workspace)
+        self.rooted_at(self.workspace)
         r = doctor.check_handoff_gate()
         self.assertEqual(r.status, WARN, r)
-        self.assertNotIn("reinit", r.hint)
+        self.assertIn("under opencode", r.detail)
+        self.assertEqual(self.ADD, r.hint)
+
+    def test_a_harness_reinit_writes_nothing_for_is_not_sent_to_reinit(self):
+        """`reinit` can only fix a harness whose layer it carries into this directory. Today
+        every harness but Claude Code is judged at the plane, so "missing here" already implies
+        "missing there" and this line cannot be reached by a real plane — which is why it had
+        no red test. It is the instruction in code all the same ("if nothing fixes it, say
+        nothing"), so it is pinned against the shape that would reach it: a session-rooted
+        harness that generates no workspace files."""
+        self._claude_rule(config.ROOT)
+        self._opencode_rule()
+        self.rooted_at(self.workspace)
+        h = registry.get(registry.CLAUDE_CODE)
+        with mock.patch.object(type(h), "workspace_files", return_value={}):
+            r = doctor.check_handoff_gate()
+        self.assertEqual(r.status, WARN, r)
+        self.assertEqual(self.ADD, r.hint)
+
+    def test_a_plane_that_denies_the_handoff_holds_no_ask_rule(self):
+        """One notion of "the plane holds this rule", not two. The predicate is the row's own
+        `apply_ask_rule` reading one root over; a substring test over `ask` + `deny` flattened
+        said yes to a plane that DENIES `charter handoff`, which holds no ask rule at all."""
+        p = config.ROOT / ".claude" / "settings.json"
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(json.dumps({"permissions": {"deny": [RULE]}}))
+        self._opencode_rule()
+        self.rooted_at(self.workspace)
+        r = doctor.check_handoff_gate()
+        self.assertEqual(r.status, WARN, r)
+        self.assertEqual(self.ADD, r.hint)
+
 
     def test_a_malformed_settings_file_is_not_read_as_a_missing_rule(self):
         p = config.ROOT / ".claude" / "settings.json"
@@ -1470,15 +1530,25 @@ class TheAskRuleReachesAWorkspaceChat(PlaneIso):
         """The security invariant, from the angle the test above cannot reach: a permissive
         rule must not appear ANYWHERE in the generated text, whichever plane file it came
         from. `ask` and `deny` restrict; `allow` widens, and widening is the plane's own
-        business."""
+        business.
+
+        **Both generated sets, because they read different plane files.** The local file's
+        rules ride only in `checkout_files` (`.claude/settings.local.json`); iterating
+        `workspace_files` alone reads the shared document twice and never looks at the local
+        one — which is what the first version of this test did, while its name and this PR's
+        body both claimed otherwise. #948's own `test_a_local_grant_does_not_travel_either`
+        pins the local half; this one holds the handoff-shaped plane to the same line."""
         p = config.ROOT / ".claude"
         p.mkdir(parents=True, exist_ok=True)
         p.joinpath("settings.json").write_text(json.dumps(
             {"enabledPlugins": self.PLUGINS,
              "permissions": {"ask": [RULE], "allow": ["Bash(ls *)"]}}))
         p.joinpath("settings.local.json").write_text(json.dumps(
-            {"permissions": {"allow": ["Bash(curl *)"]}}))
-        for rel, text in registry.get(registry.CLAUDE_CODE).workspace_files().items():
+            {"permissions": {"allow": ["Bash(curl *)"], "ask": ["Bash(local *)"]}}))
+        h = registry.get(registry.CLAUDE_CODE)
+        generated = {**h.workspace_files(), **h.checkout_files()}
+        self.assertIn(".claude/settings.local.json", generated, "the local file must be read")
+        for rel, text in generated.items():
             with self.subTest(generated=rel):
                 self.assertNotIn("Bash(ls *)", text)
                 self.assertNotIn("Bash(curl *)", text)

--- a/tests/test_a_handoff_waits_for_a_yes.py
+++ b/tests/test_a_handoff_waits_for_a_yes.py
@@ -27,6 +27,7 @@ import time
 import unittest
 from contextlib import redirect_stderr
 from pathlib import Path
+from types import SimpleNamespace
 from unittest import mock
 
 from charter import commands, config, doctor, hooks, workspace
@@ -1363,15 +1364,25 @@ class DoctorNamesTheGate(SessionRootCase):
            "this rule is the prompt that asks you first, and on Claude Code it asks under "
            "bypassPermissions too. Add it: charter guard ask 'charter handoff *'. Removing it "
            "is your choice — this row says so, and charter does not put it back.")
-    NOWHERE = ("A handoff's brief becomes a new chat's first message and runs with your "
-               "authority; this rule is the prompt that asks you first, and on Claude Code it "
-               "asks under bypassPermissions too. It cannot be put in force for a chat rooted "
-               "in this directory: charter writes these settings at the plane root and at a "
-               "workspace's or checkout's own root, and a chat reads them from the directory "
-               "it starts in. `charter guard ask` reaches workspaces by mirroring into each "
-               "one, not by writing where you are standing — so start the chat in the plane "
-               "root, a workspace, or a checkout, and it is gated there. Removing it is your "
-               "choice — this row says so, and charter does not put it back.")
+    _LEAD = ("A handoff's brief becomes a new chat's first message and runs with your "
+             "authority; this rule is the prompt that asks you first, and on Claude Code it "
+             "asks under bypassPermissions too. ")
+    _TAIL = " Removing it is your choice — this row says so, and charter does not put it back."
+    _WHERE = ("charter writes these settings at the plane root and at a workspace's or "
+              "checkout's own root, and a chat reads them from the directory it starts in")
+    #: Unwired directory, plane HOLDS the rule: no command, and no guarantee it cannot make
+    #: from here — a workspace whose layer is behind is not gated, which is the state this row
+    #: exists to surface.
+    NOWHERE = (_LEAD + "It cannot be put in force for a chat rooted in this directory: " +
+               _WHERE + ". A chat started in the plane root is gated; charter gates a "
+               "workspace or a checkout once it has written the rule there, and this row says "
+               "so in any whose layer is behind." + _TAIL)
+    #: Unwired directory, NOTHING holds the rule: `guard ask` is not inert — run from here it
+    #: writes the plane's settings — so it is named, with what it cannot do said plainly.
+    NOWHERE_ADD = (_LEAD + "Add it: charter guard ask 'charter handoff *' — that gates a chat "
+                   "started in the plane root, and reaches workspaces and checkouts by "
+                   "mirroring into them. It cannot gate a chat rooted in this directory: " +
+                   _WHERE + "." + _TAIL)
     REFRESH = ("A handoff's brief becomes a new chat's first message and runs with your "
                "authority; this rule is the prompt that asks you first, and on Claude Code it "
                "asks under bypassPermissions too. The plane already holds it for claude-code, "
@@ -1423,6 +1434,49 @@ class DoctorNamesTheGate(SessionRootCase):
                 self.assertEqual(WARN, r.status, r)
                 self.assertEqual(self.NOWHERE, r.hint)
 
+    def test_an_unwired_directory_with_no_rule_anywhere_still_names_guard_ask(self):
+        """The state round 2 got wrong: with NOTHING holding the rule, `charter guard ask` is
+        not inert here — run from `docs/` it writes the plane's own settings, and the plane root
+        and every workspace go clean afterwards. Round 2 suppressed a useful command along with
+        a useless one, because all three states it measured happened to hold the rule already.
+
+        The cross-directory walk is the evidence: run the command where the hint appears, then
+        stand in the directory the hint talks about and read the row there."""
+        docs = config.ROOT / "docs"
+        docs.mkdir(parents=True, exist_ok=True)
+        self.rooted_at(docs.resolve())
+        r = doctor.check_handoff_gate()
+        self.assertEqual(WARN, r.status, r)
+        self.assertEqual(self.NOWHERE_ADD, r.hint)
+        commands.cmd_guard_ask(SimpleNamespace(pattern="charter handoff *", local=False,
+                                               dry_run=False, yes=True))
+        with self.subTest(then_standing_in="the plane root"):
+            self.rooted_at(config.ROOT.resolve())
+            self.assertEqual(OK, doctor.check_handoff_gate().status)
+        with self.subTest(then_standing_in="a workspace"):
+            self.rooted_at(self.workspace)
+            self.assertEqual(OK, doctor.check_handoff_gate().status)
+
+    def test_the_no_command_sentence_is_true_with_a_workspace_whose_layer_is_behind(self):
+        """State A's sentence claims something about OTHER directories, so it must stay true in
+        the worst of them: a workspace whose layer is behind is NOT gated, and that is the very
+        state this row exists to surface. So the sentence promises the plane root — measured —
+        and says of a workspace only that charter gates it once it has written there, and that
+        this row says so in any that is behind. Standing in `docs/`, charter cannot see which
+        workspaces are current, so it must not enumerate a guarantee."""
+        self._claude_rule(config.ROOT)        # the plane holds it
+        self._opencode_rule()                 # the workspace layer does NOT
+        docs = config.ROOT / "docs"
+        docs.mkdir(parents=True, exist_ok=True)
+        self.rooted_at(docs.resolve())
+        self.assertEqual(self.NOWHERE, doctor.check_handoff_gate().hint)
+        with self.subTest(walked_to="the plane root — the one thing the sentence promises"):
+            self.rooted_at(config.ROOT.resolve())
+            self.assertEqual(OK, doctor.check_handoff_gate().status)
+        with self.subTest(walked_to="the stale workspace — which the sentence does NOT promise"):
+            self.rooted_at(self.workspace)
+            self.assertEqual(WARN, doctor.check_handoff_gate().status)
+
     def test_the_plane_root_is_still_told_to_add_it(self):
         """The plane root IS a directory charter writes, so `guard ask` works there and the row
         keeps naming it — the no-command sentence is about directories charter does not wire,
@@ -1464,6 +1518,52 @@ class DoctorNamesTheGate(SessionRootCase):
         r = doctor.check_handoff_gate()
         self.assertEqual(WARN, r.status, r)
         self.assertEqual(self.REFRESH, r.hint)
+
+    def test_an_unreadable_workspaces_directory_cannot_decide_the_plane_root(self):
+        """`charter guard ask` writes at the plane root, so the advice there cannot depend on
+        whether some *other* directory is readable. Asked after the stale clause it did: the
+        clause reads `workspaces/` to find a reinit target, and an unreadable one reached the
+        answer — emitting "cannot be put in force" where `guard ask` genuinely works, a FALSE
+        sentence rather than an inert one (#982 review round 2b).
+
+        Worse than the wrong sentence, and why this is ordered rather than merely defaulted:
+        `list_workspaces` raising escaped `_reinit_target` entirely — its own `try` is inside
+        the loop — and took `charter doctor` down with it, the whole command, not this row."""
+        self._opencode_rule()
+        self.rooted_at(config.ROOT.resolve())
+        with mock.patch.object(workspace, "list_workspaces", side_effect=OSError("EACCES")):
+            r = doctor.check_handoff_gate()
+        self.assertEqual(WARN, r.status, r)
+        self.assertEqual(self.ADD, r.hint)
+
+    def test_when_charter_cannot_tell_where_it_stands_it_gives_the_useless_answer(self):
+        """The default when even the plane-root comparison raises. CONSTRUCTED — nothing makes
+        `Path.resolve` fail on a real plane — so read it as a guard, not as coverage.
+
+        It answers `guard ask` rather than the no-command sentence because the two fail
+        differently: `guard ask` is right at the plane root and merely inert elsewhere, while
+        "it cannot be put in force" is FALSE at the plane root, where `guard ask` works. An
+        inert hint costs a minute; a false one is believed."""
+        self._opencode_rule()
+        docs = config.ROOT / "docs"
+        docs.mkdir(parents=True, exist_ok=True)
+        self.rooted_at(docs.resolve())
+        with mock.patch.object(type(config.ROOT), "resolve", side_effect=OSError("EIO")):
+            r = doctor.check_handoff_gate()
+        self.assertEqual(WARN, r.status, r)
+        self.assertEqual(self.ADD, r.hint)
+
+    def test_an_unreadable_workspaces_directory_still_answers_elsewhere(self):
+        """And away from the plane root it answers rather than raising: charter cannot tell
+        whether this directory is one it wires, so it says what is true of the rule itself."""
+        self._opencode_rule()
+        docs = config.ROOT / "docs"
+        docs.mkdir(parents=True, exist_ok=True)
+        self.rooted_at(docs.resolve())
+        with mock.patch.object(workspace, "list_workspaces", side_effect=OSError("EACCES")):
+            r = doctor.check_handoff_gate()
+        self.assertEqual(WARN, r.status, r)
+        self.assertEqual(self.NOWHERE_ADD, r.hint)
 
     def test_one_unreadable_workspace_does_not_hide_the_rest(self):
         """`_reinit_target`'s `except OSError: continue`. No plane builds a workspace whose path

--- a/tests/test_a_handoff_waits_for_a_yes.py
+++ b/tests/test_a_handoff_waits_for_a_yes.py
@@ -1422,12 +1422,17 @@ class DoctorNamesTheGate(SessionRootCase):
         self.assertEqual(self.ADD, r.hint)
 
     def test_a_harness_reinit_writes_nothing_for_is_not_sent_to_reinit(self):
-        """`reinit` can only fix a harness whose layer it carries into this directory. Today
-        every harness but Claude Code is judged at the plane, so "missing here" already implies
-        "missing there" and this line cannot be reached by a real plane — which is why it had
-        no red test. It is the instruction in code all the same ("if nothing fixes it, say
-        nothing"), so it is pinned against the shape that would reach it: a session-rooted
-        harness that generates no workspace files."""
+        """`reinit` can only fix a harness whose layer it carries into this directory.
+
+        **This test reaches a branch no real plane reaches**, and says so rather than reading
+        as coverage. Every harness but Claude Code is judged at the plane, so "missing here"
+        already implies "missing at the plane" and the clause has bowed out before this line
+        matters — which is why it had no red test. The shape below is CONSTRUCTED: Claude Code
+        with its `workspace_files` patched empty, which is a harness that is judged at the
+        session root and generates nothing there. Kept because it is the instruction in code
+        ("if nothing fixes it, say nothing rather than naming a command that will not work"),
+        and the day another harness generates workspace files its absence would be a defect
+        nobody could trace (#982 review round 1)."""
         self._claude_rule(config.ROOT)
         self._opencode_rule()
         self.rooted_at(self.workspace)

--- a/tests/test_a_handoff_waits_for_a_yes.py
+++ b/tests/test_a_handoff_waits_for_a_yes.py
@@ -21,6 +21,7 @@ import json
 import os
 import shutil
 import stat
+import subprocess
 import tempfile
 import time
 import unittest
@@ -1362,6 +1363,15 @@ class DoctorNamesTheGate(SessionRootCase):
            "this rule is the prompt that asks you first, and on Claude Code it asks under "
            "bypassPermissions too. Add it: charter guard ask 'charter handoff *'. Removing it "
            "is your choice — this row says so, and charter does not put it back.")
+    NOWHERE = ("A handoff's brief becomes a new chat's first message and runs with your "
+               "authority; this rule is the prompt that asks you first, and on Claude Code it "
+               "asks under bypassPermissions too. It cannot be put in force for a chat rooted "
+               "in this directory: charter writes these settings at the plane root and at a "
+               "workspace's or checkout's own root, and a chat reads them from the directory "
+               "it starts in. `charter guard ask` reaches workspaces by mirroring into each "
+               "one, not by writing where you are standing — so start the chat in the plane "
+               "root, a workspace, or a checkout, and it is gated there. Removing it is your "
+               "choice — this row says so, and charter does not put it back.")
     REFRESH = ("A handoff's brief becomes a new chat's first message and runs with your "
                "authority; this rule is the prompt that asks you first, and on Claude Code it "
                "asks under bypassPermissions too. The plane already holds it for claude-code, "
@@ -1390,24 +1400,38 @@ class DoctorNamesTheGate(SessionRootCase):
         self.assertEqual(r.status, WARN, r)
         self.assertEqual(self.ADD, r.hint)
 
-    def test_only_a_directory_reinit_writes_is_sent_to_reinit(self):
-        """`reinit(name)` writes `workspaces/<name>` and the checkouts inside it, and nothing
-        else. Everywhere else it cannot clear this row, so naming it would send the operator to
-        run something that provably does not work — the plane root included, which needs no
-        guard of its own once the question is asked this way."""
+    def test_a_directory_charter_does_not_wire_is_given_no_command(self):
+        """Review round 2. Charter writes these settings at the plane root and at a workspace's
+        or checkout's own root; Claude Code reads them from the session's EXACT directory
+        (#855). So for a chat rooted anywhere else there is NO command that puts the rule in
+        force — `charter guard ask` is as inert there as `reinit` was before round 1 stopped
+        naming it, and all three of these rows were measured unchanged after running it.
+
+        The row still warns, because the rule really is not in force for that chat. What it
+        must not do is name a command that cannot work: a hint with no command beats a hint
+        with a command that does nothing."""
         self._claude_rule(config.ROOT)
         self._opencode_rule()
         deep = self.workspace / "repo" / "src" / "deep"
-        for name, where in (("the plane root", config.ROOT),
-                            ("docs/", config.ROOT / "docs"),
+        for name, where in (("docs/", config.ROOT / "docs"),
                             ("a persona directory", config.ROOT / "personas" / "x"),
                             ("a deep directory inside a checkout", deep)):
             with self.subTest(rooted_in=name):
                 where.mkdir(parents=True, exist_ok=True)
                 self.rooted_at(where.resolve())
                 r = doctor.check_handoff_gate()
-                if r.status == WARN:
-                    self.assertEqual(self.ADD, r.hint)
+                self.assertEqual(WARN, r.status, r)
+                self.assertEqual(self.NOWHERE, r.hint)
+
+    def test_the_plane_root_is_still_told_to_add_it(self):
+        """The plane root IS a directory charter writes, so `guard ask` works there and the row
+        keeps naming it — the no-command sentence is about directories charter does not wire,
+        not about everywhere that is not a workspace."""
+        self._opencode_rule()
+        self.rooted_at(config.ROOT.resolve())
+        r = doctor.check_handoff_gate()
+        self.assertEqual(WARN, r.status, r)
+        self.assertEqual(self.ADD, r.hint)
 
     def test_the_harness_that_is_missing_the_rule_is_the_one_named(self):
         """With only opencode lacking the rule, `reinit` copies nothing — opencode generates no
@@ -1420,6 +1444,48 @@ class DoctorNamesTheGate(SessionRootCase):
         self.assertEqual(r.status, WARN, r)
         self.assertIn("under opencode", r.detail)
         self.assertEqual(self.ADD, r.hint)
+
+    def test_a_chat_in_a_guest_checkout_is_sent_to_reinit(self):
+        """A checkout inside a workspace is a directory `reinit` writes, so the clause belongs
+        there too — and nothing pinned it. Deleting the guest-checkout match left the suite
+        green, because `charter guard ask` mirrors into guest checkouts as a side effect and
+        the row would still clear; only the HINT would be wrong, saying "Add it" where the
+        plane already holds the rule. That is the exact contradiction this PR fixed, restored
+        with every test passing (#982 review round 2), so this uses a real checkout."""
+        repo = self.workspace / "repo"
+        repo.mkdir(parents=True, exist_ok=True)
+        # env=None: the suite has already redirected git's config, and building one by hand is
+        # what `tests/_planeguard.py` refuses (#641).
+        subprocess.run(["git", "init", "-q", str(repo)], check=True)
+        self._claude_rule(config.ROOT)
+        self._opencode_rule()
+        self.assertIn(repo.resolve(), [t.resolve() for t in workspace.guest_trees("fleet")])
+        self.rooted_at(repo.resolve())
+        r = doctor.check_handoff_gate()
+        self.assertEqual(WARN, r.status, r)
+        self.assertEqual(self.REFRESH, r.hint)
+
+    def test_one_unreadable_workspace_does_not_hide_the_rest(self):
+        """`_reinit_target`'s `except OSError: continue`. No plane builds a workspace whose path
+        raises, so this is a CONSTRUCTED shape — like the harness fail-safe above, read it as a
+        guard, not as coverage. It is kept rather than deleted because the alternative is an
+        `OSError` escaping into the preflight from a directory charter only wanted to compare
+        against, which would take the whole row down instead of skipping one workspace."""
+        self._claude_rule(config.ROOT)
+        self._opencode_rule()
+        self.rooted_at(self.workspace)
+        real = workspace.workspace_dir
+
+        def one_raises(name):
+            if name == "boom":
+                raise OSError("stat: I/O error")
+            return real(name)
+
+        (config.ROOT / "workspaces" / "boom").mkdir(parents=True, exist_ok=True)
+        with mock.patch.object(workspace, "workspace_dir", side_effect=one_raises):
+            r = doctor.check_handoff_gate()
+        self.assertEqual(WARN, r.status, r)
+        self.assertEqual(self.REFRESH, r.hint)
 
     def test_a_harness_reinit_writes_nothing_for_is_not_sent_to_reinit(self):
         """`reinit` can only fix a harness whose layer it carries into this directory.


### PR DESCRIPTION
Task 4 **Phase 2** of the chat-handoff plan, on top of #972 (Phase 1) and #948. Closes the two items Phase 1 deferred: the `#948`-path tests and doctor's `{stale}` hint.

## The rule reaches the chat that runs the command

Phase 1 could only assert the gate indirectly — that the rule was written, and that the hook refuses what the prompt cannot cover. Nothing held the step in between: a chat launched in `workspaces/<ws>/` reads that directory's settings and nowhere else, so the gate is in force there only if the plane's `ask` rule rides into the generated document. #942 (PR #948) built that path; this pins the **handoff** rule travelling it.

`#948`'s own suite never names `charter handoff` (0 hits), so this is coverage rather than a second opinion.

Six tests, asserting the two things Task 4 owns rather than the whole document:

- the ask rule **is** in the workspace document's `permissions["ask"]`, and there is **no `allow` key at all**;
- no `allow` rule appears anywhere in the generated text, reading `workspace_files()` **and** `checkout_files()` — the plane's LOCAL file rides only in the second. **Corrected in review round 1:** the first version iterated `workspace_files()` alone, so its local half read the shared document twice and never looked at the local one; this sentence claimed otherwise. The local invariant is pinned for every plane by #948's own `test_a_local_grant_does_not_travel_either` — this holds the handoff-shaped plane to the same line rather than claiming that coverage;
- a wrong-shaped `ask` bucket travels as nothing; a non-string rule is dropped without costing the rules beside it;
- `WORKSPACE_KEYS` stays `("enabledPlugins", "env")`, so an unrelated plane rule does not read as charter's layer going stale;
- a workspace that already existed picks the rule up on the next launch.

**`deny` is asserted nowhere.** #948 mirrors it deliberately, measured and reviewed. Two suites pinning one behaviour from different angles is how a guard ends up half-pinned.

## Doctor's stale clause

A chat whose plane holds the rule while its own directory does not has a different problem from a plane that never had one: nothing needs adding, the layer is behind. The hint now names `charter workspace reinit` — and only there:

| Situation | Hint |
| --- | --- |
| plane holds it, this directory does not | `charter workspace reinit` |
| no harness holds it | `charter guard ask 'charter handoff *'` — `reinit` would copy nothing |
| session at the plane root | no clause — there is no layer to refresh |

Whether the plane holds it comes from `Harness.restrictive_rules` — #948's own surface, the one `doctor`'s `workspace layer` row already counts — so "does the plane hold this rule" has one answer and the two rows cannot disagree. Reading `.claude/settings.json` again inside `doctor` would be a second notion of the plane's policy, and *which* of it travels is a fact about each harness's config format.

## The plan disagreed with main, and is corrected rather than worked around

Task 4's `#948`-path test list predated #948. Measured on main with the plan's own fixture:

```
workspace permissions: {"ask": ["Bash(charter handoff *)"], "deny": ["Bash(rm *)"]}
```

So two of its seven entries were false: `test_a_deny_rule_does_not_travel_either` (deny **does** travel), and the equality assertion `permissions == {"ask": [...]}` (fails on any plane with a deny, and again whenever a neighbouring feature adds a key). Task 4 ruling 4 already governs — Task 4 "asserts nothing about `deny`, which #942 carries" — so:

- the deny entry is **struck** in `docs/superpowers/plans/2026-09-10-chat-handoff.md`, with the reason;
- the equality entry is **rewritten** to membership plus the `allow` invariant;
- a dated Phase 2 note records the measurement, so the next reader does not re-derive the conflict.

## Checks

- **Full suite: 12701 tests, OK (skipped=9), 905 s.**
- The `{stale}` clause was written test-first and watched fail before the implementation; the six `#948`-path tests pin behaviour that already ships.
- Mutation sweep runs in the background; I'll report the gate line.

## Review round 1

The clause was wrong in more states than it was right, and my own test ratified one of the contradictions. Re-measured, state by state — **`reinit` is named only where `reinit` fixes it**:

| Session is rooted in | Row | Names |
| --- | --- | --- |
| a workspace whose plane holds the rule | WARN | **`charter workspace reinit fleet`** |
| a deep directory inside a checkout | WARN | `charter guard ask` |
| `docs/` | WARN | `charter guard ask` |
| the plane root | OK | — |
| a workspace, no rule anywhere | WARN | `charter guard ask` |
| a workspace, plane *denies* the handoff | WARN | `charter guard ask` |
| a workspace, only opencode missing | WARN | `charter guard ask` |

**1 — the hint told the operator two things at once.** It read *"Add it: charter guard ask 'charter handoff \*' — the plane already holds it…"*. The docs, the news entry and the docstring all said `reinit` **instead of** `guard ask`; the code was the odd one out. It now says one thing, and both hints are asserted **whole, by equality**. `assertIn("reinit", hint)` passed while the sentence around it contradicted itself.

**2 — it fired where the command cannot help.** The only guard was `session_root() != ROOT`. `reinit(name)` writes `workspaces/<name>` and the checkouts inside it, so the question is now "is this a directory `reinit` writes" — which subsumes the plane-root case rather than guarding it separately.

**3 — it blamed the wrong harness.** It keyed off the whole row's WARN; with only opencode lacking the rule the detail said "under opencode" while the hint blamed a stale Claude Code layer. It now asks the harness actually missing the rule, and stays silent when `reinit` writes nothing for it.

**4 — there were two notions of "the plane holds this rule" after all.** A substring test over `ask`+`deny` flattened disagreed with the row's own `apply_ask_rule`: a plane that *denies* `charter handoff` fired the clause. It is now the row's own reading one root over, taken inside the row's existing `try`, so one `OSError` handler covers both. The second `except` went with it — measured dead, since every harness answers rather than raising — and the docstring no longer describes a branch that never runs.

### What could be broken with nothing noticing

That was the reviewer's question, and it is a better one than mine: I asked *which test notices this breakage*, which only confirms coverage. All four now go red, each by the test that names it:

| Breakage | Noticed by |
| --- | --- |
| an `allow` rule travels via `checkout_files` | `…carries_the_planes_asks`, `…an_allow_rule_never_travels…` |
| the reinit-target guard deleted | `…only_a_directory_reinit_writes_is_sent_to_reinit` |
| the `HANDOFF_ASK_PATTERN` match deleted | `…a_plane_that_denies_the_handoff_holds_no_ask_rule` |
| the harness-can-be-refreshed test deleted | `…a_harness_reinit_writes_nothing_for_is_not_sent_to_reinit` |

The last one **is unreachable by any real plane today, and is kept deliberately — read it as a fail-safe, not as coverage.** Every harness but Claude Code is judged against `config.ROOT`, so "missing here" already implies "missing at the plane" and the `present` test has bowed out before that line matters. Its test reaches it with a **constructed** shape (Claude Code with `workspace_files` patched empty), so the green tick there is not evidence any plane exercises it.

It is kept because it is the code form of the defect this round fixed — naming a command that does nothing for the harness that is actually stale. The day another harness starts generating workspace files, deleting it would turn the clause back into advice that cannot work, with nobody left to remember why. The docstring and the test both say all of this, so the next reader neither trusts coverage that is not real nor removes it as dead — and a deletion sweep that nominates it has its answer in place.

### The breakage → test mapping, derived independently

Confirmed by the reviewer deriving the same mapping without seeing mine. The last two rows were mine: after running the three breakages I was given, two of my six tests had not been exercised by any of them, so I built a breakage for each rather than leave them unvalued.

| Breakage | Noticed by |
| --- | --- |
| drop the ask mirroring | `…carries_the_planes_asks`, `…a_launch_refreshes…`, `…a_rule_that_is_not_a_string_is_dropped`, `…stale_workspace_is_sent_to_reinit` |
| make an `allow` rule travel | `…carries_the_planes_asks` **and** `…an_allow_rule_never_travels…` |
| empty `restrictive_rules` | `…stale_workspace_is_sent_to_reinit` |
| add `permissions` to `WORKSPACE_KEYS` *(mine)* | `…the_layer_row_still_judges_by_charters_own_keys` |
| let a wrong-shaped `ask` bucket travel *(mine)* | `…an_ask_bucket_of_the_wrong_shape_travels_as_nothing` |

**Full suite on 1cadca8:** 12704 tests, OK (skipped=9), 1338 s. (9ca5525 is comments only — the docstrings above.) `docs/handoff.md`'s `#942` link pointed at `pull/948`; it says `#948` now.

## Review round 2

Round 1 stopped the hint naming `reinit` where reinit could not clear the row. **The fallback was just as inert**: in `docs/`, `personas/<p>/` and a deep directory inside a checkout it said `charter guard ask 'charter handoff *'`, and running that leaves the row warning — the bug moved rather than closed.

The cause is not the clause's logic. Charter writes these settings in exactly two kinds of place — the plane root, and a workspace's or checkout's own root — while Claude Code reads them from the session's **exact** directory (#855). The row is right to warn; the advice was wrong. It now says what is true and names nothing:

> It cannot be put in force for a chat rooted in this directory: charter writes these settings at the plane root and at a workspace's or checkout's own root, and a chat reads them from the directory it starts in. `charter guard ask` reaches workspaces by mirroring into each one, not by writing where you are standing — so start the chat in the plane root, a workspace, or a checkout, and it is gated there.

**A hint with no command beats a hint with a command that does nothing.** Charter is deliberately not taught to write settings into arbitrary directories to rescue the old advice. The sentence explains the mirroring in passing, because *why* `guard ask` works in six states and not in these three is the model a reader needs.

### The nine states, re-measured

| Session rooted in | Row | Hint |
| --- | --- | --- |
| workspace, plane holds the rule | WARN | `charter workspace reinit fleet` |
| guest checkout, plane holds the rule | WARN | `charter workspace reinit fleet` |
| workspace, nothing holds it | WARN | `charter guard ask …` |
| workspace, plane *denies* the handoff | WARN | `charter guard ask …` |
| workspace, only opencode missing | WARN | `charter guard ask …` |
| the plane root, rule missing | WARN | `charter guard ask …` |
| `docs/` | WARN | **no command** |
| `personas/<p>/` | WARN | **no command** |
| deep directory inside a checkout | WARN | **no command** |
| the plane root, rule present | OK | — |

Every row that names a command was verified by **running it and re-reading doctor**: both `reinit` rows clear, and the `guard ask` row clears. The three no-command rows are the ones where nothing clears them, which is why they name nothing.

### Two guards nothing noticed

Both found by hand mutation, not by the suite, and both now red:

| Guard | Deleting it | Pinned by |
| --- | --- | --- |
| the guest-checkout match in `_reinit_target` | suite stayed green — the row still cleared (`guard ask` mirrors into checkouts as a side effect) while the HINT wrongly said "Add it", **restoring the contradiction this PR fixed** | `…a_chat_in_a_guest_checkout_is_sent_to_reinit`, with a real `git init` checkout |
| `except OSError: continue` | suite stayed green — nothing builds a workspace whose path raises | `…one_unreadable_workspace_does_not_hide_the_rest`, a **constructed** raise, labelled as such |

The second is kept rather than deleted: without it an `OSError` escapes into the preflight from a directory charter only wanted to compare against, taking the whole row down instead of skipping one workspace.

**Full suite on 2176238:** 12707 tests, OK (skipped=9), 862 s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
