### PR TITLE
Pin the three guards #982's sweep found unpinned (chat handoff, task 4)

### DIFF
--- a/tests/test_a_handoff_waits_for_a_yes.py
+++ b/tests/test_a_handoff_waits_for_a_yes.py
@@ -1499,6 +1499,68 @@ class DoctorNamesTheGate(SessionRootCase):
         self.assertIn("under opencode", r.detail)
         self.assertEqual(self.ADD, r.hint)
 
+    def _workspaces_through_a_symlink(self) -> None:
+        """Point charter's `workspaces/` at a SYMLINK to itself, so every path it builds from
+        that directory needs normalising before it can be compared with a session's cwd.
+
+        Built here rather than relied upon: `SessionRootCase` documents that macOS reaches its
+        temp directory through `/var` → `/private/var`, and that is exactly the accident these
+        two `.resolve()` calls were leaning on. On Linux there is no such symlink, so dropping
+        either `.resolve()` left CI's whole suite green while the same mutation died on a
+        developer's machine — a guard pinned by the platform and not by a test (#982's sweep,
+        `drop-normalise` at `_reinit_target`). A symlink the fixture makes itself pins them
+        everywhere.
+        """
+        real = (config.ROOT / "workspaces").resolve()
+        real.mkdir(parents=True, exist_ok=True)
+        link = config.ROOT / "workspaces-by-another-name"
+        if not link.is_symlink():
+            link.symlink_to(real, target_is_directory=True)
+        self.enterContext(mock.patch.object(config, "WORKSPACES_DIR", link))
+
+    def test_a_workspace_reached_through_a_symlink_is_still_this_workspace(self):
+        """The session stands at the workspace's REAL path; charter builds the same directory's
+        path through the symlink. They are one directory, and only normalising says so."""
+        self._workspaces_through_a_symlink()
+        self._claude_rule(config.ROOT)
+        self._opencode_rule()
+        self.rooted_at(self.workspace)
+        r = doctor.check_handoff_gate()
+        self.assertEqual(WARN, r.status, r)
+        self.assertEqual(self.REFRESH, r.hint)
+
+    def test_a_guest_checkout_reached_through_a_symlink_is_still_that_checkout(self):
+        """The same for the guest tree, whose path charter builds by walking the symlinked
+        workspace directory — a second `.resolve()`, and the sweep reads the pair together
+        because neither was pinned alone."""
+        self._workspaces_through_a_symlink()
+        repo = self.workspace / "repo"
+        repo.mkdir(parents=True, exist_ok=True)
+        # env=None: the suite has already redirected git's config (#641).
+        subprocess.run(["git", "init", "-q", str(repo)], check=True)
+        self._claude_rule(config.ROOT)
+        self._opencode_rule()
+        self.rooted_at(repo.resolve())
+        r = doctor.check_handoff_gate()
+        self.assertEqual(WARN, r.status, r)
+        self.assertEqual(self.REFRESH, r.hint)
+
+    def test_one_harness_holding_the_rule_is_enough_to_call_the_layer_behind(self):
+        """`any`, not `all`, over the harnesses that are missing the rule. With two missing and
+        only one of them held by the plane, the two answers part company: `any` says the layer
+        here is behind — which it is, for Claude Code — while `all` says nothing is held and
+        offers `guard ask`. Every earlier test had a single missing harness, where the two
+        quantifiers agree, which is how this survived (#982's sweep, `swap-synonym`)."""
+        self._claude_rule(config.ROOT)          # the plane holds it for claude-code
+        # …and NOT for opencode, so both harnesses are missing here but only one is held.
+        docs = config.ROOT / "docs"
+        docs.mkdir(parents=True, exist_ok=True)
+        self.rooted_at(docs.resolve())
+        r = doctor.check_handoff_gate()
+        self.assertEqual(WARN, r.status, r)
+        self.assertIn("opencode", r.detail)
+        self.assertEqual(self.NOWHERE, r.hint)
+
     def test_a_chat_in_a_guest_checkout_is_sent_to_reinit(self):
         """A checkout inside a workspace is a directory `reinit` writes, so the clause belongs
         there too — and nothing pinned it. Deleting the guest-checkout match left the suite


### PR DESCRIPTION
Tests only. Follow-up to #982, off main at d44a866.

#982's CI sweep reached a verdict rather than timing out, and named three survivors — all in `charter/doctor.py`, all introduced by that PR:

```
gate: 1 unpinned, 2 in masked cluster(s), 0 platform-deferred, 0 unresolved, 0 out of time, 0 not applied, 0 withheld, 17 pinned, 0 shard(s) refused
gate: 3 survivors
```

## Two guards were pinned by the platform, not by a test

`_reinit_target` compares the session's cwd with paths built from `workspaces/`, normalising both first. Dropping either `.resolve()`:

| | macOS | Linux (CI) |
| --- | --- | --- |
| `workspace_dir(name).resolve()` → `workspace_dir(name)` | dies | **survives the full suite** |
| `tree.resolve()` → `tree` | dies | **survives the full suite** |

The temp directory is reached through `/var` → `/private/var` on macOS and directly on Linux. `SessionRootCase` documents that asymmetry in a comment — and these tests were leaning on it, so CI could never see the guard was unpinned.

The fixture now **makes its own symlink**: `config.WORKSPACES_DIR` points at a link to the real `workspaces/`, the session stands at the real path, and the two are one directory only if charter normalises. That holds on every platform.

They are pinned **separately**, which is what breaks the masked cluster — the sweep read them together because neither failed alone. Verified with CI's own mutations: line 1980 reddens `…a_workspace_reached_through_a_symlink…` and not the guest test; line 1982 reddens `…a_guest_checkout_reached_through_a_symlink…`. Two guards that now fail independently, not one pin claimed twice.

## The third was hidden by every test having one missing harness

`_how_to_fix` asks `any(plane.get(h.name) == "present" for h in missing)` — does the plane hold the rule for **any** harness missing it here? With a single missing harness `any` and `all` agree, and every earlier test had exactly one. With two they part company:

- Claude Code missing here and **held** by the plane;
- opencode missing and **not** held.

`any` → this directory's layer is behind, which it is. `all` → nothing is held, offering `guard ask`. Pinned with that plane.

## Method note

Each mutation was applied **verbatim from the sweep's own artifact**, not retyped from the warning text. That mattered: the first three I wrote by hand all died locally while CI's real ones survived — which is exactly how the platform-dependence surfaced. A guessed mutation is a guessed pin.

## Checks

- **Full suite: 12876 tests, OK (skipped=9), 1067 s.**
- All three of CI's survivors now red, each caught by the test written for it.
- A pending sweep blocks merge on this repo regardless of the gate's "reporting only" line — filed as #988.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
