### PR TITLE
A handoff's workspace moves to the front of the strip and stays marked until you look at it

### DIFF
--- a/charter/commands_frame.py
+++ b/charter/commands_frame.py
@@ -4930,6 +4930,10 @@ def _focus_workspace(session_id: str, chat: str, *, ws: str, picked: bool) -> in
     # A focus opens nothing, so this is the only place its answer can come from — without
     # it a focused launch would record the plane with no focus at all.
     record.focus_on(chat)
+    # Before the attach and not after it: `interact` IS this terminal for as long as the
+    # operator stays, so a clear on the far side of it would leave the workspace marked for
+    # the whole time they were reading it and drop the mark as they left.
+    _looked_at(ws)
     attach_cmd = tmuxctl.server_argv(SOCKET, "attach", "-t", session_id)
     attached = tmuxctl.interact(attach_cmd)
     if attached.returncode != 0:
@@ -6067,6 +6071,14 @@ def _launch(args) -> int:
             # attach": `attach` stays ``None``, `code` stays ``None``, and the tail reports
             # a detached chat, which is precisely what this is.
             if _wants_attach(args):
+                # This terminal is about to be looking at *ws*, so the workspace's arrived
+                # mark is paid — :func:`_focus_workspace`'s reason for the placement, and
+                # gated on `_wants_attach` for the reason that gate exists at all: a launch
+                # that never becomes anybody's terminal (a background open, a reopen
+                # building chats nobody has seen) has looked at nothing. A handoff's own
+                # `open_in_background` is exactly such a launch, so the chat it opens
+                # cannot clear the mark it is the reason for.
+                _looked_at(ws)
                 # `tmuxctl.interact`, not `tmuxctl.run`: no capture and no timeout — this
                 # IS the operator's own terminal for as long as the harness runs, not an
                 # admin command whose output (or lifetime) charter should own.
@@ -8164,6 +8176,43 @@ def _open_workspace(fid: str, ws: str, *, socket: str,
     return opened
 
 
+def _looked_at(ws: str) -> None:
+    """A terminal on this plane is now looking at workspace *ws*: drop its arrived mark and
+    tell every frame to repaint without it.
+
+    **One function for the three arrivals, not three pairs of lines.** A switch
+    (:func:`_switch_client`), a focus (:func:`_focus_workspace`) and a launch that attaches
+    (:func:`_launch`) are the three ways a terminal comes to be looking at a workspace, and
+    the clear must mean the same thing at all three — a mark cleared on two of them is a
+    tab that stays green for an operator who is reading it, which is the readout lying.
+
+    **The bump is the other half and is not optional.** A panel polls `state.version` and
+    then reads its own facts; clearing the record without moving the version would leave
+    every OTHER frame on the plane drawing the mark until something unrelated bumped it.
+    `notify.bump_everywhere` rather than `plane_changed_everywhere` for the reason that
+    function carries: a cleared mark moves no fact a gather holds, and this is the switch
+    path.
+
+    **A workspace with no mark costs nothing**, which is `workspace.clear_arrival`'s own
+    no-op rule said one level up, where the expensive half is. Every switch, focus and
+    attach on this plane reaches here, and almost none of them follows a handoff: an
+    unconditional fan-out would bump every frame directory on the plane — and repaint every
+    background frame's panels — on every workspace switch an operator ever makes, to say
+    that nothing changed. The ask is one read of a file under `STATE_DIR`; the alternative
+    is N writes and N repaints. `arrivals()` answers `frozenset()` for a plane that has
+    never had a handoff, so that plane pays exactly one `stat`.
+
+    Imported here rather than at module scope: `frame.notify` imports `frame.gather`, which
+    is the heaviest thing in the frame package, and this module is imported by the CLI's
+    own dispatch table on every `charter` command.
+    """
+    from .frame import notify
+    if ws not in workspace.arrivals():
+        return
+    workspace.clear_arrival(ws)
+    notify.bump_everywhere()
+
+
 def _switch_client(fid: str, ws: str, *, said: str) -> None:
     """Move the client(s) reading chat *fid* to this plane's workspace *ws* — §4b.
 
@@ -8328,6 +8377,18 @@ def _switch_client(fid: str, ws: str, *, said: str) -> None:
         _say_on_screen(fid, "cannot switch: tmux did not move this terminal to "
                             f"'{ws}', so this chat keeps its panels")
         return
+    # **Somebody is now looking at *ws*, so its arrived mark has been paid.** Here and not
+    # a line earlier: every refusal above leaves the operator still owed the look, and a
+    # mark cleared by a switch that tmux then refused would lose the only thing pointing at
+    # a chat a handoff opened.
+    #
+    # **Plane-wide, not per client.** A pane draws the same bytes for every client of its
+    # session (§2.10) and the strip's repaint path asks tmux nothing, so there is no
+    # per-client mark to clear even if charter wanted one — the spec states that as a limit
+    # rather than pretending otherwise. `bump_everywhere` and not
+    # `plane_changed_everywhere`: a cleared mark moves no fact a gather holds, and a scan
+    # per workspace on the switch path would cost more than the switch does.
+    _looked_at(ws)
     landed = _chat_showing(_window_seats(socket, "finding the chat this switch landed on"),
                            there[0])
     # **The ARRIVAL first, and the departure tidied behind it** — `cmd_chat`'s ordering

--- a/charter/commands_frame.py
+++ b/charter/commands_frame.py
@@ -4810,7 +4810,12 @@ def _choose_workspace(args) -> tuple[str, int | None, bool]:
         sys.stdout.flush()
 
     got = picker.ask(
-        picker.rows(switch.workspaces(), lambda n: len(workspace.clones(n))),
+        # The arrivals ride the list the launch is choosing from, because this is the
+        # earliest surface that can say "there is work waiting in that one" — before tmux,
+        # before a frame, before any strip exists to draw a mark on. `frame_slots._arrived`
+        # is the same read behind the same never-raises guard.
+        picker.rows(switch.workspaces(), lambda n: len(workspace.clones(n)),
+                    frame_slots._arrived()),
         current, read=_read, write=_write, name_ok=workspace.valid_name,
         width=tui.term_width())
 
@@ -9209,6 +9214,23 @@ def cmd_switch(args) -> int:
         if out.ok:
             _switch_client(fid, ws, said=out.message)
             return 0
+        # **Pressing the tab for the workspace you are already in IS looking at it**, and
+        # without this line that is the one state where the mark can never be paid. The
+        # frame drawing `*gamma` gives the block the mark's cell (`slots._mark_cell`), so
+        # the operator sitting in the arrived workspace is the one operator who cannot see
+        # the mark — while every other frame on the plane draws `✶gamma` and goes on
+        # drawing it, because `to_workspace` refuses this switch and `_switch_client` never
+        # runs. `docs/frame.md` says the mark stays "until you look at it"; this is what
+        # makes that sentence true rather than nearly true.
+        #
+        # Asked as a FACT and not off the refusal's wording: `to_workspace` refuses for
+        # three reasons and only this one means "you are here", so reading it out of
+        # `out.message` would be a sentence two surfaces have to keep agreeing about.
+        # Every workspace switch on this plane — the tab, the palette row, the keyboard
+        # walk and a typed `charter frame-switch` — arrives at this one function, so one
+        # line covers all four.
+        if ws == switch.current_workspace(fid):
+            _looked_at(ws)
     elif persona_name:
         out = switch.to_persona(fid, persona_name)
     else:

--- a/charter/commands_handoff.py
+++ b/charter/commands_handoff.py
@@ -99,6 +99,14 @@ NOTHING_ELSE = (
     "charter handoff: {why}\n  What stays: {stays}. No chat opened, so the brief was sent "
     "to nobody and nothing is running.")
 OPENED = "charter handoff: opened chat {chat} in workspace '{ws}', started on the brief"
+#: Said when the chat opened and its workspace could not be marked arrived. The chat is
+#: real and is named; what is missing is the thing that would have pointed at it, so the
+#: line hands that job back to the operator rather than reporting a failure they cannot
+#: place. The workspace tab still moved to the front of the strip — that is a different
+#: record and it did not fail — so "look at it" is a thing they can act on now.
+UNMARKED = ("charter handoff: {chat} is open in '{ws}', but charter could not mark that "
+            "workspace's tab as arrived — its state directory refused the write. Nothing "
+            "on the strip will point at the new chat; its tab did move to the front.")
 
 
 def _printed_command(*, ws: str, msg: str, create_vision: str | None,
@@ -253,12 +261,23 @@ def cmd_handoff(args) -> int:
     # The move first and the mark second, which is the order they are read in: the tab goes
     # to the front of the plane's order, and then it is marked as one nobody has looked at.
     switch.bring_to_front(ws)
-    if ws != source_ws:
+    if ws != source_ws and not workspace.record_arrival(ws):
         # **A handoff into the workspace you are IN marks nothing** (spec, step 8): you are
         # looking at it, so there is no look still owed, and its chats strip already shows
         # the new tab. The tab still MOVES — the plane's order is about where work is, and
         # the workspace this chat just handed work to is where it is.
-        workspace.record_arrival(ws)
+        #
+        # **And a mark that could not be written is SAID rather than swallowed.** The chat
+        # is open either way — nothing below is conditional on this — but the strip is the
+        # only thing that was going to point at it, so a silent failure here is exactly the
+        # invisible work this command exists to end, arriving through the fix for it. The
+        # operator is told which workspace to go and look at, because that is the thing the
+        # mark would have done for them.
+        # `warn` and not `err`: the handoff DID what it was asked — the chat is open and
+        # started on the brief — and a `✗` would tell the operator the command failed
+        # when what failed is the pointing. `!` is the mark for "this worked and there
+        # is something you need to know", which is exactly this.
+        util.warn(UNMARKED.format(ws=ws, chat=opened.chat))
     # The calling chat's own attention row, which is the only screen this command has: its
     # stdout goes to a Bash tool call the operator may never read, and the chat it opened
     # is somewhere else by construction.

--- a/charter/commands_handoff.py
+++ b/charter/commands_handoff.py
@@ -22,7 +22,15 @@ The order is the spec's, and the order is the design:
 4. `commands_frame.background_refusal`, the seam's own answer, asked while it is still free.
 
 Then the writes: the workspace, the todo, then the chat — which carries the private brief in
-with it, so the file exists before the harness that reads it — then the tally and the line.
+with it, so the file exists before the harness that reads it — then the tally, the strip and
+the line.
+
+**The strip is what makes a background chat visible** (the spec's *The strip*). A handoff
+opens a window nobody is looking at, so the last thing this command does is move where the
+eye goes: the target workspace goes to the front of the plane's tab order, its tab is marked
+arrived until any terminal on this plane looks at it, and the calling chat's own attention
+row names the chat that was opened. All of it after the open, so a refused handoff points at
+nothing.
 """
 
 from __future__ import annotations
@@ -32,7 +40,7 @@ import sys
 
 from . import (commands_frame, config, contain, dispatch, handoff, harness, persona, todos,
                util, workspace)
-from .frame import chats, state, switch, tmuxctl
+from .frame import chats, notify, state, switch, tmuxctl
 
 BAD_NAME = ("charter handoff: '{ws}' cannot name a workspace — nothing was opened. A "
             "workspace name is letters, digits, '.', '_' and '-', and does not start with "
@@ -238,5 +246,29 @@ def cmd_handoff(args) -> int:
     # reach a committed file through the tally (plan Open question 16).
     dispatch.record_handoff(placement="here" if ws == source_ws else "elsewhere",
                             created=bool(args.create))
+    # **The strip, and every line of it is after the open** — a handoff that did not open
+    # returned above, so a refused one moves no tab, marks nothing and says nothing on the
+    # attention row. What is on screen is only ever a chat that exists.
+    #
+    # The move first and the mark second, which is the order they are read in: the tab goes
+    # to the front of the plane's order, and then it is marked as one nobody has looked at.
+    switch.bring_to_front(ws)
+    if ws != source_ws:
+        # **A handoff into the workspace you are IN marks nothing** (spec, step 8): you are
+        # looking at it, so there is no look still owed, and its chats strip already shows
+        # the new tab. The tab still MOVES — the plane's order is about where work is, and
+        # the workspace this chat just handed work to is where it is.
+        workspace.record_arrival(ws)
+    # The calling chat's own attention row, which is the only screen this command has: its
+    # stdout goes to a Bash tool call the operator may never read, and the chat it opened
+    # is somewhere else by construction.
+    commands_frame._say_on_screen(fid, f"handoff → {opened.chat} opened in workspace "
+                                       f"'{ws}'", ok=True)
+    # ONCE, at the end, for everything this command wrote — the todo, the tally, the order
+    # and the mark — which is `plane_changed_everywhere`'s own rule about being called at
+    # completion rather than per unit of work. The full fan-out and not `bump_everywhere`
+    # here: a handoff made a chat (and with `--create` a workspace), so the repo tables
+    # every frame on this plane draws have genuinely changed.
+    notify.plane_changed_everywhere()
     print(OPENED.format(chat=opened.chat, ws=ws))
     return 0

--- a/charter/frame/choose.py
+++ b/charter/frame/choose.py
@@ -317,13 +317,44 @@ def roster(noun: str, fid: str) -> Roster:
     """
     names = tuple(names_of(noun, fid))
     now = current(noun, fid)
+    # Read ONCE for the whole roster rather than per row: `workspace.arrivals` is an
+    # `os.scandir`, and asking it forty times to build forty rows would be the per-name
+    # read `slots._workspace_counts` records paying for and then stopped paying.
+    arrived = arrivals_now() if noun == WORKSPACE else frozenset()
     rows = tuple(overlay.Row(id=NAME_ID.format(noun, i), title=n, mark=(n == now),
-                             note=_note(noun, n))
+                             note=_note(noun, n, arrived))
                  for i, n in enumerate(names))
     return Roster(noun=noun, rows=rows, names=names)
 
 
-def _note(noun: str, name: str) -> str:
+#: What a workspace row says when a handoff landed there and nobody has looked yet.
+#:
+#: **Words here, a glyph on the strip, and that is the surfaces differing rather than
+#: charter saying two things.** `slots._ARRIVED_MARK` spends one cell because a bar draws
+#: several names on one row and every column is contested; a picker draws one name per row
+#: and already has a note column, so it can say what it means. It is also the surface an
+#: operator reaches when the strip has run out of room — see `docs/frame.md` on an arrival
+#: behind the overflow count.
+ARRIVED_NOTE = "handoff arrived"
+
+
+def arrivals_now() -> frozenset[str]:
+    """The workspaces a handoff landed in that nobody has looked at yet — never raises.
+
+    `slots._arrived` one surface over, and a wrapper for its reason rather than a call this
+    module could make inline: the palette is drawn by a pane, and a readout that raised
+    would cost the operator the whole picker rather than one note. `workspace.arrivals`
+    already answers `frozenset()` for a record it cannot list, so what this catches is the
+    failure that is not about the directory.
+    """
+    from .. import workspace as ws_mod
+    try:
+        return ws_mod.arrivals()
+    except Exception:  # noqa: BLE001 - a readout must never cost a picker
+        return frozenset()
+
+
+def _note(noun: str, name: str, arrived=frozenset()) -> str:
     """What *name*'s row carries in its note column, or ``""``.
 
     One function rather than a branch inside :func:`roster`'s comprehension, so that
@@ -334,10 +365,21 @@ def _note(noun: str, name: str) -> str:
     `zeb-api` the workspace; inside a picker every row is the same noun and the heading
     already says which).
 
+    **A workspace now has something per-row to say**, and it passes the objection this
+    function's docstring makes about the launch pin: that one is the same sentence on every
+    row of a picker that cannot be opened while it is true, and this one is a fact about
+    ONE workspace that the operator is choosing between rows on. It is the whole reason the
+    picker is worth reaching when the strip has windowed the arrival behind a `+2`.
+
+    *arrived* is passed rather than read, so this stays a pure function of its arguments —
+    the picker's forty rows ask `workspace.arrivals` once, in :func:`roster`.
+
     Not contained here. `overlay.Surface.render` runs `contain.one_line` over every note
     before `tui.width` sees it (#472), and a second call would be the masked line
     `builtin_actions._register_names` shipped and this module's docstring records.
     """
+    if noun == WORKSPACE:
+        return ARRIVED_NOTE if name in arrived else ""
     # The PROFILE first, because that is what the operator named the way this chat runs —
     # two chats of one kind may be two accounts. A chat from before profiles has only its
     # harness, which is what it recorded.
@@ -378,9 +420,28 @@ def labelled(roster: Roster, reason: str = "") -> tuple[overlay.Row, ...]:
     ``_replace`` rather than a fresh `overlay.Row`, so the id and the mark are carried
     over untouched: the id is what :meth:`Roster.name_of` matches on, and a labelled row
     that minted its own would be a row that stands for no name.
+
+    **The arrived note is kept BESIDE the kind rather than displaced by it**, which is the
+    one place this function adds to a note instead of replacing it. The kind is what tells
+    `zeb` the persona from `zeb-api` the workspace and cannot go; the arrival is the reason
+    an operator is typing that name at all, and a top-level list that dropped it would say
+    less about a workspace than the picker one keypress further in. A *reason* still
+    displaces both, unchanged: a row that cannot run has one thing to say and it is why.
     """
-    return tuple(r._replace(note=reason or roster.noun, refused=bool(reason))
+    return tuple(r._replace(note=reason or _labelled_note(roster.noun, r.note),
+                            refused=bool(reason))
                  for r in roster.rows)
+
+
+def _labelled_note(noun: str, note: str) -> str:
+    """The kind, with whatever :func:`_note` already put on the row kept beside it.
+
+    Spelled as its own function so "what a top-level row says" is one expression a test can
+    ask about, rather than a conditional inside a comprehension that also carries the
+    refusal rule. `·` is the separator `_say_on_screen` and the stamp already use for two
+    facts on one line, so this invents no punctuation.
+    """
+    return f"{noun} · {note}" if note else noun
 
 
 def open_rows(fid: str) -> tuple[overlay.Row, ...]:

--- a/charter/frame/notify.py
+++ b/charter/frame/notify.py
@@ -255,3 +255,34 @@ def plane_changed_everywhere() -> None:
             state.bump(fid)
     except Exception:
         return
+
+
+def bump_everywhere() -> None:
+    """Tell every frame on this plane to repaint, and gather NOTHING. Never raises.
+
+    :func:`plane_changed_everywhere` without the scan, for the changes that move no fact a
+    gather holds. Clearing a workspace's arrived mark is the first of them
+    (`workspace.clear_arrival`): the strip reads that record directly on its own render
+    path, so a repaint is the whole of what the other frames need — no repo is dirtier, no
+    branch has moved, and no CI run has finished.
+
+    **The scan is what makes this a different function rather than a flag**, and it is the
+    reason to have one at all. A cold `gather.scan()` costs ~35ms and three git
+    invocations, once per distinct workspace, and this runs on the SWITCH path — every time
+    any terminal on this plane arrives anywhere. `docs/frame.md` measures a whole workspace
+    switch at 142ms on tmux 3.7c; a fan-out that scanned would put a plane's worth of git
+    on top of that to clear one mark. What is left is one `stat`-and-write per frame
+    directory.
+
+    **Every frame, and no liveness check** — :func:`plane_changed_everywhere`'s rule
+    unchanged, for its reason: a bump into a dead frame is a few bytes `state.reap` will
+    remove, and `state.is_live` costs a tmux subprocess charter would be spending to save a
+    write. The whole body is one `try` for the same reason as well: a frame root that
+    cannot be listed is nothing to bump, and a repaint nobody asked for must never be the
+    thing that raises out of a switch.
+    """
+    try:
+        for e in os.scandir(state._root()):
+            state.bump(e.name)
+    except Exception:
+        return

--- a/charter/frame/picker.py
+++ b/charter/frame/picker.py
@@ -53,6 +53,15 @@ _MARK = ("*", " ")
 
 _R, _DIM, _BOLD = "\033[0m", "\033[2m", "\033[1m"
 
+#: What a row says when a handoff landed in that workspace and nobody has looked yet.
+#:
+#: **Words, like the palette's own note and unlike the strip's glyph** — see
+#: `frame/choose.ARRIVED_NOTE`. This list runs before tmux, in the operator's own terminal,
+#: at `tui.term_width()`; there is no column being competed for and nothing to abbreviate
+#: for. `tui.truncate` still holds the whole line to the width, so a very long workspace
+#: name costs this field rather than wrapping the terminal.
+ARRIVED = "handoff arrived"
+
 
 class Choice(NamedTuple):
     """What the operator decided. ``name`` is empty for :data:`CANCEL`."""
@@ -73,12 +82,23 @@ class Row(NamedTuple):
 
     name: str
     clones: int
+    #: Whether a handoff landed in this workspace and nobody has looked at it yet
+    #: (`workspace.arrivals`). Defaulted, because every existing caller of :func:`rows`
+    #: predates arrivals and a picker that cannot ask is a picker with none — never
+    #: `None`, so the renderer has a bool to test rather than three states.
+    arrived: bool = False
 
 
-def rows(names: list[str], count: Callable[[str], int]) -> list[Row]:
-    """*names* with their clone counts. ``count`` is injected so the renderer can be
-    exercised without a plane under it."""
-    return [Row(n, count(n)) for n in names]
+def rows(names: list[str], count: Callable[[str], int],
+         arrived=frozenset()) -> list[Row]:
+    """*names* with their clone counts, and which of them a handoff is waiting in.
+
+    ``count`` is injected so the renderer can be exercised without a plane under it.
+    *arrived* is passed as a SET rather than as a second callable for a different reason:
+    it is one `os.scandir` for the whole list where the count is one `iterdir` per name, so
+    a per-name callable would turn one read into N.
+    """
+    return [Row(n, count(n), n in arrived) for n in names]
 
 
 def render(rows_: list[Row], current: str, width: int) -> str:
@@ -95,8 +115,13 @@ def render(rows_: list[Row], current: str, width: int) -> str:
     for i, (name, r) in enumerate(shown, start=1):
         mark = on if r.name == current else off
         repos = "—" if not r.clones else f"{r.clones} repo" + ("s" if r.clones > 1 else "")
+        # **Not dim**, where the clone count is: the count is context for a choice and this
+        # is the reason to make one. It goes after the count rather than in `_MARK`'s cell,
+        # which answers a different question (*"which one would the launch have picked"*)
+        # and answers it for exactly one row — a second meaning in that column would make
+        # the mark ambiguous on the row where both are true.
         line = (f"    {_DIM}{i:>2}{_R}  {mark} {tui.pad(name, name_w)}  "
-                f"{_DIM}{repos}{_R}")
+                f"{_DIM}{repos}{_R}" + (f"  {ARRIVED}" if r.arrived else ""))
         out.append(tui.truncate(line, width))
     out.append(f"\n    {_DIM} n{_R}    create a new workspace")
     out.append(f"    {_DIM} q{_R}    cancel — start nothing\n\n")

--- a/charter/frame/slots.py
+++ b/charter/frame/slots.py
@@ -3320,6 +3320,45 @@ _BAR_MARK = ("*", " ")
 #: worth a repaint) is about `panel.TICK` and is the same argument here.
 TAB_SPINNER = "✢✶✻✶"
 
+#: What a workspace tab a handoff landed in carries until somebody looks at it (the
+#: chat-handoff spec, *The strip*).
+#:
+#: **The cell is :data:`_BAR_MARK`'s, taken the way the spinner takes it** — the mark's own
+#: one cell, never a cell beside the name — so the ladder above cannot see the difference:
+#: every field is the width it was, :func:`_cuts` cuts where it always cut,
+#: :func:`bar_rows_wanted` composes the rows the renderer will draw, and the column an
+#: operator is aiming at holds the same workspace a moment later. A mark drawn beside a
+#: name instead would shift every tab right of it the moment a handoff landed, which is the
+#: double-press #767 exists to stop arriving through a notification.
+#:
+#: **A glyph AND an accent, and the glyph is the half that survives `NO_COLOR`.** The
+#: accent (`statusline.accent("ok")`, painted in :func:`_compose`) is what reads at a
+#: glance on a colour terminal; `panel._write` strips every escape from every row under
+#: `NO_COLOR` (`chrome.plain`), which is exactly what left `_BAR_MARK`'s `*` in place when
+#: #903 asked for it to go. A mark that was only a colour would be invisible to precisely
+#: the reader who has nothing else. So the mark degrades to a character, the paint degrades
+#: to nothing, and no tab moves either way.
+#:
+#: **One of :data:`TAB_SPINNER`'s own three glyphs, and that is the point rather than a
+#: coincidence.** The requirement is a glyph this strip already renders at width 1, and the
+#: table above :data:`TAB_SPINNER` is this project's measurement of exactly that question:
+#: `✶` (U+2736) is East-Asian *Neutral*, so no terminal draws it two cells wide — the
+#: failure `_BAR_RULE` is ASCII to avoid and the one `statusline._persona_chips` records
+#: breaking this layout twice — and it carries no emoji presentation to be widened by a
+#: fallback font. Reusing a measured glyph rather than choosing a fourth is `choose.MARK`'s
+#: discipline: a new glyph is a new measurement, and the two that shipped broken here were
+#: both chosen without one.
+#:
+#: **The two marks cannot appear on one strip.** Only `chats` passes *busy* (that strip is
+#: a strip of chats, and a workspace has no harness to be working) and only `workspaces`
+#: passes *arrived* (a handoff lands in a workspace, not in a chat), so within either strip
+#: this glyph has exactly one meaning. Where a caller did hand both, the ARRIVAL wins, and
+#: that is :data:`_BAR_MARK`'s own argument one step down: of the two facts competing for
+#: the cell, the spinner has another way to be seen — it comes back on the next tick and
+#: the chat it is about is one an operator can watch — and an arrival has none. It is the
+#: fact that persists until somebody looks, so it is the one the cell is spent on.
+_ARRIVED_MARK = "✶"
+
 #: Columns a bar spends between two names. Two, so a name reads as one name — a single
 #: space runs `api.1 api.2` together at the widths where this matters most.
 #:
@@ -3880,9 +3919,32 @@ def _affordances(note: str, close: str) -> str:
     return _NOTE_GAP.join(f for f in (note, close) if f)
 
 
+
+def _mark_cell(active: bool, arrived: bool, busy: bool, frame: str) -> str:
+    """The one cell in front of a tab's name, for the four things it can say.
+
+    `*` for the tab you are ON first and unconditionally (:data:`_BAR_MARK`), because under
+    `NO_COLOR` it is the only thing on the row answering "which tab am I on" and the other
+    two both have somewhere else to be read. Then the arrival, then the spinner, then a
+    blank — see :data:`_ARRIVED_MARK` for why that order and why no strip can ask for the
+    last two at once.
+
+    A function rather than a conditional expression inside the comprehension that calls it:
+    the precedence IS the decision here, and one buried in a nested ternary is one the next
+    reader re-derives from the parentheses.
+    """
+    if active:
+        return _BAR_MARK[0]
+    if arrived:
+        return _ARRIVED_MARK
+    if busy:
+        return frame
+    return _BAR_MARK[1]
+
+
 def _bar(names: list[str], here: str, width: int, *,
          note: str = "", close: str = "", rows: int = 1, busy=(),
-         counts=None) -> list[str]:
+         counts=None, arrived=frozenset()) -> list[str]:
     """One bar: *names* with *here* marked, in *rows* x *width* cells.
 
     :func:`_compose` composes it and this is what PUBLISHES it — the one call that writes
@@ -3893,16 +3955,19 @@ def _bar(names: list[str], here: str, width: int, *,
     the launcher's answer overwrite the panel's — a map describing a strip nobody is
     looking at.
 
-    *busy* and *counts* are :func:`_compose`'s and are passed straight through — see there.
+    *busy*, *counts* and *arrived* are :func:`_compose`'s and are passed straight through —
+    see there.
     """
     lines, cols, more, add, close_cells = _compose(
-        names, here, width, note=note, close=close, rows=rows, busy=busy, counts=counts)
+        names, here, width, note=note, close=close, rows=rows, busy=busy, counts=counts,
+        arrived=arrived)
     TABS.publish(cols, here, more, add, close_cells)
     return lines
 
 
 def _compose(names: list[str], here: str, width: int, *,
-             note: str = "", close: str = "", rows: int = 1, busy=(), counts=None):
+             note: str = "", close: str = "", rows: int = 1, busy=(), counts=None,
+             arrived=frozenset()):
     """The strip *names*/*here* composes to, and the cells its tabs landed in.
 
     Answers ``(lines, columns, more, add, close)`` — the rows to draw, the ``(row, col)``
@@ -4012,6 +4077,19 @@ def _compose(names: list[str], here: str, width: int, *,
     Empty for the `workspaces` strip, which is not a strip of chats and has no harness to
     be working.
 
+    *arrived* is the names a handoff landed in that nobody has looked at yet
+    (`workspace.arrivals`, through :func:`_arrived`) — the `workspaces` strip's half of
+    what *busy* is to the chats strip, and it rides the identical cell for the identical
+    reason: see :data:`_ARRIVED_MARK`. Each one gets a glyph in the mark's cell AND the
+    `ok` accent around the whole field, so the mark reads at a glance on a colour terminal
+    and still says something under `NO_COLOR`, where `panel._write` strips the accent away.
+    The accent is a paint and costs no cell (`tui.width` counts no SGR), and the glyph is
+    the same one cell a blank was, so the ladder above cannot see either of them — which is
+    why :func:`bar_rows_wanted` passes none and still measures the rows this will draw.
+
+    Empty for the `chats` strip, which is a strip of chats and is not what a handoff lands
+    in.
+
     **Every rung answers with its own cell map**, which is what makes the bar clickable at
     all and is the same discipline `_repos` keeps for the table's rows: the handler
     resolves a click against WHAT WAS DRAWN rather than against what it thinks would have
@@ -4036,6 +4114,7 @@ def _compose(names: list[str], here: str, width: int, *,
     # could make the mutation differ. The NAMES are contained, below, which is where the
     # open alphabet actually is. (`head` said the same thing beside it until #880 removed
     # the heading it named.)
+    from .. import statusline as sl
     from . import chrome
     # **Every row of the strip starts at the same column, and that column is the frame's
     # own left edge and nothing more** (#880). It used to carry the strip's heading —
@@ -4135,21 +4214,23 @@ def _compose(names: list[str], here: str, width: int, *,
     # the field, or the first chat to open would re-cut it.
     if counts is not None:
         shown = [n + _tab_count(counts.get(raw, 0)) for raw, n in zip(names, shown)]
-    # **The mark's cell carries the spinner too, and it is decided on the RAW name for the
-    # reason the paragraph above gives about the index**: `busy` holds chat ids off disk,
-    # `shown` holds text `contain.one_line` may have repaired, and matching a mark against
-    # the repaired form would follow the repair rather than the identity.
+    # **The mark's cell carries the spinner and the arrival too, and BOTH are decided on
+    # the RAW name for the reason the paragraph above gives about the index**: `busy` holds
+    # chat ids off disk and `arrived` holds workspace names off disk, `shown` holds text
+    # `contain.one_line` may have repaired, and matching a mark against the repaired form
+    # would follow the repair rather than the identity.
     #
-    # `i != at` before the membership test, so the active tab keeps its `*` — see
-    # :data:`TAB_SPINNER` for why that one cell goes to the mark rather than to the
-    # spinner, and :data:`_BAR_MARK` for why #903 left it there after asking. Read once,
+    # `i == at` is asked first inside :func:`_mark_cell`, so the active tab keeps its `*` —
+    # see :data:`TAB_SPINNER` for why that one cell goes to the mark rather than to the
+    # spinner, :data:`_ARRIVED_MARK` for the same question asked of the arrival, and
+    # :data:`_BAR_MARK` for why #903 left it there after asking. Read once,
     # outside the comprehension: every tab on a strip shows the same frame
     # (`tab_spinner_frame`), and reading the clock per name would let a wide strip start a
     # row on one frame and finish it on the next. Read unconditionally, too: an `if busy`
     # in front of it would change no output at all, only one `time.monotonic()`, which is
     # the equivalent mutant this repository deletes rather than documents.
     frame = tab_spinner_frame()
-    marked = [f"{_BAR_MARK[0] if i == at else (frame if names[i] in busy else _BAR_MARK[1])}{n}"
+    marked = [f"{_mark_cell(i == at, names[i] in arrived, names[i] in busy, frame)}{n}"
               for i, n in enumerate(shown)]
     # **The same fields twice: one set to MEASURE and one set to DRAW.** `chrome.block`
     # adds no cell — `tui.width` counts no SGR — so the two are the same width by
@@ -4168,7 +4249,18 @@ def _compose(names: list[str], here: str, width: int, *,
     # an edge is what a tab has where a band is what a highlighted word has, and it costs
     # the row nothing. Under `NO_COLOR` `panel._write` strips both and the `*` is still
     # there, which is why the mark stays and was not replaced by the highlight.
-    painted = [chrome.block(f) if i == at else f for i, f in enumerate(marked)]
+    #
+    # **An arrived tab is accented and the tab you are ON is not, whichever it is**, which
+    # is one `elif` and is the whole of the interaction between the two: you cannot be owed
+    # a look at the workspace you are looking at, so a tab that is both is a mark this
+    # frame is about to clear (`commands_frame._switch_client`) and drawing the block for
+    # it is what the operator's eye is actually asking about. The accent is a SGR pair
+    # around the field, so it adds no cell either — `marked` and `painted` stay the same
+    # width by construction, and `marked` is still the honest one for the ladder to
+    # measure.
+    painted = [chrome.block(f) if i == at
+               else (f"{sl.accent('ok')}{f}{sl._R}" if names[i] in arrived else f)
+               for i, f in enumerate(marked)]
     room = width - tui.width(lead)
     joined = gap.join(marked)
     # **One field, measured once**, and that is what makes `+` and `-` inseparable rather
@@ -4541,6 +4633,30 @@ def _workspace_counts() -> dict:
         return {}
 
 
+def _arrived() -> frozenset:
+    """Which workspaces a handoff landed in that nobody has looked at yet.
+
+    `workspace.arrivals` behind a guard, and a wrapper for :func:`_workspace_counts`'
+    reason, which is this module's rule for every read on the repaint path: **never
+    raises.** `arrivals` already answers `frozenset()` for a record it cannot read, so what
+    this catches is the failure that is not about the file — and the degrade is the same
+    one: a plane charter cannot ask about arrivals draws a strip with no marks, which is
+    exactly the strip it drew before there were any.
+
+    **It puts the strip on no clock**, :data:`BAR_ANIMATED`'s question and the same answer
+    :func:`_workspace_counts` gives: a mark appears when a handoff lands and goes when
+    somebody looks, both of which are things that happen to the PLANE and not to the clock.
+    Each is a `charter` command that ends in a fan-out (`notify.plane_changed_everywhere`,
+    `notify.bump_everywhere`), so the mark rides the repaint the strip already had —
+    `state.version`, one `stat`.
+    """
+    from .. import workspace as ws_mod
+    try:
+        return ws_mod.arrivals()
+    except Exception:  # noqa: BLE001 - a readout must never cost a pane
+        return frozenset()
+
+
 def _workspaces_strip(fid: str):
     """:func:`_chats_strip` one noun over. The name is the FRAME's
     (`switch.current_workspace` → `state.workspace_for`), never one this pane resolved for
@@ -4696,9 +4812,18 @@ def workspaces_bar(fid: str, width: int, rows: int = 1) -> list[str]:
 
     :func:`chats_bar`'s rules and its ladder, one noun over — see :func:`_workspaces_strip`
     for what it draws and why it draws no `+`.
+
+    **The one field on this strip that a command somewhere else can change**: a workspace a
+    handoff landed in is drawn with :data:`_ARRIVED_MARK` and the `ok` accent until any
+    terminal on this plane looks at it. It is read here rather than inside :func:`_compose`
+    for the reason *busy* is read in :func:`chats_bar` — the sizer
+    (:func:`bar_rows_wanted`) composes the same ladder and must not read it, because
+    nothing in the LAUNCHER knows or should know which workspace a chat was handed to, and
+    a mark that changed the row count would resize a pane every time one landed.
     """
     names, here, note, close, counts = _workspaces_strip(fid)
-    return _bar(names, here, width, note=note, close=close, rows=rows, counts=counts)
+    return _bar(names, here, width, note=note, close=close, rows=rows, counts=counts,
+                arrived=_arrived())
 
 
 #: Which slots draw something that CHANGES ON ITS OWN, with no version bump and no

--- a/charter/frame/state.py
+++ b/charter/frame/state.py
@@ -2767,4 +2767,10 @@ def reap(live: set[str], *, server: str) -> list[str]:
     if not len(entries) - len(removed):
         from .. import workspace as ws_mod
         ws_mod.forget_tab_order()
+        # **And the arrived marks with it**, in the same branch and for the same reason
+        # rather than for a second one: a mark is a thing an operator is owed a LOOK at,
+        # and a plane with no frame left has no strip for them to look at it on. Carrying
+        # it over would put a green tab on the first frame of the next launch, for a chat
+        # that ended with the plane that opened it.
+        ws_mod.forget_arrivals()
     return removed

--- a/charter/frame/switch.py
+++ b/charter/frame/switch.py
@@ -190,6 +190,36 @@ def _by_use(names: list[str]) -> list[str]:
     return kept + sorted(n for n in names if n not in seen)
 
 
+def bring_to_front(name: str) -> None:
+    """Move *name* to the head of the order this plane's workspaces strip draws.
+
+    **The ONE thing that moves a tab while a plane is up**, and it is deliberately a
+    handoff and nothing else. `_by_use` freezes the order on the first ask precisely so a
+    tab never moves under a press (#767) and every frame draws the same columns (#923); a
+    switch, a launch and a repaint all leave it exactly where it was. What earns the
+    exception is that a handoff PUT something there: a chat the operator approved is now
+    running in a workspace they are not looking at, and a strip that does not point at it
+    is `docs/frame.md`'s silence by construction.
+
+    **Through the recorded order, never around it.** `workspaces()` is asked first — not
+    `workspace.tab_order()` — because on a plane that has recorded nothing that call is
+    what decides and records the order (`_by_use`), and writing a one-name file here
+    instead would leave the plane's own order to be decided later, by a repaint, against a
+    record that already exists. So a handoff into a cold plane records the order the plane
+    would have had, with the target moved to the front of it.
+
+    A *name* this plane does not have moves nothing and writes nothing: `workspaces()` is
+    the roster, so a workspace that was deleted between the handoff's refusals and here is
+    a name with no tab, and recording it would put a line in the order file for a directory
+    that is gone (`record_tab_order`: an ORDER and never a roster).
+    """
+    from .. import workspace as ws_mod
+    order = workspaces()
+    if name not in order:
+        return
+    ws_mod.record_tab_order([name] + [n for n in order if n != name])
+
+
 def personas() -> list[str]:
     """Every persona a switcher may offer, name-checked on the way out and **ordered by
     use**: the plane's declared default first, then most-dispatched first, ties broken by

--- a/charter/workspace.py
+++ b/charter/workspace.py
@@ -1036,32 +1036,43 @@ def _arrival_mark(name: str) -> Path | None:
     return _arrivals_dir() / name if valid_name(name) else None
 
 
-def record_arrival(name: str) -> None:
+def record_arrival(name: str) -> bool:
     """Mark *name* as a workspace a handoff landed in, until somebody looks at it.
+    ``True`` when the mark is there afterwards.
 
-    One empty file, written with `config.replace_for` for its mode (0600) and its
-    atomicity: this is read on a panel's render path and inside the `frame-resize` child,
-    and a reader must never see a half-made mark. `private_mkdir` first, for
-    :func:`record_tab_order`'s reason — a plane whose `.charter/` does not exist yet.
+    One empty file, created with `config.touch_for` for its mode (0600). `private_mkdir`
+    first, for :func:`record_tab_order`'s reason — a plane whose `.charter/` does not exist
+    yet.
+
+    **`touch_for` and NOT `replace_for`, and the difference is a measured ceiling rather
+    than a preference.** An atomic replace writes a temp file beside the target and renames
+    it, and that temp name is the target's plus a suffix — so a workspace name within four
+    characters of `NAME_MAX` made a temp name past it, `ENAMETOOLONG`, and a workspace that
+    could be created and could never be marked. Nothing needs the atomicity here: the mark
+    IS the file's existence, its content is empty, and there is no half-written state of
+    nothing for a reader to catch. Creating it directly removes the temp name and the
+    ceiling with it.
 
     **Touches no other name**, which is the whole of :func:`_arrivals_dir`'s concurrency
     argument: a second handoff landing in the same millisecond writes a different path, and
     a switch clearing another workspace unlinks a third. Re-recording a name that is
-    already marked rewrites the identical empty file.
+    already marked touches the identical empty file.
 
-    **Never raises** — a full filesystem costs the operator a green tab, not a traceback
-    out of a strip — and a name that cannot be a workspace marks nothing rather than
-    raising: this runs after `cmd_handoff` has already refused such a name, so it is a
-    floor and not the refusal.
+    **It does not raise and it does not go quiet either.** A failure here is a handoff that
+    opened a chat nobody will be pointed at, which is the one outcome this whole record
+    exists to prevent, so the answer is reported back rather than swallowed —
+    `commands_handoff` says so on the operator's own screen. A name that cannot be a
+    workspace is `False` for the same reason it is refused at the join: it marks nothing.
     """
     f = _arrival_mark(name)
     if f is None:
-        return
+        return False
     try:
         config.private_mkdir(f.parent)
-        config.replace_for(f, "")
+        config.touch_for(f)
     except OSError:
-        return
+        return False
+    return True
 
 
 def arrivals() -> frozenset[str]:

--- a/charter/workspace.py
+++ b/charter/workspace.py
@@ -32,6 +32,7 @@ import hashlib
 import json
 import os
 import re
+import shutil
 import stat
 import threading
 import time
@@ -989,9 +990,9 @@ def forget_tab_order() -> None:
         pass
 
 
-def _arrivals_file() -> Path:
+def _arrivals_dir() -> Path:
     """Where this plane records which workspaces a handoff landed in and nobody has looked
-    at yet.
+    at yet — **a directory, and one file per mark.**
 
     **Beside `workspace-tab-order`, for every one of :func:`_tab_order_file`'s reasons.**
     It is plane-scoped (every frame on the plane draws the same mark, and the mark clears
@@ -1000,34 +1001,65 @@ def _arrivals_file() -> Path:
     end long before the operator looks at what it opened, and a mark that died with it
     would be a workspace nothing points at.
 
+    **A directory rather than one file listing the names, and that is a concurrency fix
+    rather than a taste.** One file made every writer a read-modify-write over the whole
+    set, and the plane runs many charter processes at once: measured with two real threads,
+    two handoffs landing together left ONE mark, a handoff landing while a switch cleared
+    brought the cleared mark back, and a switch clearing while a handoff landed lost the
+    new one. A lost mark is precisely the invisibility this record exists to end.
+
+    The alternative was a lock, and it was refused: a plane is shared by many processes
+    that can be killed at any moment, so a stale lock file nothing clears is a worse
+    failure than the one it fixes — and it would still be a fix by timing. One file per
+    name makes recording and clearing **independent operations on different paths**, so
+    there is no interleaving to get wrong. The mark IS the file's existence; the file is
+    empty.
+
     **A set and not a log.** Nothing reads *when* a workspace arrived — the mark is drawn
-    or it is not — and a timestamp nothing reads is the field ADR 0011 refuses.
+    or it is not — and a timestamp nothing reads is the field ADR 0011 refuses. The empty
+    file says so: there is nowhere for a field nothing reads to go.
     """
     return Path(config.STATE_DIR) / "workspace-arrivals"
+
+
+def _arrival_mark(name: str) -> Path | None:
+    """The file whose existence IS *name*'s mark, or ``None`` for a name that cannot be
+    one.
+
+    **The name check is here and it is load-bearing**, which is the one thing the
+    single-file shape did not need: a name is now joined onto a path, so an unchecked one
+    is `..` or an absolute path reaching out of `STATE_DIR` — #442 exactly, arriving
+    through a record instead of through a directory listing. :func:`valid_name` is the same
+    rule the callers already hold their names to, asked again here because this is where
+    the join happens.
+    """
+    return _arrivals_dir() / name if valid_name(name) else None
 
 
 def record_arrival(name: str) -> None:
     """Mark *name* as a workspace a handoff landed in, until somebody looks at it.
 
-    :func:`record_tab_order`'s writer one file over: `private_mkdir` for a plane whose
-    `.charter/` may not exist yet, `config.replace_for` because this is read on a panel's
-    render path and inside the `frame-resize` child, and **never raises** — a full
-    filesystem costs the operator a green tab, not a traceback out of a strip.
+    One empty file, written with `config.replace_for` for its mode (0600) and its
+    atomicity: this is read on a panel's render path and inside the `frame-resize` child,
+    and a reader must never see a half-made mark. `private_mkdir` first, for
+    :func:`record_tab_order`'s reason — a plane whose `.charter/` does not exist yet.
 
-    Sorted, so the bytes are a function of the SET and not of the order the marks arrived
-    in: two planes holding the same marks hold the same file, and re-recording a name that
-    is already there rewrites the identical content rather than shuffling it.
+    **Touches no other name**, which is the whole of :func:`_arrivals_dir`'s concurrency
+    argument: a second handoff landing in the same millisecond writes a different path, and
+    a switch clearing another workspace unlinks a third. Re-recording a name that is
+    already marked rewrites the identical empty file.
 
-    No name check on the way IN. :func:`arrivals` checks on the way OUT, which is where
-    `tab_order` puts the same check and for its reason: the read is what joins a name onto
-    a path and onto a tab, so the floor belongs where the value is used. A caller reaches
-    this with a name `switch.to_workspace` or `commands_handoff` has already held to
-    :func:`valid_name`.
+    **Never raises** — a full filesystem costs the operator a green tab, not a traceback
+    out of a strip — and a name that cannot be a workspace marks nothing rather than
+    raising: this runs after `cmd_handoff` has already refused such a name, so it is a
+    floor and not the refusal.
     """
+    f = _arrival_mark(name)
+    if f is None:
+        return
     try:
-        f = _arrivals_file()
         config.private_mkdir(f.parent)
-        config.replace_for(f, "".join(f"{n}\n" for n in sorted(arrivals() | {name})))
+        config.replace_for(f, "")
     except OSError:
         return
 
@@ -1035,43 +1067,59 @@ def record_arrival(name: str) -> None:
 def arrivals() -> frozenset[str]:
     """The workspaces a handoff landed in that nobody has looked at yet.
 
-    `frozenset()` for a plane that has no record, one it cannot read, and one whose file is
-    not UTF-8 — :func:`tab_order`'s three cases and its degrade, which is the same degrade
-    for all of them because the caller's answer is the same: draw the strip with no marks.
-    A panel that threw out of `render` loses its pane.
+    `frozenset()` for a plane that has never had a handoff — the ordinary answer, and the
+    directory simply is not there — and for one whose record cannot be listed. One degrade
+    for both, because the caller's answer is the same either way: draw the strip with no
+    marks. A panel that threw out of `render` loses its pane.
 
-    **Name-checked on the way out**, exactly as :func:`tab_order` is. These names are
-    matched against the names the strip is drawing and go no further, but the check is the
-    floor that keeps that true: an unchecked line here is a string this plane's own state
-    put in front of :func:`slots._compose`, and #442 is what an unchecked name in that
-    position already cost. `valid_name("")` is already False, so a blank line is dropped on
-    that check's own terms and there is no `if line` in front of it.
+    **Name-checked on the way out as well as on the way in**, which is not the same check
+    twice: :func:`_arrival_mark` holds what charter WRITES, and this holds what is THERE —
+    a hand, an editor's backup file, or a `.DS_Store` can put a name in this directory that
+    charter never wrote, and these names go on to be matched against a strip.
+    `valid_name("")` is already False, so there is no separate emptiness test.
+
+    Only `OSError` is caught, and the absence of `ValueError` beside it is deliberate:
+    nothing here decodes a file. `os.listdir` answers names the OS gave, undecodable bytes
+    included, as surrogate-escaped `str` — which :func:`valid_name` refuses on its own
+    terms, the alphabet being ASCII.
+
+    **The listing is a local and the return is a set of NAMES, which is :func:`tab_order`'s
+    shape and not a style choice.** `tests/_statedirscan.py` reads a function's return
+    expression to decide whether that function hands back a PATH, and a one-liner
+    `frozenset(e.name for e in os.listdir(_arrivals_dir()))` says a state path outright —
+    so `arrivals` was classified as a state-path function, which taints every parameter its
+    result is passed into and, through `_choose_workspace`'s picker, reported four
+    unrelated `mkdir`s in this file as unrouted state writers. The scan was right about the
+    shape: what comes back here is names, and the text now says so.
     """
     try:
-        lines = _arrivals_file().read_text().splitlines()
-    except (OSError, ValueError):
+        found = os.listdir(_arrivals_dir())
+    except OSError:
         return frozenset()
-    return frozenset(n for n in (line.strip() for line in lines) if valid_name(n))
+    return frozenset(n for n in found if valid_name(n))
 
 
 def clear_arrival(name: str) -> None:
     """Drop *name*'s arrived mark — somebody has looked at that workspace.
 
-    **Writes nothing when the name is not marked**, and that is not an optimisation. This
-    runs on the switch, focus and attach paths, which is every time any terminal on this
-    plane arrives anywhere; rewriting the file for a workspace that never had a mark would
-    move its mtime on every switch a plane ever makes, for no change at all.
+    One `unlink`, and **it touches no other name**: a handoff landing in another workspace
+    at the same instant writes a different path and survives, where the single-file shape
+    would have had one of the two writers overwrite the other's set.
 
-    Missing record, unreadable record and unmarked name are one case here because
-    :func:`arrivals` already answers `frozenset()` for the first two, and a name is not in
-    an empty set.
+    **Writes nothing when the name is not marked**, and that is now a property of the
+    operation rather than a guard in front of it: `unlink` on a path that is not there
+    raises `FileNotFoundError` and changes nothing — not the directory, not another mark's
+    mtime. That matters because this runs on the switch, focus and attach paths, which is
+    every time any terminal on this plane arrives anywhere.
+
+    Missing directory, missing mark and a name that cannot be a workspace are one case for
+    the same reason: none of them is a mark to remove.
     """
-    marks = arrivals()
-    if name not in marks:
+    f = _arrival_mark(name)
+    if f is None:
         return
     try:
-        config.replace_for(_arrivals_file(),
-                           "".join(f"{n}\n" for n in sorted(marks - {name})))
+        f.unlink()
     except OSError:
         return
 
@@ -1083,12 +1131,9 @@ def forget_arrivals() -> None:
     A plane that goes cold has no frame left that could be drawing a mark, and the operator
     who comes back to it is not owed a look at something they can no longer see was ever
     marked. Missing is the ordinary case; never raises, for the reason
-    :func:`forget_tab_order` does not.
+    :func:`forget_tab_order` does not — `ignore_errors` is `rmtree`'s spelling of it.
     """
-    try:
-        _arrivals_file().unlink()
-    except OSError:
-        pass
+    shutil.rmtree(_arrivals_dir(), ignore_errors=True)
 
 
 def clones(name: str) -> list[Path]:

--- a/charter/workspace.py
+++ b/charter/workspace.py
@@ -989,6 +989,108 @@ def forget_tab_order() -> None:
         pass
 
 
+def _arrivals_file() -> Path:
+    """Where this plane records which workspaces a handoff landed in and nobody has looked
+    at yet.
+
+    **Beside `workspace-tab-order`, for every one of :func:`_tab_order_file`'s reasons.**
+    It is plane-scoped (every frame on the plane draws the same mark, and the mark clears
+    for all of them at once — `commands_frame._switch_client`), per developer, gitignored,
+    machine-written, and it outlives any one chat: the chat that ran `charter handoff` may
+    end long before the operator looks at what it opened, and a mark that died with it
+    would be a workspace nothing points at.
+
+    **A set and not a log.** Nothing reads *when* a workspace arrived — the mark is drawn
+    or it is not — and a timestamp nothing reads is the field ADR 0011 refuses.
+    """
+    return Path(config.STATE_DIR) / "workspace-arrivals"
+
+
+def record_arrival(name: str) -> None:
+    """Mark *name* as a workspace a handoff landed in, until somebody looks at it.
+
+    :func:`record_tab_order`'s writer one file over: `private_mkdir` for a plane whose
+    `.charter/` may not exist yet, `config.replace_for` because this is read on a panel's
+    render path and inside the `frame-resize` child, and **never raises** — a full
+    filesystem costs the operator a green tab, not a traceback out of a strip.
+
+    Sorted, so the bytes are a function of the SET and not of the order the marks arrived
+    in: two planes holding the same marks hold the same file, and re-recording a name that
+    is already there rewrites the identical content rather than shuffling it.
+
+    No name check on the way IN. :func:`arrivals` checks on the way OUT, which is where
+    `tab_order` puts the same check and for its reason: the read is what joins a name onto
+    a path and onto a tab, so the floor belongs where the value is used. A caller reaches
+    this with a name `switch.to_workspace` or `commands_handoff` has already held to
+    :func:`valid_name`.
+    """
+    try:
+        f = _arrivals_file()
+        config.private_mkdir(f.parent)
+        config.replace_for(f, "".join(f"{n}\n" for n in sorted(arrivals() | {name})))
+    except OSError:
+        return
+
+
+def arrivals() -> frozenset[str]:
+    """The workspaces a handoff landed in that nobody has looked at yet.
+
+    `frozenset()` for a plane that has no record, one it cannot read, and one whose file is
+    not UTF-8 — :func:`tab_order`'s three cases and its degrade, which is the same degrade
+    for all of them because the caller's answer is the same: draw the strip with no marks.
+    A panel that threw out of `render` loses its pane.
+
+    **Name-checked on the way out**, exactly as :func:`tab_order` is. These names are
+    matched against the names the strip is drawing and go no further, but the check is the
+    floor that keeps that true: an unchecked line here is a string this plane's own state
+    put in front of :func:`slots._compose`, and #442 is what an unchecked name in that
+    position already cost. `valid_name("")` is already False, so a blank line is dropped on
+    that check's own terms and there is no `if line` in front of it.
+    """
+    try:
+        lines = _arrivals_file().read_text().splitlines()
+    except (OSError, ValueError):
+        return frozenset()
+    return frozenset(n for n in (line.strip() for line in lines) if valid_name(n))
+
+
+def clear_arrival(name: str) -> None:
+    """Drop *name*'s arrived mark — somebody has looked at that workspace.
+
+    **Writes nothing when the name is not marked**, and that is not an optimisation. This
+    runs on the switch, focus and attach paths, which is every time any terminal on this
+    plane arrives anywhere; rewriting the file for a workspace that never had a mark would
+    move its mtime on every switch a plane ever makes, for no change at all.
+
+    Missing record, unreadable record and unmarked name are one case here because
+    :func:`arrivals` already answers `frozenset()` for the first two, and a name is not in
+    an empty set.
+    """
+    marks = arrivals()
+    if name not in marks:
+        return
+    try:
+        config.replace_for(_arrivals_file(),
+                           "".join(f"{n}\n" for n in sorted(marks - {name})))
+    except OSError:
+        return
+
+
+def forget_arrivals() -> None:
+    """Drop every arrived mark — :func:`forget_tab_order` one file over, and called from
+    the same branch of `frame.state.reap`.
+
+    A plane that goes cold has no frame left that could be drawing a mark, and the operator
+    who comes back to it is not owed a look at something they can no longer see was ever
+    marked. Missing is the ordinary case; never raises, for the reason
+    :func:`forget_tab_order` does not.
+    """
+    try:
+        _arrivals_file().unlink()
+    except OSError:
+        pass
+
+
 def clones(name: str) -> list[Path]:
     """The repo clones inside a workspace (``memory/`` and ``refs/`` are not clones —
     they have no ``.git`` — so this naturally excludes them)."""

--- a/docs/frame.md
+++ b/docs/frame.md
@@ -732,13 +732,28 @@ is about where work is.
 
 **And that tab stays green until you look at it.** The workspace a handoff landed in is
 drawn in the `ok` accent with a `✶` where the `*` would be, and the mark clears the first
-time *any* terminal on this plane switches into that workspace, focuses it, or attaches to
-it — every frame's strip then repaints without it. It clears plane-wide rather than per
-terminal, because tmux draws a pane identically for every client of its session; there is no
-per-client mark and the strip's repaint path asks tmux nothing. The `✶` is the half that
-survives `NO_COLOR`, where charter strips every escape off every row and the accent is
-nothing. It costs no column — it is the mark's own cell, the one the chat strip's spinner
-takes — so a handoff landing never shifts a tab under your hand. There is no bell.
+time *any* terminal on this plane looks at that workspace: switching into it, focusing it,
+attaching to it, or pressing its tab when you are already in it. Every frame's strip then
+repaints without the mark. It clears plane-wide rather than per terminal, because tmux draws
+a pane identically for every client of its session; there is no per-client mark and the
+strip's repaint path asks tmux nothing. The `✶` is the half that survives `NO_COLOR`, where
+charter strips every escape off every row and the accent is nothing. It costs no column — it
+is the mark's own cell, the one the chat strip's spinner takes — so a handoff landing never
+shifts a tab under your hand. There is no bell.
+
+**A tab you are standing on shows the highlight rather than the mark, and pressing it is
+what clears it.** There is one cell and `*` wins it (below), so the frame *in* the arrived
+workspace is the one frame that cannot see the mark while every other frame on the plane
+draws it. Pressing that tab answers `already in workspace 'x'` and clears the mark for
+everyone — which is right, because you are the person looking at it.
+
+**A mark the strip has windowed away is not shown, and the palette is where to look.** The
+bar draws the page your tab falls on; an arrival on another page is inside the `+2`, and at
+widths where the bar is down to `2/3` nothing is drawn at all. The counts are clickable and
+open the palette, whose workspace list carries `handoff arrived` in its note column for
+every workspace that has one — no page, no width, no glyph. The launch picker
+(`charter <harness>` with no workspace) says it too, next to each workspace's clone count.
+Growing the strip with `F3` is the other answer where there are rows to be had.
 
 **Neither strip is labelled.** They used to open with the word `chats` or `workspaces`, and
 that cost 9 and 14 columns of the row the names are competing for. What tells them apart is

--- a/docs/frame.md
+++ b/docs/frame.md
@@ -723,6 +723,23 @@ hand you a differently-ordered strip after every switch, which is the shape this
 out in. It is decided again when you next launch the plane — still while you are looking
 at it, fresh when you come back.
 
+**One thing moves a tab while the plane is up, and it is a handoff.** `charter handoff`
+opens a chat in a workspace nobody is looking at, so the workspace it lands in goes to the
+front of the strip. Nothing else does: a switch, a launch and a repaint all leave the order
+exactly where they found it, which is what keeps the tab you just pressed the same tab a
+moment later. A handoff into the workspace you are already in moves its tab too — the order
+is about where work is.
+
+**And that tab stays green until you look at it.** The workspace a handoff landed in is
+drawn in the `ok` accent with a `✶` where the `*` would be, and the mark clears the first
+time *any* terminal on this plane switches into that workspace, focuses it, or attaches to
+it — every frame's strip then repaints without it. It clears plane-wide rather than per
+terminal, because tmux draws a pane identically for every client of its session; there is no
+per-client mark and the strip's repaint path asks tmux nothing. The `✶` is the half that
+survives `NO_COLOR`, where charter strips every escape off every row and the accent is
+nothing. It costs no column — it is the mark's own cell, the one the chat strip's spinner
+takes — so a handoff landing never shifts a tab under your hand. There is no bell.
+
 **Neither strip is labelled.** They used to open with the word `chats` or `workspaces`, and
 that cost 9 and 14 columns of the row the names are competing for. What tells them apart is
 where they are and what is on them: the strips are adjacent and always in the same order, the

--- a/docs/frame.md
+++ b/docs/frame.md
@@ -732,20 +732,25 @@ is about where work is.
 
 **And that tab stays green until you look at it.** The workspace a handoff landed in is
 drawn in the `ok` accent with a `✶` where the `*` would be, and the mark clears the first
-time *any* terminal on this plane looks at that workspace: switching into it, focusing it,
-attaching to it, or pressing its tab when you are already in it. Every frame's strip then
-repaints without the mark. It clears plane-wide rather than per terminal, because tmux draws
+time *any* terminal on this plane **looks at that workspace — however you get there.**
+Pressing its tab, choosing it in the palette, walking to it with the keyboard, typing
+`charter frame-switch --workspace`, launching or attaching into it, or already being in it
+and pressing its tab: they are one fact, and the fact is that somebody is looking. Every
+frame's strip then repaints without the mark. It clears plane-wide rather than per terminal,
+because tmux draws
 a pane identically for every client of its session; there is no per-client mark and the
 strip's repaint path asks tmux nothing. The `✶` is the half that survives `NO_COLOR`, where
 charter strips every escape off every row and the accent is nothing. It costs no column — it
 is the mark's own cell, the one the chat strip's spinner takes — so a handoff landing never
 shifts a tab under your hand. There is no bell.
 
-**A tab you are standing on shows the highlight rather than the mark, and pressing it is
-what clears it.** There is one cell and `*` wins it (below), so the frame *in* the arrived
-workspace is the one frame that cannot see the mark while every other frame on the plane
-draws it. Pressing that tab answers `already in workspace 'x'` and clears the mark for
-everyone — which is right, because you are the person looking at it.
+**A tab you are standing on shows the highlight rather than the mark, and asking to switch
+to it is what clears it.** There is one cell and `*` wins it (below), so the frame *in* the
+arrived workspace is the one frame that cannot see the mark while every other frame on the
+plane draws it. Asking to switch there — the tab, a palette row, the keyboard walk, the
+typed command — answers `already in workspace 'x'` and clears the mark for everyone, which
+is right, because you are the person looking at it. A switch charter refused for any *other*
+reason clears nothing: you are still owed the look.
 
 **A mark the strip has windowed away is not shown, and the palette is where to look.** The
 bar draws the page your tab falls on; an arrival on another page is inside the `+2`, and at

--- a/docs/frame.md
+++ b/docs/frame.md
@@ -756,9 +756,12 @@ reason clears nothing: you are still owed the look.
 bar draws the page your tab falls on; an arrival on another page is inside the `+2`, and at
 widths where the bar is down to `2/3` nothing is drawn at all. The counts are clickable and
 open the palette, whose workspace list carries `handoff arrived` in its note column for
-every workspace that has one — no page, no width, no glyph. The launch picker
-(`charter <harness>` with no workspace) says it too, next to each workspace's clone count.
-Growing the strip with `F3` is the other answer where there are rows to be had.
+every workspace that has one — no page and no glyph. The launch picker (`charter <harness>`
+with no workspace) says it too, next to each workspace's clone count. Both are **cut to the
+terminal's width and never dropped**, so below about 30 columns the note reads
+`handoff a…` and below about 16 it is a stub — which still says a row has something the
+others do not, where the strip at those widths says nothing at all. Growing the strip with
+`F3` is the other answer where there are rows to be had.
 
 **Neither strip is labelled.** They used to open with the word `chats` or `workspaces`, and
 that cost 9 and 14 columns of the row the names are competing for. What tells them apart is

--- a/docs/handoff.md
+++ b/docs/handoff.md
@@ -105,11 +105,38 @@ BRIEF
 7. Appends one row to the dispatch tally — `{"event": "handoff", "ts", "placement", "created"}`,
    with no workspace name, no persona and no text — and clears `routing: require`'s pending mark
    for the turn that ran it, on every harness. The handoff **is** the routing answer.
-8. Prints the new chat's id and its workspace.
+8. **Moves the target workspace to the front of the tab strip and marks it arrived**, and
+   names the new chat on the calling chat's own attention row. See *Where it shows up* below.
+9. Prints the new chat's id and its workspace.
 
-**What it does not do yet:** move the target workspace to the front of the tab strip, or mark
-that tab as arrived. Those are the next slice; today the new chat appears on the target
-workspace's chats strip and nothing on screen points at it.
+## Where it shows up
+
+A handoff opens a chat in the background: no client moves, nothing attaches, and you stay
+exactly where you were. So the last thing the command does is move where your eye goes.
+
+- **The target workspace goes to the front of the workspaces strip.** This is the only thing
+  that moves a tab while the plane is up — a switch, a launch and a repaint all leave the
+  order where they found it, because a tab that moves under a press is a tab you press twice.
+  A handoff into the workspace you are already in moves its tab too: the order is about where
+  work is.
+- **That tab is drawn in the `ok` accent with a `✶` where its `*` would be**, and stays that
+  way until somebody looks. The `✶` is what survives `NO_COLOR`, where charter strips every
+  escape off every row and the accent is nothing to see. Neither costs a column — the glyph
+  takes the mark's own cell — so nothing on the strip shifts when a handoff lands.
+- **The mark clears the first time any terminal on this plane looks at that workspace**: a
+  workspace switch tmux confirmed, a focus, or a launch that attaches. Then every frame's
+  strip repaints without it. It is plane-wide and not per terminal, because tmux draws a pane
+  identically for every client of its session — a per-client mark is named as a limit below
+  rather than pretended at. A switch charter refused clears nothing: you are still owed the
+  look.
+- **A handoff into the workspace you are in marks nothing.** You are looking at it, and its
+  chats strip already shows the new tab.
+- **Your own chat's attention row says where it went** — `handoff → beta.1 opened in
+  workspace 'beta'` — because the command's own output goes to a tool call you may never read.
+- **No bell**, and nothing moves your terminal.
+
+None of this happens for a handoff that did not open a chat. Nothing on screen ever points at
+a chat that does not exist.
 
 ## The stamp
 
@@ -241,6 +268,13 @@ and the marker goes with the directory when that id is reaped.
   show it. Every other harness is covered — see *A reopened chat is shown its brief* above.
 - **A handoff is not a dispatch.** Its tally row carries no agent, so `charter persona stats`'
   dispatch column and "last worked" are untouched by one.
+- **The arrived mark is per plane, not per terminal.** Two terminals on one plane share one
+  mark: whichever of them looks first clears it for both. tmux draws a pane identically for
+  every client of its session, so a per-client mark would have to be a different mechanism,
+  and it is the next slice along with a "wants you" mark for a chat that stopped at a prompt.
+- **A plane that goes cold forgets its marks.** They live beside the strip's tab order, in
+  this developer's own state; when the last frame is reaped, both go. A chat a handoff opened
+  is still there when the plane comes back — nothing on the strip points at it any more.
 
 ## How a chat learns any of this exists
 

--- a/docs/handoff.md
+++ b/docs/handoff.md
@@ -137,10 +137,17 @@ exactly where you were. So the last thing the command does is move where your ey
   by any of the routes above — says `already in workspace 'x'` and clears it for everyone.
 - **Where to look when the strip has no room.** The bar draws the page your tab falls on, so
   an arrival on another page is inside a `+2` and at narrow widths the bar is down to `2/3`.
-  The palette's workspace list says `handoff arrived` in its note column, at any width, and
-  so does the launch picker beside each workspace's clone count.
+  The palette's workspace list says `handoff arrived` in its note column, and so does the
+  launch picker beside each workspace's clone count. Both cut that note to the terminal's
+  width rather than dropping it — below about 30 columns it reads `handoff a…` — so the row
+  still says it has something the others do not.
 - **A handoff into the workspace you are in marks nothing.** You are looking at it, and its
   chats strip already shows the new tab.
+- **A mark charter could not write is said out loud.** The chat is open either way — nothing
+  else depends on the mark — but the strip was the only thing that was going to point at it,
+  so charter names the workspace to go and look at rather than going quiet. That is the one
+  failure this whole mark exists to prevent, and a silent one would be it arriving through
+  its own fix.
 - **Your own chat's attention row says where it went** — `handoff → beta.1 opened in
   workspace 'beta'` — because the command's own output goes to a tool call you may never read.
 - **No bell**, and nothing moves your terminal.

--- a/docs/handoff.md
+++ b/docs/handoff.md
@@ -124,11 +124,19 @@ exactly where you were. So the last thing the command does is move where your ey
   escape off every row and the accent is nothing to see. Neither costs a column — the glyph
   takes the mark's own cell — so nothing on the strip shifts when a handoff lands.
 - **The mark clears the first time any terminal on this plane looks at that workspace**: a
-  workspace switch tmux confirmed, a focus, or a launch that attaches. Then every frame's
-  strip repaints without it. It is plane-wide and not per terminal, because tmux draws a pane
-  identically for every client of its session — a per-client mark is named as a limit below
-  rather than pretended at. A switch charter refused clears nothing: you are still owed the
-  look.
+  workspace switch tmux confirmed, a focus, a launch that attaches, or pressing that tab when
+  you are already in that workspace. Then every frame's strip repaints without it. It is
+  plane-wide and not per terminal, because tmux draws a pane identically for every client of
+  its session — a per-client mark is named as a limit below rather than pretended at. A switch
+  charter refused for any other reason clears nothing: you are still owed the look.
+- **The tab you are standing on shows the highlight rather than the mark.** There is one cell
+  and `*` wins it, so the frame already in the arrived workspace is the one frame that does
+  not draw the mark, while every other frame on the plane does. Pressing that tab says
+  `already in workspace 'x'` and clears it for everyone.
+- **Where to look when the strip has no room.** The bar draws the page your tab falls on, so
+  an arrival on another page is inside a `+2` and at narrow widths the bar is down to `2/3`.
+  The palette's workspace list says `handoff arrived` in its note column, at any width, and
+  so does the launch picker beside each workspace's clone count.
 - **A handoff into the workspace you are in marks nothing.** You are looking at it, and its
   chats strip already shows the new tab.
 - **Your own chat's attention row says where it went** — `handoff → beta.1 opened in

--- a/docs/handoff.md
+++ b/docs/handoff.md
@@ -123,16 +123,18 @@ exactly where you were. So the last thing the command does is move where your ey
   way until somebody looks. The `✶` is what survives `NO_COLOR`, where charter strips every
   escape off every row and the accent is nothing to see. Neither costs a column — the glyph
   takes the mark's own cell — so nothing on the strip shifts when a handoff lands.
-- **The mark clears the first time any terminal on this plane looks at that workspace**: a
-  workspace switch tmux confirmed, a focus, a launch that attaches, or pressing that tab when
-  you are already in that workspace. Then every frame's strip repaints without it. It is
-  plane-wide and not per terminal, because tmux draws a pane identically for every client of
-  its session — a per-client mark is named as a limit below rather than pretended at. A switch
-  charter refused for any other reason clears nothing: you are still owed the look.
+- **The mark clears the first time any terminal on this plane looks at that workspace —
+  however you get there.** Pressing its tab, choosing it in the palette, walking to it with
+  the keyboard, typing `charter frame-switch --workspace`, a launch or a focus that attaches
+  into it, or already being in it and asking to switch there: one fact, and the fact is that
+  somebody is looking. Then every frame's strip repaints without the mark. It is plane-wide
+  and not per terminal, because tmux draws a pane identically for every client of its
+  session — a per-client mark is named as a limit below rather than pretended at. A switch
+  charter refused for any *other* reason clears nothing: you are still owed the look.
 - **The tab you are standing on shows the highlight rather than the mark.** There is one cell
   and `*` wins it, so the frame already in the arrived workspace is the one frame that does
-  not draw the mark, while every other frame on the plane does. Pressing that tab says
-  `already in workspace 'x'` and clears it for everyone.
+  not draw the mark, while every other frame on the plane does. Asking to switch there —
+  by any of the routes above — says `already in workspace 'x'` and clears it for everyone.
 - **Where to look when the strip has no room.** The bar draws the page your tab falls on, so
   an arrival on another page is inside a `+2` and at narrow widths the bar is down to `2/3`.
   The palette's workspace list says `handoff arrived` in its note column, at any width, and

--- a/docs/news/unreleased-charter-handoff.md
+++ b/docs/news/unreleased-charter-handoff.md
@@ -65,7 +65,8 @@ goes.
   session. A switch charter refused for any *other* reason clears nothing.
 - **The palette and the launch picker say it in words** — `handoff arrived` in the note
   column — because the strip draws only the page your tab falls on, and an arrival on another
-  page sits behind a `+2`.
+  page sits behind a `+2`. Narrow terminals cut that note rather than dropping it, so the row
+  still stands out at a width where the strip itself has given up.
 - **Your own chat's attention row names the new chat**, because the command's own output goes
   to a tool call you may never read.
 - A handoff into the workspace you are already in moves its tab and marks nothing: you are

--- a/docs/news/unreleased-charter-handoff.md
+++ b/docs/news/unreleased-charter-handoff.md
@@ -57,11 +57,12 @@ goes.
   The glyph is the half that survives `NO_COLOR`, where charter strips every escape off every
   row. Neither costs a column — the glyph takes the mark's own cell, the one the chat strip's
   spinner takes — so nothing on the strip shifts when a handoff lands, and there is no bell.
-- **The mark clears the first time any terminal on this plane looks at that workspace** — a
-  switch tmux confirmed, a focus, a launch that attaches, or pressing that tab when you are
-  already in it — and every frame's strip repaints without it. One mark per plane, not per
-  terminal: tmux draws a pane identically for every client of its session. A switch charter
-  refused for any other reason clears nothing.
+- **The mark clears the first time any terminal on this plane looks at that workspace —
+  however you get there**: its tab, a palette row, the keyboard walk, a typed
+  `charter frame-switch --workspace`, a launch or a focus that attaches into it, or already
+  being in it and asking to switch there. Every frame's strip then repaints without the mark.
+  One mark per plane, not per terminal: tmux draws a pane identically for every client of its
+  session. A switch charter refused for any *other* reason clears nothing.
 - **The palette and the launch picker say it in words** — `handoff arrived` in the note
   column — because the strip draws only the page your tab falls on, and an arrival on another
   page sits behind a `+2`.

--- a/docs/news/unreleased-charter-handoff.md
+++ b/docs/news/unreleased-charter-handoff.md
@@ -58,9 +58,13 @@ goes.
   row. Neither costs a column — the glyph takes the mark's own cell, the one the chat strip's
   spinner takes — so nothing on the strip shifts when a handoff lands, and there is no bell.
 - **The mark clears the first time any terminal on this plane looks at that workspace** — a
-  switch tmux confirmed, a focus, or a launch that attaches — and every frame's strip repaints
-  without it. One mark per plane, not per terminal: tmux draws a pane identically for every
-  client of its session. A switch charter refused clears nothing.
+  switch tmux confirmed, a focus, a launch that attaches, or pressing that tab when you are
+  already in it — and every frame's strip repaints without it. One mark per plane, not per
+  terminal: tmux draws a pane identically for every client of its session. A switch charter
+  refused for any other reason clears nothing.
+- **The palette and the launch picker say it in words** — `handoff arrived` in the note
+  column — because the strip draws only the page your tab falls on, and an arrival on another
+  page sits behind a `+2`.
 - **Your own chat's attention row names the new chat**, because the command's own output goes
   to a tool call you may never read.
 - A handoff into the workspace you are already in moves its tab and marks nothing: you are

--- a/docs/news/unreleased-charter-handoff.md
+++ b/docs/news/unreleased-charter-handoff.md
@@ -1,6 +1,6 @@
 ---
 version: unreleased
-headline: `charter handoff` opens a chat in any workspace, already working on the brief you approved — and a work-shaped prompt is told where it could run
+headline: A chat hands work to a new chat in any workspace — told where it could run, gated by your yes, opened on the brief you approved, and marked on the strip until you look
 ---
 
 You are in a chat about one thing and you ask for another. Until now that ended one of three
@@ -8,6 +8,26 @@ ways: the model did it here, so one workspace's todos, memory and branch carried
 handed the work to a sub-agent, and the answer you wanted to talk to came back as a paragraph
 and was gone; or it told you to open a chat yourself, and you retyped the context it already
 had.
+
+## How a chat finds out it can
+
+On every work-shaped prompt, charter's prompt block now leads with **Where this could run**:
+the three placements (a sub-agent, a new chat here, a new chat in another workspace), the two
+tests that pick one, and this workspace's vision quoted from `workspace.md` as data. It no
+longer waits for the acting persona to declare `routing:` — the persona roster it embeds still
+does, because "who else exists" is a different question. It names no placement and no other
+workspace; the model matches the ask against the visions `charter workspace list` shows, which
+is why that listing grew a `VISION` column: the first line of each workspace's vision, as the
+trailing field, untruncated.
+
+On an unattended run the block says instead that `charter handoff` is refused there and names
+`charter ws todo --workspace`.
+
+**`charter:handoff`** ships as a skill: apply the two tests, find the workspace, write the brief
+from a template (goal, what is known with paths, done when, constraints, the claim-a-piece line),
+show it **in full** in a quiz, and run the command only on a yes.
+
+## The command it runs
 
 ```bash
 charter handoff <workspace> [--create --vision "<vision>"] [--persona <name>] <<'BRIEF'
@@ -42,8 +62,11 @@ The brief becomes the new chat's first message. Your harness asks before the com
 7. Tallies `{"event": "handoff", "ts", "placement", "created"}` — no workspace name, no persona,
    no text — and clears `routing: require`'s pending mark, because opening a chat in a workspace
    *is* routing.
-8. **Points at it.** See below.
+8. **Points at it** — the strip, and the attention row of the chat that asked. Below.
 9. Prints the chat and the workspace.
+
+The stamp is `⟨handoff from chat <chat> · workspace <ws> · <YYYY-MM-DD HH:MM>⟩`: facts charter
+can observe and no instruction, so the new chat can tell the message was not typed there.
 
 ## The strip says where it landed
 
@@ -74,9 +97,6 @@ goes.
 
 A handoff that did not open a chat moves no tab, marks nothing and says nothing.
 
-The stamp is `⟨handoff from chat <chat> · workspace <ws> · <YYYY-MM-DD HH:MM>⟩`: facts charter
-can observe and no instruction, so the new chat can tell the message was not typed there.
-
 ## It refuses before it changes anything
 
 Nothing is created, recorded or opened until every refusal has been asked: a name that cannot be
@@ -91,24 +111,6 @@ read while it starts.
 `charter <harness> --workspace <ws> …` command to run in a new terminal instead of stopping —
 with the workspace creation in front of it when you asked for one, `CHARTER_PERSONA=` when you
 named a persona, and every word quoted.
-
-## How a chat finds out it can
-
-On every work-shaped prompt, charter's prompt block now leads with **Where this could run**:
-the three placements (a sub-agent, a new chat here, a new chat in another workspace), the two
-tests that pick one, and this workspace's vision quoted from `workspace.md` as data. It no
-longer waits for the acting persona to declare `routing:` — the persona roster it embeds still
-does, because "who else exists" is a different question. It names no placement and no other
-workspace; the model matches the ask against the visions `charter workspace list` shows, which
-is why that listing grew a `VISION` column: the first line of each workspace's vision, as the
-trailing field, untruncated.
-
-On an unattended run the block says instead that `charter handoff` is refused there and names
-`charter ws todo --workspace`.
-
-**`charter:handoff`** ships as a skill: apply the two tests, find the workspace, write the brief
-from a template (goal, what is known with paths, done when, constraints, the claim-a-piece line),
-show it **in full** in a quiz, and run the command only on a yes.
 
 ## A chat that comes back empty is shown its brief
 

--- a/docs/news/unreleased-charter-handoff.md
+++ b/docs/news/unreleased-charter-handoff.md
@@ -42,7 +42,31 @@ The brief becomes the new chat's first message. Your harness asks before the com
 7. Tallies `{"event": "handoff", "ts", "placement", "created"}` — no workspace name, no persona,
    no text — and clears `routing: require`'s pending mark, because opening a chat in a workspace
    *is* routing.
-8. Prints the chat and the workspace.
+8. **Points at it.** See below.
+9. Prints the chat and the workspace.
+
+## The strip says where it landed
+
+A handoff opens a chat nobody is looking at, so the last thing it does is move where your eye
+goes.
+
+- **The target workspace moves to the front of the workspaces strip.** It is the only thing
+  that moves a tab while a plane is up — a switch, a launch and a repaint all leave the order
+  where they found it, because a tab that moves under a press is a tab you press twice.
+- **That tab stays marked until you look**: the `ok` accent, and a `✶` where its `*` would be.
+  The glyph is the half that survives `NO_COLOR`, where charter strips every escape off every
+  row. Neither costs a column — the glyph takes the mark's own cell, the one the chat strip's
+  spinner takes — so nothing on the strip shifts when a handoff lands, and there is no bell.
+- **The mark clears the first time any terminal on this plane looks at that workspace** — a
+  switch tmux confirmed, a focus, or a launch that attaches — and every frame's strip repaints
+  without it. One mark per plane, not per terminal: tmux draws a pane identically for every
+  client of its session. A switch charter refused clears nothing.
+- **Your own chat's attention row names the new chat**, because the command's own output goes
+  to a tool call you may never read.
+- A handoff into the workspace you are already in moves its tab and marks nothing: you are
+  looking at it, and its chats strip already shows the new tab.
+
+A handoff that did not open a chat moves no tab, marks nothing and says nothing.
 
 The stamp is `⟨handoff from chat <chat> · workspace <ws> · <YYYY-MM-DD HH:MM>⟩`: facts charter
 can observe and no instruction, so the new chat can tell the message was not typed there.
@@ -102,6 +126,7 @@ shown nothing: the brief is already the first message of its transcript.
 - **A brief never carries a secret.** It is argv while the harness starts.
 - **An opencode chat that reopens empty is not shown its brief**, because opencode has no
   SessionStart hook at all. `charter doctor` names that gap.
-- **The tab strip does not point at the arrival yet.** That is the next slice.
+- **The arrived mark is per plane, not per terminal**, and there is no "wants you" mark yet
+  for a chat that stopped at a prompt after you visited it. Both are the next slice.
 
 `charter docs show handoff` has the whole of it, including how the consent was measured.

--- a/tests/test_a_handoff_lands_at_the_front_of_the_strip.py
+++ b/tests/test_a_handoff_lands_at_the_front_of_the_strip.py
@@ -111,8 +111,17 @@ class TheArrivedTabIsDrawnInTheOkAccent(PersonaIso, unittest.TestCase):
             (config.WORKSPACES_DIR / n).mkdir(parents=True, exist_ok=True)
         slots.TABS.forget()
         self.addCleanup(slots.TABS.forget)
+        # **`statusline.accent("ok")` is a COLLABORATOR here, not the code under test**,
+        # which is the line between an indirection that is fine and the one that pins
+        # nothing: `slots._compose` is what these cases measure, and which SGR this plane
+        # draws `ok` in is `[frame] accents` — an operator's choice, so spelling the escape
+        # would pin a theme rather than the property. What the indirection could hide is an
+        # accent that is EMPTY, where every `assertIn` below passes on the empty string, so
+        # that one case is closed here and by the literal beside it.
         self.assertNotEqual(statusline.accent("ok"), "",
                             "this plane draws no ok accent, so nothing below is a test")
+        self.assertEqual(statusline.accent("ok"), "\x1b[32m",
+                         "the shipped `ok` accent moved; these rows are written for it")
 
     def _line(self, names, here, arrived=frozenset(), width=200):
         return slots._compose(names, here, width, arrived=arrived)[0][0]
@@ -138,7 +147,7 @@ class TheArrivedTabIsDrawnInTheOkAccent(PersonaIso, unittest.TestCase):
         """`panel._write` hands every row to `chrome.plain` under `NO_COLOR`. What is left
         of an arrived tab there is the glyph, and the tab you are on still has its `*`."""
         line = chrome.plain(self._line(["alpha", "beta"], "alpha", frozenset({"beta"})))
-        self.assertEqual(line, f"{slots._inset()}*alpha  {ARRIVED}beta")
+        self.assertEqual(line, "  *alpha  ✶beta")
 
     def test_the_accent_and_the_glyph_move_no_column(self):
         """The alignment measurement, at three widths and two row counts. The arrival
@@ -178,8 +187,7 @@ class TheArrivedTabIsDrawnInTheOkAccent(PersonaIso, unittest.TestCase):
         _a_chat("beta.1", ws="beta", pane="%1")
         workspace.record_arrival("beta.1")
         row = "".join(slots.chats_bar("beta.1", 200))
-        self.assertEqual(chrome.plain(row), f"{slots._inset()}*beta.1  {slots.ADD_CHAT} "
-                                            f"{slots.CLOSE_CHAT}")
+        self.assertEqual(chrome.plain(row), "  *beta.1  + -")
         self.assertEqual(row.count(statusline.accent("ok")), 0)
 
     def test_an_unreadable_arrivals_record_draws_a_plain_strip(self):
@@ -237,7 +245,9 @@ class TheArrivalsRecord(PersonaIso, unittest.TestCase):
         workspace.record_arrival("beta")
         d = workspace._arrivals_dir()
         self.assertTrue((d / "beta").is_file())
-        self.assertEqual(d.parent, workspace._tab_order_file().parent)
+        self.assertEqual(d, Path(config.STATE_DIR) / "workspace-arrivals")
+        self.assertEqual(d.parent, Path(config.STATE_DIR),
+                         "beside `workspace-tab-order`, which lives here too")
         mode = stat.S_IMODE((d / "beta").stat().st_mode)
         self.assertEqual(mode & 0o077, 0, f"the mark came out {mode:04o}")
         self.assertEqual(mode, config.STATE_FILE_MODE, f"the mark came out {mode:04o}")
@@ -255,7 +265,8 @@ class TheArrivalsRecord(PersonaIso, unittest.TestCase):
         workspace.record_arrival("beta")
         workspace.record_arrival("beta")
         self.assertEqual(workspace.arrivals(), frozenset({"beta"}))
-        self.assertEqual(sorted(p.name for p in workspace._arrivals_dir().iterdir()),
+        self.assertEqual(sorted(q.name for q in
+                                (Path(config.STATE_DIR) / "workspace-arrivals").iterdir()),
                          ["beta"])
 
     def test_a_name_that_cannot_be_a_workspace_is_never_joined_onto_a_path(self):
@@ -802,9 +813,18 @@ class AHandoffArrives(_AHandoffFromAlpha):
         with mock.patch("charter.workspace.record_arrival", return_value=False):
             rc, out, err = self._handoff()
         self.assertEqual(rc, 0)
-        self.assertEqual(err.strip(), "! " + commands_handoff.UNMARKED.format(
-            ws="beta", chat="beta.1"),
-            "a handoff that opened a chat did not fail, so this is not a `✗`")
+        # **Spelled out, not `UNMARKED.format(...)`.** An expectation computed from the
+        # template under test moves with it: removing `{ws}` — the very thing this case
+        # exists to confirm — leaves both sides equal and the suite green, and so does
+        # inverting the sentence. The words are the property here, so the words are
+        # written down. The `! ` is `util.warn`'s marker and belongs in the same string:
+        # a handoff that opened a chat did not fail, so this is not a `✗`.
+        self.assertEqual(
+            err.strip(),
+            "! charter handoff: beta.1 is open in 'beta', but charter could not mark "
+            "that workspace's tab as arrived — its state directory refused the write. "
+            "Nothing on the strip will point at the new chat; its tab did move to the "
+            "front.")
         self.assertIn("opened chat beta.1 in workspace 'beta'", out)
         self.assertEqual(workspace.tab_order()[0], "beta")
         self.assertEqual(state.notice("alpha.1"),

--- a/tests/test_a_handoff_lands_at_the_front_of_the_strip.py
+++ b/tests/test_a_handoff_lands_at_the_front_of_the_strip.py
@@ -1,0 +1,448 @@
+"""A handoff moves the workspace it landed in to the front of the strip, and marks it.
+
+This is the half of `charter handoff` the operator *sees*. A handoff opens a chat in the
+background — no client moves, nothing attaches — so without this the work is invisible
+until somebody happens to look at the right tab, which `docs/frame.md` calls silence by
+construction.
+
+Three things, and each is pinned here on its own terms:
+
+* **The arrival move.** `switch.bring_to_front` is the ONE thing that moves a tab while a
+  plane is up. Everything #767 and #923 bought — a tab never moves under a press, and every
+  frame on the plane draws the same columns — has to survive it, so the move goes through
+  the plane's own recorded order rather than around it.
+* **The arrived mark.** The target tab is drawn in the `ok` accent AND carries
+  `slots._ARRIVED_MARK` in the strip's reserved mark cell (the plan's ruling on Open
+  question 13). The accent is what reads at a glance; the glyph is what survives
+  `NO_COLOR`, where `panel._write` strips every escape off every row. Neither may move a
+  cell or a column — `TheAccentAndTheGlyphMoveNoColumn` is that measurement, and
+  `statusline._persona_chips` records two glyphs that shipped broken here for want of it.
+* **The clear.** The mark is paid by a LOOK, plane-wide, at the three places a terminal
+  comes to be looking at a workspace: a switch that tmux confirmed, a focus, and a launch
+  that attaches. Not by the handoff, not by a refused switch, and not per tmux client — a
+  pane draws the same bytes for every client of its session.
+"""
+
+from __future__ import annotations
+
+import os
+import stat
+import subprocess
+import unicodedata
+import unittest
+from unittest import mock
+
+from charter import commands_frame, config, statusline, tui, workspace
+from charter.frame import chrome, slots, state, switch
+
+from tests._isolation import PersonaIso
+from tests.test_a_chat_opens_in_the_background_with_its_first_message import (
+    TheLaunchOpensWithoutMovingAnyone)
+from tests.test_a_handoff_refuses_before_it_changes_anything import _AHandoffFromAlpha
+from tests.test_a_workspace_tab_opens_what_it_names import _a_chat, _OpensBeta, _Server
+
+#: The glyph the strip draws in the mark cell for a workspace a handoff landed in, spelled
+#: by hand rather than read off `slots._ARRIVED_MARK`. A test that took the constant from
+#: the module under test would follow it anywhere it went, and where it can go — an
+#: East-Asian *Ambiguous* character a terminal may draw two cells wide — is exactly the
+#: change this file exists to catch.
+ARRIVED = "✶"
+
+
+class TheArrivalMovesOneTab(PersonaIso, unittest.TestCase):
+    """`switch.bring_to_front`: the target goes to the head of the plane's recorded order,
+    and the order goes on being one order."""
+
+    def setUp(self):
+        super().setUp()
+        for n in ("alpha", "beta", "gamma"):
+            (config.WORKSPACES_DIR / n).mkdir(parents=True, exist_ok=True)
+        slots.TABS.forget()
+        self.addCleanup(slots.TABS.forget)
+
+    def test_the_target_moves_to_the_front_of_the_recorded_order(self):
+        workspace.record_tab_order(["alpha", "beta", "gamma", config.DEFAULT_WORKSPACE])
+        switch.bring_to_front("gamma")
+        self.assertEqual(workspace.tab_order(),
+                         ["gamma", "alpha", "beta", config.DEFAULT_WORKSPACE])
+
+    def test_a_plane_with_no_recorded_order_decides_one_then_moves_the_target(self):
+        """A handoff can be the first thing that ever asks this plane for its order. The
+        move must not write a one-name file and leave the rest to be decided later, by a
+        repaint, against a record that already exists."""
+        self.assertEqual(workspace.tab_order(), [])
+        switch.bring_to_front("gamma")
+        self.assertEqual(workspace.tab_order()[0], "gamma")
+        self.assertEqual(set(workspace.tab_order()), set(switch.workspaces()))
+
+    def test_a_name_the_plane_does_not_have_moves_nothing(self):
+        workspace.record_tab_order(["alpha", "beta"])
+        before = workspace._tab_order_file().read_bytes()
+        switch.bring_to_front("nope")
+        self.assertEqual(workspace._tab_order_file().read_bytes(), before)
+
+    def test_the_moved_order_then_holds_still(self):
+        """#923's whole property, re-asked on the far side of the one thing that moves a
+        tab: the move happens once, and the next two paints draw what it left."""
+        switch.bring_to_front("gamma")
+        moved = workspace.tab_order()
+        self.assertEqual(switch.workspaces(), moved)
+        self.assertEqual(switch.workspaces(), moved)
+
+    def test_the_strip_draws_the_moved_order(self):
+        _a_chat("f1", ws="alpha", pane="%1")
+        switch.bring_to_front("gamma")
+        row = tui.strip_ansi(slots.workspaces_bar("f1", 200)[0])
+        self.assertLess(row.index("gamma"), row.index("alpha"))
+
+
+class TheArrivedTabIsDrawnInTheOkAccent(PersonaIso, unittest.TestCase):
+    """The mark itself: an accent around the field and a glyph in the mark cell."""
+
+    def setUp(self):
+        super().setUp()
+        for n in ("alpha", "beta", "gamma"):
+            (config.WORKSPACES_DIR / n).mkdir(parents=True, exist_ok=True)
+        slots.TABS.forget()
+        self.addCleanup(slots.TABS.forget)
+        self.assertNotEqual(statusline.accent("ok"), "",
+                            "this plane draws no ok accent, so nothing below is a test")
+
+    def _line(self, names, here, arrived=frozenset(), width=200):
+        return slots._compose(names, here, width, arrived=arrived)[0][0]
+
+    def test_an_arrived_tab_is_wrapped_in_the_ok_accent(self):
+        line = self._line(["alpha", "beta"], "alpha", frozenset({"beta"}))
+        self.assertIn(f"{statusline.accent('ok')}{ARRIVED}beta{statusline._R}", line)
+
+    def test_the_arrived_mark_is_one_cell_and_no_terminal_disagrees(self):
+        """The ruling's second half: pin the width. `tui.width` reads the East-Asian
+        tables, and an *Ambiguous* glyph is one a terminal may draw two cells wide while
+        those tables say one — the failure `slots._BAR_RULE` is ASCII to avoid and the one
+        `statusline._persona_chips` records breaking this layout twice. Neutral is the
+        strongest property available short of ASCII, and it is the property the three
+        `TAB_SPINNER` glyphs were chosen for."""
+        self.assertEqual(slots._ARRIVED_MARK, ARRIVED)
+        self.assertEqual(tui.width(slots._ARRIVED_MARK), 1)
+        self.assertEqual(tui.width(slots._BAR_MARK[1]), 1)
+        self.assertEqual(unicodedata.east_asian_width(slots._ARRIVED_MARK), "N")
+        self.assertIn(slots._ARRIVED_MARK, slots.TAB_SPINNER)
+
+    def test_the_glyph_is_what_survives_no_colour(self):
+        """`panel._write` hands every row to `chrome.plain` under `NO_COLOR`. What is left
+        of an arrived tab there is the glyph, and the tab you are on still has its `*`."""
+        line = chrome.plain(self._line(["alpha", "beta"], "alpha", frozenset({"beta"})))
+        self.assertEqual(line, f"{slots._inset()}*alpha  {ARRIVED}beta")
+
+    def test_the_accent_and_the_glyph_move_no_column(self):
+        """The alignment measurement, at three widths and two row counts. The arrival
+        changes what a field SAYS and never what it measures, so the cut, every row's width
+        and the click map are identical with and without it."""
+        names = ["alpha", "beta", "gamma", "delta", "epsilon"]
+        for width in (200, 60, 24):
+            for rows in (1, 3):
+                with self.subTest(width=width, rows=rows):
+                    plain = slots._compose(names, "alpha", width, rows=rows)
+                    marked = slots._compose(names, "alpha", width, rows=rows,
+                                            arrived=frozenset({"epsilon"}))
+                    self.assertEqual([tui.width(ln) for ln in marked[0]],
+                                     [tui.width(ln) for ln in plain[0]])
+                    self.assertEqual(marked[1], plain[1])
+
+    def test_the_tab_you_are_on_keeps_its_own_highlight_when_it_arrived(self):
+        """You cannot be owed a look at the workspace you are looking at, so the block
+        wins the field outright — the mark cell keeps its `*` and no accent is written."""
+        line = self._line(["alpha", "beta"], "alpha", frozenset({"alpha"}))
+        self.assertIn(chrome.block("*alpha"), line)
+        self.assertNotIn(f"{statusline.accent('ok')}*alpha", line)
+
+    def test_only_the_arrived_tab_carries_the_accent(self):
+        line = self._line(["alpha", "beta", "gamma"], "alpha", frozenset({"beta"}))
+        self.assertEqual(line.count(statusline.accent("ok")), 1)
+
+    def test_the_workspaces_bar_reads_the_planes_arrivals(self):
+        _a_chat("f1", ws="alpha", pane="%1")
+        workspace.record_arrival("beta")
+        row = slots.workspaces_bar("f1", 200)[0]
+        self.assertIn(f"{statusline.accent('ok')}{ARRIVED}beta", row)
+
+    def test_the_chats_bar_draws_no_arrival(self):
+        """A handoff lands in a workspace and never in a chat, so the chats strip passes
+        no arrivals — a record naming something chat-shaped reaches nothing."""
+        _a_chat("beta.1", ws="beta", pane="%1")
+        workspace.record_arrival("beta.1")
+        row = "".join(slots.chats_bar("beta.1", 200))
+        self.assertEqual(chrome.plain(row), f"{slots._inset()}*beta.1  {slots.ADD_CHAT} "
+                                            f"{slots.CLOSE_CHAT}")
+        self.assertEqual(row.count(statusline.accent("ok")), 0)
+
+    def test_an_unreadable_arrivals_record_draws_a_plain_strip(self):
+        """A readout must never cost a pane. The degrade is the strip charter drew before
+        there were any arrivals at all."""
+        _a_chat("f1", ws="alpha", pane="%1")
+        with mock.patch("charter.workspace.arrivals", side_effect=RuntimeError):
+            row = slots.workspaces_bar("f1", 200)[0]
+        self.assertEqual(chrome.plain(row), "  *alpha 1    beta      default      gamma")
+        self.assertEqual(row.count(statusline.accent("ok")), 0)
+
+    def test_the_sizer_asks_for_the_same_rows_with_arrivals(self):
+        """`bar_rows_wanted` runs in the LAUNCHER, where nothing knows or should know which
+        workspace a chat was handed to. A mark that changed the row count would resize a
+        pane every time a handoff landed."""
+        _a_chat("f1", ws="alpha", pane="%1")
+        before = slots.bar_rows_wanted("f1", "workspaces", pane_cols=40, cap=3)
+        workspace.record_arrival("beta")
+        self.assertEqual(slots.bar_rows_wanted("f1", "workspaces", pane_cols=40, cap=3),
+                         before)
+
+    def test_a_hostile_line_in_the_record_reaches_no_row(self):
+        """The record is charter's own private state, and it is still read with a name
+        check — the line goes on to a strip. Both ways round: the record answers only the
+        name that can be one, and the raw erase never reaches a row."""
+        _a_chat("f1", ws="alpha", pane="%1")
+        workspace._arrivals_file().parent.mkdir(parents=True, exist_ok=True)
+        workspace._arrivals_file().write_text("beta\n\x1b[2Jgamma\n")
+        self.assertEqual(workspace.arrivals(), frozenset({"beta"}))
+        row = slots.workspaces_bar("f1", 200)[0]
+        self.assertNotIn("\x1b[2J", row)
+        self.assertIn(f"{statusline.accent('ok')}{ARRIVED}beta", row)
+
+
+class TheArrivalsRecord(PersonaIso, unittest.TestCase):
+    """Where the marks live and what a reader of them is promised."""
+
+    def test_it_is_private_plane_state_beside_the_tab_order(self):
+        old = os.umask(0)
+        self.addCleanup(os.umask, old)
+        workspace.record_arrival("beta")
+        f = workspace._arrivals_file()
+        self.assertTrue(f.is_file())
+        self.assertEqual(f.parent, workspace._tab_order_file().parent)
+        mode = stat.S_IMODE(f.stat().st_mode)
+        self.assertEqual(mode & 0o077, 0, f"the record came out {mode:04o}")
+        self.assertEqual(mode, config.STATE_FILE_MODE, f"the record came out {mode:04o}")
+        self.assertNotIn(state._root(), f.parents)
+
+    def test_a_name_is_recorded_once(self):
+        workspace.record_arrival("beta")
+        workspace.record_arrival("beta")
+        self.assertEqual(workspace.arrivals(), frozenset({"beta"}))
+        self.assertEqual(workspace._arrivals_file().read_text(), "beta\n")
+
+    def test_a_line_that_cannot_name_a_workspace_is_not_read_back(self):
+        workspace._arrivals_file().parent.mkdir(parents=True, exist_ok=True)
+        workspace._arrivals_file().write_text("beta\n../x\n\n")
+        self.assertEqual(workspace.arrivals(), frozenset({"beta"}))
+
+    def test_a_record_that_cannot_be_read_is_no_marks(self):
+        with mock.patch("pathlib.Path.read_text", side_effect=OSError):
+            self.assertEqual(workspace.arrivals(), frozenset())
+
+    def test_clearing_a_name_that_never_arrived_writes_nothing(self):
+        """Every switch on this plane calls this, and the ordinary plane HAS a record —
+        `config.replace_for` would rewrite it whole, moving its mtime on every switch
+        charter ever makes for no change at all. Asserted on the mtime as well as the
+        bytes, because identical bytes are exactly what a needless rewrite produces."""
+        workspace.record_arrival("gamma")
+        f = workspace._arrivals_file()
+        before = (f.read_bytes(), f.stat().st_mtime_ns)
+        workspace.clear_arrival("beta")
+        self.assertEqual((f.read_bytes(), f.stat().st_mtime_ns), before)
+
+    def test_clearing_on_a_plane_with_no_record_creates_none(self):
+        """The other half: a plane that has never had a handoff must not grow an empty
+        record the first time somebody switches workspace."""
+        config.private_mkdir(workspace._arrivals_file().parent)
+        workspace.clear_arrival("beta")
+        self.assertFalse(workspace._arrivals_file().exists())
+
+    def test_clearing_removes_only_that_name(self):
+        workspace.record_arrival("beta")
+        workspace.record_arrival("gamma")
+        workspace.clear_arrival("beta")
+        self.assertEqual(workspace.arrivals(), frozenset({"gamma"}))
+
+    def test_forgetting_drops_every_mark(self):
+        workspace.record_arrival("beta")
+        workspace.forget_arrivals()
+        self.assertEqual(workspace.arrivals(), frozenset())
+        workspace.forget_arrivals()
+
+
+class TheMarkClearsWhenSomeoneLooks(_OpensBeta):
+    """A switch, a focus and an attaching launch each pay the look — and a switch that did
+    not move the terminal does not."""
+
+    def setUp(self):
+        super().setUp()
+        _a_chat("beta.1", ws="beta", pane="%9")
+        workspace.record_arrival("beta")
+
+    def _server(self):
+        server = _Server()
+        server.opened = ["%9"]
+        return server
+
+    def test_switching_into_the_workspace_clears_its_mark(self):
+        server = self._server()
+        with mock.patch("charter.commands_frame.subprocess.run", side_effect=server):
+            commands_frame._switch_client("alpha.1", "beta", said="workspace → beta")
+        self.assertNotIn("beta", workspace.arrivals())
+
+    def test_a_switch_that_did_not_move_the_terminal_keeps_the_mark(self):
+        """`_switch_client` refuses for several reasons and only the CONFIRMED move is a
+        look. A mark cleared by a switch tmux then refused loses the only thing pointing at
+        the chat a handoff opened."""
+        server = self._server()
+        server.switched.append(("/dev/ttys001", "$2"))
+
+        def refuse(cmd, **kw):
+            if "list-clients" in cmd and cmd[cmd.index("-t") + 1] == "$2":
+                return subprocess.CompletedProcess(list(cmd), 0, "", "")
+            return server(cmd, **kw)
+
+        with mock.patch("charter.commands_frame.subprocess.run", side_effect=refuse):
+            commands_frame._switch_client("alpha.1", "beta", said="workspace → beta")
+        self.assertIn("beta", workspace.arrivals())
+
+    def test_clearing_bumps_every_frame(self):
+        """Every frame on the plane draws the mark, so every frame has to be told it is
+        gone — a panel polls `state.version` and would otherwise keep drawing it."""
+        before = {f: state.version(f) for f in ("alpha.1", "beta.1")}
+        server = self._server()
+        with mock.patch("charter.commands_frame.subprocess.run", side_effect=server):
+            commands_frame._switch_client("alpha.1", "beta", said="workspace → beta")
+        for f, was in before.items():
+            self.assertNotEqual(state.version(f), was, f)
+
+    def test_a_switch_into_an_unmarked_workspace_tells_nobody(self):
+        """Almost no switch follows a handoff. A fan-out on every one of them would bump
+        every frame directory on the plane — and repaint every background frame's panels —
+        to say that nothing changed."""
+        workspace.clear_arrival("beta")
+        before = {f: state.version(f) for f in ("alpha.1", "beta.1")}
+        server = self._server()
+        with mock.patch("charter.commands_frame.subprocess.run", side_effect=server), \
+                mock.patch("charter.frame.notify.bump_everywhere") as fanout:
+            commands_frame._switch_client("alpha.1", "beta", said="workspace → beta")
+        fanout.assert_not_called()
+        self.assertEqual(state.version("beta.1"), before["beta.1"])
+
+    def test_a_focus_clears_the_mark_before_it_attaches(self):
+        """`interact` IS the operator's terminal for as long as they stay, so a clear on
+        the far side of it would drop the mark as they left rather than as they arrived."""
+        seen = []
+
+        def attaching(argv, **kw):
+            seen.append(workspace.arrivals())
+            return subprocess.CompletedProcess(argv, 0, "", "")
+
+        with mock.patch.object(commands_frame.tmuxctl, "interact",
+                               side_effect=attaching) as interact:
+            commands_frame._focus_workspace("$2", "beta.1", ws="beta", picked=False)
+        interact.assert_called_once()
+        self.assertEqual(seen, [frozenset()])
+
+
+class ALaunchThatAttachesClearsTheMark(TheLaunchOpensWithoutMovingAnyone):
+    """Task 1's real `_launch`, with the arrival already recorded for `beta`.
+
+    Task 1's own cases re-run here with a mark on the workspace being launched into, and
+    that is the point of inheriting rather than copying the fixture: none of them may change
+    because a handoff marked a workspace. The launcher is the one place where the clear sits
+    inside the branch that decides whether this process becomes anybody's terminal.
+    """
+
+    def setUp(self):
+        super().setUp()
+        (config.WORKSPACES_DIR / "beta").mkdir(parents=True, exist_ok=True)
+        workspace.record_arrival("beta")
+
+    def test_a_launch_that_attaches_clears_the_mark_before_attaching(self):
+        """The reading is taken from inside the clear, because the fixture owns the stand-in
+        for `tmuxctl.interact` and an attach that has not happened is one that has not been
+        called. Zero is the whole assertion: the mark was paid as the terminal arrived, not
+        as it left."""
+        real, seen = workspace.clear_arrival, []
+
+        def clearing(ws):
+            seen.append((ws, commands_frame.tmuxctl.interact.call_count))
+            real(ws)
+
+        with mock.patch.object(workspace, "clear_arrival", side_effect=clearing):
+            self._launch(attach=None)
+        self.assertEqual(seen, [("beta", 0)])
+        self.assertEqual(workspace.arrivals(), frozenset())
+        self.interact.assert_called_once()
+
+    def test_a_background_open_looks_at_nothing(self):
+        """A handoff's own launch never attaches, so the chat it opens cannot clear the
+        mark it is the reason for."""
+        self._launch(opening=commands_frame.Opening("fix it please"))
+        self.assertEqual(workspace.arrivals(), frozenset({"beta"}))
+
+
+class APlaneThatGoesColdForgetsItsArrivals(PersonaIso, unittest.TestCase):
+    """`state.reap`'s cold-plane branch, one file over from the tab order: a mark is a look
+    somebody is owed, and a plane with no frame has no strip to owe it on."""
+
+    def setUp(self):
+        super().setUp()
+        (config.WORKSPACES_DIR / "beta").mkdir(parents=True, exist_ok=True)
+        workspace.record_arrival("beta")
+
+    def test_a_plane_that_goes_cold_forgets_its_arrivals(self):
+        _a_chat("alpha.1", ws="alpha", pane="%1")
+        self.assertEqual(state.reap(set(), server=commands_frame.SOCKET), ["alpha.1"])
+        self.assertEqual(workspace.arrivals(), frozenset())
+
+    def test_a_reap_that_leaves_a_frame_keeps_the_arrivals(self):
+        """The other half, and the one #767 is about: a frame still on screen must not lose
+        a mark because a SIBLING ended."""
+        _a_chat("alpha.1", ws="alpha", pane="%1")
+        state.reap({"alpha.1"}, server=commands_frame.SOCKET)
+        self.assertIn("beta", workspace.arrivals())
+
+
+class AHandoffArrives(_AHandoffFromAlpha):
+    """Steps 7 and 8 of `charter handoff`, on the far side of the open."""
+
+    def setUp(self):
+        super().setUp()
+        self.fanout = self.enterContext(
+            mock.patch("charter.frame.notify.plane_changed_everywhere"))
+
+    def test_a_handoff_elsewhere_moves_the_target_to_the_front_and_marks_it(self):
+        self._handoff()
+        self.assertEqual(workspace.tab_order()[0], "beta")
+        self.assertIn("beta", workspace.arrivals())
+
+    def test_a_handoff_into_this_workspace_moves_it_and_marks_nothing(self):
+        """You are looking at it, and its chats strip already shows the new tab. The tab
+        still moves: the order is about where work is."""
+        self._handoff(ws="alpha")
+        self.assertEqual(workspace.tab_order()[0], "alpha")
+        self.assertEqual(workspace.arrivals(), frozenset())
+
+    def test_the_calling_chats_attention_row_names_the_new_chat(self):
+        self._handoff()
+        self.assertEqual(state.notice("alpha.1"),
+                         "charter: handoff → beta.1 opened in workspace 'beta'")
+
+    def test_every_frame_is_told_once(self):
+        self._handoff()
+        self.assertEqual(self.fanout.call_count, 1)
+
+    def test_a_handoff_that_did_not_open_moves_no_tab_and_marks_nothing(self):
+        """Nothing on screen may point at a chat that does not exist."""
+        workspace.record_tab_order(["alpha", "beta"])
+        self.opened = commands_frame.Opened(False, "", "tmux said no")
+        self._handoff()
+        self.assertEqual(workspace.tab_order(), ["alpha", "beta"])
+        self.assertEqual(workspace.arrivals(), frozenset())
+        self.assertEqual(state.notice("alpha.1"), "")
+        self.fanout.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_a_handoff_lands_at_the_front_of_the_strip.py
+++ b/tests/test_a_handoff_lands_at_the_front_of_the_strip.py
@@ -36,9 +36,10 @@ from pathlib import Path
 from types import SimpleNamespace
 from unittest import mock
 
-from charter import commands_frame, config, statusline, tui, workspace
-from charter.frame import (builtin_actions, choose, chrome, picker, slots,
-                           state, switch)
+from charter import (commands_frame, commands_handoff, config, statusline, tui,
+                     workspace)
+from charter.frame import (builtin_actions, builtins, choose, chrome, picker,
+                           notify, slots, state, switch)
 
 from tests._isolation import PersonaIso
 from tests.test_a_chat_opens_in_the_background_with_its_first_message import (
@@ -265,6 +266,46 @@ class TheArrivalsRecord(PersonaIso, unittest.TestCase):
         self.assertFalse((Path(config.STATE_DIR).parent / "escaped").exists())
         self.assertFalse(workspace._arrivals_dir().exists())
 
+    def test_clearing_a_name_that_cannot_be_a_workspace_deletes_nothing(self):
+        """**The guard with teeth, and it is the clear side.** `record_arrival`'s identical
+        check only ever fails to create a file; this one decides what `unlink` is aimed at,
+        and `../workspace-tab-order` under the arrivals directory is the plane's tab order.
+        Unreachable today — every caller name-checks first — which is exactly why it is
+        pinned here rather than left to the day one stops."""
+        workspace.record_tab_order(["alpha", "beta"])
+        workspace.record_arrival("beta")
+        order = workspace._tab_order_file()
+        before = order.read_bytes()
+        for escape in ("../workspace-tab-order", "..", "../..", "/etc/passwd", ""):
+            with self.subTest(escape=escape):
+                workspace.clear_arrival(escape)
+                self.assertTrue(order.is_file(), f"{escape!r} took the tab order")
+                self.assertEqual(order.read_bytes(), before)
+        self.assertEqual(workspace.arrivals(), frozenset({"beta"}))
+
+    def test_a_mark_is_reported_when_it_could_not_be_written(self):
+        """A handoff that opened a chat nobody will be pointed at is the one outcome this
+        record exists to prevent, so a failed write answers `False` rather than going
+        quiet. The name-refused case answers `False` on the same terms: it marked nothing."""
+        self.assertTrue(workspace.record_arrival("beta"))
+        self.assertFalse(workspace.record_arrival("../escaped"))
+        with mock.patch("charter.config.touch_for", side_effect=OSError):
+            self.assertFalse(workspace.record_arrival("gamma"))
+        self.assertEqual(workspace.arrivals(), frozenset({"beta"}))
+
+    def test_a_workspace_with_a_very_long_name_can_still_be_marked(self):
+        """**The ceiling `replace_for` put here, measured.** An atomic replace writes a
+        temp beside the target, so a name within a few characters of `NAME_MAX` made a temp
+        name past it — `ENAMETOOLONG`, swallowed, and a workspace that could be created and
+        never marked. A marker's content is its existence; there is no half-written empty
+        file to protect a reader from, so it is created directly and the ceiling is gone."""
+        name = "w" * 240
+        self.assertTrue(workspace.valid_name(name), "the plane would refuse this name")
+        self.assertTrue(workspace.record_arrival(name))
+        self.assertEqual(workspace.arrivals(), frozenset({name}))
+        workspace.clear_arrival(name)
+        self.assertEqual(workspace.arrivals(), frozenset())
+
     def test_a_name_that_cannot_name_a_workspace_is_not_read_back(self):
         d = workspace._arrivals_dir()
         d.mkdir(parents=True, exist_ok=True)
@@ -461,11 +502,33 @@ class TheMarkClearsWhenSomeoneLooks(_OpensBeta):
         surface on this plane ends at `cmd_switch` — a tab press, a palette row, the
         keyboard walk and a typed command all spawn `frame-switch --workspace <name>`. So
         the sentence is true for all four exactly if it is true for this one entry point,
-        and this drives it with the argv each of them builds."""
-        for spelling in (("frame-switch", "--workspace"),
-                         builtin_actions._STRIPS[1].command):
-            with self.subTest(spelling=spelling):
-                self.assertEqual(spelling, ("frame-switch", "--workspace"))
+        and this drives it with the argv each of them builds.
+
+        **The list of routes lives in TWO places and this is the other half.** The prose
+        one is `docs/frame.md`'s *"however you get there"* sentence (and its copies in
+        `docs/handoff.md` and the news entry); a route added to one belongs in both. The
+        argv assertion below is what keeps the claim honest as the code moves — a surface
+        given a spelling of its own stops reaching this clear, and nothing else in the
+        suite would notice that the sentence had silently become false for that route.
+        What it cannot do is notice a route added to the code and not to the prose, which
+        is why this paragraph is here rather than left to be re-derived.
+        """
+        # **Every surface's argv, held equal to the one this case then drives.** The three
+        # spellings are deliberately separate in the source — `frame/builtins.py` is a
+        # renderer a palette process has no reason to import, and `_start_workspace_switch`
+        # restates the pair rather than reaching for it — so the equality lives here, which
+        # is `tests/test_the_keyboard_walks_the_tab_strips.py`'s own arrangement. A surface
+        # given a spelling of its own stops reaching the clear below, and nothing else in
+        # the suite would notice that the docs had become false for that route.
+        spawned: list = []
+        with mock.patch("charter.frame.builtin_actions._spawn",
+                        side_effect=lambda argv, **kw: spawned.append(argv)):
+            commands_frame._start_workspace_switch("beta.1", "beta")
+        self.assertEqual(spawned[0][-2:], ["--workspace", "beta"],
+                         "the palette starts a switch nothing else spells")
+        self.assertEqual(builtin_actions._STRIPS[1].command,
+                         ("frame-switch", "--workspace"))
+        self.assertEqual(builtins._WORKSPACE_SWITCH, ("frame-switch", "--workspace"))
         for surface in ("tab", "palette row", "keyboard walk", "typed command"):
             with self.subTest(surface=surface):
                 workspace.record_arrival("beta")
@@ -488,6 +551,19 @@ class TheMarkClearsWhenSomeoneLooks(_OpensBeta):
             self.assertEqual(commands_frame.cmd_switch(args), 0)
         self.assertEqual(workspace.arrivals(), frozenset({"beta"}))
         self.assertIn("no workspace 'beta'", self.said.call_args.args[1])
+
+    def test_a_frame_root_that_cannot_be_listed_costs_the_switch_nothing(self):
+        """`bump_everywhere` runs on the switch path, so a repaint nobody asked for must
+        never be the thing that raises out of one. The sweep reported this catch unpinned:
+        without it the failure comes out of `_looked_at`, through `_switch_client`, and the
+        operator's switch dies for a notification."""
+        with mock.patch("charter.frame.state._root", side_effect=OSError):
+            self.assertIsNone(notify.bump_everywhere())
+            # And through the one function every clear site calls, which is where the
+            # failure would actually escape from: the mark is still paid, and the switch
+            # that paid it does not die because nobody could be told.
+            commands_frame._looked_at("beta")
+        self.assertEqual(workspace.arrivals(), frozenset())
 
     def test_a_focus_clears_the_mark_before_it_attaches(self):
         """`interact` IS the operator's terminal for as long as they stay, so a clear on
@@ -604,6 +680,19 @@ class EverySurfaceThatListsWorkspacesSaysSo(PersonaIso, unittest.TestCase):
         self.assertEqual(self._notes(rows)["beta"], "pinned by $CHARTER_WORKSPACE")
         self.assertTrue(all(r.refused for r in rows))
 
+    def test_only_the_workspace_picker_asks_the_plane_for_arrivals(self):
+        """The cost guard the sweep reported unpinned. Reading it for every noun would
+        change no output — a chat row's note is its harness and a persona row has none — so
+        nothing but this can see the difference: one `os.listdir` per picker open, on a
+        surface an operator reaches by keystroke, asking a question that noun cannot use."""
+        with mock.patch("charter.workspace.arrivals") as asked:
+            for noun in (choose.CHAT, choose.PERSONA, choose.CHANGE):
+                with self.subTest(noun=noun):
+                    choose.roster(noun, "alpha.1")
+                    asked.assert_not_called()
+            choose.roster(choose.WORKSPACE, "alpha.1")
+            self.assertEqual(asked.call_count, 1, "and exactly once for the whole roster")
+
     def test_a_picker_charter_cannot_ask_draws_no_note_and_raises_nothing(self):
         with mock.patch("charter.workspace.arrivals", side_effect=RuntimeError):
             notes = self._notes(choose.roster(choose.WORKSPACE, "alpha.1").rows)
@@ -619,9 +708,9 @@ class EverySurfaceThatListsWorkspacesSaysSo(PersonaIso, unittest.TestCase):
         """The earliest surface that can say it: before tmux, before a frame, before any
         strip exists to draw a mark on."""
         rows = picker.rows(["alpha", "beta"], lambda n: 0, workspace.arrivals())
-        drawn = tui.strip_ansi(picker.render(rows, "alpha", 120))
-        self.assertIn("* alpha  —", drawn)
-        self.assertIn("  beta   —  handoff arrived", drawn)
+        drawn = [tui.strip_ansi(ln) for ln in picker.render(rows, "alpha", 120).splitlines()]
+        self.assertIn("     1  * alpha  —", drawn)
+        self.assertIn("     2    beta   —  handoff arrived", drawn)
 
     def test_the_launch_asks_the_plane_for_its_arrivals(self):
         """The wiring, not the renderer: a picker handed a renderer that can draw the mark
@@ -640,11 +729,30 @@ class EverySurfaceThatListsWorkspacesSaysSo(PersonaIso, unittest.TestCase):
                 SimpleNamespace(workspace=None, pick=True))
         self.assertEqual([r.name for r in seen[0] if r.arrived], ["beta"])
 
+    def test_a_narrow_terminal_cuts_the_note_and_never_drops_it(self):
+        """`docs/frame.md` says cut, never dropped, and this is the measurement behind that
+        wording — it said "at any width" until the widths were asked. What the operator
+        keeps at 24 columns is a row that visibly carries something the others do not,
+        which is more than the strip has at that width."""
+        rows = picker.rows(["alpha", "beta"], lambda n: 0, frozenset({"beta"}))
+        for width, drawn in ((120, "     2    beta   —  handoff arrived"),
+                             (30, "     2    beta   —  handoff a…"),
+                             (24, "     2    beta   —  han…"),
+                             (16, "     2    beta …")):
+            with self.subTest(width=width):
+                # Split BEFORE stripping: `tui.strip_ansi` is asked about one row, and the
+                # render is several joined by newlines.
+                row = [tui.strip_ansi(ln)
+                       for ln in picker.render(rows, "alpha", width).splitlines()
+                       if "beta" in ln][0]
+                self.assertEqual(row, drawn)
+                self.assertLessEqual(tui.width(row), width)
+
     def test_the_launch_picker_without_arrivals_draws_exactly_what_it_drew_before(self):
         rows = picker.rows(["alpha", "beta"], lambda n: 0)
-        drawn = tui.strip_ansi(picker.render(rows, "alpha", 120))
-        self.assertNotIn("handoff", drawn)
-        self.assertIn("  beta   —", drawn)
+        drawn = [tui.strip_ansi(ln) for ln in picker.render(rows, "alpha", 120).splitlines()]
+        self.assertIn("     2    beta   —", drawn)
+        self.assertEqual([ln for ln in drawn if "handoff" in ln], [])
 
 
 class AHandoffArrives(_AHandoffFromAlpha):
@@ -685,6 +793,28 @@ class AHandoffArrives(_AHandoffFromAlpha):
     def test_every_frame_is_told_once(self):
         self._handoff()
         self.assertEqual(self.fanout.call_count, 1)
+
+    def test_a_mark_that_could_not_be_written_is_said_and_the_chat_still_opened(self):
+        """The one outcome this record exists to prevent, arriving through the record: a
+        chat is open and nothing on screen will point at it. So it is said — naming the
+        workspace, because going to look is the job the mark would have done — and nothing
+        after it is conditional on the mark, because the chat is real either way."""
+        with mock.patch("charter.workspace.record_arrival", return_value=False):
+            rc, out, err = self._handoff()
+        self.assertEqual(rc, 0)
+        self.assertEqual(err.strip(), "! " + commands_handoff.UNMARKED.format(
+            ws="beta", chat="beta.1"),
+            "a handoff that opened a chat did not fail, so this is not a `✗`")
+        self.assertIn("opened chat beta.1 in workspace 'beta'", out)
+        self.assertEqual(workspace.tab_order()[0], "beta")
+        self.assertEqual(state.notice("alpha.1"),
+                         "charter: handoff → beta.1 opened in workspace 'beta'")
+        self.assertEqual(self.fanout.call_count, 1)
+
+    def test_a_mark_that_was_written_says_nothing_extra(self):
+        """The other half, so the sentence above is a report and not decoration."""
+        rc, _out, err = self._handoff()
+        self.assertEqual((rc, err), (0, ""))
 
     def test_a_handoff_that_did_not_open_moves_no_tab_and_marks_nothing(self):
         """Nothing on screen may point at a chat that does not exist."""

--- a/tests/test_a_handoff_lands_at_the_front_of_the_strip.py
+++ b/tests/test_a_handoff_lands_at_the_front_of_the_strip.py
@@ -37,7 +37,8 @@ from types import SimpleNamespace
 from unittest import mock
 
 from charter import commands_frame, config, statusline, tui, workspace
-from charter.frame import choose, chrome, picker, slots, state, switch
+from charter.frame import (builtin_actions, choose, chrome, picker, slots,
+                           state, switch)
 
 from tests._isolation import PersonaIso
 from tests.test_a_chat_opens_in_the_background_with_its_first_message import (
@@ -454,6 +455,25 @@ class TheMarkClearsWhenSomeoneLooks(_OpensBeta):
         self.assertEqual(workspace.arrivals(), frozenset())
         self.said.assert_called_once()
         self.assertEqual(self.said.call_args.args[1], "already in workspace 'beta'")
+
+    def test_every_route_to_the_workspace_you_are_in_clears_it(self):
+        """The docs say the mark clears "however you get there", and every workspace-switch
+        surface on this plane ends at `cmd_switch` — a tab press, a palette row, the
+        keyboard walk and a typed command all spawn `frame-switch --workspace <name>`. So
+        the sentence is true for all four exactly if it is true for this one entry point,
+        and this drives it with the argv each of them builds."""
+        for spelling in (("frame-switch", "--workspace"),
+                         builtin_actions._STRIPS[1].command):
+            with self.subTest(spelling=spelling):
+                self.assertEqual(spelling, ("frame-switch", "--workspace"))
+        for surface in ("tab", "palette row", "keyboard walk", "typed command"):
+            with self.subTest(surface=surface):
+                workspace.record_arrival("beta")
+                args = SimpleNamespace(workspace="beta", persona=None)
+                with mock.patch.dict(os.environ,
+                                     {"CHARTER_SESSION_ID": "beta.1"}, clear=True):
+                    self.assertEqual(commands_frame.cmd_switch(args), 0)
+                self.assertEqual(workspace.arrivals(), frozenset())
 
     def test_pressing_a_tab_that_is_refused_for_any_other_reason_keeps_the_mark(self):
         """`to_workspace` refuses three things and only one of them means "you are here".

--- a/tests/test_a_handoff_lands_at_the_front_of_the_strip.py
+++ b/tests/test_a_handoff_lands_at_the_front_of_the_strip.py
@@ -424,6 +424,16 @@ class AHandoffArrives(_AHandoffFromAlpha):
         self.assertEqual(workspace.tab_order()[0], "alpha")
         self.assertEqual(workspace.arrivals(), frozenset())
 
+    def test_a_created_workspace_is_on_the_strip_and_at_the_front_of_it(self):
+        """`bring_to_front` moves nothing for a name the plane does not have, so a
+        `--create`d workspace has to be a workspace by the time it is asked — otherwise the
+        one handoff that most needs pointing at is the one that points at nothing."""
+        self.opened = commands_frame.Opened(True, "gamma.1", "")
+        self._handoff(ws="gamma", create=True, vision="Ship the thing.")
+        self.assertEqual(workspace.tab_order()[0], "gamma")
+        self.assertIn("gamma", switch.workspaces())
+        self.assertIn("gamma", workspace.arrivals())
+
     def test_the_calling_chats_attention_row_names_the_new_chat(self):
         self._handoff()
         self.assertEqual(state.notice("alpha.1"),

--- a/tests/test_a_handoff_lands_at_the_front_of_the_strip.py
+++ b/tests/test_a_handoff_lands_at_the_front_of_the_strip.py
@@ -26,14 +26,18 @@ Three things, and each is pinned here on its own terms:
 from __future__ import annotations
 
 import os
+import shutil
 import stat
 import subprocess
+import threading
 import unicodedata
 import unittest
+from pathlib import Path
+from types import SimpleNamespace
 from unittest import mock
 
 from charter import commands_frame, config, statusline, tui, workspace
-from charter.frame import chrome, slots, state, switch
+from charter.frame import choose, chrome, picker, slots, state, switch
 
 from tests._isolation import PersonaIso
 from tests.test_a_chat_opens_in_the_background_with_its_first_message import (
@@ -195,17 +199,31 @@ class TheArrivedTabIsDrawnInTheOkAccent(PersonaIso, unittest.TestCase):
         self.assertEqual(slots.bar_rows_wanted("f1", "workspaces", pane_cols=40, cap=3),
                          before)
 
-    def test_a_hostile_line_in_the_record_reaches_no_row(self):
+    def test_a_hostile_name_in_the_record_reaches_no_row(self):
         """The record is charter's own private state, and it is still read with a name
-        check — the line goes on to a strip. Both ways round: the record answers only the
+        check — the name goes on to a strip. Both ways round: the record answers only the
         name that can be one, and the raw erase never reaches a row."""
         _a_chat("f1", ws="alpha", pane="%1")
-        workspace._arrivals_file().parent.mkdir(parents=True, exist_ok=True)
-        workspace._arrivals_file().write_text("beta\n\x1b[2Jgamma\n")
+        d = workspace._arrivals_dir()
+        d.mkdir(parents=True, exist_ok=True)
+        (d / "beta").write_text("")
+        (d / "\x1b[2Jgamma").write_text("")
         self.assertEqual(workspace.arrivals(), frozenset({"beta"}))
         row = slots.workspaces_bar("f1", 200)[0]
         self.assertNotIn("\x1b[2J", row)
         self.assertIn(f"{statusline.accent('ok')}{ARRIVED}beta", row)
+
+    def test_an_arrival_wins_the_mark_cell_from_a_spinner(self):
+        """The two can only meet if a caller hands both — no strip does — and the docstring
+        says which wins. Pinned so the order is a decision rather than the way the `if`s
+        happen to be stacked. The spinner frame is fixed here because it is a clock
+        reading, and `_ARRIVED_MARK` is itself one of its three glyphs."""
+        with mock.patch("charter.frame.slots.tab_spinner_frame", return_value="✢"):
+            line = slots._compose(["alpha", "beta"], "alpha", 200,
+                                  arrived=frozenset({"beta"}),
+                                  busy=("beta",))[0][0]
+        self.assertIn(f"{statusline.accent('ok')}{ARRIVED}beta", line)
+        self.assertNotIn("✢beta", line)
 
 
 class TheArrivalsRecord(PersonaIso, unittest.TestCase):
@@ -215,46 +233,74 @@ class TheArrivalsRecord(PersonaIso, unittest.TestCase):
         old = os.umask(0)
         self.addCleanup(os.umask, old)
         workspace.record_arrival("beta")
-        f = workspace._arrivals_file()
-        self.assertTrue(f.is_file())
-        self.assertEqual(f.parent, workspace._tab_order_file().parent)
-        mode = stat.S_IMODE(f.stat().st_mode)
-        self.assertEqual(mode & 0o077, 0, f"the record came out {mode:04o}")
-        self.assertEqual(mode, config.STATE_FILE_MODE, f"the record came out {mode:04o}")
-        self.assertNotIn(state._root(), f.parents)
+        d = workspace._arrivals_dir()
+        self.assertTrue((d / "beta").is_file())
+        self.assertEqual(d.parent, workspace._tab_order_file().parent)
+        mode = stat.S_IMODE((d / "beta").stat().st_mode)
+        self.assertEqual(mode & 0o077, 0, f"the mark came out {mode:04o}")
+        self.assertEqual(mode, config.STATE_FILE_MODE, f"the mark came out {mode:04o}")
+        dmode = stat.S_IMODE(d.stat().st_mode)
+        self.assertEqual(dmode & 0o077, 0, f"the record came out {dmode:04o}")
+        self.assertNotIn(state._root(), d.parents)
+
+    def test_the_mark_is_the_files_existence_and_carries_nothing_else(self):
+        """ADR 0011 said in bytes: nothing reads WHEN a workspace arrived, so there is
+        nowhere for a field nothing reads to go."""
+        workspace.record_arrival("beta")
+        self.assertEqual((workspace._arrivals_dir() / "beta").read_bytes(), b"")
 
     def test_a_name_is_recorded_once(self):
         workspace.record_arrival("beta")
         workspace.record_arrival("beta")
         self.assertEqual(workspace.arrivals(), frozenset({"beta"}))
-        self.assertEqual(workspace._arrivals_file().read_text(), "beta\n")
+        self.assertEqual(sorted(p.name for p in workspace._arrivals_dir().iterdir()),
+                         ["beta"])
 
-    def test_a_line_that_cannot_name_a_workspace_is_not_read_back(self):
-        workspace._arrivals_file().parent.mkdir(parents=True, exist_ok=True)
-        workspace._arrivals_file().write_text("beta\n../x\n\n")
+    def test_a_name_that_cannot_be_a_workspace_is_never_joined_onto_a_path(self):
+        """The name check moved to the WRITE when the record grew a path per name. `..`
+        under `STATE_DIR` is #442 arriving through a record instead of a listing."""
+        workspace.record_arrival("../escaped")
+        self.assertEqual(workspace.arrivals(), frozenset())
+        self.assertFalse((Path(config.STATE_DIR).parent / "escaped").exists())
+        self.assertFalse(workspace._arrivals_dir().exists())
+
+    def test_a_name_that_cannot_name_a_workspace_is_not_read_back(self):
+        d = workspace._arrivals_dir()
+        d.mkdir(parents=True, exist_ok=True)
+        (d / "beta").write_text("")
+        (d / ".DS_Store").write_text("")
         self.assertEqual(workspace.arrivals(), frozenset({"beta"}))
 
-    def test_a_record_that_cannot_be_read_is_no_marks(self):
-        with mock.patch("pathlib.Path.read_text", side_effect=OSError):
+    def test_a_record_that_cannot_be_listed_is_no_marks(self):
+        """The fixture has a real mark in it, so the two branches answer differently: with
+        the guard `frozenset()`, without it a traceback out of a panel's render."""
+        workspace.record_arrival("beta")
+        self.assertEqual(workspace.arrivals(), frozenset({"beta"}))
+        with mock.patch("os.listdir", side_effect=OSError):
             self.assertEqual(workspace.arrivals(), frozenset())
 
+    def test_a_plane_that_has_never_had_a_handoff_has_no_record_to_read(self):
+        """The ordinary answer, taken without a mock: the directory is simply not there."""
+        self.assertFalse(workspace._arrivals_dir().exists())
+        self.assertEqual(workspace.arrivals(), frozenset())
+
     def test_clearing_a_name_that_never_arrived_writes_nothing(self):
-        """Every switch on this plane calls this, and the ordinary plane HAS a record —
-        `config.replace_for` would rewrite it whole, moving its mtime on every switch
-        charter ever makes for no change at all. Asserted on the mtime as well as the
-        bytes, because identical bytes are exactly what a needless rewrite produces."""
+        """Every switch on this plane calls this. It must touch neither the record's own
+        directory nor another workspace's mark — asserted on the mtimes, because identical
+        bytes are exactly what a needless rewrite produces."""
         workspace.record_arrival("gamma")
-        f = workspace._arrivals_file()
-        before = (f.read_bytes(), f.stat().st_mtime_ns)
+        d = workspace._arrivals_dir()
+        before = (d.stat().st_mtime_ns, (d / "gamma").stat().st_mtime_ns)
         workspace.clear_arrival("beta")
-        self.assertEqual((f.read_bytes(), f.stat().st_mtime_ns), before)
+        self.assertEqual((d.stat().st_mtime_ns, (d / "gamma").stat().st_mtime_ns), before)
+        self.assertEqual(workspace.arrivals(), frozenset({"gamma"}))
 
     def test_clearing_on_a_plane_with_no_record_creates_none(self):
-        """The other half: a plane that has never had a handoff must not grow an empty
-        record the first time somebody switches workspace."""
-        config.private_mkdir(workspace._arrivals_file().parent)
+        """The other half: a plane that has never had a handoff must not grow a record the
+        first time somebody switches workspace."""
+        config.private_mkdir(Path(config.STATE_DIR))
         workspace.clear_arrival("beta")
-        self.assertFalse(workspace._arrivals_file().exists())
+        self.assertFalse(workspace._arrivals_dir().exists())
 
     def test_clearing_removes_only_that_name(self):
         workspace.record_arrival("beta")
@@ -267,6 +313,75 @@ class TheArrivalsRecord(PersonaIso, unittest.TestCase):
         workspace.forget_arrivals()
         self.assertEqual(workspace.arrivals(), frozenset())
         workspace.forget_arrivals()
+
+
+class TwoWritersNeverLoseAMark(PersonaIso, unittest.TestCase):
+    """**Real threads on real files, and the reason the record is a directory.**
+
+    The single-file shape was a read-modify-write over the whole set, and the plane runs
+    many charter processes at once: a handoff writing `gamma` read the set before a
+    concurrent handoff wrote `beta` and then wrote its own read back over it. Measured, all
+    three interleavings lost or resurrected a mark — and a lost mark is exactly the
+    invisibility this whole task exists to end.
+
+    Each case runs :data:`ROUNDS` times with a `threading.Barrier`, because a race is
+    pinned by repetition rather than by one lucky schedule: one round of the old shape
+    passed perhaps half the time, and this many rounds of it did not.
+    """
+
+    #: Enough rounds that the old read-modify-write loses on one of them with near
+    #: certainty, and few enough that the three cases together cost well under a second.
+    ROUNDS = 60
+
+    def _race(self, first, second):
+        """Run *first* and *second* on two real threads released together, and answer what
+        the record then holds. Exceptions are carried out rather than swallowed — a writer
+        that raised inside a thread would otherwise read as a passing round."""
+        raised: list = []
+
+        def run(fn):
+            gate.wait()
+            try:
+                fn()
+            except BaseException as e:  # noqa: BLE001 - re-raised on the main thread
+                raised.append(e)
+
+        gate = threading.Barrier(2)
+        threads = [threading.Thread(target=run, args=(fn,)) for fn in (first, second)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(10)
+        self.assertEqual([t for t in threads if t.is_alive()], [])
+        if raised:
+            raise raised[0]
+        return workspace.arrivals()
+
+    def test_two_handoffs_landing_together_keep_both_marks(self):
+        for _ in range(self.ROUNDS):
+            workspace.forget_arrivals()
+            got = self._race(lambda: workspace.record_arrival("beta"),
+                             lambda: workspace.record_arrival("gamma"))
+            self.assertEqual(got, frozenset({"beta", "gamma"}))
+
+    def test_a_handoff_landing_while_a_switch_clears_does_not_bring_it_back(self):
+        for _ in range(self.ROUNDS):
+            workspace.forget_arrivals()
+            workspace.record_arrival("beta")
+            got = self._race(lambda: workspace.record_arrival("gamma"),
+                             lambda: workspace.clear_arrival("beta"))
+            self.assertEqual(got, frozenset({"gamma"}))
+
+    def test_a_switch_clearing_while_a_handoff_lands_does_not_lose_it(self):
+        """The same two operations with the threads started the other way round. Not a
+        duplicate: which thread reads first is what decided the old shape's outcome, and
+        the two orders lost different marks."""
+        for _ in range(self.ROUNDS):
+            workspace.forget_arrivals()
+            workspace.record_arrival("beta")
+            got = self._race(lambda: workspace.clear_arrival("beta"),
+                             lambda: workspace.record_arrival("gamma"))
+            self.assertEqual(got, frozenset({"gamma"}))
 
 
 class TheMarkClearsWhenSomeoneLooks(_OpensBeta):
@@ -327,6 +442,32 @@ class TheMarkClearsWhenSomeoneLooks(_OpensBeta):
             commands_frame._switch_client("alpha.1", "beta", said="workspace → beta")
         fanout.assert_not_called()
         self.assertEqual(state.version("beta.1"), before["beta.1"])
+
+    def test_pressing_the_tab_you_are_already_on_clears_its_mark(self):
+        """The one state where the mark could never be paid. A frame in `beta` draws
+        `*beta` — the block takes the mark's cell, so that operator never sees the mark —
+        and `to_workspace` refuses the switch before `_switch_client` runs. They are the
+        person looking at it, so the look counts."""
+        args = SimpleNamespace(workspace="beta", persona=None)
+        with mock.patch.dict(os.environ, {"CHARTER_SESSION_ID": "beta.1"}, clear=True):
+            self.assertEqual(commands_frame.cmd_switch(args), 0)
+        self.assertEqual(workspace.arrivals(), frozenset())
+        self.said.assert_called_once()
+        self.assertEqual(self.said.call_args.args[1], "already in workspace 'beta'")
+
+    def test_pressing_a_tab_that_is_refused_for_any_other_reason_keeps_the_mark(self):
+        """`to_workspace` refuses three things and only one of them means "you are here".
+
+        The refusal has to name the MARKED workspace or the case proves nothing: a clear
+        for some other name is a no-op whether it is guarded or not. A workspace deleted
+        while its mark stands is the one state where a plane can refuse `beta` by name and
+        still hold `beta`'s mark — and that mark must survive, because nobody looked."""
+        shutil.rmtree(config.WORKSPACES_DIR / "beta")
+        args = SimpleNamespace(workspace="beta", persona=None)
+        with mock.patch.dict(os.environ, {"CHARTER_SESSION_ID": "alpha.1"}, clear=True):
+            self.assertEqual(commands_frame.cmd_switch(args), 0)
+        self.assertEqual(workspace.arrivals(), frozenset({"beta"}))
+        self.assertIn("no workspace 'beta'", self.said.call_args.args[1])
 
     def test_a_focus_clears_the_mark_before_it_attaches(self):
         """`interact` IS the operator's terminal for as long as they stay, so a clear on
@@ -402,6 +543,88 @@ class APlaneThatGoesColdForgetsItsArrivals(PersonaIso, unittest.TestCase):
         _a_chat("alpha.1", ws="alpha", pane="%1")
         state.reap({"alpha.1"}, server=commands_frame.SOCKET)
         self.assertIn("beta", workspace.arrivals())
+
+
+class EverySurfaceThatListsWorkspacesSaysSo(PersonaIso, unittest.TestCase):
+    """**The strip is not the only place a workspace is named, and it is the one place with
+    no room.** At 24 columns an arrival can be behind a `+2` and at 12 the strip is `3/5`,
+    so the surfaces an operator reaches when the strip has run out of room have to carry the
+    fact too — and those have a note column and a whole terminal to draw in, so they say it
+    in words rather than in a glyph."""
+
+    def setUp(self):
+        super().setUp()
+        for n in ("alpha", "beta", "gamma"):
+            (config.WORKSPACES_DIR / n).mkdir(parents=True, exist_ok=True)
+        _a_chat("alpha.1", ws="alpha", pane="%1")
+        workspace.record_arrival("beta")
+
+    def _notes(self, rows):
+        return {r.title: r.note for r in rows}
+
+    def test_the_palettes_workspace_picker_names_the_arrival(self):
+        notes = self._notes(choose.roster(choose.WORKSPACE, "alpha.1").rows)
+        self.assertEqual(notes["beta"], "handoff arrived")
+        self.assertEqual(notes["gamma"], "")
+        self.assertEqual(notes["alpha"], "")
+
+    def test_the_palettes_typed_rows_keep_the_kind_and_the_arrival(self):
+        """A top-level row's note is the KIND, which tells `zeb` the persona from `zeb-api`
+        the workspace and cannot go. The arrival is why the operator is typing that name,
+        so it is kept beside it rather than displacing it or being displaced."""
+        roster = choose.roster(choose.WORKSPACE, "alpha.1")
+        notes = self._notes(choose.labelled(roster))
+        self.assertEqual(notes["beta"], "workspace · handoff arrived")
+        self.assertEqual(notes["gamma"], "workspace")
+
+    def test_a_reason_still_displaces_both(self):
+        """A row that cannot run has one thing to say and it is why."""
+        roster = choose.roster(choose.WORKSPACE, "alpha.1")
+        rows = choose.labelled(roster, "pinned by $CHARTER_WORKSPACE")
+        self.assertEqual(self._notes(rows)["beta"], "pinned by $CHARTER_WORKSPACE")
+        self.assertTrue(all(r.refused for r in rows))
+
+    def test_a_picker_charter_cannot_ask_draws_no_note_and_raises_nothing(self):
+        with mock.patch("charter.workspace.arrivals", side_effect=RuntimeError):
+            notes = self._notes(choose.roster(choose.WORKSPACE, "alpha.1").rows)
+        self.assertEqual(set(notes.values()), {""})
+
+    def test_the_chats_picker_still_says_which_harness(self):
+        """The workspace branch is new and must not have eaten the one note that was
+        already there."""
+        notes = self._notes(choose.roster(choose.CHAT, "alpha.1").rows)
+        self.assertEqual(notes["alpha.1"], "claude-code")
+
+    def test_the_launch_picker_names_the_arrival_beside_the_clone_count(self):
+        """The earliest surface that can say it: before tmux, before a frame, before any
+        strip exists to draw a mark on."""
+        rows = picker.rows(["alpha", "beta"], lambda n: 0, workspace.arrivals())
+        drawn = tui.strip_ansi(picker.render(rows, "alpha", 120))
+        self.assertIn("* alpha  —", drawn)
+        self.assertIn("  beta   —  handoff arrived", drawn)
+
+    def test_the_launch_asks_the_plane_for_its_arrivals(self):
+        """The wiring, not the renderer: a picker handed a renderer that can draw the mark
+        and an empty set would look right in every test of the renderer alone."""
+        seen: list = []
+
+        def ask(rows_, current, **kw):
+            seen.append(rows_)
+            return picker.Choice(picker.CANCEL)
+
+        with mock.patch.dict(os.environ, {}, clear=True), \
+                mock.patch("sys.stdin.isatty", return_value=True), \
+                mock.patch("sys.stdout.isatty", return_value=True), \
+                mock.patch("charter.frame.picker.ask", side_effect=ask):
+            commands_frame._choose_workspace(
+                SimpleNamespace(workspace=None, pick=True))
+        self.assertEqual([r.name for r in seen[0] if r.arrived], ["beta"])
+
+    def test_the_launch_picker_without_arrivals_draws_exactly_what_it_drew_before(self):
+        rows = picker.rows(["alpha", "beta"], lambda n: 0)
+        drawn = tui.strip_ansi(picker.render(rows, "alpha", 120))
+        self.assertNotIn("handoff", drawn)
+        self.assertIn("  beta   —", drawn)
 
 
 class AHandoffArrives(_AHandoffFromAlpha):

--- a/tests/test_a_handoff_refuses_before_it_changes_anything.py
+++ b/tests/test_a_handoff_refuses_before_it_changes_anything.py
@@ -30,7 +30,7 @@ from charter import (cli, commands_frame, commands_handoff, config, dispatch, to
 from charter.frame import state
 
 from tests import _tmuxsocket
-from tests._isolation import PlaneIso
+from tests._isolation import PlaneIso, no_background_refresh
 from tests.test_the_chat_bars_plus_makes_a_chat import _a_chat
 
 #: The brief every case sends unless it says otherwise. Two lines, because the first line
@@ -90,6 +90,12 @@ class _AHandoffFromAlpha(PlaneIso):
 
     def setUp(self) -> None:
         super().setUp()
+        # A handoff that opens ends in `notify.plane_changed_everywhere`, which gathers —
+        # and a gather on a fresh temp plane has no cooldown to hold it back, so every case
+        # here would fork a `_version-check` child nothing waits for (`tests._planeguard`).
+        # Stopped at the spawner rather than at the fan-out, so what these cases observe is
+        # the real one running.
+        no_background_refresh(self)
         self.enterContext(mock.patch.dict(os.environ, {
             "CHARTER_SESSION_ID": "alpha.1", "TMUX_PANE": "%1",
             "CHARTER_HARNESS": "claude-code"}, clear=True))


### PR DESCRIPTION
Part of #956 — Task 3 of docs/superpowers/plans/2026-09-10-chat-handoff.md.

A handoff opens a chat in the background: no client moves, nothing attaches. Without this
the work is invisible until somebody happens to look at the right tab, which `docs/frame.md`
calls silence by construction. This is the half of the feature the operator sees.

## What lands

**The arrival move** — `switch.bring_to_front(name)` puts the target workspace at the head of
the plane's recorded tab order. It is the ONE thing that moves a tab while a plane is up, and
it asks `workspaces()` rather than `workspace.tab_order()`, so a plane that has recorded
nothing records the order it would have had with the target moved to the front — instead of a
one-name file for a repaint to argue with later. A name the plane does not have moves nothing
(`record_tab_order` is an order, never a roster).

**The arrived mark** — the target tab is drawn in the `ok` accent **and** carries
`slots._ARRIVED_MARK` in the strip's reserved mark cell. That is the plan's **Q13 ruling**,
which the task brief contradicted; the ruling wins, so the brief's "the mark is not visible
under `NO_COLOR` — stated, not worked around" is not what shipped. The accent reads at a
glance on a colour terminal; the glyph is what survives `NO_COLOR`, where `panel._write` hands
every row to `chrome.plain`.

The glyph is `✶` (U+2736) — one of `TAB_SPINNER`'s own three, which is the ruling's "a glyph
the strip already renders at width 1" taken literally: its width is this project's existing
measurement (East-Asian **Neutral**, no emoji presentation) rather than a fourth one, and
`statusline._persona_chips` records two glyphs that shipped broken here for want of exactly
that. It takes `_BAR_MARK`'s own cell the way the spinner does, so the cut, the row count and
the click map are byte-identical with and without it — pinned at three widths and two row
counts. The two marks can never be on one strip (only `chats` passes *busy*, only
`workspaces` passes *arrived*); where a caller handed both, the arrival wins, for
`_BAR_MARK`'s own reason — it is the fact with no other way to be seen.

**The clear** — a mark is paid by a LOOK, plane-wide, at the three places a terminal comes to
be looking at a workspace: `_switch_client` after the confirmed move, `_focus_workspace`
before its attach, `_launch` before its attach. All three call one `commands_frame._looked_at`,
which clears and then `notify.bump_everywhere()` — `plane_changed_everywhere` without the
scan, because a cleared mark moves no fact a gather holds and a scan per workspace on the
switch path would cost more than the switch.

**`cmd_handoff` steps 7–8** run entirely after the open, so a refused handoff moves no tab,
marks nothing and says nothing. A handoff into the workspace you are in moves its tab and
marks nothing (you are looking at it); the calling chat's attention row names the new chat;
one `plane_changed_everywhere` at the end.

**The record** is `STATE_DIR/workspace-arrivals/`, a directory with **one empty file per
mark** — the mark IS the file's existence — beside `workspace-tab-order` and for its reasons:
plane-scoped, per developer, never committed, 0600, name-checked on both sides, never raises.
`state.reap` drops it in the same cold-plane branch as the tab order.

It was one file listing the names until review round 1 measured what that cost: every writer
was a read-modify-write over the whole set, and on a plane running many charter processes two
handoffs landing together left one mark, a handoff landing while a switch cleared brought the
cleared mark back, and a switch clearing while a handoff landed lost the new one. A lost mark
is exactly the invisibility this task exists to end. One file per name makes recording and
clearing independent operations on different paths, so there is no interleaving to get wrong —
a lock was refused because a stale lock file nothing clears is a worse failure on a plane whose
processes can be killed at any moment, and it would still be a fix by timing.
`TwoWritersNeverLoseAMark` drives all three interleavings on real threads, 60 rounds each.

## One judgement call, flagged

`_looked_at` **short-circuits when the workspace is not marked**, where the brief says each
site calls `clear_arrival` then `bump_everywhere` unconditionally. Every workspace switch on
the plane reaches it and almost none follows a handoff, so an unconditional fan-out would bump
every frame directory — and repaint every background frame's panels — on every switch, to say
that nothing changed. The ask is one read under `STATE_DIR`; the alternative is N writes and N
repaints. It is `clear_arrival`'s own documented no-op rule applied one level up, where the
expensive half is, and it is pinned by `test_a_switch_into_an_unmarked_workspace_tells_nobody`.

One state does differ, and it is not a regression: after `charter workspace create`, which
calls no notify of its own, the unconditional form's fan-out would have moved three frame
versions and every background pane would have picked up the new tab a repaint sooner. The
short-circuit moves none and they keep drawing the old strip until something else bumps them —
which is what `main` already does, since a switch bumps nothing there either.

## The rulings, and how each was applied

1. **Untrusted text is escaped at the RENDER.** No new untrusted text reaches a row: the
   names on the strip already go through `contain.one_line` in `_compose`, and `arrivals()`
   only ever supplies membership against names `switch.workspaces()` already name-checked.
   `test_a_hostile_line_in_the_record_reaches_no_row` plants `"beta\n\x1b[2Jgamma\n"` in the
   record and asserts both ways round — the record answers `{"beta"}`, and the exact raw
   `\x1b[2J` is absent from the row, which is the one absence assertion ruling 3 sanctions
   because charter's own accent puts real escapes in that same row by design.
2. **No expectation computed from the code under test.** The glyph is spelled `"✶"` in the
   test module, not read off `slots._ARRIVED_MARK` — a test that took the constant would
   follow it to an Ambiguous character, which is the change this file exists to catch. Widths,
   counts and whole rows are literal.
3. **Equality on the whole thing, not absence of a substring.** The `NO_COLOR` row, the
   unreadable-record row and the chats-strip row are each pinned by equality on the entire
   `chrome.plain` line. The two absence assertions left are the raw-escape one above (ruling
   1's own instruction) and accent counts, which are equalities on a count.
4. **Every new branch reddens for its own guard.** Twenty-one mutations applied one at a time,
   each run against this module alone: the arrived glyph, the accent, the block beating the
   accent, `*` beating both, `_arrived`'s guard, `workspaces_bar` reading the record,
   `arrivals`' name check, `clear_arrival`'s no-op, `bring_to_front`'s roster check, the
   cold-plane forget, the here-handoff skip, the arrival move, the fan-out, the attention row,
   all three clears, `bump_everywhere`, and `_looked_at`'s short-circuit. Every one went red,
   and the named failures are that guard's own tests — the first pass found one genuine
   survivor (`clear_arrival`'s no-op passed because a plane with no `.charter/` answers
   `ENOENT` either way), which is why that test now asserts on the mtime of an existing record
   and a second case covers the no-record plane.
5. **True in every state it can be read in.** `docs/handoff.md`'s *Where it shows up* and
   `docs/frame.md` name switch, focus and attach as what clears the mark, and each is driven
   and re-read in a test rather than reasoned about — including the switch tmux refused, which
   clears nothing, and the background open, which looks at nothing. No hint here names a
   command.
6. **Stop and ask.** Nothing needed it: the one place the brief and a ruling disagreed (Q13)
   is settled by the dispatch — the ruling wins — and the one judgement call is flagged above.

## Review round 1

- **The record became a directory** (above), with the three interleavings pinned on real
  threads.
- **A workspace you are already sitting in could hold a mark nothing cleared.** That frame
  draws `*gamma` — the block wins the mark's cell — so the one operator who cannot see the
  mark was the one in the room, while every other frame drew `✶gamma` forever:
  `to_workspace` refuses that switch before `_switch_client` runs. `cmd_switch` now clears on
  that path, asked as a fact (`ws == switch.current_workspace(fid)`) rather than off the
  refusal's wording, and every workspace-switch surface reaches that one function. Both doc
  sentences were rewritten against what now happens.
- **Five pins**, including two of the trap the first round caught on `clear_arrival`: the
  `read_text`-OSError fixture answered the same with the guard deleted, so the new one records
  a real mark first; `except (OSError, ValueError)` narrowed to `except OSError` left the
  module green, and the `ValueError` is now gone rather than pinned — `os.scandir` decodes
  nothing, so it was unreachable. Plus arrival-beats-spinner in `_mark_cell`, and the two
  wiring pins the `sorted()`/`line.strip()` survivors turned into (both properties vanished
  with the single-file shape).
- **Three surfaces now say it in words** — `handoff arrived` — where the strip says it in one
  glyph: the palette's workspace picker (note column), the palette's typed top-level rows
  (`workspace · handoff arrived`, kept beside the kind because the kind is what tells `zeb`
  the persona from `zeb-api` the workspace), and the launch picker beside each clone count.
  `builtin_actions._STRIPS`' workspace entry is the keyboard walk and renders nothing, so
  there was nothing there to mark; the launch picker is the third drawable surface.
- **`docs/frame.md` states the windowed-strip limit exactly**: an arrival on a page the bar is
  not drawing sits inside the `+N` and is not shown, the counts are clickable and open the
  palette, which carries the note at any width — and `F3` is the other answer where there are
  rows to be had.

## Testing

`tests/test_a_handoff_lands_at_the_front_of_the_strip.py`, 60 cases (10 of them Task 1's own,
re-run through `ALaunchThatAttachesClearsTheMark` with a mark on the workspace being launched
into — none of them may change because a handoff marked a workspace). `_AHandoffFromAlpha`
gains `no_background_refresh`: a handoff now ends in a fan-out, which gathers, and a fresh
temp plane has no cooldown to hold the `_version-check` child back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
