### PR TITLE
`charter handoff` opens a chat in a named workspace that starts on the brief you approved

### DIFF
--- a/README.md
+++ b/README.md
@@ -447,6 +447,9 @@ copy wins, is compared to nothing, and drifts unwatched in both directions.
   what changes inside it (scrollback, mouse, the hotkey palette), the two tab strips, quit
   and `charter reopen`, how exit codes get out, what happens when the terminal is too
   small, and every `[frame]` setting.
+- [docs/handoff.md](docs/handoff.md) — `charter handoff`: when a request belongs in another
+  chat, opening one there on a brief you approved, what the command refuses before it changes
+  anything, and why the consent is your harness's own permission prompt.
 - [docs/git-policy.md](docs/git-policy.md) — the one-credential rule, and why a denial from
   the plugin's guard is the rule working rather than a bug.
 - [docs/hooks.md](docs/hooks.md) — everything the plugin does without being asked: what

--- a/charter/cli.py
+++ b/charter/cli.py
@@ -12,6 +12,7 @@ from . import (
     commands,
     commands_change,
     commands_frame,
+    commands_handoff,
     commands_harness,
     commands_persona,
     commands_report,
@@ -227,6 +228,33 @@ def build_parser() -> argparse.ArgumentParser:
                           "date (2026-07-01). Undated memories are excluded and counted.")
     rcl.add_argument("--limit", type=int, default=8, help="Max results (0 = no cap).")
     rcl.set_defaults(func=commands.cmd_recall)
+
+    # Registered HERE, inside `build_parser` and therefore before `_add_frame_parsers`
+    # snapshots `sub.choices`, so `handoff` is a core command a harness registering
+    # `cli_name = "handoff"` would collide with loudly rather than silently take.
+    #
+    # The workspace is a positional and always named, the current one included: the
+    # permission prompt that is this command's consent has to say where the chat goes, and
+    # `.` says nothing (`docs/handoff.md`). There is no `--brief-file` — a prompt that
+    # shows a path is an approval of a path, not of the brief — no `--harness` (a handoff
+    # runs the calling chat's), and no `--repo` (the brief says what to clone, and the new
+    # chat owns its own setup).
+    hof = sub.add_parser(
+        "handoff",
+        help="Open a chat in a workspace you name, already working on a brief you pass as "
+             "a quoted heredoc on stdin. Your harness asks before it runs.")
+    hof.add_argument("workspace",
+                     help="Where the chat opens — an existing workspace, or a new one with "
+                          "--create. Always named, this workspace included.")
+    hof.add_argument("--create", action="store_true",
+                     help="Make the workspace first (LOCAL, never LIVE). Needs --vision.")
+    hof.add_argument("--vision",
+                     help="What the new workspace is for, one line. A workspace with no "
+                          "vision is never proposed as a handoff target.")
+    hof.add_argument("--persona",
+                     help="Pin the new chat's persona. Without it the chat gets whatever a "
+                          "new chat in that workspace gets.")
+    hof.set_defaults(func=commands_handoff.cmd_handoff)
 
     gp = sub.add_parser("git-policy",
                         help="Golden rule: one credential — check/apply token-only git auth "

--- a/charter/commands_frame.py
+++ b/charter/commands_frame.py
@@ -4866,7 +4866,7 @@ class Opening:
     one, which is what lets "no chat came back" be reported rather than inferred.
     """
 
-    def __init__(self, first_message: str, persona: str = "") -> None:
+    def __init__(self, first_message: str, persona: str = "", brief: str = "") -> None:
         #: The whole first message. It reaches the harness through the launch's `rest`
         #: (`harness.base.first_message_argv`); it is carried here so the driver's record of
         #: what it opened says what the chat was started on.
@@ -4874,6 +4874,13 @@ class Opening:
         #: The persona to point the new chat at before its harness starts, or ``""`` for
         #: whichever one a new chat in that workspace gets when nothing is pinned.
         self.persona = persona
+        #: The brief to keep in the new chat's private state, or ``""`` for a background
+        #: open that carries none. Here rather than written by the caller afterwards
+        #: because the caller cannot: the chat id is allocated inside `cmd_launch`, so the
+        #: earliest moment a per-chat file can be written at all is the same moment the
+        #: persona pointer is written — and for the same reason. A brief written after the
+        #: harness has started races the SessionStart that reads it.
+        self.brief = brief
         #: The chat id the launcher allocated, or ``""`` if it never got one.
         self.fid = ""
 
@@ -5422,6 +5429,12 @@ def _launch(args) -> int:
     opening = _opening(args)
     if opening is not None:
         opening.fid = fid
+        # The brief the chat was opened on, written here for the same two reasons and one
+        # more: it is the thing the new chat exists to read, and `charter reopen`'s
+        # SessionStart block reads it as the harness starts. Written by `cmd_handoff` after
+        # the launch returned, it existed only after the harness it is for was already
+        # running — a race that reproduces on nobody's machine.
+        state.record_brief(fid, opening.brief)
         if opening.persona:
             from . import persona as persona_mod
             persona_mod.set_active(opening.persona, session_id=fid, terminal_id="")
@@ -10695,7 +10708,7 @@ def background_refusal(ws: str, *, caller: str, first_message: str) -> str:
 
 
 def open_in_background(ws: str, *, caller: str, first_message: str,
-                       persona: str = "") -> Opened:
+                       persona: str = "", brief: str = "") -> Opened:
     """Open a chat in workspace *ws*, started on *first_message*, and move nobody.
 
     **The seam `charter handoff` drives** (chat-handoff plan, Task 1): `cmd_launch` run for
@@ -10723,6 +10736,11 @@ def open_in_background(ws: str, *, caller: str, first_message: str,
 
     **Success is a chat id with a harness pane, never a return code**: a launcher that
     answered 0 and handed back no id has proved nothing exists.
+
+    *brief* is kept in the new chat's private state (`state.record_brief`) at the moment
+    the id is allocated, which is the earliest one there is and the last one before the
+    harness starts. A caller writing it afterwards would be writing the file the new chat's
+    SessionStart is already looking for.
     """
     refusal = background_refusal(ws, caller=caller, first_message=first_message)
     if refusal:
@@ -10741,7 +10759,7 @@ def open_in_background(ws: str, *, caller: str, first_message: str,
         return Opened(False, "", f"cannot open a chat in '{ws}': charter cannot enter its "
                                  "directory. Nothing was opened.")
     from types import SimpleNamespace
-    opening = Opening(first_message, persona)
+    opening = Opening(first_message, persona, brief)
     pins = {name: os.environ.get(name) for name in ("CHARTER_WORKSPACE", "CHARTER_PERSONA")}
     try:
         for name in pins:

--- a/charter/commands_handoff.py
+++ b/charter/commands_handoff.py
@@ -21,7 +21,8 @@ The order is the spec's, and the order is the design:
 3. the frame — this shell has to be a chat charter can open a background window beside;
 4. `commands_frame.background_refusal`, the seam's own answer, asked while it is still free.
 
-Then the writes: the workspace, the todo, the chat, the private brief, the tally, the line.
+Then the writes: the workspace, the todo, then the chat — which carries the private brief in
+with it, so the file exists before the harness that reads it — then the tally and the line.
 """
 
 from __future__ import annotations
@@ -81,8 +82,14 @@ STAMPED_MESSAGE = (
     "  The bytes counted are the message the new chat is sent: the stamp line, a blank "
     "line, then your brief, which is {n} bytes on its own. A brief that fits alone can be "
     "over once it is stamped.")
+#: What a partway failure says. It names what is left behind and then what did NOT happen,
+#: and it stops short of "nothing else was written": the launcher that failed had already
+#: claimed a chat directory and put this brief in it (`commands_frame.Opening.brief`), and
+#: that directory is the launcher's to leave and `state.reap`'s to clear. What the operator
+#: is actually asking is whether something is out there working on this.
 NOTHING_ELSE = (
-    "charter handoff: {why}\n  What stays: {stays}. Nothing else was written.")
+    "charter handoff: {why}\n  What stays: {stays}. No chat opened, so the brief was sent "
+    "to nobody and nothing is running.")
 OPENED = "charter handoff: opened chat {chat} in workspace '{ws}', started on the brief"
 
 
@@ -156,8 +163,14 @@ def cmd_handoff(args) -> int:
     # A chat of THIS plane whose harness pane is this process's: the two halves `state.is_live`
     # documents, because a frame id can be inherited by a shell that is not in the frame.
     in_a_chat = chats.is_chat(fid) and state.is_live(fid, pane=os.environ.get("TMUX_PANE"))
-    source_chat = fid if in_a_chat else (fid or handoff.NO_CHAT)
-    source_ws = state.workspace_for(fid) if in_a_chat else workspace.resolve()
+    # Neither stamp value asks `in_a_chat`, and the deletion sweep is what settled that.
+    # `chats.is_chat("")` is False, so a chat's id is never empty and `fid or NO_CHAT` is
+    # `fid` for every chat; and `state.workspace_for` ENDS in `workspace.resolve()` for an
+    # id it knows nothing about, so it already answers the outside-a-frame case. Two
+    # conditionals no input could make observable, which in this repository is the same
+    # finding as dead code.
+    source_chat = fid or handoff.NO_CHAT
+    source_ws = state.workspace_for(fid)
     msg = handoff.first_message(handoff.stamp(source_chat, source_ws), brief)
     if not in_a_chat or tmuxctl.is_operator_socket(state.frame_server(fid)
                                                    or commands_frame.SOCKET,
@@ -189,7 +202,12 @@ def cmd_handoff(args) -> int:
         workspace.ensure(ws)
         workspace.set_vision(ws, args.vision)
     text = handoff.todo_text(brief, source_chat=source_chat, source_workspace=source_ws)
-    dup = todos.duplicate_of(ws, text)
+    # `by_title`, and it is not a tweak: every handoff todo ends in the same nine-word
+    # provenance sentence, and compared over the whole text that boilerplate reads as
+    # agreement — `Fix the widget` and `Ship the release` scored 0.750, so the second
+    # handoff into a workspace recorded nothing at all. What two todos are ABOUT is their
+    # first lines (`todos.duplicate_of`).
+    dup = todos.duplicate_of(ws, text, by_title=True)
     if dup:
         # Reported and continued, not refused: a second chat on the same brief may be
         # exactly what was approved, and charter makes no judgement about the content of
@@ -197,8 +215,12 @@ def cmd_handoff(args) -> int:
         util.info(f"already on '{ws}'s list: {contain.one_line(dup)} — not recorded twice")
     else:
         todos.add(ws, text)
+    # The brief rides INTO the launch rather than being written after it: the chat id is
+    # allocated inside `cmd_launch`, so the earliest moment this file can exist is the
+    # moment the id does — and that is still before the harness, whose SessionStart is
+    # what reads it back (`commands_frame.Opening.brief`).
     opened = commands_frame.open_in_background(ws, caller=fid, first_message=msg,
-                                               persona=args.persona or "")
+                                               persona=args.persona or "", brief=brief)
     if not opened.ok:
         # What stays has to be TRUE, so the duplicate case says what actually happened:
         # a reader told "the todo is recorded" who then finds one older row would read the
@@ -209,9 +231,6 @@ def cmd_handoff(args) -> int:
             stays.append(f"the workspace '{ws}' was created")
         util.err(NOTHING_ELSE.format(why=opened.message, stays=", and ".join(stays)))
         return 1
-    # Private state, never committed and never listed by `clear_shape`: the brief is what
-    # the chat was opened to do, which is the same kind of durable fact as its workspace.
-    state.record_brief(opened.chat, brief)
     # No workspace name, no persona, no brief. A LOCAL workspace's name would otherwise
     # reach a committed file through the tally (plan Open question 16).
     dispatch.record_handoff(placement="here" if ws == source_ws else "elsewhere",

--- a/charter/commands_handoff.py
+++ b/charter/commands_handoff.py
@@ -1,0 +1,220 @@
+"""``charter handoff`` — open a chat in a workspace you name, started on an approved brief.
+
+    charter handoff <workspace> [--create --vision "<vision>"] [--persona <name>] <<'BRIEF'
+    <the brief>
+    BRIEF
+
+**The consent is the harness's own permission prompt for that exact spelling**, not
+anything in this file: the brief becomes the new chat's first user message and runs with
+the operator's authority, so `charter init` writes an `ask` rule for `charter handoff *`
+and `hooks.pretooluse`'s A7 refuses the spellings that rule was measured not to match
+(`docs/handoff.md`). What this file adds is every refusal a permission prompt cannot see,
+and it asks all of them **before the first write**, because charter fails toward no change:
+a handoff that created the workspace and then discovered the brief was empty has already
+cost somebody a cleanup.
+
+The order is the spec's, and the order is the design:
+
+1. the workspace name, the flag pairs, the persona — questions answered from the plane;
+2. the brief on stdin, read before the frame check because the command charter prints when
+   there is no frame has to carry it;
+3. the frame — this shell has to be a chat charter can open a background window beside;
+4. `commands_frame.background_refusal`, the seam's own answer, asked while it is still free.
+
+Then the writes: the workspace, the todo, the chat, the private brief, the tally, the line.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+from . import (commands_frame, config, contain, dispatch, handoff, harness, persona, todos,
+               util, workspace)
+from .frame import chats, state, switch, tmuxctl
+
+BAD_NAME = ("charter handoff: '{ws}' cannot name a workspace — nothing was opened. A "
+            "workspace name is letters, digits, '.', '_' and '-', and does not start with "
+            "a dot.")
+VISION_WITHOUT_CREATE = (
+    "charter handoff: --vision describes a workspace this call creates, and '{ws}' is not "
+    "being created — nothing was opened. Set an existing workspace's vision with: charter "
+    "workspace vision --workspace {ws} \"<the goal>\"")
+CREATE_WITHOUT_VISION = (
+    "charter handoff: --create needs --vision — a workspace with no vision is never "
+    "proposed as a target, so it would be created unfindable. Nothing was opened.")
+ALREADY_EXISTS = (
+    "charter handoff: workspace '{ws}' already exists, and --create only makes a new one — "
+    "nothing was opened. Drop --create to hand off into it.")
+NO_SUCH_WORKSPACE = (
+    "charter handoff: no workspace '{ws}' on this plane — nothing was opened. Create it in "
+    "the same call: charter handoff {ws} --create --vision \"<what it is for>\"")
+NO_SUCH_PERSONA = (
+    "charter handoff: no persona '{p}' — have: {have}. Nothing was opened.")
+#: The kind, never the matched text — `hooks._secret_kind`'s own discipline, reused rather
+#: than a second classifier (plan Open question 20).
+SECRET_BRIEF = (
+    "charter handoff: the brief looks like it carries a secret ({kind}) — nothing was "
+    "opened. A "
+    "brief travels to the new chat as a command-line argument any local process can read "
+    "while the harness starts, so it never carries a secret. Name where the credential "
+    "lives (a vault and key) instead of pasting it.")
+NOT_IN_A_FRAME = (
+    "charter handoff: this shell is not a chat in a charter frame, so there is no frame to "
+    "open a chat in the background of — nothing was opened.\n"
+    "  Run this in a new terminal instead:\n  {command}")
+YOUR_OWN_TMUX = (
+    "charter handoff: this chat is a window in a tmux you already had, where charter's "
+    "launcher stays awake for the life of the harness it starts, so it cannot open a chat "
+    "in the background — nothing was opened.\n"
+    "  Run this in a new terminal instead:\n  {command}")
+#: Said under the command above when nothing names a harness. charter prints the word it
+#: cannot know rather than picking one — the brief is already in that argv.
+NO_HARNESS_NAMED = (
+    "  Nothing here says which harness to start and this plane declares no `[harness] "
+    "default`, so put the one you want where `{placeholder}` stands (opencode takes "
+    "`--prompt` in front of the message; `claude` and `codex` take it as it is).")
+#: The byte bound belongs to `commands_frame`, which measures the MESSAGE. Only this
+#: command knows that message is a stamp, a blank line and a brief — so only this command
+#: can say why a brief that fits alone was refused.
+STAMPED_MESSAGE = (
+    "  The bytes counted are the message the new chat is sent: the stamp line, a blank "
+    "line, then your brief, which is {n} bytes on its own. A brief that fits alone can be "
+    "over once it is stamped.")
+NOTHING_ELSE = (
+    "charter handoff: {why}\n  What stays: {stays}. Nothing else was written.")
+OPENED = "charter handoff: opened chat {chat} in workspace '{ws}', started on the brief"
+
+
+def _printed_command(*, ws: str, msg: str, create: bool, vision: str | None,
+                     persona_name: str | None) -> tuple[str, bool]:
+    """``(the command to run in a new terminal, whether a harness could be named)``.
+
+    The harness is the one THIS process is running inside — a handoff never changes harness
+    (spec: Limits) — read from `harness.current()`, which trusts ``$CHARTER_HARNESS``
+    first. A plane's `[harness] default` is the fallback, which is `_same_harness_as`'s
+    second rung said for a shell that is not a chat.
+    """
+    h = harness.get(harness.current())
+    if h is None:
+        # `harness.current()` hands back ``$CHARTER_HARNESS`` verbatim even for a name
+        # charter has never met, so `get` answering None covers both "nothing said" and
+        # "something charter cannot launch".
+        fallback = (config.HARNESS or {}).get("default")
+        h = next((x for x in harness.all() if x.cli_name == fallback), None)
+    # A harness charter has not measured the first message of answers `None` here, and is
+    # treated as no harness at all rather than handed the positional spelling as a guess —
+    # `background_refusal` refuses that harness for the same reason one seam over.
+    extra = h.first_message_argv(msg) if h is not None else None
+    named = extra is not None
+    return handoff.terminal_command(
+        cli_name=h.cli_name if named else handoff.UNKNOWN_HARNESS, workspace=ws,
+        extra=extra if named else [msg], create=create, vision=vision,
+        persona=persona_name), named
+
+
+def cmd_handoff(args) -> int:
+    ws = args.workspace
+    if not workspace.valid_name(ws):
+        util.err(BAD_NAME.format(ws=contain.one_line(ws)))
+        return 1
+    if args.vision and not args.create:
+        util.err(VISION_WITHOUT_CREATE.format(ws=ws))
+        return 1
+    if args.create and not args.vision:
+        util.err(CREATE_WITHOUT_VISION)
+        return 1
+    # `cmd_workspace_use`'s rule, asked rather than re-invented: the always-present
+    # workspace exists whether or not its directory does, so `--create default` on a fresh
+    # plane is a name collision rather than a creation.
+    exists = ws in workspace.list_workspaces() or ws == config.DEFAULT_WORKSPACE
+    if args.create and exists:
+        util.err(ALREADY_EXISTS.format(ws=ws))
+        return 1
+    if not args.create and not exists:
+        util.err(NO_SUCH_WORKSPACE.format(ws=ws))
+        return 1
+    if args.persona and (not persona.valid_name(args.persona)
+                         or args.persona not in persona.list_personas()):
+        util.err(NO_SUCH_PERSONA.format(p=contain.one_line(args.persona),
+                                        have=switch._some(persona.list_personas())))
+        return 1
+
+    brief, refusal = handoff.read_brief(sys.stdin, ws)
+    if refusal:
+        util.err(refusal)
+        return 1
+    # The guard's own classifier, so the brief a handoff refuses and the command a leak
+    # guard refuses are the same set of shapes.
+    from . import hooks
+    kind = hooks._secret_kind(brief)
+    if kind:
+        util.err(SECRET_BRIEF.format(kind=kind))
+        return 1
+
+    fid = os.environ.get("CHARTER_SESSION_ID", "")
+    # A chat of THIS plane whose harness pane is this process's: the two halves `state.is_live`
+    # documents, because a frame id can be inherited by a shell that is not in the frame.
+    in_a_chat = chats.is_chat(fid) and state.is_live(fid, pane=os.environ.get("TMUX_PANE"))
+    source_chat = fid if in_a_chat else (fid or handoff.NO_CHAT)
+    source_ws = state.workspace_for(fid) if in_a_chat else workspace.resolve()
+    msg = handoff.first_message(handoff.stamp(source_chat, source_ws), brief)
+    if not in_a_chat or tmuxctl.is_operator_socket(state.frame_server(fid)
+                                                   or commands_frame.SOCKET,
+                                                   own=commands_frame.SOCKET):
+        command, named = _printed_command(ws=ws, msg=msg, create=bool(args.create),
+                                          vision=args.vision, persona_name=args.persona)
+        said = (NOT_IN_A_FRAME if not in_a_chat else YOUR_OWN_TMUX).format(command=command)
+        if not named:
+            said += "\n" + NO_HARNESS_NAMED.format(placeholder=handoff.UNKNOWN_HARNESS)
+        util.err(said)
+        return 1
+    refusal = commands_frame.background_refusal(ws, caller=fid, first_message=msg)
+    if refusal:
+        size = len(os.fsencode(msg))
+        # Compared against the seam's own sentence rather than re-deriving its bound here:
+        # two places counting bytes is how the note comes to appear beside a refusal that
+        # was about something else.
+        if refusal == commands_frame.LONG_FIRST_MESSAGE.format(
+                n=size, max=commands_frame.FIRST_MESSAGE_MAX_BYTES):
+            refusal += "\n" + STAMPED_MESSAGE.format(n=len(os.fsencode(brief)))
+        util.err(f"charter handoff: {refusal}")
+        return 1
+
+    # ---- past every refusal; from here charter writes ---------------------------------
+    if args.create:
+        # `ensure` scaffolds, so the workspace is a workspace and not a bare directory.
+        # Never `set_live`: a created workspace is LOCAL, and a LIVE one would commit the
+        # todo recorded below into a repository nobody asked to publish it to.
+        workspace.ensure(ws)
+        workspace.set_vision(ws, args.vision)
+    text = handoff.todo_text(brief, source_chat=source_chat, source_workspace=source_ws)
+    dup = todos.duplicate_of(ws, text)
+    if dup:
+        # Reported and continued, not refused: a second chat on the same brief may be
+        # exactly what was approved, and charter makes no judgement about the content of
+        # work (CONTEXT.md).
+        util.info(f"already on '{ws}'s list: {contain.one_line(dup)} — not recorded twice")
+    else:
+        todos.add(ws, text)
+    opened = commands_frame.open_in_background(ws, caller=fid, first_message=msg,
+                                               persona=args.persona or "")
+    if not opened.ok:
+        # What stays has to be TRUE, so the duplicate case says what actually happened:
+        # a reader told "the todo is recorded" who then finds one older row would read the
+        # sentence as a lie about the one thing a failed handoff leaves behind.
+        stays = [f"the todo was already on '{ws}'s list" if dup
+                 else f"the todo is recorded in '{ws}'"]
+        if args.create:
+            stays.append(f"the workspace '{ws}' was created")
+        util.err(NOTHING_ELSE.format(why=opened.message, stays=", and ".join(stays)))
+        return 1
+    # Private state, never committed and never listed by `clear_shape`: the brief is what
+    # the chat was opened to do, which is the same kind of durable fact as its workspace.
+    state.record_brief(opened.chat, brief)
+    # No workspace name, no persona, no brief. A LOCAL workspace's name would otherwise
+    # reach a committed file through the tally (plan Open question 16).
+    dispatch.record_handoff(placement="here" if ws == source_ws else "elsewhere",
+                            created=bool(args.create))
+    print(OPENED.format(chat=opened.chat, ws=ws))
+    return 0

--- a/charter/commands_handoff.py
+++ b/charter/commands_handoff.py
@@ -93,7 +93,7 @@ NOTHING_ELSE = (
 OPENED = "charter handoff: opened chat {chat} in workspace '{ws}', started on the brief"
 
 
-def _printed_command(*, ws: str, msg: str, create: bool, vision: str | None,
+def _printed_command(*, ws: str, msg: str, create_vision: str | None,
                      persona_name: str | None) -> tuple[str, bool]:
     """``(the command to run in a new terminal, whether a harness could be named)``.
 
@@ -116,7 +116,7 @@ def _printed_command(*, ws: str, msg: str, create: bool, vision: str | None,
     named = extra is not None
     return handoff.terminal_command(
         cli_name=h.cli_name if named else handoff.UNKNOWN_HARNESS, workspace=ws,
-        extra=extra if named else [msg], create=create, vision=vision,
+        extra=extra if named else [msg], create_vision=create_vision,
         persona=persona_name), named
 
 
@@ -175,8 +175,11 @@ def cmd_handoff(args) -> int:
     if not in_a_chat or tmuxctl.is_operator_socket(state.frame_server(fid)
                                                    or commands_frame.SOCKET,
                                                    own=commands_frame.SOCKET):
-        command, named = _printed_command(ws=ws, msg=msg, create=bool(args.create),
-                                          vision=args.vision, persona_name=args.persona)
+        # `--create` without `--vision` was refused above, so the vision is there whenever
+        # the workspace is being made, and `None` says it is not.
+        command, named = _printed_command(ws=ws, msg=msg,
+                                          create_vision=args.vision if args.create else None,
+                                          persona_name=args.persona)
         said = (NOT_IN_A_FRAME if not in_a_chat else YOUR_OWN_TMUX).format(command=command)
         if not named:
             said += "\n" + NO_HARNESS_NAMED.format(placeholder=handoff.UNKNOWN_HARNESS)

--- a/charter/commands_workspace.py
+++ b/charter/commands_workspace.py
@@ -1182,7 +1182,9 @@ def cmd_workspace_todo(args) -> int:
     # left. Warn and skip rather than merge, so the writer learns it is already there.
     dup = todos.duplicate_of(name, text)
     if dup:
-        util.err(f"already on the list: {dup}")
+        # Contained for `_list_todos`' reason, one surface over: the title named here is a
+        # stored one, and since `charter handoff` a stored title can be a model's prose.
+        util.err(f"already on the list: {contain.one_line(dup)}")
         util.info(f"  See it: charter ws todo --workspace {name}")
         return 1
 
@@ -1252,7 +1254,18 @@ def _close_todo(name: str, slug: str, *, journal: bool) -> int:
 
 
 def _list_todos(name: str, query: str | None) -> int:
-    """Open todos, oldest first — the ranking the whole feature uses."""
+    """Open todos, oldest first — the ranking the whole feature uses.
+
+    **Every title goes through `contain.one_line` on the way to the terminal**, both here
+    and on the `--query` path. These rows are ``  <slug>  <age>  <title>``, charter's own
+    format with structure in it, and a title carrying `\\n` writes a second row that looks
+    exactly as much like charter's output as the first (#453's mechanism).
+
+    Pre-existing rows, and what changed is who writes the title: until `charter handoff` a
+    todo's title was typed by the operator, and it is now the first line of a brief a MODEL
+    wrote. Escaped at the render and never on the way into storage — the file a person
+    opens must still hold the text they approved.
+    """
     from . import todos
     if query:
         hits = todos.search(name, query)
@@ -1260,7 +1273,7 @@ def _list_todos(name: str, query: str | None) -> int:
             util.info(f"No todos in '{name}' match {query!r}.")
             return 0
         for p, title, _score in hits:
-            print(f"  {p.stem}  {title}")
+            print(f"  {p.stem}  {contain.one_line(title)}")
         return 0
 
     open_ = todos.open_todos(name)
@@ -1270,7 +1283,7 @@ def _list_todos(name: str, query: str | None) -> int:
         return 0
 
     for t in open_:
-        print(f"  {t['slug']}  {t['age_days']}d  {t['title']}")
+        print(f"  {t['slug']}  {t['age_days']}d  {contain.one_line(t['title'])}")
     return 0
 
 

--- a/charter/dispatch.py
+++ b/charter/dispatch.py
@@ -189,7 +189,13 @@ def record_handoff(*, placement: str, created: bool,
         line = json.dumps({"created": bool(created), "event": HANDOFF,
                            "placement": placement,
                            "ts": when.isoformat(timespec="seconds")}, sort_keys=True) + "\n"
-        fd = os.open(p, os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o644)
+        # `O_NOFOLLOW` makes the line above ATOMIC for the one shape a flag can cover.
+        # `write_refusal` is check-then-open: a link planted in the window between the two
+        # is followed, and the row lands wherever it points. The check stays — it is what
+        # catches a FIFO, a directory, and a PARENT that is a link out of the plane, none
+        # of which this flag sees — and the flag closes the race on the final component
+        # for free. The three writers above predate it and keep their own shape.
+        fd = os.open(p, os.O_WRONLY | os.O_CREAT | os.O_APPEND | os.O_NOFOLLOW, 0o644)
         try:
             os.write(fd, line.encode())
         finally:

--- a/charter/dispatch.py
+++ b/charter/dispatch.py
@@ -160,6 +160,45 @@ def record_resume(agent: str, when: datetime | None = None) -> Path | None:
         return None
 
 
+#: Marks a row where a chat handed work to a NEW CHAT rather than to a sub-agent — a
+#: handoff (`charter/commands_handoff.py`, `docs/handoff.md`). Its own kind for `RESUME`'s
+#: reason: `tally()` answers "times dispatched as a sub-agent", and a handoff is the
+#: placement a chat chose INSTEAD of one.
+HANDOFF = "handoff"
+
+
+def record_handoff(*, placement: str, created: bool,
+                   when: datetime | None = None) -> Path | None:
+    """Append one handoff event: when, here-or-elsewhere, and whether it made the workspace.
+
+    **Four fields, and the three that are missing are the design.** No workspace name — a
+    LOCAL workspace's name must not reach a committed file, and this store is committed by
+    any plane whose `[memory].share` says so. No persona. No brief, and no part of one:
+    the brief is the operator's approved prose and never leaves the chat it opened (spec:
+    Limits). What is left answers the only question the tally exists to ask — how often the
+    model routes work to a new chat, and whether it reaches for a new workspace to do it.
+
+    Best-effort, like every writer in this module: a tally must never break a turn.
+    """
+    when = when or _now()
+    p = path_for(when)
+    if contain.write_refusal(p):
+        return None  # a committed link at this fixed name — see contain.write_refusal
+    try:
+        p.parent.mkdir(parents=True, exist_ok=True)
+        line = json.dumps({"created": bool(created), "event": HANDOFF,
+                           "placement": placement,
+                           "ts": when.isoformat(timespec="seconds")}, sort_keys=True) + "\n"
+        fd = os.open(p, os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o644)
+        try:
+            os.write(fd, line.encode())
+        finally:
+            os.close(fd)
+        return p
+    except OSError:
+        return None
+
+
 def resume_tally(days: int | None = None) -> int:
     rows = [o for o in _read_all() if o.get("event") == RESUME]
     if days is not None:

--- a/charter/frame/state.py
+++ b/charter/frame/state.py
@@ -1976,6 +1976,57 @@ def chat_cwd(fid: str) -> str | None:
     return val if val and os.path.isabs(val) else None
 
 
+#: The brief a handoff opened this chat on — the whole context that chat started with
+#: (`charter/handoff.py`, `docs/handoff.md`).
+#:
+#: **Here rather than in the workspace, because a brief is never committed.** A LIVE
+#: workspace commits `todos/**` and `memory/**`; the todo a handoff records carries the
+#: brief's first line and its provenance, and this file carries the rest. It is per-chat,
+#: private to this developer's state directory, at the mode `config.open_for` gives
+#: everything under it.
+_BRIEF_FILE = "brief"
+
+
+def record_brief(fid: str, text: str) -> None:
+    """Write down the brief chat *fid* was opened on, verbatim.
+
+    :func:`record_cwd`'s shape and its reason: atomic, never raises, and deliberately NOT
+    deleted by :func:`clear_shape`. The four files that list argues about are *readings* —
+    a density somebody pressed, a pane map — and every one of them is wrong for the next
+    frame. A brief is what the chat was opened to do, which is the same kind of durable
+    per-chat fact as `workspace` and `cwd`.
+    """
+    d = frame_dir(fid, create=True)
+    if d is None:
+        return
+    try:
+        config.replace_for(d / _BRIEF_FILE, text)
+    except OSError:
+        return
+
+
+def brief(fid: str) -> str | None:
+    """The brief recorded for *fid*, exactly as it was written, or ``None``.
+
+    **Verbatim, with no strip.** This is the text the new chat was sent, and a reader
+    showing it back — `charter reopen`'s SessionStart block (Task 5) — must show what was
+    approved rather than a tidied copy of it.
+
+    ``None`` for a chat opened by a charter that predates this, for a directory that is not
+    a chat's, for a file that cannot be read, and for an EMPTY file: every caller does the
+    same thing with all four — say nothing — and a chat shown an empty labelled block would
+    read it as "your brief was blank".
+    """
+    d = frame_dir(fid)
+    if d is None:
+        return None
+    try:
+        text = (d / _BRIEF_FILE).read_text()
+    except (OSError, ValueError):
+        return None
+    return text or None
+
+
 #: What :func:`record_closed` writes, and the whole difference between a chat the operator
 #: CLOSED and a chat that merely stopped (§4i, and the accepted cost in the reopen design).
 #:

--- a/charter/frame/state.py
+++ b/charter/frame/state.py
@@ -1995,7 +1995,14 @@ def record_brief(fid: str, text: str) -> None:
     a density somebody pressed, a pane map — and every one of them is wrong for the next
     frame. A brief is what the chat was opened to do, which is the same kind of durable
     per-chat fact as `workspace` and `cwd`.
+
+    **An empty brief writes no file**, because :func:`brief` already reads an empty one as
+    "no brief" — so the file would be one more thing in a chat directory that means
+    nothing. Every background open passes through here (`commands_frame.Opening.brief`),
+    and every one that is not a handoff carries none.
     """
+    if not text:
+        return
     d = frame_dir(fid, create=True)
     if d is None:
         return

--- a/charter/handoff.py
+++ b/charter/handoff.py
@@ -16,14 +16,25 @@ from __future__ import annotations
 
 import datetime
 import shlex
+import sys
 
 from . import contain
 
-#: The most characters one codepoint can become in `contain.one_line`'s escaping — the
-#: `\\uXXXX` form. Used to ask that function for the escape WITHOUT its report clip: the
-#: printed command is not a report line, it is a line whose whole point is that it can be
-#: pasted and run, and `DISPLAY_LIMIT` would cut a 12 KB brief off after 160 characters.
-_WIDEST_ESCAPE = 6
+#: What :func:`_shown` passes as `contain.one_line`'s *limit* to mean **do not clip**. That
+#: function's own budget is 160 characters, which is right for a report row and wrong for a
+#: line whose whole point is that it can be pasted and run: a 12 KB brief would arrive
+#: ending in `…`.
+#:
+#: **A ceiling rather than a width computed per character, because the width was wrong.**
+#: The first spelling multiplied the input by the widest escape it believed in — 6, for the
+#: `\\uXXXX` form. `one_line` formats with `:04x`, which is a MINIMUM width, so a codepoint
+#: outside the BMP renders as SEVEN characters: `\\ue0001` for the language tag, and the
+#: same for the musical format controls. At about a thousand of those the budget
+#: under-shot, the helper clipped, and the pasted line ended in `…` — the exact failure
+#: this exists to prevent. Counting to seven instead would be the same mistake with a
+#: better number: it is a claim about which categories Unicode has assigned where, and
+#: `contain._INVISIBLE`'s own docstring is about why charter does not make those.
+_NO_CLIP = sys.maxsize
 
 #: The first line of every handoff's first message. Facts charter can observe and no
 #: instruction: where it came from, which workspace that was, and when. The new chat — and
@@ -217,5 +228,8 @@ def _shown(command: str) -> str:
     rather than as the character, so the chat that command opens is sent `\\x1b` as four
     characters. That is the right way round — a brief has nothing to say in ESC — and the
     operator can see on screen exactly what the command would send.
+
+    The escape is asked for without `one_line`'s report clip (:data:`_NO_CLIP`), because a
+    command cut off after 160 characters is not a command.
     """
-    return contain.one_line(command, limit=len(command) * _WIDEST_ESCAPE)
+    return contain.one_line(command, limit=_NO_CLIP)

--- a/charter/handoff.py
+++ b/charter/handoff.py
@@ -35,6 +35,11 @@ NO_CHAT = "none"
 #: already in its argv.
 UNKNOWN_HARNESS = "<harness>"
 
+NO_STDIN = (
+    "charter handoff: this shell has no stdin at all — the command was run with its input "
+    "closed, so there is nothing to read a brief from and nothing was opened. Pass the "
+    "brief as a quoted heredoc in the same call:\n"
+    "  charter handoff {ws} <<'BRIEF'\n  <the brief>\n  BRIEF")
 TTY_BRIEF = (
     "charter handoff: reads its brief from stdin, and stdin here is a terminal — nothing "
     "was opened. Pass the brief as a quoted heredoc in the same call:\n"
@@ -92,12 +97,20 @@ def read_brief(stream, ws: str) -> tuple[str, str]:
 
     **`isatty()` before any read, and that order is the whole function.** A read on a
     terminal blocks forever with nothing on screen to say why, which inside an agent's Bash
-    tool is a turn that never ends. The three refusals name the heredoc in the same breath,
+    tool is a turn that never ends. The refusals name the heredoc in the same breath,
     because a chat that reached here typed the command without one.
+
+    **A CLOSED stdin is a refusal, not a traceback.** Python hands `sys.stdin` as ``None``
+    when fd 0 is closed, so `charter handoff beta 0<&-` — a spelling the Bash guard allows,
+    because the two words in front of it are the exact ones — reached `isatty()` on
+    ``None`` and drafted a crash report. Charter classifies what it refuses (ADR 0009), and
+    nothing about this is a surprise to the process it happened in.
 
     The brief is kept **verbatim** — leading blank lines, trailing newline and all. It is
     what the new chat is sent, and a handoff that tidied it would send text nobody approved.
     """
+    if stream is None:
+        return "", NO_STDIN.format(ws=ws)
     if stream.isatty():
         return "", TTY_BRIEF.format(ws=ws)
     # `.buffer`, not `.read()`: the decision "is this UTF-8" has to be charter's, and a

--- a/charter/handoff.py
+++ b/charter/handoff.py
@@ -17,6 +17,14 @@ from __future__ import annotations
 import datetime
 import shlex
 
+from . import contain
+
+#: The most characters one codepoint can become in `contain.one_line`'s escaping — the
+#: `\\uXXXX` form. Used to ask that function for the escape WITHOUT its report clip: the
+#: printed command is not a report line, it is a line whose whole point is that it can be
+#: pasted and run, and `DISPLAY_LIMIT` would cut a 12 KB brief off after 160 characters.
+_WIDEST_ESCAPE = 6
+
 #: The first line of every handoff's first message. Facts charter can observe and no
 #: instruction: where it came from, which workspace that was, and when. The new chat — and
 #: whoever reads the transcript a month later — can tell this message was not typed there.
@@ -82,13 +90,25 @@ def first_message(stamp_line: str, brief: str) -> str:
 def title(brief: str) -> str:
     """*brief*'s first non-blank line, stripped — the todo's title and nothing else.
 
-    Non-blank rather than ``splitlines()[0]``: a heredoc written with the delimiter on its
-    own line often opens with a newline, and a todo titled by an empty string is one
+    Non-blank rather than ``[0]``: a heredoc written with the delimiter on its own line
+    often opens with a newline, and a todo titled by an empty string is one
     `memstore.write` refuses.
+
+    **Split on ``\\n`` and nothing else.** `str.splitlines` also breaks on ``\\r``,
+    ``\\x0b``, ``\\x0c``, ``\\x1c``–``\\x1e``, U+2028 and U+2085, so a brief whose first
+    line carried any of those was titled by a PREFIX of the line the operator wrote —
+    charter's "first line" and theirs meaning different things, silently. A shell heredoc
+    ends a line at ``\\n``, which is what the operator typed into. What a control character
+    then does on screen is a rendering question, answered where the rendering is
+    (`contain.one_line`), not by cutting the text short here.
     """
-    for line in brief.splitlines():
-        if line.strip():
-            return line.strip()
+    for line in brief.split("\n"):
+        # Stripped ONCE and bound: two `strip()` calls on one line are two places for the
+        # deletion sweep to ask whether `lstrip` would do, and only one of them can be
+        # answered — for a whitespace-only line the test above is the same either way.
+        stripped = line.strip()
+        if stripped:
+            return stripped
     return ""
 
 
@@ -120,7 +140,10 @@ def read_brief(stream, ws: str) -> tuple[str, str]:
         text = stream.buffer.read().decode("utf-8")
     except UnicodeDecodeError:
         return "", NOT_UTF8_BRIEF
-    if not text.strip():
+    # `split()` and never `strip()`, which `commands_frame.background_refusal` settled one
+    # seam over: `not text.strip()` and `not text.lstrip()` answer alike for every string,
+    # so the strip is a line nothing can turn red. No words is an empty brief.
+    if not text.split():
         return "", EMPTY_BRIEF.format(ws=ws)
     return text, ""
 
@@ -137,8 +160,8 @@ def todo_text(brief: str, *, source_chat: str, source_workspace: str) -> str:
             f"{source_workspace}. The full brief is private to the chat it opened.")
 
 
-def terminal_command(*, cli_name: str, workspace: str, extra: list[str], create: bool,
-                     vision: str | None, persona: str | None) -> str:
+def terminal_command(*, cli_name: str, workspace: str, extra: list[str],
+                     create_vision: str | None, persona: str | None) -> str:
     """The command to run in a new terminal, when there is no frame to open a chat in.
 
     A handoff needs a frame — charter's own tmux server, with a launcher that can go away
@@ -152,16 +175,47 @@ def terminal_command(*, cli_name: str, workspace: str, extra: list[str], create:
 
     *persona* rides as a ``CHARTER_PERSONA=`` prefix rather than a flag, because that
     variable is the pin `charter <harness>` already reads (plan Open question 12), and
-    *create* rides as a `charter workspace create … &&` in front, because the workspace has
-    to exist before the launcher resolves it.
+    *create_vision* rides as a `charter workspace create … &&` in front, because the
+    workspace has to exist before the launcher resolves it.
+
+    **One parameter for "create it, and this is its vision", not two.** `--create` without
+    `--vision` is refused before this is reached, so a `create` flag beside an optional
+    *vision* is a pair that can only be wrong together — and the `or ""` that stood in for
+    the impossible half was a fallback no input could reach (`shlex.quote(None)` answers
+    ``"''"`` anyway, so it could not even be seen). ``None`` means the workspace is there
+    already.
     """
     q = shlex.quote
     head = ""
-    if create:
-        head += f"charter workspace create {q(workspace)} --vision {q(vision or '')} && "
+    if create_vision is not None:
+        head += f"charter workspace create {q(workspace)} --vision {q(create_vision)} && "
     if persona:
         head += f"CHARTER_PERSONA={q(persona)} "
     # `cli_name` unquoted: it is a registered harness's own word, or the literal
     # `<harness>` placeholder, and quoting the placeholder would hide that it is one.
     words = [f"charter {cli_name}", "--workspace", q(workspace), *(q(a) for a in extra)]
-    return head + " ".join(words)
+    return _shown(head + " ".join(words))
+
+
+def _shown(command: str) -> str:
+    """*command*, safe to PRINT on the terminal charter is printing to.
+
+    **`shlex.quote` escapes nothing.** It wraps a word in single quotes, which is what the
+    SHELL needs and says nothing about what a terminal does with the bytes inside them —
+    measured: ESC, `\\r`, backspace and a bidirectional override all pass through it
+    untouched. And the word this line carries is the whole brief, which is arbitrary text
+    the operator approved for a model to read, not for a terminal to execute.
+
+    That matters most here of anywhere, because this is the one refusal that tells the
+    operator to **paste the line into a new terminal**: a brief opening
+    `\\r✓ opened chat beta.9` repaints charter's own refusal as a success, on the line the
+    operator is about to trust. `commands_handoff.BAD_NAME` has contained a workspace name
+    for the same reason since this command shipped; the brief is the same defect on a
+    surface a thousand times larger.
+
+    **The cost, stated:** a brief carrying a control character is pasted as its escape
+    rather than as the character, so the chat that command opens is sent `\\x1b` as four
+    characters. That is the right way round — a brief has nothing to say in ESC — and the
+    operator can see on screen exactly what the command would send.
+    """
+    return contain.one_line(command, limit=len(command) * _WIDEST_ESCAPE)

--- a/charter/handoff.py
+++ b/charter/handoff.py
@@ -1,0 +1,154 @@
+"""The facts a handoff is made of: the stamp, the first message, the brief, the todo text,
+and the command to run when there is no frame to open a chat in.
+
+**No I/O beyond the one stream :func:`read_brief` is handed**, and no plane, so every
+string a handoff produces can be checked without a control plane, a tmux or a workspace on
+disk. `charter/commands_handoff.py` is where the refusals are ordered and the writes
+happen; this module only knows how each piece is spelled.
+
+A handoff opens a chat whose first message is a brief the operator approved
+(`docs/handoff.md`). That message travels to the harness as a command-line argument, so it
+is world-readable on this machine while the harness starts — which is why
+`cmd_handoff` refuses a credential-shaped brief before any of this runs.
+"""
+
+from __future__ import annotations
+
+import datetime
+import shlex
+
+#: The first line of every handoff's first message. Facts charter can observe and no
+#: instruction: where it came from, which workspace that was, and when. The new chat — and
+#: whoever reads the transcript a month later — can tell this message was not typed there.
+#: The brackets are ⟨⟩ rather than <> so the line cannot be read as markup by anything that
+#: renders the transcript.
+STAMP = "⟨handoff from chat {chat} · workspace {workspace} · {when}⟩"
+
+#: What the stamp calls a source that has no chat id — a handoff proposed from a shell
+#: outside any frame, which is refused, but whose printed command still carries the stamp
+#: so the chat it opens is marked the same way (plan Open question 12).
+NO_CHAT = "none"
+
+#: Stands where the harness's own word goes when nothing says which harness this is: no
+#: ``$CHARTER_HARNESS``, no native evidence, and no ``[harness] default`` on the plane.
+#: Printed literally, because a guess here starts the wrong tool with the operator's brief
+#: already in its argv.
+UNKNOWN_HARNESS = "<harness>"
+
+TTY_BRIEF = (
+    "charter handoff: reads its brief from stdin, and stdin here is a terminal — nothing "
+    "was opened. Pass the brief as a quoted heredoc in the same call:\n"
+    "  charter handoff {ws} <<'BRIEF'\n  <the brief>\n  BRIEF")
+NOT_UTF8_BRIEF = (
+    "charter handoff: the brief on stdin is not UTF-8 text — nothing was opened.")
+EMPTY_BRIEF = (
+    "charter handoff: the brief on stdin is empty — nothing was opened. Pass it as a "
+    "quoted heredoc in the same call:\n"
+    "  charter handoff {ws} <<'BRIEF'\n  <the brief>\n  BRIEF")
+
+
+def _now() -> datetime.datetime:
+    """Local time. Its own function so a test can freeze it without freezing the clock."""
+    return datetime.datetime.now()
+
+
+def stamp(source_chat: str, source_workspace: str,
+          when: datetime.datetime | None = None) -> str:
+    """The stamp line for a handoff leaving *source_chat* in *source_workspace*.
+
+    Minutes, not seconds: the stamp is read by a person deciding whether this message is
+    the one they approved a moment ago, and a second's precision answers no question they
+    have. Local time, because the reader is in it.
+    """
+    when = when or _now()
+    return STAMP.format(chat=source_chat, workspace=source_workspace,
+                        when=when.strftime("%Y-%m-%d %H:%M"))
+
+
+def first_message(stamp_line: str, brief: str) -> str:
+    """The whole of what the new chat is sent: the stamp, a blank line, the brief verbatim.
+
+    The blank line is what keeps the stamp from reading as the brief's first line — which
+    is also the line :func:`title` turns into a todo.
+    """
+    return f"{stamp_line}\n\n{brief}"
+
+
+def title(brief: str) -> str:
+    """*brief*'s first non-blank line, stripped — the todo's title and nothing else.
+
+    Non-blank rather than ``splitlines()[0]``: a heredoc written with the delimiter on its
+    own line often opens with a newline, and a todo titled by an empty string is one
+    `memstore.write` refuses.
+    """
+    for line in brief.splitlines():
+        if line.strip():
+            return line.strip()
+    return ""
+
+
+def read_brief(stream, ws: str) -> tuple[str, str]:
+    """``(brief, refusal)`` read from *stream* — the brief is ``""`` whenever it refuses.
+
+    **`isatty()` before any read, and that order is the whole function.** A read on a
+    terminal blocks forever with nothing on screen to say why, which inside an agent's Bash
+    tool is a turn that never ends. The three refusals name the heredoc in the same breath,
+    because a chat that reached here typed the command without one.
+
+    The brief is kept **verbatim** — leading blank lines, trailing newline and all. It is
+    what the new chat is sent, and a handoff that tidied it would send text nobody approved.
+    """
+    if stream.isatty():
+        return "", TTY_BRIEF.format(ws=ws)
+    # `.buffer`, not `.read()`: the decision "is this UTF-8" has to be charter's, and a
+    # text stream has already made it — with whatever errors= and encoding the environment
+    # handed it, which on a machine with a non-UTF-8 locale is a different answer.
+    try:
+        text = stream.buffer.read().decode("utf-8")
+    except UnicodeDecodeError:
+        return "", NOT_UTF8_BRIEF
+    if not text.strip():
+        return "", EMPTY_BRIEF.format(ws=ws)
+    return text, ""
+
+
+def todo_text(brief: str, *, source_chat: str, source_workspace: str) -> str:
+    """The todo a handoff records in the TARGET workspace: the title and where it came from.
+
+    **The brief is not in it, and that is not brevity.** A LIVE workspace commits
+    `todos/**`, and a brief never reaches a committed file (spec: Limits). The title is
+    enough for the person reading the list to recognise the work, and the chat that was
+    opened is holding the rest.
+    """
+    return (f"{title(brief)}\n\nHanded off from chat {source_chat} · workspace "
+            f"{source_workspace}. The full brief is private to the chat it opened.")
+
+
+def terminal_command(*, cli_name: str, workspace: str, extra: list[str], create: bool,
+                     vision: str | None, persona: str | None) -> str:
+    """The command to run in a new terminal, when there is no frame to open a chat in.
+
+    A handoff needs a frame — charter's own tmux server, with a launcher that can go away
+    once the chat exists. Outside one, and inside the operator's own tmux (where the
+    launcher stays awake for the life of the harness it starts), there is nothing to open a
+    chat in the background OF. So charter prints the equivalent command instead of
+    refusing and stopping: everything the handoff would have done, minus the background.
+
+    Every word goes through `shlex.quote`, including the message — it carries the brief,
+    which is arbitrary approved prose with quotes and newlines in it.
+
+    *persona* rides as a ``CHARTER_PERSONA=`` prefix rather than a flag, because that
+    variable is the pin `charter <harness>` already reads (plan Open question 12), and
+    *create* rides as a `charter workspace create … &&` in front, because the workspace has
+    to exist before the launcher resolves it.
+    """
+    q = shlex.quote
+    head = ""
+    if create:
+        head += f"charter workspace create {q(workspace)} --vision {q(vision or '')} && "
+    if persona:
+        head += f"CHARTER_PERSONA={q(persona)} "
+    # `cli_name` unquoted: it is a registered harness's own word, or the literal
+    # `<harness>` placeholder, and quoting the placeholder would hide that it is one.
+    words = [f"charter {cli_name}", "--workspace", q(workspace), *(q(a) for a in extra)]
+    return head + " ".join(words)

--- a/charter/hooks.py
+++ b/charter/hooks.py
@@ -5921,6 +5921,18 @@ def pretooluse() -> int:
         # deciding which part of it is safe.
         _trace("deny", sid, reason=reason)
         return rc
+    # A handoff that survived A7 IS the routing answer `routing: require` asked for — the
+    # same rule `pretooluse_dispatch` applies to a dispatch, for the same reason: the mark
+    # says "the roster fired and nothing was routed", and opening a chat in a workspace is
+    # routing. AFTER A7 on purpose (Task 4 dispatch ruling 2): a refused handoff opened
+    # nothing, so that turn still owes its answer, and
+    # `test_a_refused_handoff_leaves_the_routing_mark` returns above before reaching here.
+    #
+    # In the hook rather than in `cmd_handoff` because the mark is keyed on the PAYLOAD's
+    # session id, which the CLI knows only for Claude Code (`state.harness_session`) — so a
+    # handoff from opencode or Codex would otherwise clear nothing.
+    if plane and _is_handoff(cmd):
+        _route_mark_clear(sid)
     # B WAS HERE: the clone-commit nudge, removed in #371 — see the note where it lived.
     # Nothing on this handler asks any more; every remaining verdict is a deny or an allow.
     # fall through to the allow-only persona tool-gate

--- a/charter/memstore.py
+++ b/charter/memstore.py
@@ -28,6 +28,26 @@ def slug(title: str) -> str:
     return s[:48] or "note"
 
 
+#: The longest a memory title may be. It becomes a `# ` heading, an index row and — through
+#: :func:`slug` — part of a filename, so it is one line and it is short.
+TITLE_MAX = 72
+
+
+def title_of(text: str) -> str:
+    """The title :func:`write` derives from a memory's body: its first line, capped.
+
+    **Its own function because a READER has to be able to compute the same string.**
+    `todos.duplicate_of` asks whether a todo it is about to write already exists, and one
+    side of that comparison is a title `write` derived this way — so a second spelling of
+    "the first line, stripped, capped" is how the writer and the reader come to disagree
+    about which todos are the same one.
+
+    ``""`` for a body with nothing in it; :func:`write` refuses such a body outright.
+    """
+    body = (text or "").strip()
+    return body.splitlines()[0].strip()[:TITLE_MAX] if body else ""
+
+
 def index_path(mem_dir: Path) -> Path:
     return mem_dir / "MEMORY.md"
 
@@ -75,7 +95,7 @@ def write(mem_dir: Path, text: str, title: str | None = None, *, timestamped: bo
     text = (text or "").strip()
     if not text:
         raise ValueError("empty memory")
-    title = (title or text.splitlines()[0]).strip()[:72]
+    title = title.strip()[:TITLE_MAX] if title else title_of(text)
     # Before the mkdir, and before a byte is written: both targets are checked up front so
     # a refusal leaves the store exactly as it was, rather than a memory file on disk that
     # nothing indexes.

--- a/charter/memstore.py
+++ b/charter/memstore.py
@@ -43,9 +43,18 @@ def title_of(text: str) -> str:
     about which todos are the same one.
 
     ``""`` for a body with nothing in it; :func:`write` refuses such a body outright.
+
+    **One `strip`, on the line, rather than one on the body and one on the line.** The
+    outer one only ever skipped leading blank lines — its trailing half was redundant with
+    the inner one, so `strip` and `lstrip` answered alike there for every input and the
+    deletion sweep had a synonym nothing could settle. Written as the loop it is, "how
+    much" is asked once and a title with padding at either end pins it.
     """
-    body = (text or "").strip()
-    return body.splitlines()[0].strip()[:TITLE_MAX] if body else ""
+    for line in (text or "").splitlines():
+        title = line.strip()
+        if title:
+            return title[:TITLE_MAX]
+    return ""
 
 
 def index_path(mem_dir: Path) -> Path:

--- a/charter/todos.py
+++ b/charter/todos.py
@@ -39,6 +39,22 @@ _HEADER = (
 #: is identical in kind, and one threshold is easier to reason about than two.
 _DUPLICATE_THRESHOLD = 0.5
 
+#: The fewest words two todos must AGREE ON before that overlap is evidence about them.
+#:
+#: **A rule about how much signal a comparison needs, not a second threshold.** Below it
+#: the ratio is arithmetic with nothing behind it, and it is wrong in both directions at
+#: once. `memstore.wordset` keeps only words longer than three characters, so `fix the bug`
+#: has NO comparable word at all: two of them agree on nothing, score nothing, and the same
+#: todo recorded twice was recorded twice with no notice. And one shared word out of two is
+#: 0.5 exactly, so `Fix the widget` and `Break the widget` — and `Update the README file`
+#: beside `Delete the README file`, two words out of four — collapsed into one.
+#:
+#: Moving :data:`_DUPLICATE_THRESHOLD` to 0.51 answers the second pair and neither of the
+#: others, and is a number that will be wrong again on the next shape. Where the overlap
+#: cannot distinguish, the comparison falls back to whether the two titles ARE the same
+#: title (:func:`_normal`) — which needs no threshold and cannot be wrong about identity.
+_MIN_SHARED_WORDS = 3
+
 
 def todos_dir(name: str) -> Path:
     """``workspaces/<name>/todos/`` — a *sibling* of ``memory/``, never a child."""
@@ -96,24 +112,50 @@ def duplicate_of(name: str, text: str, *, by_title: bool = False) -> str | None:
     The stored side is `memstore.entries`' title, and the asking side is
     `memstore.title_of` — the same rule `memstore.write` titled it by, asked rather than
     respelled.
+
+    **Where the word overlap has nothing to say, identity decides** — see
+    :data:`_MIN_SHARED_WORDS`, which is why. The one case that survives both rules: two
+    titles that differ only past `memstore.TITLE_MAX` are stored as the same 72 characters
+    and read as one todo. Said rather than engineered around; a todo whose first 72
+    characters are another's is one somebody has to read twice anyway.
     """
     existing = memstore.entries(todos_dir(name))
     if not existing:
         return None
     words = _words(memstore.title_of(text) if by_title else text)
-    if not words:
-        return None
+    mine = _normal(memstore.title_of(text))
     for _p, title, body in existing:
         other = _words(title if by_title else f"{title} {memstore.body(body)}")
-        if not other:
+        shared = words & other
+        if len(shared) < _MIN_SHARED_WORDS:
+            # No signal — decided by identity rather than by arithmetic (see
+            # :data:`_MIN_SHARED_WORDS`). Two todos that read the same ARE the same todo
+            # however short their words; two that read differently are not. No emptiness
+            # guard in front of it: `memstore.entries` falls back to the filename stem, so
+            # a stored title is never empty, and a `mine` that is would be a todo nothing
+            # on either side of this call would write.
+            if mine == _normal(title):
+                return title
             continue
         # Jaccard — intersection over UNION, the same metric `memstore.duplicates` uses.
         # Dividing by max(len) instead looks equivalent and is not: on text this short a
         # single shared word is half the content, so "first thing" and "second thing"
         # scored 0.5 and the second was refused as a duplicate of the first.
-        if len(words & other) / len(words | other) >= _DUPLICATE_THRESHOLD:
+        if len(shared) / len(words | other) >= _DUPLICATE_THRESHOLD:
             return title
     return None
+
+
+def _normal(title: str) -> str:
+    """*title* with the differences that are not differences taken out — the case it was
+    typed in and the runs of whitespace between its words.
+
+    The identity test the no-signal fallback decides by, and deliberately not
+    `memstore.body`'s normalisation: that one strips headings and stamps out of a whole
+    memory to compare BODIES, and running it over a title would answer a different
+    question. `casefold` rather than `lower` because this is a comparison, not a display.
+    """
+    return " ".join((title or "").split()).casefold()
 
 
 def _words(text: str) -> set[str]:

--- a/charter/todos.py
+++ b/charter/todos.py
@@ -74,21 +74,37 @@ def add(name: str, text: str, *, stamp: datetime.datetime | None = None) -> Path
     return memstore.write(todos_dir(name), text, timestamped=True, index=True, stamp=stamp)
 
 
-def duplicate_of(name: str, text: str) -> str | None:
+def duplicate_of(name: str, text: str, *, by_title: bool = False) -> str | None:
     """The title of an existing todo that already says this, or None.
 
     Deliberately a query rather than something :func:`add` enforces: the *policy* — warn
     and skip — belongs to the command, so the store stays a store. Scoped to one workspace,
     since an identical todo in another is a different task's business.
+
+    **`by_title` compares FIRST LINES, on both sides, and it exists because a writer whose
+    todos all end in the same sentence otherwise reads as agreeing with itself.**
+    `charter handoff` is that writer: its todo is the brief's first line plus a nine-word
+    provenance sentence every handoff todo carries. Measured on the whole text, `Fix the
+    widget` and `Ship the release` — briefs with no word in common — scored **0.750** and
+    the second was refused as a duplicate of the first; any two handoff titles of four or
+    fewer distinct words collided that way, so the second handoff into a workspace recorded
+    nothing. The threshold was not the defect and moving it would not have fixed it: the
+    boilerplate is not part of what makes two todos the same piece of work, so it does not
+    belong in the comparison. What the todos are ABOUT is their first lines, which is what
+    "already says this" was always meant to mean.
+
+    The stored side is `memstore.entries`' title, and the asking side is
+    `memstore.title_of` — the same rule `memstore.write` titled it by, asked rather than
+    respelled.
     """
     existing = memstore.entries(todos_dir(name))
     if not existing:
         return None
-    words = _words(text)
+    words = _words(memstore.title_of(text) if by_title else text)
     if not words:
         return None
     for _p, title, body in existing:
-        other = _words(f"{title} {memstore.body(body)}")
+        other = _words(title if by_title else f"{title} {memstore.body(body)}")
         if not other:
             continue
         # Jaccard — intersection over UNION, the same metric `memstore.duplicates` uses.

--- a/charter/todos.py
+++ b/charter/todos.py
@@ -39,15 +39,18 @@ _HEADER = (
 #: is identical in kind, and one threshold is easier to reason about than two.
 _DUPLICATE_THRESHOLD = 0.5
 
-#: The fewest words two todos must AGREE ON before that overlap is evidence about them.
+#: The fewest words two TITLES must AGREE ON before that overlap is evidence about them.
+#: :func:`_same_work` only — see :func:`duplicate_of` for why the whole-text path does not
+#: want it.
 #:
 #: **A rule about how much signal a comparison needs, not a second threshold.** Below it
-#: the ratio is arithmetic with nothing behind it, and it is wrong in both directions at
-#: once. `memstore.wordset` keeps only words longer than three characters, so `fix the bug`
-#: has NO comparable word at all: two of them agree on nothing, score nothing, and the same
-#: todo recorded twice was recorded twice with no notice. And one shared word out of two is
-#: 0.5 exactly, so `Fix the widget` and `Break the widget` — and `Update the README file`
-#: beside `Delete the README file`, two words out of four — collapsed into one.
+#: the ratio is arithmetic with nothing behind it, and on titles it is wrong in both
+#: directions at once. `memstore.wordset` keeps only words longer than three characters, so
+#: `fix the bug` has NO comparable word at all: two of them agree on nothing, score nothing,
+#: and the same handoff recorded twice was recorded twice with no notice. And one shared
+#: word out of two is 0.5 exactly, so `Fix the widget` and `Break the widget` — and `Update
+#: the README file` beside `Delete the README file`, two words out of four — collapsed into
+#: one, which for a handoff means a real todo silently dropped.
 #:
 #: Moving :data:`_DUPLICATE_THRESHOLD` to 0.51 answers the second pair and neither of the
 #: others, and is a number that will be wrong again on the next shape. Where the overlap
@@ -113,34 +116,74 @@ def duplicate_of(name: str, text: str, *, by_title: bool = False) -> str | None:
     `memstore.title_of` — the same rule `memstore.write` titled it by, asked rather than
     respelled.
 
-    **Where the word overlap has nothing to say, identity decides** — see
-    :data:`_MIN_SHARED_WORDS`, which is why. The one case that survives both rules: two
-    titles that differ only past `memstore.TITLE_MAX` are stored as the same 72 characters
-    and read as one todo. Said rather than engineered around; a todo whose first 72
-    characters are another's is one somebody has to read twice anyway.
+    **The two paths tolerate OPPOSITE errors, because their callers do** — which is why
+    :data:`_MIN_SHARED_WORDS` scopes to *by_title* and the whole-text path is untouched.
+    `charter ws todo` REFUSES on a duplicate, so a false one costs the operator a rephrase
+    while a missed one leaves two near-identical todos, and closing one of those leaves its
+    twin looking outstanding; it wants the catching rule. `charter handoff` RECORDS NOTHING
+    on a duplicate and opens the chat anyway, so a false one silently drops a real handoff's
+    todo and the work goes invisible; it wants the careful one. The same measurement served
+    both badly: applied to the whole text it turned five hand-written retitles — `Fix the
+    login bug` beside `Fix the login issue`, `Update the README` beside `Update the README
+    file` — from caught into missed. A tiny-set overlap cannot tell "retitled by a word"
+    from "different work sharing a word"; the caller can say which way to be wrong.
     """
     existing = memstore.entries(todos_dir(name))
     if not existing:
         return None
-    words = _words(memstore.title_of(text) if by_title else text)
-    mine = _normal(memstore.title_of(text))
+    if by_title:
+        return _same_work(memstore.title_of(text), existing)
+    return _same_text(text, existing)
+
+
+def _same_text(text: str, existing) -> str | None:
+    """The whole of *text* against the whole of each stored todo — `charter ws todo`'s rule.
+
+    Unchanged since before the handoff existed, deliberately: this is the path that REFUSES,
+    and its stated preference is to catch a near-duplicate at the cost of the occasional
+    false one (`commands_workspace.cmd_ws_todo`).
+    """
+    words = _words(text)
+    if not words:
+        return None
     for _p, title, body in existing:
-        other = _words(title if by_title else f"{title} {memstore.body(body)}")
-        shared = words & other
-        if len(shared) < _MIN_SHARED_WORDS:
-            # No signal — decided by identity rather than by arithmetic (see
-            # :data:`_MIN_SHARED_WORDS`). Two todos that read the same ARE the same todo
-            # however short their words; two that read differently are not. No emptiness
-            # guard in front of it: `memstore.entries` falls back to the filename stem, so
-            # a stored title is never empty, and a `mine` that is would be a todo nothing
-            # on either side of this call would write.
-            if mine == _normal(title):
-                return title
+        other = _words(f"{title} {memstore.body(body)}")
+        if not other:
             continue
         # Jaccard — intersection over UNION, the same metric `memstore.duplicates` uses.
         # Dividing by max(len) instead looks equivalent and is not: on text this short a
         # single shared word is half the content, so "first thing" and "second thing"
         # scored 0.5 and the second was refused as a duplicate of the first.
+        if len(words & other) / len(words | other) >= _DUPLICATE_THRESHOLD:
+            return title
+    return None
+
+
+def _same_work(subject: str, existing) -> str | None:
+    """*subject* — a todo's first line — against each stored todo's TITLE, `charter
+    handoff`'s rule.
+
+    **Where the word overlap has nothing to say, identity decides** (:data:`_MIN_SHARED_WORDS`).
+    The one case that survives both rules: two titles differing only past
+    `memstore.TITLE_MAX` are stored as the same 72 characters and read as one todo. Said
+    rather than engineered around; a todo whose first 72 characters are another's is one
+    somebody has to read twice anyway. Punctuation is not collapsed either, so `Fix the
+    widget!` is a second todo beside `Fix the widget`.
+    """
+    words = _words(subject)
+    mine = _normal(subject)
+    for _p, title, _body in existing:
+        other = _words(title)
+        shared = words & other
+        if len(shared) < _MIN_SHARED_WORDS:
+            # No signal — decided by identity rather than by arithmetic. Two todos that
+            # read the same ARE the same todo however short their words; two that read
+            # differently are not. No emptiness guard in front of it: `memstore.entries`
+            # falls back to the filename stem, so a stored title is never empty, and a
+            # `mine` that is would be a todo nothing on either side of this call writes.
+            if mine == _normal(title):
+                return title
+            continue
         if len(shared) / len(words | other) >= _DUPLICATE_THRESHOLD:
             return title
     return None

--- a/docs/frame.md
+++ b/docs/frame.md
@@ -645,9 +645,8 @@ it.
 ### A chat opened for you in the background
 
 **A chat that hands work to a new chat has to start that chat without taking your screen.**
-`charter handoff` — the next piece of the chat-handoff plan, not shipped yet — opens a chat in
-a workspace you name and starts it on a first message you approved. The opening underneath
-it exists now, and it is built so nothing you are looking at changes:
+[`charter handoff`](handoff.md) opens a chat in a workspace you name and starts it on a first
+message you approved. The opening underneath it is built so nothing you are looking at changes:
 
 - **No client moves.** The chat is a new window in the target workspace's session, created
   detached. It is not selected, nothing attaches, and the chat you are on keeps its panels.

--- a/docs/handoff.md
+++ b/docs/handoff.md
@@ -65,12 +65,21 @@ BRIEF
    provenance under it. **Not the brief** — a LIVE workspace commits `todos/**`, and a brief
    never reaches a committed file. If a todo already on that workspace's list says the same
    work, charter names it, records nothing, and carries on: a second chat on the same work may
-   be exactly what you approved. "The same work" is the word-overlap rule any todo is checked
-   against (Jaccard ≥ 0.5), asked over the **first lines** — every handoff todo ends in the same
-   nine-word provenance sentence, and compared over the whole text that boilerplate reads as
-   agreement: `Fix the widget` and `Ship the release`, which share no word at all, scored 0.750
-   and the second was dropped as a duplicate of the first. Over first lines they score 0.000,
-   and two handoffs on the same brief still score 1.000.
+   be exactly what you approved.
+
+   **"The same work" is asked over the first lines, and only where the words can answer it.**
+   Every handoff todo ends in the same nine-word provenance sentence, so over the whole text
+   that boilerplate reads as agreement — `Fix the widget` and `Ship the release`, which share no
+   word at all, scored 0.750 and the second was dropped. Over first lines they score 0.000. But
+   an overlap can also be too thin to mean anything: word comparison keeps only words longer
+   than three characters, so `fix the bug` has no comparable word at all and two of them agree
+   on nothing, while one shared word out of two is 0.5 exactly and `Fix the widget` swallowed
+   `Break the widget`. So an overlap of fewer than three shared words is not read as evidence in
+   either direction — those are decided by whether the two first lines **are the same line**,
+   ignoring case and runs of spaces. `fix the bug` twice is one todo; `Fix the widget` and
+   `Break the widget` are two. The one case that survives both rules, stated rather than
+   engineered around: two first lines that differ only past the 72nd character are stored as the
+   same title and read as one todo.
 3. Opens a chat in the target workspace **in the background**. No client moves, nothing
    attaches, and the chat you are on keeps its panels — measured on tmux 3.7c and at charter's
    3.2 floor, with real clients attached: the session's current window is the same one before

--- a/docs/handoff.md
+++ b/docs/handoff.md
@@ -1,10 +1,190 @@
-# A handoff's brief runs with your authority, so your harness asks you first
+# You asked one chat for a second thing, and it did it there
+
+You are in a chat about the API and you ask about the deploy script. Three things happen
+today, and all three cost you:
+
+- the model does it here, so one workspace's todos, memory and branch now carry two tasks;
+- the model hands it to a sub-agent, and the answer you wanted to talk to comes back as a
+  paragraph folded into this conversation and is then gone;
+- the model tells you to open a chat yourself, and you retype the context it already had.
+
+The fourth way did not exist. `charter frame-new-chat` opens a chat only in the presser's own
+workspace, sends it nothing and moves the view; `charter claude …` run from an agent's Bash tool
+has no terminal, so it execs a bare harness inside that tool call. `charter handoff` is the one
+that does: a chat in a workspace you name, opened without taking your screen, already working on
+a brief you read and approved.
+
+## Three places a request can run, and the two questions that pick one
+
+1. **A sub-agent** — your harness's own. charter never gates, rewrites or converts an Agent
+   call; nothing on this page touches one.
+2. **A new chat in this workspace.**
+3. **A new chat in another workspace**, existing or new.
+
+2 and 3 are one mechanism — a **handoff** — because a chat belongs to its workspace for life.
+The only thing that differs is the workspace.
+
+**Sub-agent or chat: who reads the result?** If this chat needs the answer to continue, it is a
+sub-agent. If you will read it and talk to it, it is a chat. There is no report-back channel
+from a handed-off chat; a parent that needs the answer wanted a sub-agent.
+
+**This workspace or another: does the ask serve this workspace's vision?** Yes → a chat here.
+No → another workspace, matched against other workspaces' visions. charter supplies the facts
+and never names the answer (ADR 0016) — and these are rules for the *proposal*, not for the
+command. `charter handoff` refuses none of them, so a chat already in `default` can still hand
+off within it.
+
+## The command
+
+```bash
+charter handoff <workspace> [--create --vision "<vision>"] [--persona <name>] <<'BRIEF'
+<the brief>
+BRIEF
+```
+
+- **The workspace is always named**, the current one included. The permission prompt has to say
+  where the chat goes, and `.` says nothing.
+- **The brief arrives on stdin, as one quoted heredoc in the same call**, so the prompt shows
+  the exact text the new chat will be sent. There is no `--brief-file`: a prompt that shows a
+  path is an approval of a path. A brief may still *name* files, and naming them is what a good
+  brief does.
+- **The harness is this chat's.** There is no `--harness`: a handoff into a different harness is
+  #538's backlog. There is no `--repo` either — the brief says what to clone, and the new chat
+  owns its own setup.
+- `--persona` pins the new chat's persona, visibly in the prompt. Without it the chat gets
+  whatever a new chat in that workspace gets: the launch empties `$CHARTER_WORKSPACE` and
+  `$CHARTER_PERSONA`, so a pinned caller cannot file the new chat under its own workspace.
+- `--create` makes the workspace first, and needs `--vision`. A workspace with no vision is
+  never proposed as a handoff target, so one created without it would be created unfindable. A
+  workspace `--create` makes is LOCAL.
+
+## What a handoff does, in order
+
+1. With `--create`, creates the workspace and records its vision.
+2. Records a todo in the target workspace, titled by the brief's first line, with one line of
+   provenance under it. **Not the brief** — a LIVE workspace commits `todos/**`, and a brief
+   never reaches a committed file. If that todo is already on the list, charter records nothing,
+   says so, and carries on: a second chat on the same brief may be exactly what you approved.
+3. Opens a chat in the target workspace **in the background**. No client moves, nothing
+   attaches, and the chat you are on keeps its panels — measured on tmux 3.7c and at charter's
+   3.2 floor, with real clients attached: the session's current window is the same one before
+   and after. The new window still gets its panels before anyone looks at it, as a reopened chat
+   does.
+4. Sends it the first message: the stamp line, a blank line, then the brief verbatim. It rides
+   the harness's own argv (`claude "<message>"` on Claude Code 2.1.268, `codex "<message>"` on
+   codex-cli 0.147.0, `opencode --prompt "<message>"` on opencode 1.18.23, each read from that
+   version's `--help`), never typed into its pane.
+5. The chat is **born locked to its workspace** and asks no workspace question at session start.
+   That lock depends on the harness keeping the chat id charter starts it with, and two are
+   named as not doing that yet: opencode's plugin overwrites `$CHARTER_SESSION_ID` (#946), and
+   Codex gets no session id outside a frame (#954).
+6. Keeps the full brief in that chat's private state, under `.charter/`, never committed.
+7. Appends one row to the dispatch tally — `{"event": "handoff", "ts", "placement", "created"}`,
+   with no workspace name, no persona and no text — and clears `routing: require`'s pending mark
+   for the turn that ran it, on every harness. The handoff **is** the routing answer.
+8. Prints the new chat's id and its workspace.
+
+**What it does not do yet:** move the target workspace to the front of the tab strip, or mark
+that tab as arrived. Those are the next slice; today the new chat appears on the target
+workspace's chats strip and nothing on screen points at it.
+
+## The stamp
+
+```
+⟨handoff from chat <source-chat> · workspace <source-workspace> · <YYYY-MM-DD HH:MM>⟩
+```
+
+Facts charter can observe, and no instruction. The new chat — and whoever reads the transcript
+later — can tell the first message was not typed there. A handoff proposed from a shell with no
+`$CHARTER_SESSION_ID` stamps its source as `chat none`. Minutes, not seconds: the stamp is read
+by a person deciding whether this is the message they approved a moment ago.
+
+## What `charter handoff` refuses before it changes anything
+
+charter fails toward no change, so every one of these is asked **before the first write** —
+nothing is created, nothing is recorded, and no chat is opened.
+
+| The call | What it says |
+| --- | --- |
+| a name that cannot be a workspace | the name rule, and that nothing was opened |
+| `--vision` without `--create` | the command that sets an existing workspace's vision |
+| `--create` without `--vision` | that a visionless workspace would be created unfindable |
+| `--create` on a workspace that exists (`default` included) | to drop `--create` |
+| an unknown workspace without `--create` | the same call with `--create --vision` |
+| `--persona` naming one that does not exist | the personas there are |
+| stdin is a terminal — asked before any read, so it never blocks | the heredoc form |
+| an empty brief | the heredoc form |
+| bytes on stdin that are not UTF-8 | that they are not text |
+| a brief shaped like a credential | the KIND, never the value |
+| no frame here, or charter is a window in a tmux you already had | the exact command to run in a new terminal |
+| anything `commands_frame.background_refusal` refuses — an empty, flag-shaped, single-word, NUL-carrying or oversized first message | the seam's own sentence |
+
+**The byte cap is on the stamped message, not on your brief.** charter refuses a first message
+past 12,288 bytes, counted the way `exec` is handed them. That bound is charter's own policy,
+not tmux's: tmux refuses a command past 16,364 bytes (measured on 3.7c and at the 3.2 floor),
+and the command that starts a chat carries the chat's names, its directory and its identity
+beside the message. What is counted is the stamp line, a blank line and your brief, so a brief
+that fits on its own can be over once it is stamped — the refusal says how big the brief was, so
+the two numbers are both on screen. Name long material by its path instead of pasting it.
+
+**Outside a frame, charter prints the command instead of stopping.** A handoff needs charter's
+own tmux server, with a launcher that can go away once the chat exists; inside a tmux you
+started yourself, that launcher stays awake for the life of the harness it starts, so there is
+nothing to open a chat in the background *of*. Both cases print the equivalent
+`charter <harness> --workspace <ws> …` line, with the workspace creation in front of it when you
+asked for one and `CHARTER_PERSONA=` when you named a persona — every word quoted, the brief
+included. If nothing says which harness this is — no `$CHARTER_HARNESS`, no `[harness] default`
+— charter prints `<harness>` where the word goes and says it could not name one, rather than
+starting the wrong tool with your brief already in its argv.
+
+## Isolation and continuation
+
+- **The brief is the whole context.** No pointer to the parent's transcript, no forked
+  conversation. Everything the new chat needs is in the text you approved.
+- **A handed-off chat that will write claims its own piece** — `charter wt add <repo> <piece>` —
+  before it writes. The handoff never pre-creates a worktree: the claimant is the creator (ADR
+  0011). This holds wherever the chat lands; any workspace with other chats in it has the same
+  two-chats-one-clone risk.
+- **The chat opens in the workspace directory**, which is the directory `charter <harness>
+  --workspace <ws>` would have used.
+- **"Starts working" means the first message is sent.** Permission prompts in the new chat
+  behave exactly as they do in any chat.
+- A handed-off chat may propose a handoff of its own, under the same gate. There is no depth
+  limit, because every hop needs its own yes.
+
+## Limits
+
+- **A handed-off chat never reports back to the chat that opened it.** If you need the answer in
+  this conversation, you wanted a sub-agent.
+- **The same harness only.** A Claude Code chat hands off to a Claude Code chat (#538's
+  backlog).
+- **The brief is a command-line argument.** It reaches the harness as `claude "<brief>"`,
+  `codex "<brief>"` or `opencode --prompt "<brief>"`, so any process on this machine that can
+  list processes can read it while the harness starts. A brief never carries a secret, and a
+  credential-shaped one is refused by kind before anything opens.
+- **12,288 bytes for the stamped message**, above. The cost, stated: a brief between roughly
+  12,200 and 15,800 bytes is refused although tmux would take it.
+- **Nothing shows a reopened chat its brief yet.** A Claude Code chat reopens with its
+  conversation (`charter reopen`); one that reopens empty is not shown the brief it was opened
+  on. opencode has no SessionStart hook at all (`charter doctor` names that gap), so there is
+  nowhere to show it there.
+- **A handoff is not a dispatch.** Its tally row carries no agent, so `charter persona stats`'
+  dispatch column and "last worked" are untouched by one.
+
+## A brief runs with your authority, so your harness asks you first
 
 A handoff opens a chat, in this workspace or another, whose first message is a brief that the
 chat you are talking to wrote. A first message is not a suggestion: the new chat starts working
 on it with your authority, and nobody reads it again before it does. So the consent for a
 handoff cannot be the model's own proposal, however faithfully that proposal quotes the brief.
 It is your harness's permission prompt, showing the exact text, in front of `charter handoff`.
+
+**The prompt is the consent for ONE spelling, and charter refuses the rest.** The rule below was
+measured against `charter handoff …` as those two bare words; Claude Code says of its own Bash
+rules that one "isn't a security boundary around the program", and 2.1.268 ran `charter
+'handoff'`, `python3 -m charter handoff` and a path to charter with no prompt at all. So the ask
+rule is not the boundary — it is the prompt for the exact spelling, and charter's own hook
+refuses the spellings it can recognise that the rule was measured not to match.
 
 ## The prompt is the consent
 

--- a/docs/handoff.md
+++ b/docs/handoff.md
@@ -63,8 +63,14 @@ BRIEF
 1. With `--create`, creates the workspace and records its vision.
 2. Records a todo in the target workspace, titled by the brief's first line, with one line of
    provenance under it. **Not the brief** — a LIVE workspace commits `todos/**`, and a brief
-   never reaches a committed file. If that todo is already on the list, charter records nothing,
-   says so, and carries on: a second chat on the same brief may be exactly what you approved.
+   never reaches a committed file. If a todo already on that workspace's list says the same
+   work, charter names it, records nothing, and carries on: a second chat on the same work may
+   be exactly what you approved. "The same work" is the word-overlap rule any todo is checked
+   against (Jaccard ≥ 0.5), asked over the **first lines** — every handoff todo ends in the same
+   nine-word provenance sentence, and compared over the whole text that boilerplate reads as
+   agreement: `Fix the widget` and `Ship the release`, which share no word at all, scored 0.750
+   and the second was dropped as a duplicate of the first. Over first lines they score 0.000,
+   and two handoffs on the same brief still score 1.000.
 3. Opens a chat in the target workspace **in the background**. No client moves, nothing
    attaches, and the chat you are on keeps its panels — measured on tmux 3.7c and at charter's
    3.2 floor, with real clients attached: the session's current window is the same one before
@@ -78,7 +84,9 @@ BRIEF
    That lock depends on the harness keeping the chat id charter starts it with, and two are
    named as not doing that yet: opencode's plugin overwrites `$CHARTER_SESSION_ID` (#946), and
    Codex gets no session id outside a frame (#954).
-6. Keeps the full brief in that chat's private state, under `.charter/`, never committed.
+6. Keeps the full brief in that chat's private state, under `.charter/`, never committed —
+   written at the moment the chat id is allocated, which is before the window that starts the
+   harness, because the brief is the thing that chat exists to read.
 7. Appends one row to the dispatch tally — `{"event": "handoff", "ts", "placement", "created"}`,
    with no workspace name, no persona and no text — and clears `routing: require`'s pending mark
    for the turn that ran it, on every harness. The handoff **is** the routing answer.
@@ -115,9 +123,14 @@ nothing is created, nothing is recorded, and no chat is opened.
 | stdin is a terminal — asked before any read, so it never blocks | the heredoc form |
 | an empty brief | the heredoc form |
 | bytes on stdin that are not UTF-8 | that they are not text |
+| stdin closed altogether (`0<&-`) | that there is nothing to read, and the heredoc form |
 | a brief shaped like a credential | the KIND, never the value |
 | no frame here, or charter is a window in a tmux you already had | the exact command to run in a new terminal |
-| anything `commands_frame.background_refusal` refuses — an empty, flag-shaped, single-word, NUL-carrying or oversized first message | the seam's own sentence |
+| the background seam's own refusals: a NUL byte in the first message or one past the byte bound; a chat that records no harness charter can launch, or one charter has not measured the first message of; a session of the target workspace's name this plane cannot prove is its own | the seam's own sentence |
+
+The seam also refuses a first message that is empty, starts with `-`, or is a single word — and
+**a handoff cannot produce one**. The stamp goes in front, so every handoff's first message opens
+with `⟨` and runs to eleven words or more: a brief of `--help me now` opens a chat.
 
 **The byte cap is on the stamped message, not on your brief.** charter refuses a first message
 past 12,288 bytes, counted the way `exec` is handed them. That bound is charter's own policy,

--- a/docs/handoff.md
+++ b/docs/handoff.md
@@ -76,10 +76,16 @@ BRIEF
    on nothing, while one shared word out of two is 0.5 exactly and `Fix the widget` swallowed
    `Break the widget`. So an overlap of fewer than three shared words is not read as evidence in
    either direction — those are decided by whether the two first lines **are the same line**,
-   ignoring case and runs of spaces. `fix the bug` twice is one todo; `Fix the widget` and
-   `Break the widget` are two. The one case that survives both rules, stated rather than
-   engineered around: two first lines that differ only past the 72nd character are stored as the
-   same title and read as one todo.
+   ignoring case and runs of spaces but not punctuation. `fix the bug` twice is one todo;
+   `Fix the widget` and `Break the widget` are two, and so are `Fix the widget` and
+   `Fix the widget!`. Two first lines that differ only past the 72nd character are stored as
+   the same title and read as one todo — stated rather than engineered around.
+
+   **This is the handoff's rule and not `charter ws todo`'s**, which compares whole texts and
+   keeps catching a todo retitled by a word. The two want opposite errors: `ws todo` REFUSES on
+   a duplicate, so a false one costs you a rephrase while a missed one leaves two near-identical
+   todos on the list; a handoff records nothing and opens the chat anyway, so a false one drops
+   a real todo and the work goes invisible.
 3. Opens a chat in the target workspace **in the background**. No client moves, nothing
    attaches, and the chat you are on keeps its panels — measured on tmux 3.7c and at charter's
    3.2 floor, with real clients attached: the session's current window is the same one before

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -712,7 +712,9 @@ never says which persona owns the prompt (ADR 0016); see `docs show personas`.
 
 At `routing: require` a second, quieter hook joins it: `PreToolUse` on `Write|Edit|MultiEdit`
 **asks** once when a turn edits after the roster fired and nothing was dispatched. It never
-denies, and a dispatch — or the next prompt — clears it.
+denies, and a dispatch, a `charter handoff` — opening a chat in a workspace *is* routing — or
+the next prompt clears it. A handoff the Bash guard refused opened nothing, so that one leaves
+the mark where it is.
 
 ## What gets counted
 
@@ -725,6 +727,11 @@ parallel-writer safe with the host in the filename so two engineers never confli
 - **Routing advice** (`personas/_dispatch/`, as `{"ts", "event": "advice"}` rows) — how
   often the roster was shown. Paired with dispatches in `charter persona stats`, it is the
   number that can say the block is not working.
+- **Handoffs** (`personas/_dispatch/`, as `{"ts", "event": "handoff", "placement", "created"}`
+  rows) — how often work went to a NEW CHAT rather than to a sub-agent, whether it went to this
+  workspace or another, and whether it made a workspace to go to. No workspace name, because a
+  LOCAL workspace's name must not reach a committed file; no persona; and no part of the brief.
+  It carries no agent, so it is not a dispatch and never moves a persona's counts.
 - **Skill invocations** (`personas/_skills/`) — a persona's declared `skills:` are preloaded
   into every dispatch of it, so declaring one is cheap to write and expensive to keep. This
   says whether the equipment was worth carrying.

--- a/docs/news/unreleased-charter-handoff.md
+++ b/docs/news/unreleased-charter-handoff.md
@@ -27,7 +27,10 @@ The brief becomes the new chat's first message. Your harness asks before the com
    handoff continues. "The same work" is asked over the first lines, because every handoff todo
    ends in the same provenance sentence and over the whole text that boilerplate read as
    agreement; and where fewer than three words overlap — too thin to be evidence in either
-   direction — it is decided by whether the two first lines are the same line.
+   direction — it is decided by whether the two first lines are the same line. That is the
+   handoff's rule, not `charter ws todo`'s: `ws todo` refuses on a duplicate, so it keeps
+   catching a todo retitled by a word, while a handoff that refused one would drop a real todo
+   and the work would go invisible.
 3. Opens a chat there in the background. No client moves, nothing attaches, and the chat you are
    on keeps its panels — measured on tmux 3.7c and at charter's 3.2 floor with real clients
    attached.

--- a/docs/news/unreleased-charter-handoff.md
+++ b/docs/news/unreleased-charter-handoff.md
@@ -1,0 +1,68 @@
+---
+version: unreleased
+headline: `charter handoff` opens a chat in any workspace, already working on the brief you approved
+---
+
+You are in a chat about one thing and you ask for another. Until now that ended one of three
+ways: the model did it here, so one workspace's todos, memory and branch carried two tasks; it
+handed the work to a sub-agent, and the answer you wanted to talk to came back as a paragraph
+and was gone; or it told you to open a chat yourself, and you retyped the context it already
+had.
+
+```bash
+charter handoff <workspace> [--create --vision "<vision>"] [--persona <name>] <<'BRIEF'
+<the brief>
+BRIEF
+```
+
+The brief becomes the new chat's first message. Your harness asks before the command runs — the
+`ask` rule the previous entry is about — and the prompt shows the exact text that will be sent.
+
+## What one does
+
+1. With `--create`, makes the workspace (LOCAL) and records its vision.
+2. Records a todo in the target workspace, titled by the brief's first line, with one line of
+   provenance under it — **never the brief**, because a LIVE workspace commits `todos/**`. A
+   todo already on the list is reported and not recorded twice, and the handoff continues.
+3. Opens a chat there in the background. No client moves, nothing attaches, and the chat you are
+   on keeps its panels — measured on tmux 3.7c and at charter's 3.2 floor with real clients
+   attached.
+4. Sends the first message: a stamp line, a blank line, then the brief verbatim, on the
+   harness's own argv (`claude "<msg>"`, `codex "<msg>"`, `opencode --prompt "<msg>"`).
+5. The chat is born locked to its workspace and asks no workspace question.
+6. Keeps the full brief in that chat's private state under `.charter/`, never committed.
+7. Tallies `{"event": "handoff", "ts", "placement", "created"}` — no workspace name, no persona,
+   no text — and clears `routing: require`'s pending mark, because opening a chat in a workspace
+   *is* routing.
+8. Prints the chat and the workspace.
+
+The stamp is `⟨handoff from chat <chat> · workspace <ws> · <YYYY-MM-DD HH:MM>⟩`: facts charter
+can observe and no instruction, so the new chat can tell the message was not typed there.
+
+## It refuses before it changes anything
+
+Nothing is created, recorded or opened until every refusal has been asked: a name that cannot be
+a workspace, `--vision` without `--create` or the reverse, `--create` on a workspace that exists
+(`default` included), an unknown workspace without `--create`, a persona nobody has, a stdin
+that is a terminal (asked before any read, so it never blocks), a brief that is empty or not
+UTF-8, and a brief shaped like a credential — named by KIND, never by value, because the brief
+reaches the harness as a command-line argument any local process can read while it starts.
+
+**Outside a frame, or inside a tmux you started yourself**, charter prints the exact
+`charter <harness> --workspace <ws> …` command to run in a new terminal instead of stopping —
+with the workspace creation in front of it when you asked for one, `CHARTER_PERSONA=` when you
+named a persona, and every word quoted.
+
+## Limits
+
+- **No report back.** A handed-off chat never answers the chat that opened it; if you need the
+  answer in this conversation, you wanted a sub-agent.
+- **The same harness only** (#538's backlog).
+- **12,288 bytes, and the cap is on the stamped message** — the stamp line, a blank line and
+  your brief — so a brief that fits on its own can be over once stamped. The refusal says both
+  numbers. That bound is charter's own, set under tmux's measured 16,364-byte command limit.
+- **A brief never carries a secret.** It is argv while the harness starts.
+- **The tab strip does not point at the arrival yet**, and a chat that reopens empty is not
+  shown its brief. Both are the next slices.
+
+`charter docs show handoff` has the whole of it, including how the consent was measured.

--- a/docs/news/unreleased-charter-handoff.md
+++ b/docs/news/unreleased-charter-handoff.md
@@ -23,9 +23,11 @@ The brief becomes the new chat's first message. Your harness asks before the com
 1. With `--create`, makes the workspace (LOCAL) and records its vision.
 2. Records a todo in the target workspace, titled by the brief's first line, with one line of
    provenance under it — **never the brief**, because a LIVE workspace commits `todos/**`. A
-   todo already on that list that says the same work — the same word-overlap rule any todo
-   is checked against, asked over the first lines, because every handoff todo ends in the
-   same provenance sentence — is named and not recorded twice, and the handoff continues.
+   todo already on that list that says the same work is named and not recorded twice, and the
+   handoff continues. "The same work" is asked over the first lines, because every handoff todo
+   ends in the same provenance sentence and over the whole text that boilerplate read as
+   agreement; and where fewer than three words overlap — too thin to be evidence in either
+   direction — it is decided by whether the two first lines are the same line.
 3. Opens a chat there in the background. No client moves, nothing attaches, and the chat you are
    on keeps its panels — measured on tmux 3.7c and at charter's 3.2 floor with real clients
    attached.

--- a/docs/news/unreleased-charter-handoff.md
+++ b/docs/news/unreleased-charter-handoff.md
@@ -23,14 +23,17 @@ The brief becomes the new chat's first message. Your harness asks before the com
 1. With `--create`, makes the workspace (LOCAL) and records its vision.
 2. Records a todo in the target workspace, titled by the brief's first line, with one line of
    provenance under it — **never the brief**, because a LIVE workspace commits `todos/**`. A
-   todo already on the list is reported and not recorded twice, and the handoff continues.
+   todo already on that list that says the same work — the same word-overlap rule any todo
+   is checked against, asked over the first lines, because every handoff todo ends in the
+   same provenance sentence — is named and not recorded twice, and the handoff continues.
 3. Opens a chat there in the background. No client moves, nothing attaches, and the chat you are
    on keeps its panels — measured on tmux 3.7c and at charter's 3.2 floor with real clients
    attached.
 4. Sends the first message: a stamp line, a blank line, then the brief verbatim, on the
    harness's own argv (`claude "<msg>"`, `codex "<msg>"`, `opencode --prompt "<msg>"`).
 5. The chat is born locked to its workspace and asks no workspace question.
-6. Keeps the full brief in that chat's private state under `.charter/`, never committed.
+6. Keeps the full brief in that chat's private state under `.charter/`, never committed, and
+   written at the moment the chat id is allocated — before the harness it is for starts.
 7. Tallies `{"event": "handoff", "ts", "placement", "created"}` — no workspace name, no persona,
    no text — and clears `routing: require`'s pending mark, because opening a chat in a workspace
    *is* routing.
@@ -44,9 +47,10 @@ can observe and no instruction, so the new chat can tell the message was not typ
 Nothing is created, recorded or opened until every refusal has been asked: a name that cannot be
 a workspace, `--vision` without `--create` or the reverse, `--create` on a workspace that exists
 (`default` included), an unknown workspace without `--create`, a persona nobody has, a stdin
-that is a terminal (asked before any read, so it never blocks), a brief that is empty or not
-UTF-8, and a brief shaped like a credential — named by KIND, never by value, because the brief
-reaches the harness as a command-line argument any local process can read while it starts.
+that is a terminal (asked before any read, so it never blocks) or closed altogether, a brief
+that is empty or not UTF-8, and a brief shaped like a credential — named by KIND, never by
+value, because the brief reaches the harness as a command-line argument any local process can
+read while it starts.
 
 **Outside a frame, or inside a tmux you started yourself**, charter prints the exact
 `charter <harness> --workspace <ws> …` command to run in a new terminal instead of stopping —

--- a/docs/workspaces.md
+++ b/docs/workspaces.md
@@ -363,5 +363,7 @@ skim the ones that matter.
 ## See also
 
 - [control-plane.md](control-plane.md) — `charter.toml`, and the plane's view of a workspace
+- [handoff.md](handoff.md) — `charter handoff`: opening a chat in another workspace on a brief
+  you approved, and why the consent is your harness's own prompt
 - [personas.md](personas.md) — the other memory base, and how a persona is dispatched
 - [adr/0010](adr/0010-the-manifest-is-a-snapshot-not-an-inventory.md) — why `workspace.json` is not an inventory

--- a/tests/test_a_chat_opens_in_the_background_with_its_first_message.py
+++ b/tests/test_a_chat_opens_in_the_background_with_its_first_message.py
@@ -101,12 +101,13 @@ class _AChatInAlpha(PersonaIso, unittest.TestCase):
             args.opening.fid = self.gives_back
         return self.rc
 
-    def _open(self, ws="beta", text="fix the widget please", persona=""):
+    def _open(self, ws="beta", text="fix the widget please", persona="", brief=""):
         with mock.patch("charter.commands_frame.subprocess.run", side_effect=self._tmux), \
                 mock.patch("charter.commands_frame.cmd_launch",
                            side_effect=self._fake_launch):
             return commands_frame.open_in_background(ws, caller=self.CALLER,
-                                                     first_message=text, persona=persona)
+                                                     first_message=text, persona=persona,
+                                                     brief=brief)
 
     def _refusal(self, ws="beta", text="fix the widget please"):
         with mock.patch("charter.commands_frame.subprocess.run", side_effect=self._tmux):
@@ -138,12 +139,23 @@ class TheOpenRunsTheLauncherForTheNamedWorkspace(_AChatInAlpha):
     def test_the_opening_carries_the_new_chat_id_back(self):
         self.assertEqual(self._open(), commands_frame.Opened(True, "beta.1", ""))
 
-    def test_the_opening_carries_the_message_and_the_persona_it_was_given(self):
-        self._open(text="fix the widget please", persona="forge")
+    def test_the_opening_carries_the_message_the_persona_and_the_brief_it_was_given(self):
+        """All three, and the brief is the one whose absence nothing else can see. It is not
+        written here — `_launch` writes it, at id allocation — so if it stops being handed to
+        the `Opening` the file is simply never made, the handoff still reports success, and
+        the chat Task 5 reopens is shown nothing. The two tests either side of this one stand
+        around that join rather than on it: the handoff suite's stand-in seam records the
+        brief itself, and the `_launch` case builds its own `Opening`."""
+        self._open(text="fix the widget please", persona="forge", brief="fix it\nplease\n")
         opening = self.launched[0].opening
         self.assertIsInstance(opening, commands_frame.Opening)
         self.assertEqual(opening.first_message, "fix the widget please")
         self.assertEqual(opening.persona, "forge")
+        self.assertEqual(opening.brief, "fix it\nplease\n")
+
+    def test_an_open_given_no_brief_carries_none(self):
+        self._open()
+        self.assertEqual(self.launched[0].opening.brief, "")
 
     def test_it_is_sized_for_the_window_the_calling_chat_is_on(self):
         self._open()

--- a/tests/test_a_chat_opens_in_the_background_with_its_first_message.py
+++ b/tests/test_a_chat_opens_in_the_background_with_its_first_message.py
@@ -416,6 +416,9 @@ class TheLaunchOpensWithoutMovingAnyone(PersonaIso, unittest.TestCase):
         self.enterContext(mock.patch.dict(os.environ, {}, clear=True))
         self.make_persona("forge")
         self.argvs: list[list[str]] = []
+        #: ``(argv, the brief on disk for beta.1 at that moment)`` per tmux call, so a test
+        #: can ask what existed BEFORE the window that starts the harness was created.
+        self.brief_at: list[tuple[list[str], str | None]] = []
 
     def _launch(self, *, opening=None, attach=False, reopening=None):
         args = SimpleNamespace(harness="claude", rest=["fix it please"], no_frame=False,
@@ -429,6 +432,7 @@ class TheLaunchOpensWithoutMovingAnyone(PersonaIso, unittest.TestCase):
 
         def run(action, argv, **kw):
             self.argvs.append(list(argv))
+            self.brief_at.append((list(argv), state.brief("beta.1")))
             return subprocess.CompletedProcess(
                 argv, 0, "%9\n" if "new-window" in argv else "", "")
 
@@ -496,6 +500,22 @@ class TheLaunchOpensWithoutMovingAnyone(PersonaIso, unittest.TestCase):
     def test_an_opening_with_no_persona_writes_no_pointer(self):
         self._launch(opening=commands_frame.Opening("fix it please"))
         self.assertIsNone(persona.for_session("beta.1"))
+
+    def test_an_openings_brief_is_on_disk_before_the_window_that_starts_the_harness(self):
+        """The brief is what the new chat exists to read, and `charter reopen`'s SessionStart
+        block (Task 5) reads it as the harness starts. Written by the CALLER after
+        `cmd_launch` returned, it appeared only once the harness was already running — a race
+        that reproduces on nobody's machine. So it is written where the persona pointer is,
+        at id allocation, and the window that starts the harness comes after."""
+        self._launch(opening=commands_frame.Opening("fix it please", brief="fix it\nplease\n"))
+        made = [(argv, brief) for argv, brief in self.brief_at if "new-window" in argv]
+        self.assertTrue(made, self.argvs)
+        self.assertEqual(made[0][1], "fix it\nplease\n")
+
+    def test_an_opening_with_no_brief_leaves_no_brief_file(self):
+        self._launch(opening=commands_frame.Opening("fix it please"))
+        self.assertIsNone(state.brief("beta.1"))
+        self.assertFalse((config.STATE_DIR / "frame" / "beta.1" / "brief").exists())
 
     def test_an_ordinary_launch_still_selects_its_window(self):
         """The gate is an `and`, not a replacement: a launch with no opening, whose `attach`

--- a/tests/test_a_handoff_refuses_before_it_changes_anything.py
+++ b/tests/test_a_handoff_refuses_before_it_changes_anything.py
@@ -43,6 +43,10 @@ BRIEF = "Fix the widget\nIt breaks on resize.\n"
 #: list is how the two come to disagree.
 AWS_KEY = "AKIAQ7VZ3RJHT2LMNPQR"
 
+#: "`_handoff` was given no stdin to use", distinct from ``None``, which is a stdin a test
+#: is stating: Python hands `sys.stdin` as ``None`` in a process whose fd 0 is closed.
+_UNSET = object()
+
 
 class _ATerminal:
     """A stdin that says it is a terminal and screams if anything reads it.
@@ -92,20 +96,26 @@ class _AHandoffFromAlpha(PlaneIso):
         self.open = self.enterContext(
             mock.patch("charter.commands_frame.open_in_background", side_effect=self._open))
 
-    def _open(self, ws, *, caller, first_message, persona=""):
+    def _open(self, ws, *, caller, first_message, persona="", brief=""):
         for fn in self.during_open:
             fn()
         if self.opened.ok:
-            # A launcher that opened a chat left its directory and its harness pane behind;
-            # `state.record_brief` needs one to write into.
+            # A launcher that opened a chat left its directory and its harness pane behind,
+            # and it recorded the brief at the moment it allocated the id — before the
+            # harness started. The stand-in does both, so what this suite observes after a
+            # handoff is what a real open leaves behind.
             _a_chat(self.opened.chat, ws=ws, pane="%9")
+            state.record_brief(self.opened.chat, brief)
         return self.opened
 
-    def _handoff(self, ws="beta", brief=BRIEF, *, stdin=None, **flags):
-        """Run `cmd_handoff` with *brief* on stdin; return ``(rc, stdout, stderr)``."""
+    def _handoff(self, ws="beta", brief=BRIEF, *, stdin=_UNSET, **flags):
+        """Run `cmd_handoff` with *brief* on stdin; return ``(rc, stdout, stderr)``.
+
+        *stdin* may be ``None``, which is what Python hands a process whose fd 0 is closed.
+        """
         args = SimpleNamespace(workspace=ws, create=flags.get("create", False),
                                vision=flags.get("vision"), persona=flags.get("persona"))
-        if stdin is None:
+        if stdin is _UNSET:
             raw = brief if isinstance(brief, bytes) else brief.encode()
             stdin = io.TextIOWrapper(io.BytesIO(raw), encoding="utf-8")
         out, err = io.StringIO(), io.StringIO()
@@ -167,11 +177,29 @@ class AHandoffRefusesBeforeItChangesAnything(_AHandoffFromAlpha):
         self.assertIn("--create --vision", err)
         self._nothing_changed()
 
+    def test_a_name_with_a_newline_in_it_cannot_write_a_second_line_of_the_refusal(self):
+        """A refusal is lines an operator reads, and the name in it is whatever was typed.
+        Unescaped, `charter handoff $'x\\n✓ opened chat beta.1'` prints charter's own success
+        line underneath charter's own refusal (`contain.one_line`)."""
+        rc, _out, err = self._handoff("x\n✓ opened chat beta.1")
+        self.assertEqual(rc, 1)
+        self.assertEqual(len(err.strip().splitlines()), 1, err)
+        self.assertIn("\\x0a", err)
+        self._nothing_changed()
+
     def test_an_unknown_persona_is_refused_listing_the_ones_there_are(self):
         self.make_persona("forge")
         rc, _out, err = self._handoff("beta", persona="forj")
         self.assertEqual(rc, 1)
         self.assertIn("no persona 'forj' — have: forge", err)
+        self._nothing_changed()
+
+    def test_a_persona_name_with_a_newline_cannot_write_a_second_line_either(self):
+        self.make_persona("forge")
+        rc, _out, err = self._handoff("beta", persona="a\n✓ opened chat beta.1")
+        self.assertEqual(rc, 1)
+        self.assertEqual(len(err.strip().splitlines()), 1, err)
+        self.assertIn("\\x0a", err)
         self._nothing_changed()
 
     # -- the brief ---------------------------------------------------------------------
@@ -180,6 +208,16 @@ class AHandoffRefusesBeforeItChangesAnything(_AHandoffFromAlpha):
         rc, _out, err = self._handoff("beta", stdin=_ATerminal())
         self.assertEqual(rc, 1)
         self.assertIn("stdin here is a terminal", err)
+        self.assertIn("<<'BRIEF'", err)
+        self._nothing_changed()
+
+    def test_a_closed_stdin_is_a_refusal_and_not_a_traceback(self):
+        """`charter handoff beta 0<&-` — a spelling the Bash guard allows, since the two
+        words in front of it are the exact ones — hands Python `sys.stdin is None`. Charter
+        classifies what it refuses (ADR 0009); a crash report is not an answer."""
+        rc, _out, err = self._handoff("beta", stdin=None)
+        self.assertEqual(rc, 1)
+        self.assertIn("no stdin at all", err)
         self.assertIn("<<'BRIEF'", err)
         self._nothing_changed()
 
@@ -264,6 +302,27 @@ class AHandoffRefusesBeforeItChangesAnything(_AHandoffFromAlpha):
         self.assertIn("which harness", err)
         self._nothing_changed()
 
+    def test_a_plane_with_no_harness_table_at_all_is_not_a_crash(self):
+        """`config.HARNESS` derives to `None` on a plane whose `charter.toml` declares no
+        `[harness]`, which is every fresh one — `_same_harness_as` carries the same fallback
+        for the same reason."""
+        with mock.patch.dict(os.environ, {}, clear=True), \
+                mock.patch.object(config, "HARNESS", None):
+            rc, _out, err = self._handoff("beta")
+        self.assertEqual(rc, 1)
+        self.assertIn("charter <harness> --workspace beta", err)
+        self._nothing_changed()
+
+    def test_the_planes_declared_default_harness_names_the_command(self):
+        """Nothing in the environment says which harness this is, so the plane's
+        `[harness] default` does — the rung `_same_harness_as` falls to one seam over."""
+        with mock.patch.dict(os.environ, {}, clear=True), \
+                mock.patch.object(config, "HARNESS", {"default": "opencode"}):
+            rc, _out, err = self._handoff("beta")
+        self.assertEqual(rc, 1)
+        self.assertIn("charter opencode --workspace beta --prompt", err)
+        self._nothing_changed()
+
     # -- the background seam --------------------------------------------------------------
 
     def test_a_refusal_from_the_background_seam_changes_nothing(self):
@@ -271,6 +330,10 @@ class AHandoffRefusesBeforeItChangesAnything(_AHandoffFromAlpha):
         rc, _out, err = self._handoff("beta")
         self.assertEqual(rc, 1)
         self.assertIn("cannot open a chat in 'beta': X", err)
+        # And the seam's sentence is passed through UNCHANGED. The stamped-message note
+        # belongs to exactly one of the seam's refusals; appended to all of them it would
+        # explain a byte count to somebody who was refused for a NUL byte.
+        self.assertNotIn("the stamp line, a blank line", err)
         self._nothing_changed()
 
     def test_a_brief_that_fits_alone_but_not_stamped_says_what_was_counted(self):
@@ -331,6 +394,7 @@ class EveryRefusalSaysSomethingDifferent(_AHandoffFromAlpha):
             self._handoff("gamma")[2],
             self._handoff("beta", persona="forj")[2],
             self._handoff("beta", stdin=_ATerminal())[2],
+            self._handoff("beta", stdin=None)[2],
             self._handoff("beta", brief=b"\xff\xfe")[2],
             self._handoff("beta", brief=" \n\n")[2],
             self._handoff("beta", brief=f"Fix it\n{AWS_KEY}\n")[2],

--- a/tests/test_a_handoff_refuses_before_it_changes_anything.py
+++ b/tests/test_a_handoff_refuses_before_it_changes_anything.py
@@ -1,0 +1,350 @@
+"""`charter handoff` refuses everything it can before it changes anything.
+
+A handoff creates a workspace, records a todo, opens a chat and sends it a first message.
+Charter fails toward NO CHANGE, so every reason to refuse is asked before the first write:
+a name that cannot be a workspace, a flag pair that contradicts itself, a persona nobody
+has, a brief that is missing, unreadable or credential-shaped, a shell that is not a chat
+in a frame, and the background seam's own refusals (`commands_frame.background_refusal`,
+which Task 1 exports for exactly this).
+
+Each refusal says the rule worked and names the fix in the same breath (CONTEXT.md), and
+`_nothing_changed` is asserted beside the sentence — a refusal that already wrote the todo
+is not a refusal.
+
+`tests/test_charter_handoff_opens_a_chat_that_starts_working.py` is the other half: what a
+handoff that is NOT refused does, in order.
+"""
+
+from __future__ import annotations
+
+import io
+import os
+import sys
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from types import SimpleNamespace
+from unittest import mock
+
+from charter import (cli, commands_frame, commands_handoff, config, dispatch, todos,
+                     workspace)
+from charter.frame import state
+
+from tests import _tmuxsocket
+from tests._isolation import PlaneIso
+from tests.test_the_chat_bars_plus_makes_a_chat import _a_chat
+
+#: The brief every case sends unless it says otherwise. Two lines, because the first line
+#: becomes the todo's title and the rest must be shown to stay out of it.
+BRIEF = "Fix the widget\nIt breaks on resize.\n"
+
+#: A live specimen of one `hooks._SECRET_CHECKS` rule, taken from
+#: `tests/test_a_secret_guard_names_the_kind_not_the_value.py` rather than invented here —
+#: the handoff refusal reuses that classifier (plan Open question 20) and a second shape
+#: list is how the two come to disagree.
+AWS_KEY = "AKIAQ7VZ3RJHT2LMNPQR"
+
+
+class _ATerminal:
+    """A stdin that says it is a terminal and screams if anything reads it.
+
+    `charter handoff` asks `isatty()` BEFORE any read, because a read on a terminal blocks
+    the turn forever with nothing on screen to say why.
+    """
+
+    def isatty(self) -> bool:
+        return True
+
+    def read(self, *a):
+        raise AssertionError("read a terminal")
+
+    @property
+    def buffer(self):
+        raise AssertionError("read a terminal")
+
+
+class _AHandoffFromAlpha(PlaneIso):
+    """Chat `alpha.1` in workspace `alpha`, a `beta` workspace beside it, the background
+    seam stood in for.
+
+    Fixture only — no test methods here, so importing it into the other Task 2 module
+    costs that module nothing. `self.bg` and `self.open` are the two Task 1 seams: what
+    this suite is about is which refusals `cmd_handoff` reaches and what it wrote by then,
+    not whether tmux really opens a window (Task 1's real-tmux module answers that).
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.enterContext(mock.patch.dict(os.environ, {
+            "CHARTER_SESSION_ID": "alpha.1", "TMUX_PANE": "%1",
+            "CHARTER_HARNESS": "claude-code"}, clear=True))
+        workspace.ensure("alpha")
+        workspace.ensure("beta")
+        _a_chat("alpha.1", ws="alpha", pane="%1")
+        #: The real one, kept so a case about a REAL refusal can hand it back as the
+        #: stand-in's `side_effect` — `enterContext` owns the patcher, and stopping it by
+        #: hand would leave the class's own cleanup stopping it twice.
+        self.real_background_refusal = commands_frame.background_refusal
+        self.bg = self.enterContext(
+            mock.patch("charter.commands_frame.background_refusal", return_value=""))
+        #: What the stand-in seam answers, and what runs while it is "opening".
+        self.opened = commands_frame.Opened(True, "beta.1", "")
+        self.during_open: list = []
+        self.open = self.enterContext(
+            mock.patch("charter.commands_frame.open_in_background", side_effect=self._open))
+
+    def _open(self, ws, *, caller, first_message, persona=""):
+        for fn in self.during_open:
+            fn()
+        if self.opened.ok:
+            # A launcher that opened a chat left its directory and its harness pane behind;
+            # `state.record_brief` needs one to write into.
+            _a_chat(self.opened.chat, ws=ws, pane="%9")
+        return self.opened
+
+    def _handoff(self, ws="beta", brief=BRIEF, *, stdin=None, **flags):
+        """Run `cmd_handoff` with *brief* on stdin; return ``(rc, stdout, stderr)``."""
+        args = SimpleNamespace(workspace=ws, create=flags.get("create", False),
+                               vision=flags.get("vision"), persona=flags.get("persona"))
+        if stdin is None:
+            raw = brief if isinstance(brief, bytes) else brief.encode()
+            stdin = io.TextIOWrapper(io.BytesIO(raw), encoding="utf-8")
+        out, err = io.StringIO(), io.StringIO()
+        was, sys.stdin = sys.stdin, stdin
+        try:
+            with redirect_stdout(out), redirect_stderr(err):
+                rc = commands_handoff.cmd_handoff(args)
+        finally:
+            sys.stdin = was
+        return rc, out.getvalue(), err.getvalue()
+
+    def _nothing_changed(self) -> None:
+        self.assertFalse((config.WORKSPACES_DIR / "gamma").exists())
+        self.assertEqual(todos.count_open("beta"), 0)
+        self.assertEqual(sorted(state._root().rglob("brief")), [])
+        self.assertEqual([o for o in dispatch._read_all() if o.get("event") == "handoff"], [])
+        self.open.assert_not_called()
+
+
+class AHandoffRefusesBeforeItChangesAnything(_AHandoffFromAlpha):
+    # -- the workspace and its flags ---------------------------------------------------
+
+    def test_a_name_that_cannot_be_a_workspace_is_refused(self):
+        rc, _out, err = self._handoff("../x")
+        self.assertEqual(rc, 1)
+        self.assertIn("cannot name a workspace", err)
+        self._nothing_changed()
+
+    def test_a_vision_without_create_is_refused(self):
+        rc, _out, err = self._handoff("beta", vision="v")
+        self.assertEqual(rc, 1)
+        self.assertIn("--vision describes a workspace this call creates", err)
+        self._nothing_changed()
+
+    def test_create_without_a_vision_is_refused(self):
+        rc, _out, err = self._handoff("gamma", create=True)
+        self.assertEqual(rc, 1)
+        self.assertIn("--create needs --vision", err)
+        self._nothing_changed()
+
+    def test_create_on_an_existing_workspace_is_refused(self):
+        rc, _out, err = self._handoff("beta", create=True, vision="v")
+        self.assertEqual(rc, 1)
+        self.assertIn("already exists", err)
+        self._nothing_changed()
+
+    def test_create_on_the_always_present_workspace_is_refused_even_with_no_directory(self):
+        """`default` is selectable whether or not its directory exists — `cmd_workspace_use`'s
+        rule, asked here rather than invented again."""
+        self.assertNotIn(config.DEFAULT_WORKSPACE, workspace.list_workspaces())
+        rc, _out, err = self._handoff(config.DEFAULT_WORKSPACE, create=True, vision="v")
+        self.assertEqual(rc, 1)
+        self.assertIn("already exists", err)
+        self._nothing_changed()
+
+    def test_an_unknown_workspace_is_refused_naming_create_and_vision(self):
+        rc, _out, err = self._handoff("gamma")
+        self.assertEqual(rc, 1)
+        self.assertIn("--create --vision", err)
+        self._nothing_changed()
+
+    def test_an_unknown_persona_is_refused_listing_the_ones_there_are(self):
+        self.make_persona("forge")
+        rc, _out, err = self._handoff("beta", persona="forj")
+        self.assertEqual(rc, 1)
+        self.assertIn("no persona 'forj' — have: forge", err)
+        self._nothing_changed()
+
+    # -- the brief ---------------------------------------------------------------------
+
+    def test_a_terminal_on_stdin_is_refused_without_reading_it(self):
+        rc, _out, err = self._handoff("beta", stdin=_ATerminal())
+        self.assertEqual(rc, 1)
+        self.assertIn("stdin here is a terminal", err)
+        self.assertIn("<<'BRIEF'", err)
+        self._nothing_changed()
+
+    def test_a_brief_that_is_not_utf8_is_refused(self):
+        rc, _out, err = self._handoff("beta", brief=b"\xff\xfe")
+        self.assertEqual(rc, 1)
+        self.assertIn("not UTF-8", err)
+        self._nothing_changed()
+
+    def test_an_empty_brief_is_refused(self):
+        rc, _out, err = self._handoff("beta", brief=" \n\n")
+        self.assertEqual(rc, 1)
+        self.assertIn("the brief on stdin is empty", err)
+        self._nothing_changed()
+
+    def test_a_brief_carrying_a_credential_is_refused_by_kind_not_value(self):
+        rc, _out, err = self._handoff("beta", brief=f"Fix the widget\nuse {AWS_KEY} for S3\n")
+        self.assertEqual(rc, 1)
+        self.assertIn("AWS access key", err)
+        self.assertNotIn(AWS_KEY, err)
+        self.assertNotIn("AKIA", err)
+        self._nothing_changed()
+
+    # -- the frame -----------------------------------------------------------------------
+
+    def test_outside_a_frame_it_refuses_and_prints_the_command_to_run(self):
+        with mock.patch.dict(os.environ, {"CHARTER_HARNESS": "claude-code"}, clear=True):
+            rc, _out, err = self._handoff("beta")
+        self.assertEqual(rc, 1)
+        self.assertIn("not a chat in a charter frame", err)
+        self.assertIn("charter claude --workspace beta", err)
+        self.assertIn("⟨handoff from chat none", err)
+        self._nothing_changed()
+
+    def test_a_chat_whose_pane_is_not_this_process_is_outside_a_frame(self):
+        with mock.patch.dict(os.environ, {"CHARTER_SESSION_ID": "alpha.1", "TMUX_PANE": "%7",
+                                          "CHARTER_HARNESS": "claude-code"}, clear=True):
+            rc, _out, err = self._handoff("beta")
+        self.assertEqual(rc, 1)
+        self.assertIn("not a chat in a charter frame", err)
+        self._nothing_changed()
+
+    def test_inside_your_own_tmux_it_refuses_and_prints_the_command(self):
+        state.record_server("alpha.1", _tmuxsocket.OPERATOR_SOCKET)
+        rc, _out, err = self._handoff("beta")
+        self.assertEqual(rc, 1)
+        self.assertIn("a tmux you already had", err)
+        self.assertIn("charter claude --workspace beta", err)
+        self._nothing_changed()
+
+    def test_the_printed_command_creates_the_workspace_first_when_asked_to(self):
+        with mock.patch.dict(os.environ, {"CHARTER_HARNESS": "claude-code"}, clear=True):
+            rc, _out, err = self._handoff("gamma", create=True, vision="a thing")
+        self.assertEqual(rc, 1)
+        self.assertIn("charter workspace create gamma --vision 'a thing' && "
+                      "charter claude --workspace gamma", err)
+        self._nothing_changed()
+
+    def test_the_printed_command_carries_the_persona_asked_for(self):
+        self.make_persona("forge")
+        with mock.patch.dict(os.environ, {"CHARTER_HARNESS": "claude-code"}, clear=True):
+            rc, _out, err = self._handoff("beta", persona="forge")
+        self.assertEqual(rc, 1)
+        self.assertIn("CHARTER_PERSONA=forge charter claude", err)
+        self._nothing_changed()
+
+    def test_the_printed_command_spells_opencodes_prompt_flag(self):
+        with mock.patch.dict(os.environ, {"CHARTER_HARNESS": "opencode"}, clear=True):
+            rc, _out, err = self._handoff("beta")
+        self.assertEqual(rc, 1)
+        self.assertIn("charter opencode --workspace beta --prompt", err)
+        self._nothing_changed()
+
+    def test_a_harness_nothing_names_leaves_the_word_to_fill_in(self):
+        """No `$CHARTER_HARNESS` and no `[harness] default`: charter prints the command with
+        `<harness>` where the word goes, and says that is what it did rather than picking."""
+        with mock.patch.dict(os.environ, {}, clear=True), \
+                mock.patch.object(config, "HARNESS", {}):
+            rc, _out, err = self._handoff("beta")
+        self.assertEqual(rc, 1)
+        self.assertIn("charter <harness> --workspace beta", err)
+        self.assertIn("which harness", err)
+        self._nothing_changed()
+
+    # -- the background seam --------------------------------------------------------------
+
+    def test_a_refusal_from_the_background_seam_changes_nothing(self):
+        self.bg.return_value = "cannot open a chat in 'beta': X"
+        rc, _out, err = self._handoff("beta")
+        self.assertEqual(rc, 1)
+        self.assertIn("cannot open a chat in 'beta': X", err)
+        self._nothing_changed()
+
+    def test_a_brief_that_fits_alone_but_not_stamped_says_what_was_counted(self):
+        """The seam measures the STAMPED message — the stamp line, a blank line, the brief —
+        so a brief under the bound can still be over once it is stamped. The seam never saw
+        a brief and cannot say that; `charter handoff` says it."""
+        self.bg.side_effect = self.real_background_refusal   # the real bound
+        cap = commands_frame.FIRST_MESSAGE_MAX_BYTES
+        brief = "Fix the widget\n" + "x" * (cap - len("Fix the widget\n"))
+        self.assertEqual(len(os.fsencode(brief)), cap)
+        rc, _out, err = self._handoff("beta", brief=brief)
+        self.assertEqual(rc, 1)
+        self.assertIn(f"past {cap} bytes", err)
+        self.assertIn("the stamp line, a blank line", err)
+        self._nothing_changed()
+
+
+class TheCommandIsReachable(unittest.TestCase):
+    """`charter handoff` is a word the CLI parses, with exactly the flags the spec names."""
+
+    def test_the_word_parses_to_the_command(self):
+        args = cli.build_parser().parse_args(
+            ["handoff", "beta", "--create", "--vision", "v", "--persona", "forge"])
+        self.assertIs(args.func, commands_handoff.cmd_handoff)
+        self.assertEqual(args.workspace, "beta")
+        self.assertIs(args.create, True)
+        self.assertEqual(args.vision, "v")
+        self.assertEqual(args.persona, "forge")
+
+    def test_the_workspace_is_always_named(self):
+        """The permission prompt has to say where the chat goes, and `.` says nothing."""
+        with self.assertRaises(SystemExit), redirect_stderr(io.StringIO()):
+            cli.build_parser().parse_args(["handoff"])
+
+    def test_there_is_no_brief_file_flag(self):
+        """A prompt that shows a path is an approval of a path, not of the brief."""
+        with self.assertRaises(SystemExit), redirect_stderr(io.StringIO()):
+            cli.build_parser().parse_args(["handoff", "beta", "--brief-file", "b.md"])
+
+    def test_there_is_no_harness_flag(self):
+        with self.assertRaises(SystemExit), redirect_stderr(io.StringIO()):
+            cli.build_parser().parse_args(["handoff", "beta", "--harness", "codex"])
+
+    def test_there_is_no_repo_flag(self):
+        with self.assertRaises(SystemExit), redirect_stderr(io.StringIO()):
+            cli.build_parser().parse_args(["handoff", "beta", "--repo", "charter"])
+
+
+class EveryRefusalSaysSomethingDifferent(_AHandoffFromAlpha):
+    def test_every_refusal_says_something_different(self):
+        """A refusal a reader cannot tell from another is a refusal that teaches nothing."""
+        self.make_persona("forge")
+        said = [
+            self._handoff("../x")[2],
+            self._handoff("beta", vision="v")[2],
+            self._handoff("gamma", create=True)[2],
+            self._handoff("beta", create=True, vision="v")[2],
+            self._handoff("gamma")[2],
+            self._handoff("beta", persona="forj")[2],
+            self._handoff("beta", stdin=_ATerminal())[2],
+            self._handoff("beta", brief=b"\xff\xfe")[2],
+            self._handoff("beta", brief=" \n\n")[2],
+            self._handoff("beta", brief=f"Fix it\n{AWS_KEY}\n")[2],
+        ]
+        with mock.patch.dict(os.environ, {"CHARTER_HARNESS": "claude-code"}, clear=True):
+            said.append(self._handoff("beta")[2])
+        state.record_server("alpha.1", _tmuxsocket.OPERATOR_SOCKET)
+        said.append(self._handoff("beta")[2])
+        state.record_server("alpha.1", commands_frame.SOCKET)   # back in charter's own tmux
+        self.bg.return_value = "cannot open a chat in 'beta': X"
+        said.append(self._handoff("beta")[2])
+        self.assertNotIn("", said)
+        self.assertEqual(len(set(said)), len(said), said)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()

--- a/tests/test_a_handoff_refuses_before_it_changes_anything.py
+++ b/tests/test_a_handoff_refuses_before_it_changes_anything.py
@@ -332,13 +332,29 @@ class AHandoffRefusesBeforeItChangesAnything(_AHandoffFromAlpha):
     def test_a_long_brief_is_printed_whole_rather_than_clipped_to_a_report_line(self):
         """`contain.one_line`'s budget is 160 characters, which is right for a report row
         and wrong for a command whose point is that it can be pasted and run. The escape is
-        asked for without that clip (`handoff._WIDEST_ESCAPE`)."""
+        asked for without that clip (`handoff._NO_CLIP`)."""
         brief = "Fix the widget\n" + "x" * 4000 + "\n"
         with mock.patch.dict(os.environ, {"CHARTER_HARNESS": "claude-code"}, clear=True):
             rc, _out, err = self._handoff("beta", brief=brief)
         self.assertEqual(rc, 1)
         self.assertIn("x" * 4000, err)
         self.assertNotIn("…", err)
+
+    def test_a_brief_made_of_escaped_characters_is_printed_whole_too(self):
+        """The half the case above cannot see: its 4,000 characters need no escaping, so it
+        is green under ANY per-character budget, right or wrong. The budget WAS wrong — 6,
+        for the `\\uXXXX` form — while `contain.one_line` formats with `:04x`, a minimum
+        width, so a codepoint outside the BMP renders as seven characters. U+E0001 is the
+        Unicode language tag, invisible by category and exactly that shape, and a thousand
+        of them clipped the pasted line to `…`: the failure the escaping exists to
+        prevent, reintroduced by the arithmetic meant to avoid it."""
+        brief = "Fix the widget\n" + "\U000e0001" * 1000 + "\n"
+        with mock.patch.dict(os.environ, {"CHARTER_HARNESS": "claude-code"}, clear=True):
+            rc, _out, err = self._handoff("beta", brief=brief)
+        self.assertEqual(rc, 1)
+        self.assertEqual(err.count("\\ue0001"), 1000)
+        self.assertNotIn("…", err)
+        self.assertNotIn("\U000e0001", err)
 
     def test_a_harness_nothing_names_leaves_the_word_to_fill_in(self):
         """No `$CHARTER_HARNESS` and no `[harness] default`: charter prints the command with

--- a/tests/test_a_handoff_refuses_before_it_changes_anything.py
+++ b/tests/test_a_handoff_refuses_before_it_changes_anything.py
@@ -43,6 +43,18 @@ BRIEF = "Fix the widget\nIt breaks on resize.\n"
 #: list is how the two come to disagree.
 AWS_KEY = "AKIAQ7VZ3RJHT2LMNPQR"
 
+#: Four ways a byte reaches a terminal and does something rather than showing something,
+#: as ``(name, the raw text, the escape it must arrive as)``. A brief is prose a MODEL
+#: wrote and charter prints it back — on the one line charter tells the operator to paste
+#: into a new terminal, which is why these are asserted both ways round: the escape is
+#: there AND the raw bytes are not.
+HOSTILE = (
+    ("an ANSI erase", "\x1b[2J", "\\x1b"),
+    ("a carriage return", "\r✓ opened chat beta.9", "\\x0d"),
+    ("a run of backspaces", "opened\x08\x08\x08\x08\x08\x08", "\\x08"),
+    ("a bidi override", "‮derepo/‬", "\\u202e"),
+)
+
 #: "`_handoff` was given no stdin to use", distinct from ``None``, which is a stdin a test
 #: is stating: Python hands `sys.stdin` as ``None`` in a process whose fd 0 is closed.
 _UNSET = object()
@@ -290,6 +302,43 @@ class AHandoffRefusesBeforeItChangesAnything(_AHandoffFromAlpha):
         self.assertEqual(rc, 1)
         self.assertIn("charter opencode --workspace beta --prompt", err)
         self._nothing_changed()
+
+    def test_the_command_it_tells_you_to_paste_carries_no_control_characters(self):
+        """`shlex.quote` wraps a word in single quotes and escapes NOTHING, which is what
+        the shell needs and says nothing about what a terminal does with the bytes inside
+        them. This line carries the whole brief — a model's prose — and it is the one
+        refusal charter tells the operator to paste into a new terminal, so a brief opening
+        `\\r✓ opened chat beta.9` would repaint charter's own refusal as a success."""
+        for name, raw, escaped in HOSTILE:
+            with self.subTest(name), \
+                    mock.patch.dict(os.environ, {"CHARTER_HARNESS": "claude-code"},
+                                    clear=True):
+                rc, _out, err = self._handoff("beta", brief=f"Fix {raw} the widget\nmore\n")
+            self.assertEqual(rc, 1)
+            self.assertIn("Run this in a new terminal instead", err)
+            self.assertIn(escaped, err)
+            self.assertNotIn(raw, err)
+
+    def test_the_same_holds_for_the_command_printed_inside_your_own_tmux(self):
+        """The second surface with the same text on it. Two refusals print this command;
+        containing one of them would be a fix that half the callers walk past."""
+        state.record_server("alpha.1", _tmuxsocket.OPERATOR_SOCKET)
+        rc, _out, err = self._handoff("beta", brief="Fix \x1b[2J the widget\nmore\n")
+        self.assertEqual(rc, 1)
+        self.assertIn("a tmux you already had", err)
+        self.assertIn("\\x1b", err)
+        self.assertNotIn("\x1b[2J", err)
+
+    def test_a_long_brief_is_printed_whole_rather_than_clipped_to_a_report_line(self):
+        """`contain.one_line`'s budget is 160 characters, which is right for a report row
+        and wrong for a command whose point is that it can be pasted and run. The escape is
+        asked for without that clip (`handoff._WIDEST_ESCAPE`)."""
+        brief = "Fix the widget\n" + "x" * 4000 + "\n"
+        with mock.patch.dict(os.environ, {"CHARTER_HARNESS": "claude-code"}, clear=True):
+            rc, _out, err = self._handoff("beta", brief=brief)
+        self.assertEqual(rc, 1)
+        self.assertIn("x" * 4000, err)
+        self.assertNotIn("…", err)
 
     def test_a_harness_nothing_names_leaves_the_word_to_fill_in(self):
         """No `$CHARTER_HARNESS` and no `[harness] default`: charter prints the command with

--- a/tests/test_charter_handoff_opens_a_chat_that_starts_working.py
+++ b/tests/test_charter_handoff_opens_a_chat_that_starts_working.py
@@ -321,18 +321,48 @@ class TheFactsAHandoffIsMadeOf(PersonaIso):
     no plane, no workspace and no tmux — and `state.brief`'s four ways of saying nothing are
     one answer."""
 
+    def test_a_first_line_ends_where_the_operator_ended_it(self):
+        """`str.splitlines` breaks on `\\r`, `\\x0b`, `\\x0c`, `\\x1c`–`\\x1e` and U+2028
+        as well as `\\n`, so charter's "first line" was a PREFIX of the line the operator
+        typed whenever a brief carried one — two meanings for one phrase, silently. A shell
+        heredoc ends a line at `\\n`, which is what they typed into."""
+        for name, ch in (("a carriage return", "\r"), ("a vertical tab", "\x0b"),
+                         ("a form feed", "\x0c"), ("a line separator", " ")):
+            with self.subTest(name):
+                self.assertEqual(handoff.title(f"Fix{ch}the widget\nmore\n"),
+                                 f"Fix{ch}the widget")
+
     def test_a_brief_with_no_words_has_no_title(self):
         """Total, so the todo writer never sees `None`. A brief this empty is refused long
         before a todo is written; the answer still has to be a string."""
         self.assertEqual(handoff.title("\n  \n"), "")
 
-    def test_the_printed_command_survives_a_create_with_no_vision(self):
-        """`--create` without `--vision` is refused before this is reached, so the empty
-        vision is this function's total answer rather than a case the command can produce."""
+    def test_a_title_is_trimmed_at_both_ends(self):
+        """A heredoc line often carries the indentation it was written with, and the
+        trailing half is the one an `lstrip` would leave on — in a `# ` heading, an index
+        row and a filename slug."""
+        self.assertEqual(handoff.title("   Fix the widget   \nmore\n"), "Fix the widget")
+
+    def test_a_chat_whose_brief_cannot_be_read_has_none(self):
+        """Every reader under `state` answers "charter does not know" rather than raising
+        into whatever was drawing. A directory where the file should be is the cheapest way
+        to make the read fail that does not depend on who is running the suite."""
+        (state.frame_dir("beta.1", create=True) / "brief").mkdir()
+        self.assertIsNone(state.brief("beta.1"))
+
+    def test_a_workspace_that_is_already_there_gets_no_create_in_front(self):
+        """One parameter says both halves: `None` is "it exists", a string is "make it with
+        this vision". `--create` without `--vision` is refused long before this, so a
+        `create` flag beside an optional vision was a pair that could only be wrong
+        together — and the `or ""` standing in for the impossible half was unreachable."""
         self.assertEqual(
-            handoff.terminal_command(cli_name="claude", workspace="g", extra=[], create=True,
-                                     vision=None, persona=None),
-            "charter workspace create g --vision '' && charter claude --workspace g")
+            handoff.terminal_command(cli_name="claude", workspace="g", extra=[],
+                                     create_vision=None, persona=None),
+            "charter claude --workspace g")
+        self.assertEqual(
+            handoff.terminal_command(cli_name="claude", workspace="g", extra=[],
+                                     create_vision="a thing", persona=None),
+            "charter workspace create g --vision 'a thing' && charter claude --workspace g")
 
     def test_a_chat_charter_knows_nothing_about_has_no_brief(self):
         self.assertIsNone(state.brief("nobody.9"))
@@ -357,6 +387,19 @@ class TheFactsAHandoffIsMadeOf(PersonaIso):
         into whatever was calling it."""
         state.record_brief("../escape", "x")
         self.assertIsNone(state.brief("../escape"))
+
+    def test_a_brief_the_filesystem_refuses_is_not_an_exception_either(self):
+        """The other half of that promise, and the one a bad path cannot reach: the id is
+        fine and the WRITE fails. This one runs inside `commands_frame._launch`, a few lines
+        before the window that starts the harness — a raise here would take the launch down
+        over a file nothing has read yet."""
+        if os.geteuid() == 0:
+            self.skipTest("root ignores the mode, so this says nothing about the guard")
+        d = state.frame_dir("beta.1", create=True)
+        d.chmod(0o500)
+        self.addCleanup(d.chmod, 0o700)
+        state.record_brief("beta.1", "fix it\n")     # must not raise
+        self.assertIsNone(state.brief("beta.1"))
 
 
 class TheHookClearsTheRoutingMark(PlaneIso):

--- a/tests/test_charter_handoff_opens_a_chat_that_starts_working.py
+++ b/tests/test_charter_handoff_opens_a_chat_that_starts_working.py
@@ -73,6 +73,10 @@ class AHandoffOpensAChatThatStartsWorking(_AHandoffFromAlpha):
         self._handoff("beta")
         self.assertEqual(self.open.call_args.args, ("beta",))
         self.assertEqual(self.open.call_args.kwargs["caller"], "alpha.1")
+        # `""` and never `None`: the seam's contract is a string, and `Opening.persona`
+        # reaches `persona.set_active` — `--persona` simply absent is not a persona named
+        # `None`.
+        self.assertEqual(self.open.call_args.kwargs["persona"], "")
 
     def test_this_workspace_is_named_like_any_other(self):
         """A chat here and a chat elsewhere are one mechanism; only the workspace differs."""
@@ -126,6 +130,19 @@ class AHandoffOpensAChatThatStartsWorking(_AHandoffFromAlpha):
         self.assertEqual(rc, 0)
         self.assertEqual(todos.count_open("beta"), 1)
         self.assertIn("not recorded twice", err)
+
+    def test_a_duplicate_notice_cannot_repaint_the_terminal_it_prints_on(self):
+        """The title in that notice is a brief's first line, which is whatever the operator
+        approved — arbitrary text, escape sequences included. charter's own lines are lines a
+        person reads, so the name goes through `contain.one_line` and an ESC arrives as its
+        own escape rather than as a command to the terminal."""
+        brief = "Fix \x1b[2Jthe widget\nIt breaks on resize.\n"
+        self._handoff("beta", brief=brief)
+        rc, _out, err = self._handoff("beta", brief=brief)
+        self.assertEqual(rc, 0)
+        self.assertIn("not recorded twice", err)
+        self.assertIn("\\x1b", err)
+        self.assertNotIn("\x1b[2J", err)
 
     def test_a_second_handoff_about_something_else_records_its_own_todo(self):
         """Every handoff todo ends in the same nine-word provenance sentence. Compared over
@@ -280,10 +297,13 @@ class AHandoffOpensAChatThatStartsWorking(_AHandoffFromAlpha):
         self.assertEqual([o for o in dispatch._read_all() if o.get("event") == "handoff"], [])
 
     def test_a_created_workspace_that_got_no_chat_is_named_in_what_stayed(self):
+        """Both halves, joined as one sentence a person reads — the two things a failed
+        handoff left on disk, in the order it made them."""
         self.opened = commands_frame.Opened(False, "", "could not open a chat in 'gamma'")
         rc, _out, err = self._handoff("gamma", create=True, vision="Ship it")
         self.assertEqual(rc, 1)
-        self.assertIn("the workspace 'gamma' was created", err)
+        self.assertIn("What stays: the todo is recorded in 'gamma', and the workspace "
+                      "'gamma' was created. ", err)
 
     def test_what_stays_says_the_todo_was_already_there_when_it_was(self):
         """What stays has to be true of THIS call: a reader told "the todo is recorded" who

--- a/tests/test_charter_handoff_opens_a_chat_that_starts_working.py
+++ b/tests/test_charter_handoff_opens_a_chat_that_starts_working.py
@@ -37,6 +37,22 @@ from tests.test_the_chat_bars_plus_makes_a_chat import _a_chat
 WHEN = datetime.datetime(2026, 9, 10, 14, 5)
 STAMP = "⟨handoff from chat alpha.1 · workspace alpha · 2026-09-10 14:05⟩"
 
+#: Every byte a handoff on :data:`BRIEF` commits, with only the recorded timestamp standing
+#: in for itself. **Spelled out rather than built from `handoff.todo_text`**: an expectation
+#: computed from the function under test moves with it, and an equality against a recomputed
+#: `todo_text` passed with the whole brief in the file. `It breaks on resize.` — the brief's
+#: second line — is the thing that must not be here, and it is not here in any shape.
+COMMITTED_TODO = (
+    "# Fix the widget\n"
+    "\n"
+    "<stamp>\n"
+    "\n"
+    "Fix the widget\n"
+    "\n"
+    "Handed off from chat alpha.1 · workspace alpha. The full brief is private to the "
+    "chat it opened.\n"
+)
+
 
 class AHandoffOpensAChatThatStartsWorking(_AHandoffFromAlpha):
     def setUp(self) -> None:
@@ -161,28 +177,27 @@ class AHandoffOpensAChatThatStartsWorking(_AHandoffFromAlpha):
         """A LIVE workspace commits `todos/**`, and a brief may quote anything — a
         transcript, a customer's data, the text of a secret it is warning the next chat off.
 
-        **Equality, on the RAW files.** Read through `open_todos()["text"]`, which is
-        `memstore.body()` — stripped and lowercased — putting the WHOLE brief in the todo
-        left 807 tests green; and a substring check for one fixture line still passed while
-        `brief[:-2]`, 34 of its 36 characters, leaked. Every byte that gets committed is
-        named here, so anything extra fails whatever shape it arrives in. Only the recorded
-        timestamp is matched rather than spelled."""
+        **The expected file is written out, byte for byte.** Three weaker spellings of this
+        assertion each let a leak through: `open_todos()["text"]` reads `memstore.body()`,
+        stripped and lowercased, so the WHOLE brief in the todo left 807 tests green; a
+        substring check for one fixture line passed `brief[:-2]`, 34 of its 36 characters;
+        and an equality against `handoff.todo_text(BRIEF, …)` recomputed here passed both of
+        those, because it is the function under test and moves with it. The trap this branch
+        already named for `TITLE_MAX`: an expectation computed from the value it checks pins
+        nothing. Only the recorded timestamp is matched rather than spelled."""
         self._handoff("beta")
         files = [p for p in sorted(todos.todos_dir("beta").rglob("*")) if p.is_file()]
         index = todos.index("beta")
         [todo] = [p for p in files if p != index]
         self.assertEqual([p.name for p in files], sorted([index.name, todo.name]))
 
-        head, blank, stamp, blank2, *rest = todo.read_text().splitlines()
-        self.assertEqual(head, "# Fix the widget")
-        self.assertEqual([blank, blank2], ["", ""])
-        self.assertRegex(stamp, r"^_\d{4}-\d{2}-\d{2} \d{2}:\d{2} · persistent_$")
-        self.assertEqual("\n".join(rest), handoff.todo_text(
-            BRIEF, source_chat="alpha.1", source_workspace="alpha"))
+        lines = todo.read_text().splitlines(keepends=True)
+        self.assertRegex(lines[2], r"^_\d{4}-\d{2}-\d{2} \d{2}:\d{2} · persistent_\n$")
+        lines[2] = "<stamp>\n"
+        self.assertEqual("".join(lines), COMMITTED_TODO)
 
-        self.assertEqual(index.read_text(),
-                         todos._HEADER.format(name="beta")
-                         + f"- [Fix the widget]({todo.name})\n")
+        rows = [ln for ln in index.read_text().splitlines() if ln.startswith("- ")]
+        self.assertEqual(rows, [f"- [Fix the widget]({todo.name})"])
 
     # -- the private brief -----------------------------------------------------------------
 

--- a/tests/test_charter_handoff_opens_a_chat_that_starts_working.py
+++ b/tests/test_charter_handoff_opens_a_chat_that_starts_working.py
@@ -1,0 +1,309 @@
+"""`charter handoff` opens a chat that is already working on the brief you approved.
+
+The other half of `tests/test_a_handoff_refuses_before_it_changes_anything.py`: what a
+handoff that is not refused DOES, in the spec's order — create the workspace, record the
+todo, open the chat in the background, keep the full brief in that chat's private state,
+tally the event with no names in it, and print where the chat landed.
+
+Three properties are load-bearing beyond "it worked":
+
+* **The first message is the stamp, a blank line and the brief verbatim.** The stamp is
+  facts charter knows and carries no instruction, so the new chat — and whoever reads it
+  later — can tell the first message was not typed there.
+* **The todo carries the title and the provenance, never the brief.** A LIVE workspace
+  commits `todos/**`, and a brief never reaches a committed file.
+* **The routing mark clears on a handoff, and only after A7 has had its say.** The handoff
+  IS the routing answer `routing: require` asked for; a handoff A7 refused opened nothing,
+  so that turn still owes one (`tests/test_a_handoff_waits_for_a_yes.py` pins that side).
+"""
+
+from __future__ import annotations
+
+import datetime
+import json
+import os
+import unittest
+from unittest import mock
+
+from charter import commands_frame, config, dispatch, handoff, hooks, todos, workspace
+from charter.frame import state
+
+from tests._isolation import PersonaIso, PlaneIso, no_background_refresh, run_hook
+from tests.test_a_handoff_refuses_before_it_changes_anything import BRIEF, _AHandoffFromAlpha
+from tests.test_the_chat_bars_plus_makes_a_chat import _a_chat
+
+#: Frozen so the stamp is a string this file can spell out rather than rebuild from the
+#: same call it is checking.
+WHEN = datetime.datetime(2026, 9, 10, 14, 5)
+STAMP = "⟨handoff from chat alpha.1 · workspace alpha · 2026-09-10 14:05⟩"
+
+
+class AHandoffOpensAChatThatStartsWorking(_AHandoffFromAlpha):
+    def setUp(self) -> None:
+        super().setUp()
+        self.enterContext(mock.patch("charter.handoff._now", return_value=WHEN))
+
+    # -- the stamp and the first message -------------------------------------------------
+
+    def test_the_stamp_is_facts_and_no_instruction(self):
+        self.assertEqual(handoff.stamp("alpha.1", "alpha", WHEN), STAMP)
+
+    def test_the_first_message_is_the_stamp_a_blank_line_and_the_brief_verbatim(self):
+        rc, _out, _err = self._handoff("beta")
+        self.assertEqual(rc, 0)
+        self.assertEqual(self.open.call_args.kwargs["first_message"], f"{STAMP}\n\n{BRIEF}")
+
+    def test_the_chat_opens_in_the_named_workspace_from_the_calling_chat(self):
+        self._handoff("beta")
+        self.assertEqual(self.open.call_args.args, ("beta",))
+        self.assertEqual(self.open.call_args.kwargs["caller"], "alpha.1")
+
+    def test_this_workspace_is_named_like_any_other(self):
+        """A chat here and a chat elsewhere are one mechanism; only the workspace differs."""
+        rc, _out, _err = self._handoff("alpha")
+        self.assertEqual(rc, 0)
+        self.assertEqual(self.open.call_args.args, ("alpha",))
+
+    def test_the_persona_asked_for_reaches_the_seam(self):
+        self.make_persona("forge")
+        rc, _out, _err = self._handoff("beta", persona="forge")
+        self.assertEqual(rc, 0)
+        self.assertEqual(self.open.call_args.kwargs["persona"], "forge")
+
+    # -- the workspace ---------------------------------------------------------------------
+
+    def test_create_makes_a_local_workspace_with_its_vision_before_the_chat_opens(self):
+        seen = []
+        self.during_open.append(lambda: seen.append(workspace.read_vision("gamma")))
+        rc, _out, _err = self._handoff("gamma", create=True, vision="Ship it")
+        self.assertEqual(rc, 0)
+        self.assertEqual(seen, ["Ship it"])
+        # LOCAL, never `set_live`: a workspace created by a handoff commits nothing, and a
+        # LIVE one would commit the todo the handoff just recorded.
+        self.assertFalse(workspace.is_live("gamma"))
+
+    # -- the todo --------------------------------------------------------------------------
+
+    def test_a_todo_titled_by_the_briefs_first_line_is_recorded_in_the_target(self):
+        self._handoff("beta")
+        rows = todos.open_todos("beta")
+        self.assertEqual([r["title"] for r in rows], ["Fix the widget"])
+        self.assertNotIn("It breaks on resize.", rows[0]["text"])
+
+    def test_the_todo_is_recorded_before_the_chat_opens(self):
+        """A chat that fails to open leaves the work written down somewhere a person reads."""
+        seen = []
+        self.during_open.append(lambda: seen.append(todos.count_open("beta")))
+        self._handoff("beta")
+        self.assertEqual(seen, [1])
+
+    def test_a_brief_whose_first_line_is_blank_is_titled_by_its_first_words(self):
+        self._handoff("beta", brief="\n\nFix it\nmore\n")
+        self.assertEqual([r["title"] for r in todos.open_todos("beta")], ["Fix it"])
+
+    def test_a_todo_already_on_the_list_is_not_recorded_twice_and_the_chat_still_opens(self):
+        """A second chat on the same brief may be exactly what was approved, so the duplicate
+        is reported and the handoff continues."""
+        todos.add("beta", handoff.todo_text(BRIEF, source_chat="alpha.1",
+                                            source_workspace="alpha"))
+        rc, _out, err = self._handoff("beta")
+        self.assertEqual(rc, 0)
+        self.assertEqual(todos.count_open("beta"), 1)
+        self.assertIn("not recorded twice", err)
+
+    # -- the private brief -----------------------------------------------------------------
+
+    def test_the_full_brief_is_kept_in_the_new_chats_private_state(self):
+        self._handoff("beta")
+        self.assertEqual(state.brief("beta.1"), BRIEF)
+        p = state.frame_dir("beta.1") / "brief"
+        self.assertTrue(p.is_relative_to(config.STATE_DIR), p)
+        self.assertEqual(os.stat(p).st_mode & 0o077, 0)
+
+    def test_a_new_frame_claiming_the_id_does_not_take_the_brief(self):
+        """`clear_shape` forgets a previous frame's READINGS. A brief is what the chat was
+        opened to do, which is the same kind of fact as its workspace."""
+        self._handoff("beta")
+        state.clear_shape("beta.1")
+        self.assertEqual(state.brief("beta.1"), BRIEF)
+
+    # -- the tally -------------------------------------------------------------------------
+
+    def test_a_handoff_event_is_tallied_with_no_names_and_no_text(self):
+        self._handoff("beta")
+        rows = [o for o in dispatch._read_all() if o.get("event") == "handoff"]
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(set(rows[0]), {"created", "event", "placement", "ts"})
+        self.assertEqual(rows[0]["placement"], "elsewhere")
+        self.assertIs(rows[0]["created"], False)
+        text = dispatch.path_for().read_text()
+        self.assertNotIn("Fix the widget", text)
+        self.assertNotIn("beta", text)
+
+    def test_a_handoff_into_this_workspace_is_tallied_as_here(self):
+        self._handoff("alpha")
+        rows = [o for o in dispatch._read_all() if o.get("event") == "handoff"]
+        self.assertEqual([r["placement"] for r in rows], ["here"])
+
+    def test_a_created_workspace_is_tallied_as_created(self):
+        self._handoff("gamma", create=True, vision="Ship it")
+        rows = [o for o in dispatch._read_all() if o.get("event") == "handoff"]
+        self.assertEqual([r["created"] for r in rows], [True])
+
+    def test_a_handoff_event_is_not_a_dispatch(self):
+        """The dispatch column is read as "times dispatched as a sub-agent", and it is what
+        personas get retired on."""
+        self._handoff("beta")
+        self.assertEqual(dispatch.tally(), {})
+        self.assertIsNone(dispatch.last_seen("beta"))
+
+    # -- what it says ----------------------------------------------------------------------
+
+    def test_the_new_chat_and_its_workspace_are_printed(self):
+        rc, out, _err = self._handoff("beta")
+        self.assertEqual(rc, 0)
+        self.assertEqual(out, "charter handoff: opened chat beta.1 in workspace 'beta', "
+                              "started on the brief\n")
+
+    def test_a_chat_that_did_not_open_says_what_stayed(self):
+        self.opened = commands_frame.Opened(
+            False, "", "could not open a chat in 'beta' — the launcher returned 1 and no "
+                       "chat came back")
+        rc, _out, err = self._handoff("beta")
+        self.assertEqual(rc, 1)
+        self.assertIn("the todo is recorded in 'beta'", err)
+        self.assertEqual(sorted(state._root().rglob("brief")), [])
+        self.assertEqual([o for o in dispatch._read_all() if o.get("event") == "handoff"], [])
+
+    def test_a_created_workspace_that_got_no_chat_is_named_in_what_stayed(self):
+        self.opened = commands_frame.Opened(False, "", "could not open a chat in 'gamma'")
+        rc, _out, err = self._handoff("gamma", create=True, vision="Ship it")
+        self.assertEqual(rc, 1)
+        self.assertIn("the workspace 'gamma' was created", err)
+
+    def test_what_stays_says_the_todo_was_already_there_when_it_was(self):
+        """What stays has to be true of THIS call: a reader told "the todo is recorded" who
+        then finds one older row reads the sentence as a lie about the one thing left behind."""
+        todos.add("beta", handoff.todo_text(BRIEF, source_chat="alpha.1",
+                                            source_workspace="alpha"))
+        self.opened = commands_frame.Opened(False, "", "could not open a chat in 'beta'")
+        rc, _out, err = self._handoff("beta")
+        self.assertEqual(rc, 1)
+        self.assertIn("the todo was already on 'beta's list", err)
+
+
+class TheFactsAHandoffIsMadeOf(PersonaIso):
+    """`charter/handoff.py` holds no I/O beyond one stream, so its strings are checkable with
+    no plane, no workspace and no tmux — and `state.brief`'s four ways of saying nothing are
+    one answer."""
+
+    def test_a_brief_with_no_words_has_no_title(self):
+        """Total, so the todo writer never sees `None`. A brief this empty is refused long
+        before a todo is written; the answer still has to be a string."""
+        self.assertEqual(handoff.title("\n  \n"), "")
+
+    def test_the_printed_command_survives_a_create_with_no_vision(self):
+        """`--create` without `--vision` is refused before this is reached, so the empty
+        vision is this function's total answer rather than a case the command can produce."""
+        self.assertEqual(
+            handoff.terminal_command(cli_name="claude", workspace="g", extra=[], create=True,
+                                     vision=None, persona=None),
+            "charter workspace create g --vision '' && charter claude --workspace g")
+
+    def test_a_chat_charter_knows_nothing_about_has_no_brief(self):
+        self.assertIsNone(state.brief("nobody.9"))
+
+    def test_an_empty_brief_file_is_no_brief(self):
+        """A chat shown an empty labelled block would read it as "your brief was blank"."""
+        state.record_brief("beta.1", "")
+        self.assertIsNone(state.brief("beta.1"))
+
+    def test_a_brief_charter_cannot_write_is_not_an_exception(self):
+        """Every writer under `state` degrades to "charter does not know" rather than raising
+        into whatever was calling it."""
+        state.record_brief("../escape", "x")
+        self.assertIsNone(state.brief("../escape"))
+
+
+class TheHookClearsTheRoutingMark(PlaneIso):
+    """`routing: require` marks a turn that saw the roster and dispatched nothing. A handoff
+    IS that routing answer, so it clears the mark the way a dispatch does."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.enterContext(mock.patch.dict(os.environ, {"CHARTER_HARNESS": "claude-code"},
+                                          clear=True))
+        workspace.ensure("alpha")
+
+    def _bash(self, command):
+        return run_hook(hooks.pretooluse, {
+            "session_id": "s", "tool_input": {"command": command},
+            "cwd": str(workspace.workspace_dir("alpha"))})
+
+    def test_a_handoff_clears_the_routing_mark_like_a_dispatch(self):
+        hooks._route_mark_set("s", ["forge"])
+        self._bash("charter handoff beta <<'BRIEF'\nfix it\nBRIEF")
+        self.assertIsNone(hooks._route_mark_take("s"))
+
+    def test_a_command_that_only_mentions_handoff_keeps_the_mark(self):
+        hooks._route_mark_set("s", ["forge"])
+        self._bash("echo 'charter handoff beta'")
+        self.assertEqual(hooks._route_mark_take("s"), ["forge"])
+
+    def test_a_handed_off_chat_with_its_brief_recorded_may_hand_off_again(self):
+        """No depth limit: every hop needs its own yes (spec: Consent). The chat that was
+        handed off carries its brief in private state, which is the variant Task 4 could not
+        write — and it changes nothing about whether the guard lets the next handoff through."""
+        _a_chat("beta.1", ws="beta", pane="%9")
+        state.record_brief("beta.1", "x")
+        with mock.patch.dict(os.environ, {"CHARTER_HARNESS": "claude-code",
+                                          "CHARTER_SESSION_ID": "beta.1"}, clear=True):
+            out = self._bash("charter handoff beta <<'BRIEF'\nFix the widget.\nBRIEF")
+        decision = ((out or {}).get("hookSpecificOutput") or {}).get("permissionDecision")
+        self.assertNotEqual(decision, "deny", out)
+
+
+class OutsideAPlaneTheMarkIsNobodysBusiness(PersonaIso):
+    """The mark lives under a plane's own state directory. Outside one, `config.STATE_DIR` is
+    whatever repository the plugin is enabled in, and charter writes nothing there (#852)."""
+
+    def test_outside_a_plane_it_touches_no_mark(self):
+        with mock.patch.dict(os.environ, {"CHARTER_HARNESS": "claude-code"}, clear=True):
+            hooks._route_mark_set("s", ["forge"])
+            run_hook(hooks.pretooluse, {
+                "session_id": "s", "cwd": str(self.tmp),
+                "tool_input": {"command": "charter handoff beta <<'BRIEF'\nfix it\nBRIEF"}})
+            self.assertEqual(hooks._route_mark_take("s"), ["forge"])
+
+
+class AHandedOffChatIsBornInItsWorkspace(PlaneIso):
+    """#936's property, observed from outside: a chat a handoff opened is locked to the
+    workspace it was launched in, so its SessionStart asks no workspace question.
+
+    `beta.1` is planted exactly the way `_launch` leaves a chat — the server marker, the
+    launch-recorded workspace, the identity the launch emptied (`open_in_background` empties
+    `$CHARTER_WORKSPACE` so the CALLING chat's pin cannot file the new chat under its own
+    workspace), and the harness pane.
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+        no_background_refresh(self)
+        workspace.ensure("beta")
+        state.frame_dir("beta.1", create=True)
+        state.record_server("beta.1", commands_frame.SOCKET)
+        state.record_workspace("beta.1", "beta")
+        state.record_identity("beta.1", {"CHARTER_WORKSPACE": "",
+                                         "CHARTER_HARNESS": "claude-code"})
+        state.record_harness_pane("beta.1", "%9")
+        self.enterContext(mock.patch.dict(os.environ, {"CHARTER_SESSION_ID": "beta.1",
+                                                       "TMUX_PANE": "%9"}, clear=True))
+
+    def test_a_handed_off_chat_is_asked_no_workspace_question(self):
+        out = run_hook(hooks.sessionstart, {"session_id": "s"})
+        context = json.dumps(out or {})
+        self.assertNotIn("Confirm the workspace before any repo work", context)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()

--- a/tests/test_charter_handoff_opens_a_chat_that_starts_working.py
+++ b/tests/test_charter_handoff_opens_a_chat_that_starts_working.py
@@ -134,18 +134,55 @@ class AHandoffOpensAChatThatStartsWorking(_AHandoffFromAlpha):
         self.assertIn("not recorded twice", err)
         self.assertEqual([r["title"] for r in todos.open_todos("beta")], ["Fix the widget"])
 
-    def test_the_brief_itself_never_reaches_the_committed_todo(self):
+    def test_the_same_short_worded_brief_twice_still_collapses_to_one_todo(self):
+        """`memstore.wordset` keeps words longer than three characters, so `fix the bug` has
+        no comparable word at all and two of them agreed on NOTHING — the same brief handed
+        off three times recorded three identical todos with no notice. Where the overlap
+        cannot distinguish, identity decides (`todos._MIN_SHARED_WORDS`)."""
+        for _ in range(2):
+            self._handoff("beta", brief="fix the bug\nit is bad.\n")
+        rc, _out, err = self._handoff("beta", brief="fix the bug\nit is bad.\n")
+        self.assertEqual(rc, 0)
+        self.assertIn("not recorded twice", err)
+        self.assertEqual([r["title"] for r in todos.open_todos("beta")], ["fix the bug"])
+
+    def test_one_word_in_common_is_not_the_same_work(self):
+        """The other end of the same defect: one shared word out of two is 0.5 exactly, so
+        `Fix the widget` swallowed `Break the widget`. The answer is not a higher threshold —
+        an overlap this thin is not evidence either way."""
+        self._handoff("beta", brief="Fix the widget\nIt breaks on resize.\n")
+        rc, _out, err = self._handoff("beta", brief="Break the widget\nOn purpose.\n")
+        self.assertEqual(rc, 0)
+        self.assertNotIn("not recorded twice", err)
+        self.assertEqual(sorted(r["title"] for r in todos.open_todos("beta")),
+                         ["Break the widget", "Fix the widget"])
+
+    def test_the_committed_todo_is_exactly_the_title_and_the_provenance(self):
         """A LIVE workspace commits `todos/**`, and a brief may quote anything — a
         transcript, a customer's data, the text of a secret it is warning the next chat off.
 
-        Asserted against the RAW files, before `memstore.body`'s strip-and-lowercase: read
-        through `open_todos()["text"]`, putting the WHOLE brief in the todo left 807 tests
-        green. The index file is read too, since it carries a row per todo."""
+        **Equality, on the RAW files.** Read through `open_todos()["text"]`, which is
+        `memstore.body()` — stripped and lowercased — putting the WHOLE brief in the todo
+        left 807 tests green; and a substring check for one fixture line still passed while
+        `brief[:-2]`, 34 of its 36 characters, leaked. Every byte that gets committed is
+        named here, so anything extra fails whatever shape it arrives in. Only the recorded
+        timestamp is matched rather than spelled."""
         self._handoff("beta")
-        written = "\n".join(p.read_text() for p in sorted(todos.todos_dir("beta").rglob("*"))
-                            if p.is_file())
-        self.assertIn("Fix the widget", written)
-        self.assertNotIn("It breaks on resize.", written)
+        files = [p for p in sorted(todos.todos_dir("beta").rglob("*")) if p.is_file()]
+        index = todos.index("beta")
+        [todo] = [p for p in files if p != index]
+        self.assertEqual([p.name for p in files], sorted([index.name, todo.name]))
+
+        head, blank, stamp, blank2, *rest = todo.read_text().splitlines()
+        self.assertEqual(head, "# Fix the widget")
+        self.assertEqual([blank, blank2], ["", ""])
+        self.assertRegex(stamp, r"^_\d{4}-\d{2}-\d{2} \d{2}:\d{2} · persistent_$")
+        self.assertEqual("\n".join(rest), handoff.todo_text(
+            BRIEF, source_chat="alpha.1", source_workspace="alpha"))
+
+        self.assertEqual(index.read_text(),
+                         todos._HEADER.format(name="beta")
+                         + f"- [Fix the widget]({todo.name})\n")
 
     # -- the private brief -----------------------------------------------------------------
 

--- a/tests/test_charter_handoff_opens_a_chat_that_starts_working.py
+++ b/tests/test_charter_handoff_opens_a_chat_that_starts_working.py
@@ -111,7 +111,50 @@ class AHandoffOpensAChatThatStartsWorking(_AHandoffFromAlpha):
         self.assertEqual(todos.count_open("beta"), 1)
         self.assertIn("not recorded twice", err)
 
+    def test_a_second_handoff_about_something_else_records_its_own_todo(self):
+        """Every handoff todo ends in the same nine-word provenance sentence. Compared over
+        the whole text, that boilerplate read as agreement: `Fix the widget` and `Ship the
+        release` — no word in common — scored 0.750, so the SECOND handoff into a workspace
+        recorded nothing at all, silently, and any two titles of four or fewer distinct words
+        collided the same way. The comparison is over first lines now."""
+        self._handoff("beta", brief="Fix the widget\nIt breaks on resize.\n")
+        self._handoff("beta", brief="Ship the release\nCut 0.61.0.\n")
+        rc, _out, err = self._handoff("beta", brief="Rotate the token\nIt expires Friday.\n")
+        self.assertEqual(rc, 0)
+        self.assertNotIn("not recorded twice", err)
+        self.assertEqual(sorted(r["title"] for r in todos.open_todos("beta")),
+                         ["Fix the widget", "Rotate the token", "Ship the release"])
+
+    def test_the_same_brief_twice_still_collapses_to_one_todo(self):
+        """The other direction, or the fix above is not pinned: a comparison loose enough to
+        let disjoint briefs through must still catch the brief that really is the same one."""
+        self._handoff("beta", brief=BRIEF)
+        rc, _out, err = self._handoff("beta", brief=BRIEF)
+        self.assertEqual(rc, 0)
+        self.assertIn("not recorded twice", err)
+        self.assertEqual([r["title"] for r in todos.open_todos("beta")], ["Fix the widget"])
+
+    def test_the_brief_itself_never_reaches_the_committed_todo(self):
+        """A LIVE workspace commits `todos/**`, and a brief may quote anything — a
+        transcript, a customer's data, the text of a secret it is warning the next chat off.
+
+        Asserted against the RAW files, before `memstore.body`'s strip-and-lowercase: read
+        through `open_todos()["text"]`, putting the WHOLE brief in the todo left 807 tests
+        green. The index file is read too, since it carries a row per todo."""
+        self._handoff("beta")
+        written = "\n".join(p.read_text() for p in sorted(todos.todos_dir("beta").rglob("*"))
+                            if p.is_file())
+        self.assertIn("Fix the widget", written)
+        self.assertNotIn("It breaks on resize.", written)
+
     # -- the private brief -----------------------------------------------------------------
+
+    def test_the_full_brief_goes_into_the_launch_that_records_it(self):
+        """Not written afterwards by this command: the chat id is allocated inside the
+        launch, so the earliest moment the file can exist is the moment the id does — and
+        that is still before the harness whose SessionStart reads it back."""
+        self._handoff("beta")
+        self.assertEqual(self.open.call_args.kwargs["brief"], BRIEF)
 
     def test_the_full_brief_is_kept_in_the_new_chats_private_state(self):
         self._handoff("beta")
@@ -119,6 +162,15 @@ class AHandoffOpensAChatThatStartsWorking(_AHandoffFromAlpha):
         p = state.frame_dir("beta.1") / "brief"
         self.assertTrue(p.is_relative_to(config.STATE_DIR), p)
         self.assertEqual(os.stat(p).st_mode & 0o077, 0)
+
+    def test_a_first_message_starting_with_a_dash_still_opens_a_chat(self):
+        """The seam refuses an empty, flag-shaped or single-word first message. A handoff
+        cannot produce one: the stamp goes in front, so every handoff's first message opens
+        with `⟨` and runs to eleven words or more. `docs/handoff.md` says so; this is why."""
+        rc, out, _err = self._handoff("beta", brief="--help me now\nand nothing else.\n")
+        self.assertEqual(rc, 0)
+        self.assertTrue(self.open.call_args.kwargs["first_message"].startswith("⟨"))
+        self.assertIn("opened chat beta.1", out)
 
     def test_a_new_frame_claiming_the_id_does_not_take_the_brief(self):
         """`clear_shape` forgets a previous frame's READINGS. A brief is what the chat was
@@ -213,9 +265,19 @@ class TheFactsAHandoffIsMadeOf(PersonaIso):
     def test_a_chat_charter_knows_nothing_about_has_no_brief(self):
         self.assertIsNone(state.brief("nobody.9"))
 
-    def test_an_empty_brief_file_is_no_brief(self):
-        """A chat shown an empty labelled block would read it as "your brief was blank"."""
+    def test_an_empty_brief_writes_no_file(self):
+        """Every background open passes a brief through, and every one that is not a handoff
+        passes none — a file that reads as "no brief" is one more thing in a chat directory
+        to explain."""
         state.record_brief("beta.1", "")
+        self.assertFalse((state.frame_dir("beta.1", create=True) / "brief").exists())
+
+    def test_a_brief_file_that_is_empty_is_no_brief(self):
+        """Written by hand, because `record_brief` refuses to make one: a truncated write or
+        an older charter can still leave one, and a chat shown an empty labelled block would
+        read it as "your brief was blank"."""
+        d = state.frame_dir("beta.1", create=True)
+        config.replace_for(d / "brief", "")
         self.assertIsNone(state.brief("beta.1"))
 
     def test_a_brief_charter_cannot_write_is_not_an_exception(self):

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import json
 import os
+import shutil
 import unittest
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -110,7 +111,17 @@ class TestAHandoffRowIsWrittenLikeEveryOtherRow(PersonaIso):
 
     def test_the_month_file_is_written_at_0644(self):
         """Committed and shared, so it is readable — and it is charter's to create, so the
-        umask does not get to decide. The same mode the other three writers here pass."""
+        umask does not get to decide. The same mode the other three writers here pass.
+
+        **The umask is set to 0 for the duration, and that is the whole test.** At the
+        suite's own 022 this assertion passes under `0o644 → 0o666`: the umask masks the
+        group and other write bits back off on disk, so the file looks right whatever
+        charter asked for. On a box running at umask 000 — a daemon, a container — that
+        same code creates a world-writable committed tally and nothing here would have
+        said. Same family as `TITLE_MAX`: an expectation taken from the environment
+        instead of stated."""
+        was = os.umask(0)
+        self.addCleanup(os.umask, was)
         p = dispatch.record_handoff(placement="here", created=True)
         self.assertEqual(p.stat().st_mode & 0o777, 0o644)
 
@@ -124,6 +135,35 @@ class TestAHandoffRowIsWrittenLikeEveryOtherRow(PersonaIso):
         self.addCleanup(lambda: outside.exists() and outside.unlink())
 
         self.assertIsNone(dispatch.record_handoff(placement="here", created=False))
+        self.assertFalse(outside.exists(), "the row was written through the link")
+
+    def test_a_dispatch_directory_that_is_a_link_out_of_the_plane_is_refused(self):
+        """The shape `O_NOFOLLOW` cannot see, so this is what keeps `write_refusal` pinned:
+        the flag judges the FINAL component, and here it is the parent that leaves the
+        plane. `personas/_dispatch` is a fixed name too."""
+        outside = Path(self.tmp).parent / "outside-dispatch-dir"
+        outside.mkdir()
+        self.addCleanup(shutil.rmtree, outside, True)
+        d = dispatch._dir()
+        d.parent.mkdir(parents=True, exist_ok=True)
+        d.symlink_to(outside, target_is_directory=True)
+
+        self.assertIsNone(dispatch.record_handoff(placement="here", created=False))
+        self.assertEqual(list(outside.iterdir()), [], "a row landed outside the plane")
+
+    def test_a_link_planted_after_the_check_is_still_refused(self):
+        """`write_refusal` is check-then-open, and a link planted in the window between the
+        two is followed. `O_NOFOLLOW` closes that for the final component, atomically and
+        for free — measured by standing the check down, which is what losing the race
+        amounts to."""
+        outside = Path(self.tmp).parent / "outside-after-the-check.jsonl"
+        self.addCleanup(lambda: outside.exists() and outside.unlink())
+        target = dispatch.path_for()
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.symlink_to(outside)
+
+        with mock.patch.object(dispatch.contain, "write_refusal", return_value=None):
+            self.assertIsNone(dispatch.record_handoff(placement="here", created=False))
         self.assertFalse(outside.exists(), "the row was written through the link")
 
     def test_a_store_that_cannot_be_written_is_not_an_exception(self):

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -7,6 +7,7 @@ sub-agent dispatches.
 from __future__ import annotations
 
 import json
+import os
 import unittest
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -87,6 +88,54 @@ class TestDispatchHook(PlaneIso):
         with mock.patch.object(dispatch, "record", side_effect=OSError("boom")):
             self.assertIsNone(self._run({"tool_name": "Task",
                                          "tool_input": {"subagent_type": "devops"}}))
+
+
+class TestAHandoffRowIsWrittenLikeEveryOtherRow(PersonaIso):
+    """`record_handoff`'s three writer guards — the ones this store has always had and
+    which `charter handoff` brought a fourth copy of (chat-handoff plan, Task 2).
+
+    A tally must never break a turn, and it must never be the thing that publishes
+    somewhere it was aimed at. Both are properties of the write, not of the row.
+    """
+
+    def _row(self):
+        rows = [o for o in dispatch._read_all() if o.get("event") == dispatch.HANDOFF]
+        return rows
+
+    def test_a_row_lands_and_says_only_the_four_things(self):
+        p = dispatch.record_handoff(placement="elsewhere", created=False)
+        self.assertIsNotNone(p)
+        self.assertEqual([set(o) for o in self._row()],
+                         [{"created", "event", "placement", "ts"}])
+
+    def test_the_month_file_is_written_at_0644(self):
+        """Committed and shared, so it is readable — and it is charter's to create, so the
+        umask does not get to decide. The same mode the other three writers here pass."""
+        p = dispatch.record_handoff(placement="here", created=True)
+        self.assertEqual(p.stat().st_mode & 0o777, 0o644)
+
+    def test_a_month_file_that_is_a_link_out_of_the_plane_is_refused(self):
+        """`contain.write_refusal`'s case, at a FIXED name an attacker needs no guess for:
+        the row would be appended wherever the link points, outside the plane."""
+        outside = Path(self.tmp).parent / "outside-the-plane.jsonl"
+        target = dispatch.path_for()
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.symlink_to(outside)
+        self.addCleanup(lambda: outside.exists() and outside.unlink())
+
+        self.assertIsNone(dispatch.record_handoff(placement="here", created=False))
+        self.assertFalse(outside.exists(), "the row was written through the link")
+
+    def test_a_store_that_cannot_be_written_is_not_an_exception(self):
+        """The tally is bookkeeping: it may miss a row, it may not break the turn it is
+        counting. Measured by taking write permission off the directory it appends in."""
+        if os.geteuid() == 0:
+            self.skipTest("root ignores the mode, so this says nothing about the guard")
+        d = dispatch._dir()
+        d.mkdir(parents=True, exist_ok=True)
+        d.chmod(0o500)
+        self.addCleanup(d.chmod, 0o700)
+        self.assertIsNone(dispatch.record_handoff(placement="here", created=False))
 
 
 class TestCommitDispatchPosture(unittest.TestCase):

--- a/tests/test_memstore.py
+++ b/tests/test_memstore.py
@@ -91,6 +91,61 @@ class MemstoreCase(PersonaIso):
         self.assertFalse(memstore.forget(self.d, "nope"))
 
 
+class TheTitleAWriteDerivesIsAlsoWhatAReaderComputes(MemstoreCase):
+    """`title_of` is `write`'s own rule, lifted out so `todos.duplicate_of` can ask what a
+    stored title WILL be instead of respelling "the first line, stripped, capped" — two
+    spellings of it are how the writer and the reader come to disagree about which todos
+    are the same one."""
+
+    def test_a_title_is_the_first_line_and_nothing_after_it(self):
+        self.assertEqual(memstore.title_of("Fix the widget\nIt breaks on resize.\n"),
+                         "Fix the widget")
+
+    def test_the_blank_lines_and_the_padding_around_it_are_not_part_of_it(self):
+        self.assertEqual(memstore.title_of("\n\n  Fix the widget  \nmore\n"),
+                         "Fix the widget")
+
+    def test_a_body_with_nothing_in_it_has_no_title(self):
+        self.assertEqual(memstore.title_of("  \n\n "), "")
+
+    def test_a_long_first_line_is_capped_at_seventy_two_characters(self):
+        """**The number is spelled out here rather than read off the constant.** A test whose
+        expectation is computed from the value it is checking moves with that value and pins
+        nothing: widening `TITLE_MAX` to 4096, and retuning it by one, both stayed green
+        against `"x" * memstore.TITLE_MAX`.
+
+        72 is what a `# ` heading, an index row and a `slug` filename carry, and it is the
+        same cap on both sides of `todos.duplicate_of`'s comparison — a reader that stopped
+        one character later would compare 73 characters against the 72 `write` stored."""
+        self.assertEqual(memstore.TITLE_MAX, 72)
+        self.assertEqual(memstore.title_of("x" * 100), "x" * 72)
+
+    def test_a_title_handed_to_write_is_capped_and_stripped_the_same_way(self):
+        """A caller's own title goes through the same two rules as a derived one, so a
+        `# ` heading and an index row look the same whichever way the title arrived."""
+        for given, stored_as in (("y" * 100, "y" * 72), ("  Padded  ", "Padded")):
+            with self.subTest(title=given[:12]):
+                p = memstore.write(self.d, "a body", given)
+                [(_p, stored, _t)] = [e for e in memstore.entries(self.d) if e[0] == p]
+                self.assertEqual(stored, stored_as)
+                # The INDEX row too, and it is the reading that can see the strip:
+                # `entries` takes the title off the `# ` heading and strips it again on the
+                # way out, so padding left in by the writer is invisible there and visible
+                # here — in the file a person reads.
+                self.assertIn(f"- [{stored_as}]({p.name})\n",
+                              memstore.index_path(self.d).read_text())
+                p.unlink()
+
+    def test_what_a_write_stores_is_what_title_of_answers(self):
+        for text in ("Fix the widget\nIt breaks.\n", "  padded  \nmore\n",
+                     "y" * (memstore.TITLE_MAX + 5)):
+            with self.subTest(text=text[:20]):
+                p = memstore.write(self.d, text)
+                [(_p, stored, _t)] = [e for e in memstore.entries(self.d) if e[0] == p]
+                self.assertEqual(stored, memstore.title_of(text))
+                p.unlink()
+
+
 class TheIndexIsExactlyTheLinesThatSurvive(MemstoreCase):
     """Two one-line conditionals in `memstore`, neither of which had a case.
 

--- a/tests/test_memstore.py
+++ b/tests/test_memstore.py
@@ -108,6 +108,12 @@ class TheTitleAWriteDerivesIsAlsoWhatAReaderComputes(MemstoreCase):
     def test_a_body_with_nothing_in_it_has_no_title(self):
         self.assertEqual(memstore.title_of("  \n\n "), "")
 
+    def test_no_body_at_all_has_no_title_either(self):
+        """Total, because a READER calls this: `todos.duplicate_of` asks it what a title
+        WILL be, and a store that answered `None` there would compare `None` against a
+        stored string and report every todo as new."""
+        self.assertEqual(memstore.title_of(None), "")
+
     def test_a_long_first_line_is_capped_at_seventy_two_characters(self):
         """**The number is spelled out here rather than read off the constant.** A test whose
         expectation is computed from the value it is checking moves with that value and pins

--- a/tests/test_todos_store.py
+++ b/tests/test_todos_store.py
@@ -180,6 +180,23 @@ class TestADuplicateJudgedByTitle(PersonaIso):
             todos.duplicate_of("alpha", "Fix the widget" + self.TAIL, by_title=True),
             "Fix the widget")
 
+    def test_the_stored_side_is_its_title_and_not_its_body_either(self):
+        """**Both sides**, and this is the case that says so. Every other case here either
+        stores a bare title — where the body IS the title, so reading one for the other
+        changes nothing — or compares titles that are identical, which the identity fallback
+        answers before the overlap is read. So neither reddens if the stored side quietly
+        goes back to `title + body`.
+
+        This pair does: two real handoff todos, each carrying the provenance tail, whose
+        titles overlap on three words at 0.750. Read as titles they are one todo; read with
+        the tail on the stored side the union grows by nine boilerplate words, the score
+        falls under the threshold, and a genuine duplicate is recorded twice."""
+        todos.add("alpha", "Rotate the staging tokens" + self.TAIL)
+        self.assertEqual(
+            todos.duplicate_of("alpha", "Rotate the staging tokens again" + self.TAIL,
+                               by_title=True),
+            "Rotate the staging tokens")
+
 
 class TestAnOverlapTooThinToBeEvidence(PersonaIso):
     """`todos._MIN_SHARED_WORDS`, on the `by_title` path — where below it the ratio is

--- a/tests/test_todos_store.py
+++ b/tests/test_todos_store.py
@@ -8,9 +8,12 @@ docs/adr/0004, and `workspaces/todos/workspace.md` for the glossary.
 from __future__ import annotations
 
 import datetime
+import io
 import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from types import SimpleNamespace
 
-from charter import memstore, todos, workspace
+from charter import commands_workspace, memstore, todos, workspace
 from tests._isolation import PersonaIso
 
 
@@ -241,6 +244,12 @@ class TestAnOverlapTooThinToBeEvidence(PersonaIso):
     def _dup(self, text):
         return todos.duplicate_of("alpha", text, by_title=True)
 
+    def test_a_title_that_is_not_there_normalises_to_nothing(self):
+        """Total, because both sides of the identity test come off disk: `memstore.entries`
+        reads whatever the store holds, and `_normal` answering `None` would raise inside a
+        comparison whose job is to decide, not to fail."""
+        self.assertEqual(todos._normal(None), "")
+
     def test_two_titles_of_only_short_words_that_read_the_same_are_the_same_todo(self):
         todos.add("alpha", "fix the bug")
         self.assertEqual(self._dup("fix the bug"), "fix the bug")
@@ -285,6 +294,115 @@ class TestAnOverlapTooThinToBeEvidence(PersonaIso):
         todos.add("alpha", "fix the bug" + tail)
         self.assertEqual(self._dup("fix the bug" + tail), "fix the bug")
         self.assertIsNone(self._dup("ask the dev" + tail))
+
+
+class TestATodoTitleCannotOwnTheTerminalItIsPrintedOn(PersonaIso):
+    """A todo title used to be something the OPERATOR typed. Since `charter handoff` it is
+    the first line of a brief a model wrote, so every renderer that prints one back is
+    printing attacker-influenced text into a format with structure in it.
+
+    Escaped at the RENDER and never on the way into storage: the file a person opens has
+    to hold the text that was approved, and a store that escaped on write would hold a
+    different one (#453's own rule, one surface over).
+    """
+
+    #: The shapes that can REACH a stored title. `\\r` cannot: `memstore` ends a title at
+    #: every Unicode line boundary, so a title carrying one is stored cut at it and the
+    #: renderer never sees it — which is a fact about the store, not a defence, and is why
+    #: `handoff.terminal_command` (where the whole brief IS on the line) is asserted against
+    #: `\\r` as well.
+    HOSTILE = (
+        ("an ANSI erase", "\x1b[2J", "\\x1b"),
+        ("a run of backspaces", "gone\x08\x08\x08\x08", "\\x08"),
+        ("a bidi override", "\u202ederepo/\u202c", "\\u202e"),
+    )
+
+    def setUp(self) -> None:
+        super().setUp()
+        workspace.ensure("alpha")
+
+    def _todo(self, ws, **flags):
+        """`charter ws todo` on *ws*, returning ``(stdout, stderr)``."""
+        out, err = io.StringIO(), io.StringIO()
+        args = SimpleNamespace(workspace=ws, text=flags.get("text", ""), slug=None,
+                               query=flags.get("query"))
+        with redirect_stdout(out), redirect_stderr(err):
+            commands_workspace.cmd_workspace_todo(args)
+        return out.getvalue(), err.getvalue()
+
+    def test_the_listing_escapes_what_a_terminal_would_act_on(self):
+        for name, raw, escaped in self.HOSTILE:
+            with self.subTest(name):
+                workspace.ensure("w")
+                todos.add("w", f"Fix {raw} the widget")
+                out, _err = self._todo("w")
+                self.assertIn(escaped, out)
+                self.assertNotIn(raw, out)
+                for f in memstore.files(todos.todos_dir("w")):
+                    f.unlink()
+
+    def test_the_query_path_escapes_the_same_way(self):
+        """A second renderer over the same titles — the half a fix reaching only the
+        listing would walk past."""
+        todos.add("alpha", "Fix \x1b[2J the widget")
+        out, _err = self._todo("alpha", query="widget")
+        self.assertIn("\\x1b", out)
+        self.assertNotIn("\x1b[2J", out)
+
+    def test_the_stored_file_still_holds_what_was_approved(self):
+        """The other direction: escaping belongs at the render, so the file a person opens
+        holds the text that was written, control characters and all."""
+        p = todos.add("alpha", "Fix \x1b[2J the widget")
+        self.assertIn("\x1b[2J", p.read_text())
+
+    def test_the_duplicate_refusal_escapes_the_title_it_names(self):
+        todos.add("alpha", "Fix \x1b[2J the widget please")
+        _out, err = self._todo("alpha", text="Fix \x1b[2J the widget please")
+        self.assertIn("already on the list", err)
+        self.assertIn("\\x1b", err)
+        self.assertNotIn("\x1b[2J", err)
+
+
+class TestTheFrameDrawsATodoTitleWithoutObeyingIt(PersonaIso):
+    """The other two readers of `open_todos()` titles — the frame's todo panel and the
+    palette row that reads them out. Both were measured rather than assumed, because a
+    handoff makes these titles a model's prose and neither surface had been driven with
+    one.
+
+    Both were already safe, and this records how: the panel escapes in `slots._todo_rows`,
+    and the palette row returns the title RAW from `builtin_actions._read_todo` and is
+    contained one layer later, where `Palette.report` composes the heading. These pin that
+    — a containment nobody can see is a containment somebody removes.
+    """
+
+    NASTY = "Fix \x1b[2Jthe \x08\x08\x08widget ‮reversed"
+
+    def test_the_frames_todo_panel_escapes_the_title_it_draws(self):
+        from charter.frame import slots
+        rows = slots._todo_rows({"todos": [{"title": self.NASTY}], "todo_count": 1}, 80, 6)
+        drawn = "\n".join(rows)
+        for escaped in ("\\x1b", "\\x08", "\\u202e"):
+            self.assertIn(escaped, drawn)
+        self.assertNotIn("\x1b[2J", drawn)
+
+    def test_the_palette_row_is_contained_where_it_is_composed(self):
+        """`_read_todo` answers raw on purpose — `Palette.report` is its only surface and
+        runs `contain.one_line` over it, and `frame/choose.py` records what a second
+        containment on the way in costs (a line no test can turn red). So the assertion is
+        on the heading, which is what reaches the terminal."""
+        from charter.frame import builtin_actions, palette
+
+        ctx = SimpleNamespace(todos=({"title": self.NASTY},),
+                              gather={"todos": [{"title": self.NASTY}], "todo_count": 1})
+        said = builtin_actions._read_todo(ctx, [0])
+        self.assertIn("\x1b[2J", said, "precondition: this layer answers raw")
+
+        p = palette.Palette.__new__(palette.Palette)
+        p.label, p.query, p.said = "F2", "", said
+        p._headline()
+        for escaped in ("\\x1b", "\\x08", "\\u202e"):
+            self.assertIn(escaped, p.heading)
+        self.assertNotIn("\x1b[2J", p.heading)
 
 
 class TestTheWholeTextPathStillCatchesARetitle(PersonaIso):

--- a/tests/test_todos_store.py
+++ b/tests/test_todos_store.py
@@ -180,6 +180,26 @@ class TestADuplicateJudgedByTitle(PersonaIso):
             todos.duplicate_of("alpha", "Fix the widget" + self.TAIL, by_title=True),
             "Fix the widget")
 
+    def test_a_score_of_exactly_the_threshold_is_still_the_same_todo(self):
+        """The boundary, on the side that matters. `_DUPLICATE_THRESHOLD` is the lowest score
+        that counts, so `>=` and not `>`: these two titles share three words out of a union of
+        six — 0.500 exactly — and under `>` they fall through to identity, read as different
+        lines, and the second handoff records a genuine duplicate. That is the failure this
+        whole rule exists to prevent, arriving at the one score a comparison can land on and
+        still be told it does not count."""
+        todos.add("alpha", "Rotate the staging tokens" + self.TAIL)
+        self.assertEqual(
+            len(memstore.wordset("Rotate the staging tokens")
+                & memstore.wordset("Rotate the staging tokens before Friday morning")), 3)
+        self.assertEqual(
+            len(memstore.wordset("Rotate the staging tokens")
+                | memstore.wordset("Rotate the staging tokens before Friday morning")), 6)
+        self.assertEqual(
+            todos.duplicate_of("alpha",
+                               "Rotate the staging tokens before Friday morning" + self.TAIL,
+                               by_title=True),
+            "Rotate the staging tokens")
+
     def test_the_stored_side_is_its_title_and_not_its_body_either(self):
         """**Both sides**, and this is the case that says so. Every other case here either
         stores a bare title — where the body IS the title, so reading one for the other

--- a/tests/test_todos_store.py
+++ b/tests/test_todos_store.py
@@ -148,5 +148,45 @@ class TestNearDuplicates(PersonaIso):
         self.assertIsNone(todos.duplicate_of("alpha", "prove the live path"))
 
 
+class TestADuplicateJudgedByTitle(PersonaIso):
+    """`by_title`, for a writer whose todos all end in the same sentence.
+
+    `charter handoff` is that writer. Scored over the whole text, its fixed nine-word
+    provenance tail read as agreement on both sides: two briefs with no word in common
+    scored 0.750 and the second was dropped, so the second handoff into a workspace recorded
+    nothing at all.
+    """
+
+    TAIL = ("\n\nHanded off from chat alpha.1 · workspace alpha. The full brief is private "
+            "to the chat it opened.")
+
+    def setUp(self) -> None:
+        super().setUp()
+        workspace.ensure("alpha")
+        todos.add("alpha", "Fix the widget" + self.TAIL)
+
+    def test_the_shared_tail_alone_used_to_make_two_todos_the_same_one(self):
+        """The measurement the flag exists for, kept as a test so it cannot quietly come
+        back: over the whole text these two are a duplicate pair."""
+        self.assertIsNotNone(todos.duplicate_of("alpha", "Ship the release" + self.TAIL))
+
+    def test_a_different_first_line_is_a_different_todo(self):
+        self.assertIsNone(
+            todos.duplicate_of("alpha", "Ship the release" + self.TAIL, by_title=True))
+
+    def test_the_same_first_line_is_still_the_same_todo(self):
+        """The other direction, or the flag is a way of never reporting a duplicate."""
+        self.assertEqual(
+            todos.duplicate_of("alpha", "Fix the widget" + self.TAIL, by_title=True),
+            "Fix the widget")
+
+    def test_a_first_line_of_only_short_words_reports_nothing(self):
+        """`memstore.wordset` keeps words longer than three characters, and a comparison
+        with no words on one side is not a judgement — the same answer the whole-text
+        comparison gives for a todo with nothing comparable in it."""
+        self.assertIsNone(todos.duplicate_of("alpha", "fix the bug" + self.TAIL,
+                                             by_title=True))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_todos_store.py
+++ b/tests/test_todos_store.py
@@ -182,53 +182,123 @@ class TestADuplicateJudgedByTitle(PersonaIso):
 
 
 class TestAnOverlapTooThinToBeEvidence(PersonaIso):
-    """`todos._MIN_SHARED_WORDS`: below it the ratio is arithmetic with nothing behind it,
-    and it was wrong in both directions at once.
+    """`todos._MIN_SHARED_WORDS`, on the `by_title` path — where below it the ratio is
+    arithmetic with nothing behind it, and wrong in both directions at once.
 
     `memstore.wordset` keeps only words longer than three characters, so `fix the bug` has
-    no comparable word at all — two of them agreed on nothing and scored nothing, and the
-    same todo recorded twice went in twice. At the other end one shared word out of two is
-    0.5 exactly, so `Fix the widget` swallowed `Break the widget`. Where the overlap cannot
+    no comparable word at all — two of them agreed on nothing and scored nothing, so the
+    same handoff recorded twice went in twice. At the other end one shared word out of two
+    is 0.5 exactly, so `Fix the widget` swallowed `Break the widget`, and for a handoff a
+    false duplicate means a real todo silently dropped. Where the overlap cannot
     distinguish, identity decides, which needs no threshold.
+
+    **The whole-text path deliberately does NOT get this rule** —
+    `TestTheWholeTextPathStillCatchesARetitle` is the other half, and `duplicate_of`'s own
+    docstring is why.
     """
 
     def setUp(self) -> None:
         super().setUp()
         workspace.ensure("alpha")
 
+    def _dup(self, text):
+        return todos.duplicate_of("alpha", text, by_title=True)
+
     def test_two_titles_of_only_short_words_that_read_the_same_are_the_same_todo(self):
         todos.add("alpha", "fix the bug")
-        self.assertEqual(todos.duplicate_of("alpha", "fix the bug"), "fix the bug")
+        self.assertEqual(self._dup("fix the bug"), "fix the bug")
 
     def test_and_the_same_words_typed_differently_are_still_the_same_todo(self):
         """Case and runs of whitespace are not differences (`todos._normal`)."""
         todos.add("alpha", "fix the bug")
-        self.assertEqual(todos.duplicate_of("alpha", "Fix   THE bug"), "fix the bug")
+        self.assertEqual(self._dup("Fix   THE bug"), "fix the bug")
 
     def test_two_titles_of_only_short_words_that_read_differently_are_not(self):
         todos.add("alpha", "fix the bug")
-        self.assertIsNone(todos.duplicate_of("alpha", "ask the dev"))
+        self.assertIsNone(self._dup("ask the dev"))
 
     def test_one_shared_word_out_of_two_is_not_the_same_todo(self):
         todos.add("alpha", "Fix the widget")
-        self.assertIsNone(todos.duplicate_of("alpha", "Break the widget"))
+        self.assertIsNone(self._dup("Break the widget"))
 
     def test_two_shared_words_out_of_four_are_not_either(self):
         todos.add("alpha", "Update the README file")
-        self.assertIsNone(todos.duplicate_of("alpha", "Delete the README file"))
+        self.assertIsNone(self._dup("Delete the README file"))
+
+    def test_three_shared_words_are_evidence_and_the_metric_decides(self):
+        """**Three, spelled out rather than read off the constant** — an expectation
+        computed from the value it checks moves with that value and pins nothing, which is
+        how `TITLE_MAX` survived two mutations before its own number was written down.
+        These titles share exactly three words at 0.750, so at a floor of four they would
+        fall to identity, read as different lines, and be recorded twice."""
+        self.assertEqual(todos._MIN_SHARED_WORDS, 3)
+        todos.add("alpha", "Rotate the staging tokens")
+        self.assertEqual(len(memstore.wordset("Rotate the staging tokens")
+                             & memstore.wordset("Rotate the staging tokens again")), 3)
+        self.assertEqual(self._dup("Rotate the staging tokens again"),
+                         "Rotate the staging tokens")
 
     def test_a_real_overlap_is_still_read_as_one(self):
         """The rule narrows what counts as evidence; it does not switch the metric off."""
         todos.add("alpha", "prove the live gh issue create path works")
-        self.assertIsNotNone(
-            todos.duplicate_of("alpha", "prove the live gh issue create path also works"))
+        self.assertIsNotNone(self._dup("prove the live gh issue create path also works"))
 
-    def test_the_same_rule_holds_for_a_handoffs_titles(self):
+    def test_the_same_rule_holds_for_a_handoffs_whole_todo_text(self):
         tail = TestADuplicateJudgedByTitle.TAIL
         todos.add("alpha", "fix the bug" + tail)
-        self.assertEqual(todos.duplicate_of("alpha", "fix the bug" + tail, by_title=True),
-                         "fix the bug")
-        self.assertIsNone(todos.duplicate_of("alpha", "ask the dev" + tail, by_title=True))
+        self.assertEqual(self._dup("fix the bug" + tail), "fix the bug")
+        self.assertIsNone(self._dup("ask the dev" + tail))
+
+
+class TestTheWholeTextPathStillCatchesARetitle(PersonaIso):
+    """The other half of the split, and the reason for it: `charter ws todo` REFUSES on a
+    duplicate, so it wants the catching rule even at the cost of a false one.
+
+    Round 2 applied the no-signal rule to this path too. Measured on 20 hand-written pairs
+    it changed 12 verdicts, and five of them were one shape — a one-line todo retitled by a
+    word — turning from caught into missed, with `commands_workspace.cmd_ws_todo` still
+    carrying the comment that says why that is the worse error: *closing one of a
+    near-identical pair leaves its twin looking outstanding*.
+    """
+
+    RETITLES = (
+        ("Fix the login bug", "Fix the login issue"),
+        ("Update the README", "Update the README file"),
+        ("Review the backlog", "Review the backlog again"),
+        ("Rotate the staging tokens", "Rotate the staging token"),
+        ("Add a retry to the webhook sender", "Add retries to the webhook sender"),
+    )
+
+    def setUp(self) -> None:
+        super().setUp()
+        workspace.ensure("alpha")
+
+    def test_a_one_line_todo_retitled_by_a_word_is_still_caught(self):
+        for first, second in self.RETITLES:
+            with self.subTest(first=first):
+                workspace.ensure("w")
+                todos.add("w", first)
+                self.assertEqual(todos.duplicate_of("w", second), first)
+                for p in memstore.files(todos.todos_dir("w")):
+                    p.unlink()
+
+    def test_and_the_by_title_path_reads_those_same_pairs_as_two_todos(self):
+        """Not a contradiction — the opposite error, chosen by the caller. A handoff that
+        refused one of these would drop a real todo and say only that it did not record it
+        twice."""
+        for first, second in self.RETITLES:
+            with self.subTest(first=first):
+                workspace.ensure("w")
+                todos.add("w", first)
+                self.assertIsNone(todos.duplicate_of("w", second, by_title=True))
+                for p in memstore.files(todos.todos_dir("w")):
+                    p.unlink()
+
+    def test_a_todo_of_only_short_words_is_still_not_compared_on_this_path(self):
+        """`memstore.wordset` has nothing to compare, and this path answers None rather than
+        falling back to identity — the behaviour `charter ws todo` had before this branch."""
+        todos.add("alpha", "fix the bug")
+        self.assertIsNone(todos.duplicate_of("alpha", "fix the bug"))
 
 
 if __name__ == "__main__":

--- a/tests/test_todos_store.py
+++ b/tests/test_todos_store.py
@@ -180,12 +180,55 @@ class TestADuplicateJudgedByTitle(PersonaIso):
             todos.duplicate_of("alpha", "Fix the widget" + self.TAIL, by_title=True),
             "Fix the widget")
 
-    def test_a_first_line_of_only_short_words_reports_nothing(self):
-        """`memstore.wordset` keeps words longer than three characters, and a comparison
-        with no words on one side is not a judgement — the same answer the whole-text
-        comparison gives for a todo with nothing comparable in it."""
-        self.assertIsNone(todos.duplicate_of("alpha", "fix the bug" + self.TAIL,
-                                             by_title=True))
+
+class TestAnOverlapTooThinToBeEvidence(PersonaIso):
+    """`todos._MIN_SHARED_WORDS`: below it the ratio is arithmetic with nothing behind it,
+    and it was wrong in both directions at once.
+
+    `memstore.wordset` keeps only words longer than three characters, so `fix the bug` has
+    no comparable word at all — two of them agreed on nothing and scored nothing, and the
+    same todo recorded twice went in twice. At the other end one shared word out of two is
+    0.5 exactly, so `Fix the widget` swallowed `Break the widget`. Where the overlap cannot
+    distinguish, identity decides, which needs no threshold.
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+        workspace.ensure("alpha")
+
+    def test_two_titles_of_only_short_words_that_read_the_same_are_the_same_todo(self):
+        todos.add("alpha", "fix the bug")
+        self.assertEqual(todos.duplicate_of("alpha", "fix the bug"), "fix the bug")
+
+    def test_and_the_same_words_typed_differently_are_still_the_same_todo(self):
+        """Case and runs of whitespace are not differences (`todos._normal`)."""
+        todos.add("alpha", "fix the bug")
+        self.assertEqual(todos.duplicate_of("alpha", "Fix   THE bug"), "fix the bug")
+
+    def test_two_titles_of_only_short_words_that_read_differently_are_not(self):
+        todos.add("alpha", "fix the bug")
+        self.assertIsNone(todos.duplicate_of("alpha", "ask the dev"))
+
+    def test_one_shared_word_out_of_two_is_not_the_same_todo(self):
+        todos.add("alpha", "Fix the widget")
+        self.assertIsNone(todos.duplicate_of("alpha", "Break the widget"))
+
+    def test_two_shared_words_out_of_four_are_not_either(self):
+        todos.add("alpha", "Update the README file")
+        self.assertIsNone(todos.duplicate_of("alpha", "Delete the README file"))
+
+    def test_a_real_overlap_is_still_read_as_one(self):
+        """The rule narrows what counts as evidence; it does not switch the metric off."""
+        todos.add("alpha", "prove the live gh issue create path works")
+        self.assertIsNotNone(
+            todos.duplicate_of("alpha", "prove the live gh issue create path also works"))
+
+    def test_the_same_rule_holds_for_a_handoffs_titles(self):
+        tail = TestADuplicateJudgedByTitle.TAIL
+        todos.add("alpha", "fix the bug" + tail)
+        self.assertEqual(todos.duplicate_of("alpha", "fix the bug" + tail, by_title=True),
+                         "fix the bug")
+        self.assertIsNone(todos.duplicate_of("alpha", "ask the dev" + tail, by_title=True))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Part of #956 — Task 2 of docs/superpowers/plans/2026-09-10-chat-handoff.md.

`charter handoff <workspace> [--create --vision "…"] [--persona <name>] <<'BRIEF'` opens a chat
in a workspace you name, in the background, already working on the brief the operator approved.
Task 4 (#972) put the gate in front of it; this is the command behind the gate.

## What it does

- **`charter/handoff.py`** — the pure facts: `STAMP`, `stamp`, `first_message`, `title`,
  `read_brief`, `todo_text`, `terminal_command`. No I/O beyond the one stream `read_brief` is
  handed, so every string is checkable without a plane.
- **`charter/commands_handoff.py`** — `cmd_handoff`: every refusal **before the first write**,
  then the writes in the spec's order. Refusals: the workspace name; `--vision` without
  `--create` and the reverse; `--create` on a workspace that exists (`default` included, which
  is `cmd_workspace_use`'s rule asked rather than re-invented); an unknown workspace without
  `--create`; an unknown persona; a terminal on stdin (`isatty()` asked before any read, so it
  never blocks a turn); a brief that is not UTF-8 or is empty; a credential-shaped brief, named
  by KIND through `hooks._secret_kind` rather than a second classifier; no frame here, or
  charter inside a tmux the operator already had — both print the exact
  `charter <harness> --workspace <ws> …` command to run in a new terminal; and everything
  `commands_frame.background_refusal` refuses.
- **The writes:** `workspace.ensure` + `set_vision` (LOCAL, never `set_live`); a todo titled by
  the brief's first line with one line of provenance and **not the brief** (a LIVE workspace
  commits `todos/**`), skipped-and-reported when `todos.duplicate_of` names one;
  `commands_frame.open_in_background`; `state.record_brief` (private, not listed by
  `clear_shape`); `dispatch.record_handoff`; one line on stdout.
- **`charter/frame/state.py`** — `record_brief` / `brief`, `record_cwd`/`chat_cwd`'s shape.
- **`charter/dispatch.py`** — `HANDOFF` and `record_handoff`: `{"created", "event", "placement",
  "ts"}` and nothing else. No workspace name (a LOCAL workspace's name must not reach a
  committed file), no persona, no text. It carries no agent, so `tally()` and `last_seen()` are
  untouched by one.
- **`charter/cli.py`** — the `handoff` parser, registered before `_add_frame_parsers` snapshots
  the core commands.
- **`charter/hooks.py`** — one line: a handoff clears `routing: require`'s pending mark.

## The rulings in the dispatch, and how each was applied

1. **Don't create `_is_handoff`.** Task 4's is consumed as-is. Its behaviour matches the brief's
   description — any segment whose charter words start `handoff`, newlines being segment
   boundaries — so there is nothing to report.
2. **The clearing line goes AFTER A7.** `if plane and _is_handoff(cmd): _route_mark_clear(sid)`
   sits directly after A7's `if hand:` block and before the persona tool-gate, with the comment
   saying why. Task 4's `test_a_refused_handoff_leaves_the_routing_mark` returns above it and
   stays green.
3. **`docs/handoff.md` was EXTENDED, not rewritten.** Task 4's *The prompt is the consent*, the
   G1–G3 measurements, *What charter refuses that the prompt cannot cover*, *What charter's hook
   does not see*, *Where nothing refuses it* and *Removing the rule* are untouched; Task 4's H1
   is now the section heading over its own paragraph. Added above it: the failure heading, the
   three placements and the two tests, the command, what a handoff does in order, the refusals
   table, the stamp, isolation and continuation, and the limits. `pyproject.toml` already
   force-includes the page (Task 4), so it is unchanged.
4. **The brief variant is re-added.**
   `TheHookClearsTheRoutingMark.test_a_handed_off_chat_with_its_brief_recorded_may_hand_off_again`
   plants `beta.1`, calls `state.record_brief("beta.1", "x")`, and runs the whole of
   `hooks.pretooluse` with `CHARTER_SESSION_ID=beta.1`.
5. **Spelling.** Every `charter handoff` charter prints or documents is the two bare words one
   ASCII space apart — the refusals that name the heredoc, the one that names `--create
   --vision`, and every example on the docs page. The outside-a-frame command is a
   `charter <harness> --workspace …` line and carries no handoff spelling at all.
6. **The byte cap is on the STAMPED message.** `background_refusal` measures stamp + blank line
   + brief, and `cmd_handoff` adds the sentence the seam cannot say — what was counted, and how
   big the brief was on its own — recognised by comparing against
   `commands_frame.LONG_FIRST_MESSAGE` formatted with the size, so the bound stays in one place.
   `test_a_brief_that_fits_alone_but_not_stamped_says_what_was_counted` pins a brief of exactly
   `FIRST_MESSAGE_MAX_BYTES` against the real seam.
6b. **The host rule is not the boundary.** The docs page says the prompt is the consent for one
   exact spelling and that charter refuses the others, quoting Claude Code's own "isn't a
   security boundary around the program" and 2.1.268's measured no-prompt spellings. No refusal
   text claims the rule covers every spelling.
7. **Docs truth bar.** Every harness or tmux sentence added carries its version and the state it
   was measured in: the first-message spellings from `claude --help` on Claude Code 2.1.268,
   `codex --help` on codex-cli 0.147.0 and `opencode --help` on opencode 1.18.23; "no client
   moves" and the 16,364-byte command limit on tmux 3.7c and at the 3.2 floor — all Task 1's
   measurements, cited rather than re-asserted. `docs/frame.md`'s "not shipped yet" line about
   `charter handoff`, true when Task 1 wrote it, is corrected in the same PR that makes it false.

## Tests

Two new modules, 56 cases:

- `tests/test_a_handoff_refuses_before_it_changes_anything.py` — every refusal, each beside
  `_nothing_changed` (no workspace, no todo, no brief file, no tally row, the seam never
  called), the parser's shape (`--brief-file`, `--harness`, `--repo` all `SystemExit`), and that
  the thirteen refusals are pairwise distinct.
- `tests/test_charter_handoff_opens_a_chat_that_starts_working.py` — the stamp, the first
  message verbatim, the todo's title and what is NOT in it, the duplicate that does not stop the
  handoff, the private brief (mode `0o077 & …  == 0`, survives `clear_shape`), the tally row's
  exact keys and `here`/`elsewhere`, the printed line, what stays when the chat does not open,
  the routing mark in and out of a plane, and #936's property observed end to end — a handed-off
  chat's SessionStart asks no workspace question.

Full suite: **12,748 tests, 9 skipped, green** (904s). The run before it had one failure —
`test_no_test_bakes_a_uid_into_a_socket_path` catching a literal `/tmp/tmux-501/default` in this
branch's own new test module, which is exactly the fixture-from-one-machine defect
CONTRIBUTING.md's *Your machine is not the runner* is about. Fixed to
`tests._tmuxsocket.OPERATOR_SOCKET` before this commit. Local sweep running; CI sweep shards on
push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Review round 1 (`f0cc56b`)

- **The second handoff into a workspace recorded no todo.** `handoff.todo_text` ends every
  handoff todo in the same nine-word provenance sentence, and `todos.duplicate_of` scored
  Jaccard over the whole text — so that boilerplate read as agreement on both sides: `Fix the
  widget` and `Ship the release`, sharing no word at all, scored **0.750**. Fixed at the cause,
  not the threshold: `duplicate_of` gains `by_title`, first line against first line on both
  sides, and those two now score **0.000** while two handoffs on the same brief still score
  **1.000**. Both directions pinned, end to end and in `tests/test_todos_store.py`.
  `memstore.title_of` is `write`'s own title rule lifted out, so the reader computes the same
  string as the writer instead of respelling it.
- **The brief is pinned out of the committed todo against the RAW files.** The old assertion
  read `open_todos()["text"]` — `memstore.body()`, stripped and lowercased — so the whole brief
  in the todo left 807 tests green. It reads every file under `todos/` now, and that mutation
  goes red.
- **A closed stdin is a classified refusal.** `charter handoff beta 0<&-` hands Python
  `sys.stdin is None`, and A7 allows that spelling, so it reached `isatty()` on `None` and
  drafted a crash report (ADR 0009).
- **The brief is written before the harness starts.** `Opening` carries it and `_launch`
  records it where the persona pointer is written, for the same stated reason. Pinned: the
  brief is on disk at the `new-window` that starts the harness.
- **The `LONG_FIRST_MESSAGE` guard is pinned** — a background refusal that is not about size
  gets no stamped-message note.
- **Two docs sentences corrected**: what the duplicate rule does, and which of the seam's
  refusals a handoff can actually produce (the stamp makes every first message open with `⟨`
  and run to eleven words or more, so empty, flag-shaped and single-word are unreachable — a
  `--help me now` brief opens a chat, and that is a test).
- **First-round sweep survivors handled**: `source_chat`'s and `source_ws`'s conditionals were
  equivalent mutants and are gone (`chats.is_chat("")` is False, and `state.workspace_for`
  already ends in `workspace.resolve()`); the two `contain.one_line` calls and the
  `[harness] default` fallback are pinned instead.

Six hand mutations, each red: `by_title` off, the whole brief in the todo, the size guard always
true, the empty-brief guard deleted, the closed-stdin guard deleted, and the brief recorded after
the launch.


## Review round 2 (`4d478f2`)

- **The duplicate rule was wrong in both directions.** `memstore.wordset` keeps only words
  longer than three characters, so `fix the bug` has no comparable word at all — two of them
  agree on nothing and the same brief handed off three times recorded three identical todos
  with no notice; and one shared word out of two is 0.5 exactly, so `Fix the widget` swallowed
  `Break the widget` and `Update the README file` swallowed `Delete the README file`. Both are
  one defect: a ratio read as evidence when the words behind it cannot tell the titles apart.
  `todos._MIN_SHARED_WORDS` — below three shared words the overlap decides nothing and the
  comparison falls back to whether the two titles ARE the same title, ignoring case and runs of
  whitespace. Identity needs no threshold and cannot be wrong about identity; 0.51 would have
  answered one of those three pairs. Measured: 0/0/1/2/1 shared words across the five shapes,
  all now decided by identity — two collapse, three do not — while a real overlap still goes
  through Jaccard. Stated rather than engineered around: two titles differing only past
  `TITLE_MAX` are stored as the same 72 characters and read as one todo.
- **The brief's wire is pinned at the join.** Dropping `brief` from
  `Opening(first_message, persona, brief)` left 13 modules green while the plane lost the brief
  and the handoff still reported success. The new case drives the real `open_in_background` and
  reads the `Opening` the launcher was handed.
- **The brief-privacy assertion is an equality** over every committed byte — heading, blank
  lines, body and index row — with only the recorded timestamp matched. The substring check it
  replaces passed `brief[:-2]`, 34 of 36 characters.
- **`TITLE_MAX` and `title_of`'s cap and strip are pinned**, with the cap's number spelled out
  in the test rather than read off the constant — an expectation computed from the value it
  checks moves with it, and widening to 4096 and retuning by one both stayed green against
  `"x" * memstore.TITLE_MAX`. `write`'s own title cap and strip are pinned through the index
  row, the only reading where the writer's strip is visible.

Eleven more hand mutations, all red.


## Review round 3 (`6bdffd3`)

- **The two duplicate callers want opposite errors, so they get different rules.** Round 2
  applied the no-signal rule to `duplicate_of`'s whole-text path too. On the reviewer's 20
  pairs the two whole-text rules disagree on **10** verdicts; on a second 20-pair corpus
  written here — the reviewer's five regressions plus fifteen more — they disagree on 12. Two
  corpora, not a disputed measurement. Five of the changed verdicts are one shape — a one-line todo
  retitled by a word (`Fix the login bug` / `Fix the login issue`, `Update the README` /
  `Update the README file`, `Review the backlog` / `Review the backlog again`, `Rotate the
  staging tokens` / `Rotate the staging token`, `Add a retry to the webhook sender` / `Add
  retries to the webhook sender`) — turning from caught into missed.

  That path's caller is `charter ws todo`, which **refuses** on a duplicate: a false one costs
  a rephrase, a missed one leaves two near-identical todos, and `cmd_ws_todo`'s own comment
  says which is worse. A handoff is the other way round — it records nothing and opens the chat
  anyway, so a false duplicate silently drops a real todo and the work goes invisible. A
  tiny-set overlap cannot tell "retitled by a word" from "different work sharing a word"; what
  differs is which way to be wrong, and that belongs to the caller.

  So `_MIN_SHARED_WORDS` scopes to `by_title`. `_same_text` is the whole-text rule exactly as
  it stood before this branch; `_same_work` is the handoff's. The tests that pinned the round-2
  whole-text behaviour are re-pointed at `by_title`, and the five retitles are pinned twice —
  caught on the whole-text path, two todos on the handoff path — with the reason on both.
- **The brief-privacy assertion is a literal.** It compared the committed body against
  `handoff.todo_text(BRIEF, …)` recomputed at assert time — the function under test — so both
  sides moved together and `brief[:-2]` and a five-character slice both stayed green with the
  leak plainly in the file. The expected file is written out byte for byte now, with only the
  recorded timestamp standing in for itself.
- **`_MIN_SHARED_WORDS` is pinned with its number written out**, the way `TITLE_MAX` is: two
  titles sharing exactly three words at 0.750 are one todo, and at a floor of four they would
  fall to identity, read as different lines, and be recorded twice.
- The docs and the news entry say whose rule it is and why the other caller keeps the old one,
  and name what identity does not collapse: punctuation, so `Fix the widget!` is a second todo.

Eight more hand mutations, all red — the three leak slices, the constant both ways, each path
swapped for the other, and the identity fallback removed.

- **Follow-up (`436fe83`): the stored side of the handoff comparison is pinned.**
  `_same_work` reads `_words(title)` — the stored todo's first line, not its body — and nothing
  reddened when that went back to `title + body`. Not an equivalent mutant: with the real
  provenance tail on the stored side the nine boilerplate words join the union and drop the
  score under the threshold, so `Rotate the staging tokens` beside `Rotate the staging tokens
  again` (three shared words, 0.750) is recorded twice. It survived because every case reaching
  that side with a real overlap stored a bare title, where the body IS the title, and the cases
  carrying the tail only ever compared identical titles — answered by the identity fallback
  before the overlap is read. `tools/sweep.py` offers no operator on that line, the same blind
  spot as the `Opening(..., brief)` join. One case with two real handoff todos fixes it; both
  halves of "first lines on both sides" are now red when dropped.

- **Follow-up (`d90cd22`): the duplicate threshold is pinned at the score that sits on it.**
  `_same_work`'s `>= _DUPLICATE_THRESHOLD` survived as `>`, and it is not equivalent: a
  `by_title` pair scoring exactly 0.500 flips from duplicate to distinct and a genuine handoff
  duplicate is recorded twice. `Rotate the staging tokens` beside `Rotate the staging tokens
  before Friday morning` — three shared words out of a union of six, both spelled out in the
  case — is that pair. Both threshold comparisons are now red under `>`.

### Expected sweep survivor, pre-existing

`_same_text`'s `if not words: return None` is dead: with an empty word set the score is
`0 / len(other)`, already below the threshold, so the early return changes no answer. It is the
whole-text rule **restored byte-for-byte from before this branch** (`5be7097`'s parent), not
code this PR introduces — it moved into its own function when the two paths split, which is why
the sweep charges it here. Left as it was rather than deleted in a review round about something
else; deleting it is a change to `charter ws todo`'s path and belongs to whoever next has a
reason to touch it.

- **Follow-up (`ff193d4`): a brief's bytes are escaped on every line charter prints them to.**
  `shlex.quote` wraps a word in single quotes and escapes nothing, so ESC, `\r`, backspace and
  a bidi override all reached the terminal raw on the printed `charter <harness> --workspace …`
  line — the one refusal charter tells the operator to PASTE, carrying the whole brief. A brief
  opening `\r✓ opened chat beta.9` repainted charter's own refusal as a success.
  `handoff._shown` runs it through `contain.one_line` without that helper's 160-character
  report clip, which would cut a 12 KB brief off mid-sentence; the cost — a control character
  is pasted as its escape — is stated in the docstring.

  `_list_todos` (listing and `--query`) and `cmd_ws_todo`'s duplicate refusal print stored
  titles, and what this PR changed is who writes one: a title used to be typed by the operator
  and is now a model's first line. Escaped at the render, never into storage, and a test pins
  that direction too. The frame's todo panel and palette row were **measured, not assumed**, and
  both were already safe — `slots._todo_rows` escapes as it draws, and `_read_todo` answers raw
  into `Palette.report`, which contains it where the heading is composed. Both now have the test
  that says so.

  Also: `handoff.title` splits on `\n` only (`str.splitlines` breaks on `\r`, `\x0b`, `\x0c`,
  `\x1c`–`\x1e` and U+2028, so charter's "first line" was a prefix of the operator's);
  `record_handoff` opens with `O_NOFOLLOW`, closing the check-then-open race on the final
  component while `write_refusal` keeps the shapes a flag cannot see; and the `0o644` test sets
  the umask, without which it passed under `0o644 → 0o666`.

### Local sweep

15 survivors out of 104 mutations against `069ba64`, every one now pinned: six in `bb86bf8`,
the `>=` boundary in `d90cd22`, and eight here — `title`'s two strips folded into one bound
name, `read_brief`'s emptiness asked with `split()` (`background_refusal`'s own settled rule),
`terminal_command`'s `create`/`vision` pair folded into one `create_vision`, `memstore.title_of`
stripping once on the line instead of once on the body and once on the line,
`state.record_brief`'s write catch, `todos._normal`'s fallback, and the two above. Twenty-one
hand mutations across the round, all red.

- **Follow-up (`06c454f`): the printed command asks for no clip instead of counting to the
  widest escape.** `_shown` multiplied the input by 6, the `\uXXXX` form — but
  `contain.one_line` formats with `:04x`, a **minimum** width, so a codepoint outside the BMP
  renders as seven characters (U+E0001, the language tag; the musical format controls). At
  about a thousand of those the budget under-shot, the helper clipped, and the pasted line
  ended in `…`: the failure the escaping exists to prevent, reintroduced by the arithmetic
  meant to avoid it. Counting to seven would be the same mistake with a better number — a
  claim about which categories Unicode has assigned where, one too small being a silent clip
  and one too large a mutant nothing can kill. There is no width now: `_NO_CLIP` is
  `sys.maxsize`, which says what the call means.

  The old test could not have seen it either — 4,000 ordinary characters need no escaping, so
  it was green under any budget, right or wrong. The new case sends a brief made **of** escaped
  characters and asserts all thousand escapes arrive, none of the raw ones do, and there is no
  `…`. Restoring the 160-character clip is red, and so is a per-character budget at 6 or at 3.
