### PR TITLE
A new or changed harness profile shows its command and asks before it runs

### DIFF
--- a/charter/commands_frame.py
+++ b/charter/commands_frame.py
@@ -5949,10 +5949,11 @@ def _launch(args) -> int:
     # Measured 2026-09-11: the eager ask above completes 6-14 ms after the start while a
     # Python launcher's first line runs at 19-22 ms, so it never catches a launcher that
     # refused — and by the time anything else could look, the teardown hook has killed the
-    # window (`_pane_last_words` answered `[]` in all 40 runs). EVERY pane records what it
-    # refused; what differs is who reads it. An attended pane also holds its own refusal on
-    # screen until somebody presses Enter, so only an unattended open — a reopen, a handoff,
-    # a background open — has nobody in front of it and waits for the answer here.
+    # window (`_pane_last_words` answered `[]` in all 40 runs). Every pane records what
+    # CHARTER refused — a decline, which the operator answered themselves, is the one thing
+    # it does not (ADR 0018) — and what differs is who reads it. An attended pane also holds
+    # its own refusal on screen until somebody presses Enter, so only an unattended open — a
+    # reopen, a handoff, a background open — has nobody in front of it and waits here.
     refused = ""
     if code is None and p is not None and not attended:
         code, refused = _await_the_launcher(SOCKET, fid, harness_pane)
@@ -8015,9 +8016,8 @@ def _the_pane_will_ask(r) -> bool:
     from . import profiletrust
     from .frame import launcher
 
-    # No `r is not None` here: both callers have already established that — `_launch` in
-    # the condition that reaches this, `_launch_refusal` in the `or` in front of it — and a
-    # third check nothing can reach is a line the deletion sweep is right to call dead.
+    # No `r is not None` of its own: `launcher.is_a_question` answers False for `None`, so
+    # "is there a refusal" and "is it the one that asks" are one question asked in one place.
     return (launcher.is_a_question(r)
             and not profiletrust.can_ask(sys.stdin, sys.stdout))
 

--- a/charter/commands_frame.py
+++ b/charter/commands_frame.py
@@ -5316,11 +5316,13 @@ def _launch(args) -> int:
         # `exec`s the profile's command with the profile's `env`. Unframed, so the
         # environment drops the inherited `CHARTER_SESSION_ID` and nothing else (review 8).
         #
-        # *attended* is what THIS process's own streams say rather than what the open was:
-        # the refusal lands in the terminal the operator is already looking at, and a
-        # question here would be asked of whoever typed the command.
-        return launcher.start(p, rest, fid=None,
-                              attended=sys.stdin.isatty() and sys.stdout.isatty())
+        # *attended* is the OPEN's own answer — somebody typed this — and not what these
+        # streams say. The two are different questions and Task 3 is what separates them:
+        # whether charter may ask at all is `profiletrust.can_ask`, asked inside the
+        # launcher, and an attended open with nowhere to put the question says exactly that
+        # ("no terminal here to ask in", review 3) rather than borrowing the sentence for a
+        # reopen, which is about nobody being there at all.
+        return launcher.start(p, rest, fid=None, attended=attended)
 
     # A REGISTERED harness whose binary is not installed never reaches tmux — and the
     # irony is worth recording, because it is what hid this for a whole review round:
@@ -5364,8 +5366,18 @@ def _launch(args) -> int:
     # for it, so `charter <profile> && …` behaves the way `<command> && …` would have.
     if p is not None:
         r = _profile_refusal(p, attended=attended)
+        if launcher.is_a_question(r):
+            # **The question is put HERE, before anything is allocated.** A no is a
+            # `return` with no session, no window and no chat directory to tear down —
+            # #518's own reason for putting the workspace picker in front of tmux rather
+            # than inside the frame. With no terminal to ask on it defers to the pane,
+            # which has one (`_the_pane_will_ask`); with nobody at the open at all this is
+            # not a `KIND_ASK` and never reaches here.
+            r = None if _the_pane_will_ask(r) else _asked_here(p, r, attended=attended)
         if r is not None:
-            util.err(f"charter: {r.text}")
+            if not launcher.already_said(r):
+                # A decline has already been answered on the terminal it was asked on.
+                util.err(f"charter: {r.text}")
             return r.exit
 
     # ONE call (correction 5): asking `tmux -V` twice on a path that branches on the
@@ -5937,9 +5949,10 @@ def _launch(args) -> int:
     # Measured 2026-09-11: the eager ask above completes 6-14 ms after the start while a
     # Python launcher's first line runs at 19-22 ms, so it never catches a launcher that
     # refused — and by the time anything else could look, the teardown hook has killed the
-    # window (`_pane_last_words` answered `[]` in all 40 runs). An ATTENDED pane holds its
-    # own refusal on screen and waits for a key, so only an unattended open — a reopen, a
-    # handoff, a background open — has nobody to read it and waits for the answer here.
+    # window (`_pane_last_words` answered `[]` in all 40 runs). EVERY pane records what it
+    # refused; what differs is who reads it. An attended pane also holds its own refusal on
+    # screen until somebody presses Enter, so only an unattended open — a reopen, a handoff,
+    # a background open — has nobody in front of it and waits for the answer here.
     refused = ""
     if code is None and p is not None and not attended:
         code, refused = _await_the_launcher(SOCKET, fid, harness_pane)
@@ -7969,6 +7982,46 @@ def _profile_refusal(p, *, attended: bool):
                             env=launcher.environment(p, os.environ, framed=True))
 
 
+def _asked_here(p, ask, *, attended: bool):
+    """Put *ask*'s question on this process's own terminal. The refusal left over, or
+    ``None`` when the launch may go ahead.
+
+    `launcher.answered` is the whole of it — the question, the four answers it can come
+    back with, and the re-run of the chain behind a yes — so there is one spelling of that
+    rule rather than two that would drift. What this call decides is only WHICH chain runs
+    again: this process's own, before tmux is asked for anything. The pane then runs it a
+    third time immediately before the `exec`, which is why there are two calls here and not
+    one — the plane can move in between.
+    """
+    from .frame import launcher
+
+    return launcher.answered(p, ask, again=lambda: _profile_refusal(p, attended=attended))
+
+
+def _the_pane_will_ask(r) -> bool:
+    """Is *r* the one refusal the PANE answers instead of this process? (N2a's nit)
+
+    Exactly one kind defers, and only from an open with no terminal of its own: the `+`, a
+    workspace tab, the palette's new chat. Those run detached with all three streams on
+    `/dev/null` (`builtin_actions._spawn`), so charter cannot put the question here — but
+    the pane they open has a terminal on both of its ends, and it runs the identical chain
+    immediately before the `exec`. `KIND_ASK` is minted only for an open somebody is in
+    front of (`profiletrust.refusal`), so an unattended open never reaches this at all.
+
+    **Only asking defers.** Every other refusal is answered before tmux, where it is a
+    `return` with nothing to tear down; carried into the pane instead, a `PATH` refusal
+    would open a window purely to say it in and close it again.
+    """
+    from . import profiletrust
+    from .frame import launcher
+
+    # No `r is not None` here: both callers have already established that — `_launch` in
+    # the condition that reaches this, `_launch_refusal` in the `or` in front of it — and a
+    # third check nothing can reach is a line the deletion sweep is right to call dead.
+    return (launcher.is_a_question(r)
+            and not profiletrust.can_ask(sys.stdin, sys.stdout))
+
+
 def _launch_refusal(p, *, attended: bool) -> str:
     """The launcher's own refusal for *p* as a sentence, or ``""`` when it may start.
 
@@ -7981,9 +8034,16 @@ def _launch_refusal(p, *, attended: bool) -> str:
 
     It costs what the chain costs — one `git status` for a declared profile — on a press,
     and nothing on a hook path: none of these callers is one.
+
+    **A press hands back nothing for the one question the pane is about to ask itself**
+    (:func:`_the_pane_will_ask`). Reporting it here would put "charter asks before it runs
+    a command it has not been shown before" on the attention row and open no chat — for a
+    profile the operator is one keypress away from approving in the pane.
     """
     r = _profile_refusal(p, attended=attended)
-    return r.text if r is not None else ""
+    if r is None or _the_pane_will_ask(r):
+        return ""
+    return r.text
 
 
 def _launch_root(ws: str):
@@ -10499,6 +10559,19 @@ def _reopen_one(c, *, quiet: bool = False) -> "Reopening | None":
                 f"charter reopen: {c.chat} is not reopened — {why}" if why
                 else REOPEN_GONE.format(
                     chat=c.chat, name=contain.readable(name or c.harness or "nothing")))
+        return None
+    # **A reopen has nobody to ask** (Task 3). Said here, by name, rather than left to the
+    # pane: without this the chat is started, its launcher refuses, and the operator is told
+    # "did not come back (launcher returned 3)" for something one `charter <profile>` would
+    # fix. The chat stays in the manifest either way, so approving the profile once and
+    # running `charter reopen` again brings it back — which is what `_consume` is for.
+    from . import profiletrust
+
+    unapproved = profiletrust.approval_needed(p)
+    if unapproved:
+        _report(quiet, util.warn,
+                profiletrust.REOPEN_UNAPPROVED.format(
+                    chat=c.chat, name=contain.readable(p.name), state=unapproved))
         return None
     rest: list[str] = []
     if _resumes(c):

--- a/charter/frame/launcher.py
+++ b/charter/frame/launcher.py
@@ -52,7 +52,7 @@ in while no harness has run in it (ADR 0018, as its 2026-09-12 amendment states)
 
 **And the same pane is where a new or changed profile is ASKED about** (Task 3). A profile
 with no launch record, or one that no longer matches it, is not refused where somebody is
-in front of it: :func:`_answered` prints its command and its environment and reads one line,
+in front of it: :func:`answered` prints its command and its environment and reads one line,
 `run this? [y/N]` (`charter/profiletrust.py`). A no exits with the workspace picker's own
 cancel code and says nothing more — the operator has just answered. An open nobody is at
 gets a refusal in place of the question, and so does one with no terminal on both of its
@@ -373,8 +373,7 @@ def answered(p: profiles.Profile, ask: Refusal, *,
     if is_a_question(left):
         return Refusal(KIND_MOVED,
                        profiletrust.CHANGED_WHILE_ASKING.format(
-                           name=contain.readable(p.name),
-                           state=profiletrust.approval_needed(p)),
+                           name=contain.readable(p.name)),
                        REFUSED_EXIT)
     return left
 

--- a/charter/frame/launcher.py
+++ b/charter/frame/launcher.py
@@ -36,11 +36,28 @@ chat passes it.
 **A refusal in the pane has to reach the operator without the dead pane** (ruling 42).
 Measured 2026-09-11: `_launch`'s eager dead-status ask completes 6-14 ms after the start
 while a Python launcher's first line runs at 19-22 ms, and on charter's server the teardown
-hook then kills the window (`_pane_last_words` answered `[]` in all 40 runs). So an
-**attended** launcher shows its refusal in the pane and waits for a key — the pane is
-charter's while no harness has run in it (ADR 0018, as the spec amends it) — and an
-**unattended** one records it under the chat, where the launch that opened the chat reads
-it back (`state.record_launch`, `commands_frame._await_the_launcher`).
+hook then kills the window (`_pane_last_words` answered `[]` in all 40 runs). So every
+refusal the pane SAYS is recorded under the chat, where the launch that opened it reads it
+back (`state.record_launch`, `commands_frame._await_the_launcher`) — and an **attended** one
+is also shown in the pane, which then waits for the operator to press **Enter**. (The one
+refusal the pane neither says nor records is a DECLINE: the operator answered that question
+here a moment ago and was told `charter: nothing started.` as they did, and a decline is
+reachable only from an attended open, which is exactly the open nobody reads the record for.
+:func:`already_said` is where that is decided.) Only the WAIT is conditional among the rest,
+and it is a LINE rather than a keystroke: reading one key means putting the
+pane's terminal into raw mode, and a `tcsetattr` from a pane on a Linux CI runner left the
+launcher killed by a signal with the refusal gone with its window
+(:func:`_wait_for_the_operator` records that measurement). The pane is charter's to write
+in while no harness has run in it (ADR 0018, as its 2026-09-12 amendment states).
+
+**And the same pane is where a new or changed profile is ASKED about** (Task 3). A profile
+with no launch record, or one that no longer matches it, is not refused where somebody is
+in front of it: :func:`_answered` prints its command and its environment and reads one line,
+`run this? [y/N]` (`charter/profiletrust.py`). A no exits with the workspace picker's own
+cancel code and says nothing more — the operator has just answered. An open nobody is at
+gets a refusal in place of the question, and so does one with no terminal on both of its
+ends, because a question nobody can answer is a chat that never starts and never says why.
+**After a yes the whole chain runs again from the top** before the `exec` (ruling 27).
 
 **Nothing here is on the import path.** `cli` and `commands_frame` reach this module at call
 time, because every `charter hook …` process builds the parser and derives config, and
@@ -72,22 +89,39 @@ NOT_EXECUTABLE_EXIT = 126
 #: stops guarding on the day it does.
 KIND_IGNORED = "ignored"
 KIND_PATH = "path"
-KIND_NOT_YET = "not-yet"
+#: The one refusal that is a QUESTION rather than an answer: a caller with a terminal asks
+#: it (`profiletrust.ask_in_terminal`) and a caller with none prints its text. It is also
+#: the only kind `commands_frame._launch` defers to the pane (N2a's nit), which is why that
+#: branch is on the kind: a pane is where a press finds the terminal it did not have.
+KIND_ASK = "ask"
+#: The same profile, at an open nobody is at — a reopen, a restore, a handoff.
+KIND_UNATTENDED = "unattended"
+#: A yes charter could not write down (N2b's nit).
+KIND_RECORD = "record"
+#: A yes the record no longer backs: it moved between the write and the re-run (S1).
+KIND_MOVED = "moved"
+#: The operator read the command and said no. Not a rule firing: their own answer.
+KIND_DECLINED = "declined"
 KIND_EXEC = "exec"
 
 
 class Refusal(NamedTuple):
     """Why a profile did not start, and what a CLI returns for it."""
 
-    #: One of the KIND_* constants above. Task 2 reads it in tests and nowhere else; it is
-    #: here because Task 3 branches on it — `KIND_ASK` is the one refusal a pane defers to
-    #: rather than prints — and ruling 27 says that branch is on the kind, never on the
-    #: text, which gets reworded.
+    #: One of the KIND_* constants above, and the ONLY thing a caller branches on
+    #: (ruling 27): a sentence gets reworded, and a comparison against one is a guard that
+    #: stops guarding on the day it does. Two questions are asked of it often enough to
+    #: have one home each — :func:`is_a_question` and :func:`already_said`.
     kind: str
-    #: The sentence, without charter's own prefix: each caller says it its own way.
+    #: The sentence, without charter's own prefix: each caller says it its own way. **``""``
+    #: for a refusal whose sentence has already been said** — today that is `KIND_DECLINED`,
+    #: which `profiletrust.ask_in_terminal` answered on the terminal it asked on. Callers
+    #: ask :func:`already_said` rather than testing this for emptiness.
     text: str
-    #: What a CLI returns for it — MISSING_EXIT for KIND_PATH, its own number for
-    #: KIND_EXEC, REFUSED_EXIT otherwise.
+    #: What a CLI returns for it: `MISSING_EXIT` for `KIND_PATH`, its own number for
+    #: `KIND_EXEC`, `profiletrust.DECLINED_EXIT` for `KIND_DECLINED` — the workspace
+    #: picker's own cancel code, because a decline is a cancel — and `REFUSED_EXIT` for the
+    #: rest.
     exit: int
 
 
@@ -103,10 +137,6 @@ IGNORED = "profile '{name}' is refused — {why}"
 NOT_ON_PATH = ("profile '{name}' runs {cmd}, which is not on PATH — nothing was started. "
                "Install it, or give the profile a command with a full path in "
                "charter.local.toml.")
-DECLARED_NOT_YET = (
-    "profile '{name}' comes from charter.local.toml, and this charter cannot yet ask before "
-    "a declared command runs, so it runs none — nothing was started. Until it can, launch a "
-    "built-in the file does not replace: {builtins}.")
 EXEC_FAILED = ("profile '{name}' could not be started — {cmd} failed to run ({why}). Nothing "
                "is running here; fix the command in charter.local.toml.")
 UNPROVEN_CHAT = ("this launch was given chat '{chat}' but is not that chat's pane, so it "
@@ -116,6 +146,37 @@ UNPROVEN_CHAT = ("this launch was given chat '{chat}' but is not that chat's pan
 #: run in it, and the keypress is what keeps the window from closing over the sentence
 #: (ruling 42).
 PRESS_ENTER = "  press Enter to close this chat."
+
+
+def is_a_question(r: Refusal | None) -> bool:
+    """Is *r* the refusal that is a QUESTION rather than an answer?
+
+    One home for a test three callers make — :func:`attempt` to know what to ask,
+    `commands_frame._launch` and `_the_pane_will_ask` to know what a pane will ask instead —
+    because each of them means the same thing by it and a fourth kind of question would
+    otherwise have to find all three.
+    """
+    return r is not None and r.kind == KIND_ASK
+
+
+def already_said(r: Refusal) -> bool:
+    """Has *r*'s sentence already reached the operator, so that saying it again would be
+    charter repeating itself?
+
+    The other test three callers make — :func:`start`, :func:`cmd_frame_launch` and
+    `commands_frame._launch` — and it has one home for the same reason. Today exactly one
+    kind answers yes: a decline, which `profiletrust.ask_in_terminal` has already answered
+    with `charter: nothing started.` on the terminal it put the question on, and whose
+    `text` is `""` because of it. Printing it again under charter's red ✗ would report the
+    operator's own answer as a rule firing on them.
+    """
+    return r.kind in _ALREADY_SAID
+
+
+#: The kinds :func:`already_said` answers yes for. A set rather than an `==`, because it is
+#: the list that is the decision: a second such kind is one entry here rather than an edit
+#: at each of the three sites that ask.
+_ALREADY_SAID = frozenset({KIND_DECLINED})
 
 
 def _nothing() -> None:
@@ -216,8 +277,8 @@ def refusal(p: profiles.Profile, *, root: Path, attended: bool,
     decides nothing about it. A declared replacement of a built-in (`[harness.claude]`) is
     declared, so `charter claude` is refused with the rest and never falls back (ruling 19).
 
-    *attended* decides nothing here yet: Task 3's approval is what asks, and this is the seam
-    it fills (`_approval_refusal`).
+    *attended* decides what the last link answers: an open somebody is in front of gets the
+    question (`KIND_ASK`), and one nobody is at gets a refusal in its place.
     """
     if p.source != profiles.BUILTIN:
         why = profiles.ignored_refusal(root)
@@ -238,26 +299,84 @@ def refusal(p: profiles.Profile, *, root: Path, attended: bool,
 
 
 def _approval_refusal(p: profiles.Profile, *, attended: bool) -> Refusal | None:
-    """Task 2's B1 refusal: a declared profile does not run until something can ask first.
+    """The last link: has the operator seen this command? (`profiletrust`)
 
-    **`main` must never run an unapproved declared command between two merges.** Nothing
-    yet stands for the operator's approval of a `command` — Task 3's launch record is what
-    will — and `charter.local.toml` is a file a chat can write with no diff to show for it.
-    So every profile the file declares is refused here, a replacement of a built-in
-    included, through `charter <profile>`, `+`, a tab, reopen and a handoff alike; only the
-    built-ins no declared profile replaces launch.
+    **`main` never runs an unapproved declared command.** `charter.local.toml` is a file a
+    chat can write with no diff to show for it, and its `command` goes to tmux rather than
+    through a harness's own permission prompt — so a profile with no launch record, or one
+    that no longer matches it, is shown and asked about before it runs. A replacement of a
+    built-in (`[harness.claude]`) is a declaration and asks with the rest; a built-in the
+    file does not replace comes out of charter's own registry and never asks.
 
-    Task 3 replaces this body with `profiletrust.refusal(p, attended=attended)` and deletes
-    :data:`DECLARED_NOT_YET`, which is why *attended* is already the parameter it takes: an
-    open nobody is at refuses where it would have asked.
+    One line, because it is a seam rather than a rule: `profiletrust` owns the record, the
+    two sentences and the question, and this is where the chain reaches them.
     """
-    if p.source == profiles.BUILTIN:
-        return None
-    builtins = ", ".join(name for name, q in profiles.current().profiles.items()
-                         if q.source == profiles.BUILTIN)
-    return Refusal(KIND_NOT_YET,
-                   DECLARED_NOT_YET.format(name=contain.readable(p.name), builtins=builtins),
-                   REFUSED_EXIT)
+    from .. import profiletrust
+
+    return profiletrust.refusal(p, attended=attended)
+
+
+def answered(p: profiles.Profile, ask: Refusal, *,
+             again: Callable[[], Refusal | None]) -> Refusal | None:
+    """Put *ask*'s question to whoever is at this process's terminal, and on a yes run the
+    whole chain *again* before answering ``None``.
+
+    **One function because it is one rule**, and it had grown two homes — `attempt` for the
+    launcher's own chain and `commands_frame._asked_here` for the one before tmux. What
+    differs between them is only which chain to re-run, so that is the parameter and the
+    rest is here.
+
+    Four answers, and each is its own kind, because every caller of this branches on one
+    (ruling 27) and none of them may tell them apart by their text:
+
+    * **no terminal** — *ask* itself comes back, and its text is `NEEDS_ASKING`: somebody
+      typed this and there is nowhere to put the question (review 3). Nothing is read from
+      the stream, which is a stronger claim than "does not block": a read on a pipe returns
+      at once and looks exactly like a question that was answered.
+    * **a yes charter could not record** — `KIND_RECORD`, and *again* is NOT run (N2b's
+      nit). Going round would find no record and ask the identical question a second time,
+      which is the one thing an operator cannot fix by answering.
+    * **anything else** — `KIND_DECLINED`, with no text at all, because
+      `profiletrust.ask_in_terminal` has already said `charter: nothing started.` on the
+      terminal the question went to. The exit code is the workspace picker's cancel (130).
+    * **a yes whose chain still asks** — `KIND_MOVED` (S1). The record lives under
+      `.charter/`, which a chat can write (ruling 13), so *again* can come back holding the
+      very same question. Asking twice is N2b's case one race along, and the sentence that
+      used to come out of here was `NEEDS_ASKING` — *no terminal here to ask in* — said on a
+      terminal that plainly had one. It says what actually happened instead.
+
+    **The whole chain, from the top** (ruling 27). A yes answers the approval question and
+    nothing else: the plane can move while the operator is reading the prompt — a
+    `.gitignore` edited, the command uninstalled, and from Task 4 a profile that stops being
+    wired — and a yes that walked straight past the checks behind it would be the one place
+    in charter where saying yes to one question waives the rest.
+    """
+    from .. import profiletrust
+
+    if not profiletrust.can_ask(sys.stdin, sys.stdout):
+        return ask
+    said = profiletrust.ask_in_terminal(p, stdin=sys.stdin, stdout=sys.stdout)
+    if said.why:
+        return Refusal(KIND_RECORD,
+                       profiletrust.RECORD_NOT_WRITTEN.format(
+                           name=contain.readable(p.name),
+                           # The PATH limit and not the display one: this sentence ends in
+                           # "fix that path and run it again", and a path clipped at 160 is
+                           # one the reader cannot act on (`contain.PATH_DISPLAY_LIMIT`).
+                           path=contain.readable(config.STATE_DIR / profiletrust.RECORD,
+                                                 contain.PATH_DISPLAY_LIMIT),
+                           why=contain.readable(said.why)),
+                       REFUSED_EXIT)
+    if not said.yes:
+        return Refusal(KIND_DECLINED, "", profiletrust.DECLINED_EXIT)
+    left = again()
+    if is_a_question(left):
+        return Refusal(KIND_MOVED,
+                       profiletrust.CHANGED_WHILE_ASKING.format(
+                           name=contain.readable(p.name),
+                           state=profiletrust.approval_needed(p)),
+                       REFUSED_EXIT)
+    return left
 
 
 def _exec_exit(e: OSError) -> int:
@@ -280,9 +399,16 @@ def attempt(p: profiles.Profile, rest: list[str], *, fid: str | None, attended: 
     *on_exec* is what a caller records the moment the pane stops being charter's, and it
     returns the undo for it: an `execvpe` that raises after it leaves a pane running nothing
     at all, and a pane running nothing must not also claim to be a chat (N7's nit).
+
+    **The ask is here**, because this is the one function every path reaches — the pane,
+    `--no-frame`, and a launch whose output is a pipe — and a question asked in only some
+    of them is an approval that depends on how the harness was started.
     """
     env = environment(p, os.environ, framed=fid is not None)
     r = refusal(p, root=config.ROOT, attended=attended, env=env)
+    if is_a_question(r):
+        r = answered(p, r, again=lambda: refusal(p, root=config.ROOT, attended=attended,
+                                                 env=env))
     if r is not None:
         return r
     undo = on_exec()
@@ -305,12 +431,18 @@ def start(p: profiles.Profile, rest: list[str], *, fid: str | None, attended: bo
     """:func:`attempt`, with the refusal said on charter's own terms. The exit code.
 
     What `charter <profile> --no-frame` and a launch with no terminal run — the refusal is
-    printed where the operator is already looking, so nothing waits for a key there.
+    printed where the operator is already looking, so nothing here holds a pane open for
+    them to read it.
+
+    **A decline says nothing more.** `profiletrust.ask_in_terminal` has already answered it
+    on the terminal the question went to, and repeating it under charter's red ✗ would
+    report the operator's own answer as a rule firing.
     """
     r = attempt(p, rest, fid=fid, attended=attended)
     if r is None:
         return 0
-    util.err(f"charter: {r.text}")
+    if not already_said(r):
+        util.err(f"charter: {r.text}")
     return r.exit
 
 
@@ -391,9 +523,17 @@ def _handed_over(fid: str | None) -> Callable[[], None]:
 def _refused_in_pane(text: str, code: int, *, fid: str | None, attended: bool) -> int:
     """Say *text* in the pane the way somebody will actually read it, and return *code*.
 
-    Ruling 42, measured: printing and exiting is exactly what nobody reads. An attended pane
-    waits for a key; an unattended one leaves the sentence under the chat, because the
-    process that opened it is the one with a terminal.
+    Ruling 42, measured: printing and exiting is exactly what nobody reads. So the sentence
+    is left under the chat **on both paths this runs on** — the record is what an unattended
+    open reads back (`commands_frame._await_the_launcher`), and an attended one that the
+    operator closes before reading has left it somewhere all the same. A decline never
+    reaches here at all (:func:`cmd_frame_launch` returns on :func:`already_said` first), and
+    does not need to: it says nothing the operator has not just been told.
+
+    **Only the wait is conditional.** An attended pane holds itself open until the operator
+    presses Enter — a LINE and not a keystroke, for the reason
+    :func:`_wait_for_the_operator` measures — and a pane nobody is at never stops on
+    anything.
     """
     util.err(f"charter: {text}")
     if fid is not None:
@@ -429,4 +569,11 @@ def cmd_frame_launch(args) -> int:
                 on_exec=lambda: _handed_over(fid))
     if r is None:
         return 0
+    if already_said(r):
+        # **The one refusal a pane neither shows, records nor waits on.** The operator
+        # answered the question in this very pane a moment ago — there is nothing here they
+        # have not read, nothing for them to press, and nothing for another process to read
+        # back, because no other process is waiting on an attended open. The window closes
+        # the way it does for any other exit, on the picker's own cancel code.
+        return r.exit
     return _refused_in_pane(r.text, r.exit, fid=fid, attended=args.attended)

--- a/charter/frame/state.py
+++ b/charter/frame/state.py
@@ -987,8 +987,12 @@ def profile(fid: str) -> str | None:
 #: completes 6-14 ms after the start while a Python launcher's first line runs at 19-22 ms,
 #: so a refusal the pane printed and exited on is never read off the pane: on charter's own
 #: server the teardown hook kills the window at once, and `_pane_last_words` answered `[]`
-#: in all 40 measured runs. An attended pane waits for a key instead; an unattended one —
-#: a reopen, a handoff — has nobody to wait for, so it leaves its answer here.
+#: in all 40 measured runs. So a pane that refuses leaves its answer here whoever is
+#: watching: an attended one also holds the sentence on screen until somebody presses Enter,
+#: and an unattended one — a reopen, a handoff — has nobody in front of it, so this record is
+#: the only copy the launch that opened the chat can read. The exception is the refusal the
+#: OPERATOR chose: a decline writes nothing, because they answered it themselves and only an
+#: unattended open ever reads this back (`launcher.already_said`).
 _LAUNCH_FILE = "launch"
 
 

--- a/charter/profiletrust.py
+++ b/charter/profiletrust.py
@@ -72,7 +72,7 @@ RECORD_NOT_WRITTEN = (
 #: than asking again — N2b's reason, one race along: a second question is one the operator
 #: cannot settle either, because whatever answered the first one can answer the next.
 CHANGED_WHILE_ASKING = (
-    "profile '{name}' is {state} again — it moved while that question was on screen, so "
+    "profile '{name}' moved while that question was on screen, so "
     "what you approved is not what would run now. Nothing was started; run it again and "
     "read the command it shows you: charter {name}")
 #: And the reopen's, which lives here beside its two siblings rather than in
@@ -216,35 +216,6 @@ def can_ask(stdin, stdout) -> bool:
     return stdin.isatty() and stdout.isatty()
 
 
-def _whole(text: str) -> str:
-    """*text* escaped to printable ASCII and **not clipped** — the prompt's containment.
-
-    **A sentence clips; a prompt does not**, and that is the difference between this and
-    `contain.readable`. A refusal is one line that ends in a remedy, so a 200-character
-    name in the middle of it pushes the remedy off the screen and `readable`'s 160-character
-    clip is right there. This prompt is the opposite surface: it exists so that somebody can
-    read the command before approving it, and a command approved with its tail hidden is
-    the one outcome the whole feature is against — `claude --settings <400 bytes of
-    somewhere else>` would be clipped to something that looks fine. It wraps instead.
-
-    `contain.escaped` for the escaping itself, so this shares one implementation of *what
-    may reach a terminal* with every other surface rather than growing a second: every byte
-    outside U+0020..U+007E comes out as a reversible escape, whatever its category. The
-    blankness rule is `readable`'s, for `readable`'s reason: after `escaped` the string is
-    printable ASCII, so "renders as nothing" is exactly "is spaces", and a word that renders
-    as nothing must not read as no word at all.
-
-    **Asked as a question about the whole string rather than as a strip**, which is the one
-    thing here that is not `readable`'s spelling. `shown.strip(" ")` and `shown.lstrip(" ")`
-    are equivalent for deciding this — either leaves nothing exactly when every character is
-    a space — so a sweep can never tell the two apart and the line comes back a survivor
-    that no test could have pinned. `set(shown) <= {" "}` IS the decision: every character is
-    a space, empty included, and there is no second spelling of it to drift to.
-    """
-    shown = contain.escaped(str(text))
-    return contain.BLANK if set(shown) <= {" "} else shown
-
-
 def _words(command: Iterable[str]) -> str:
     """A command as the prompt shows it, **contained word by word** (ruling 35), whole.
 
@@ -254,7 +225,7 @@ def _words(command: Iterable[str]) -> str:
     reason one level along: the record is under `.charter/`, which is as writable as the
     file (ruling 13).
     """
-    return " ".join(_whole(word) for word in command)
+    return " ".join(contain.readable(word, contain.NO_CLIP) for word in command)
 
 
 def _names(env: Iterable[tuple[str, str]]) -> str:
@@ -265,7 +236,8 @@ def _names(env: Iterable[tuple[str, str]]) -> str:
     `.charter/` is a `dict` whose `.items()` the caller sorts. Annotated as the pairs both
     of them are, so a third caller cannot quietly hand it a third shape.
     """
-    return " ".join(_whole(f"{name}={value}") for name, value in env)
+    return " ".join(contain.readable(f"{name}={value}", contain.NO_CLIP)
+                    for name, value in env)
 
 
 def _prompt(p: profiles.Profile, state: str, was: dict) -> str:
@@ -274,7 +246,7 @@ def _prompt(p: profiles.Profile, state: str, was: dict) -> str:
     The command and the environment on rows of their own, because they are two different
     decisions — which program, and which account — and a single line runs them together.
     """
-    lines = [HEADLINE[state].format(name=_whole(p.name)),
+    lines = [HEADLINE[state].format(name=contain.readable(p.name, contain.NO_CLIP)),
              f"  command  {_words(p.command)}"]
     if p.env:
         lines.append(f"  env      {_names(p.env)}")

--- a/charter/profiletrust.py
+++ b/charter/profiletrust.py
@@ -1,0 +1,353 @@
+"""What the operator approved a profile to run — the launch record, and the ask that fills it.
+
+Charter writes down each profile's `kind`, `command` and `env` the moment it launches one.
+A profile with no record, or one that no longer matches, is **new or changed**: charter
+shows what it would run and asks `run this? [y/N]` before it runs it. Built-ins never ask —
+their command comes out of charter's own registry, which no file and no chat can edit.
+
+**Why there is a question here at all**, when nothing else in charter stops to ask:
+
+* once `charter.local.toml` is ignored, an edit to it leaves **no diff** — no review, no
+  `git status`, nothing on a branch for anybody to notice;
+* nothing stops a chat editing plane config, and a chat is an agent with a shell;
+* the command goes to **tmux**, so it never passes a harness's own permission prompt on the
+  way — by the time a harness could ask about it, that harness IS the command;
+* Codex trusts hooks by hash for exactly this reason, and a profile's `command` is the same
+  shape of thing: a line of config that becomes a process.
+
+**The limit, at full volume** (ruling 13). A chat that can edit `charter.local.toml` can
+also edit `.charter/harness-profiles-launched.json`, which is this record: both sit under
+paths no guard covers, and a path pattern is host policy rather than charter's (ADR 0014).
+So the ask catches a command the operator did not change themselves **unless whatever
+changed it also forged the record**. That is worth having — it closes the accident and the
+careless edit, and it is the difference between a command that ran unseen and one that was
+read out loud first — and it is not a boundary. The docs say so in the same words.
+
+**Nothing here is on the import path** (ruling 43). Every `charter hook …` process builds
+the parser and derives config; profile code is charged to all of them if it joins that, and
+CI's deletion sweep cannot finish when it is. `launcher` and `commands_frame` reach this
+module at call time, and this module reaches `launcher` the same way.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING, Iterable, NamedTuple
+
+from . import config, contain, profiles
+
+if TYPE_CHECKING:                                   # pragma: no cover - typing only
+    from .frame import launcher
+
+#: The record, under `config.STATE_DIR` — which `charter init` ignores, and which
+#: `config.private_mkdir` creates at 0700.
+RECORD = "harness-profiles-launched.json"
+
+#: What a launch the operator declined returns. The workspace picker's own cancel code
+#: (`commands_frame._PICKER_CANCELLED`): 130 is the shell's "ended by SIGINT", which is what
+#: saying no to a question is, and it is deliberately not 0 — a script that got 0 back would
+#: take a frame that was never started for one that ran and exited cleanly.
+DECLINED_EXIT = 130
+
+#: The two answers :func:`approval_needed` gives, as one word each. They are read back into
+#: every sentence below, so they are words rather than flags.
+NEW = "new"
+CHANGED = "changed"
+
+#: Every sentence says the rule worked and names the fix in the same breath (CONTEXT.md,
+#: *A refusal is the rule working*), and every profile-derived value in one is contained
+#: (ruling 35).
+NEEDS_ASKING = (
+    "profile '{name}' is {state}, and charter asks before it runs a command it has not "
+    "been shown before — but there is no terminal here to ask in, so nothing was started. "
+    "Run it where you can answer: charter {name}")
+UNATTENDED = (
+    "profile '{name}' is {state}, and nobody is at this open to approve it — nothing was "
+    "started. Run it once yourself so charter can ask: charter {name}")
+RECORD_NOT_WRITTEN = (
+    "you approved profile '{name}', but charter could not record that at {path} ({why}), "
+    "so it will not start it — it would only ask you again. Nothing was started; fix that "
+    "path and run it again.")
+#: What a yes buys nothing, because the record moved under it (S1). Its own sentence rather
+#: than asking again — N2b's reason, one race along: a second question is one the operator
+#: cannot settle either, because whatever answered the first one can answer the next.
+CHANGED_WHILE_ASKING = (
+    "profile '{name}' is {state} again — it moved while that question was on screen, so "
+    "what you approved is not what would run now. Nothing was started; run it again and "
+    "read the command it shows you: charter {name}")
+#: And the reopen's, which lives here beside its two siblings rather than in
+#: `commands_frame`: all three read :data:`NEW` and :data:`CHANGED` into a sentence, and
+#: split across two modules a reword of either word is two edits with nothing holding them
+#: together. `commands_frame` fills in the chat, which is the half only a reopen knows.
+REOPEN_UNAPPROVED = ("charter reopen: {chat} runs profile '{name}', which is {state} — not "
+                     "reopened, because a reopen has nobody to ask. Run charter {name} once "
+                     "to approve it, then charter reopen.")
+
+#: The prompt, line by line. The headline says which state it is in and why that is a
+#: question; the rows are what would run; the last line is the question itself, and it is
+#: last so that it is the thing still on screen when the cursor stops.
+HEADLINE = {NEW: "charter: profile '{name}' is new — it has not run on this machine before.",
+            CHANGED: "charter: profile '{name}' has changed since it last ran."}
+QUESTION = "run this? [y/N] "
+
+#: What a decline says, on the terminal the question was asked on. `_choose_workspace` says
+#: exactly this when the workspace picker is cancelled, and a person who has just answered
+#: two of charter's questions should not have to learn two vocabularies for "no".
+NOTHING_STARTED = "charter: nothing started."
+
+#: The answers that mean yes. Everything else — a bare Enter, a typo, end of input — is no,
+#: because the fat-fingered path has to be the one that starts nothing.
+_YES = ("y", "yes")
+
+
+class Answer(NamedTuple):
+    """What the operator said, and what charter managed to do about it.
+
+    Two fields rather than a `bool`, because a yes has two outcomes and they are not the
+    same launch (the fourth review's nit): one is approved and recorded, and one is
+    approved and **not** recorded, which must refuse rather than run — re-running the chain
+    after it would find no record and ask the identical question a second time (N2b).
+    """
+
+    #: Whether the answer was yes.
+    yes: bool
+    #: Why a yes could not be written down — ``""`` on every other path.
+    why: str
+
+
+def fingerprint(p: profiles.Profile) -> dict:
+    """What is recorded for *p*: its kind, its command and its environment.
+
+    **As DECLARED, before `~` is expanded.** The file is what an edit changes, and `$HOME`
+    is not something a chat moves — a record of the expansion would read as *changed* for
+    every profile on the day somebody's home directory did move, and would ask again about
+    a command nobody touched.
+    """
+    return {"kind": p.kind, "command": list(p.command), "env": dict(p.env)}
+
+
+def _read() -> dict:
+    """Every profile's record, or ``{}``.
+
+    **Unreadable, malformed or missing all read as `{}`**, so everything declared asks
+    again. It fails towards ASKING and never towards running: a file charter cannot read
+    says nothing about what the operator approved, and treating silence as a yes is the one
+    state this record exists to keep out.
+    """
+    try:
+        got = json.loads((config.STATE_DIR / RECORD).read_text())
+    except (OSError, ValueError):
+        return {}
+    return got if isinstance(got, dict) else {}
+
+
+def last_launched(name: str) -> dict | None:
+    """*name*'s recorded fingerprint, or ``None`` when there is not one.
+
+    An entry that is not a fingerprint is not one either: the file is a plain JSON object a
+    chat can write, so `{"claude-work": "approved, honest"}` has to read as no record at
+    all rather than as something to compare against.
+    """
+    got = _read().get(name)
+    return got if isinstance(got, dict) else None
+
+
+def record_launched(p: profiles.Profile) -> str:
+    """Write *p* down as launched. ``""``, or why it could not be — **never raises**.
+
+    Called from a launch that is about to `exec` and from a press that runs under a hook,
+    where an exception is a turn that ends with a traceback instead of a chat. The caller
+    decides what a failure means, because the two callers do not agree: the ask refuses the
+    launch over it (N2b), and nothing else has to.
+
+    One object keyed by profile name, read and rewritten whole, so approving one profile
+    today does not make another ask again tomorrow.
+
+    What comes back is what the filesystem said and not where it said it: the path is
+    charter's own and every caller that quotes one already knows it
+    (:data:`RECORD_NOT_WRITTEN`), so putting it in here would print it twice.
+    """
+    try:
+        config.private_mkdir(config.STATE_DIR)
+        config.replace_for(config.STATE_DIR / RECORD,
+                           json.dumps({**_read(), p.name: fingerprint(p)}, indent=2) + "\n")
+    except OSError as e:
+        return e.strerror or str(e)
+    return ""
+
+
+def _state_and_record(p: profiles.Profile) -> tuple[str, dict]:
+    """*p*'s approval state and the fingerprint it was compared against — **read once**.
+
+    One read rather than two, and that is why this exists instead of the prompt asking
+    `last_launched` again for itself: between two reads the file can change, and the second
+    answer would have to carry a fallback for a record the first one had already seen. A
+    fallback nothing can reach is a line the deletion sweep is right to call dead.
+    """
+    if p.source == profiles.BUILTIN:
+        return "", {}
+    was = last_launched(p.name)
+    if was is None:
+        return NEW, {}
+    return ("" if was == fingerprint(p) else CHANGED), was
+
+
+def approval_needed(p: profiles.Profile) -> str:
+    """:data:`NEW`, :data:`CHANGED`, or ``""`` when *p* may run.
+
+    **A built-in never asks.** Its command comes out of charter's own registry rather than
+    out of a file, so what a chat could have written decides nothing about it — and a
+    question that never carries risk is one an operator learns to answer yes to without
+    reading. A profile the file DECLARES with a built-in's name (`[harness.claude]`) is a
+    declaration and asks with the rest: the name is the built-in's, and the command is the
+    file's.
+    """
+    return _state_and_record(p)[0]
+
+
+def can_ask(stdin, stdout) -> bool:
+    """Is there a terminal here to put a question on? (ruling 23)
+
+    **Both, and that is the whole point of asking twice.** `charter claude-work > log` has
+    somebody at the keyboard and nowhere to print the question; `charter claude-work <
+    /dev/null` has the screen and nothing to read back. Either one asked anyway is a
+    process that never returns, which is worse than any refusal.
+    """
+    return stdin.isatty() and stdout.isatty()
+
+
+def _whole(text: str) -> str:
+    """*text* escaped to printable ASCII and **not clipped** — the prompt's containment.
+
+    **A sentence clips; a prompt does not**, and that is the difference between this and
+    `contain.readable`. A refusal is one line that ends in a remedy, so a 200-character
+    name in the middle of it pushes the remedy off the screen and `readable`'s 160-character
+    clip is right there. This prompt is the opposite surface: it exists so that somebody can
+    read the command before approving it, and a command approved with its tail hidden is
+    the one outcome the whole feature is against — `claude --settings <400 bytes of
+    somewhere else>` would be clipped to something that looks fine. It wraps instead.
+
+    `contain.escaped` for the escaping itself, so this shares one implementation of *what
+    may reach a terminal* with every other surface rather than growing a second: every byte
+    outside U+0020..U+007E comes out as a reversible escape, whatever its category. The
+    blankness rule is `readable`'s, for `readable`'s reason: after `escaped` the string is
+    printable ASCII, so "renders as nothing" is exactly "is spaces", and a word that renders
+    as nothing must not read as no word at all.
+
+    **Asked as a question about the whole string rather than as a strip**, which is the one
+    thing here that is not `readable`'s spelling. `shown.strip(" ")` and `shown.lstrip(" ")`
+    are equivalent for deciding this — either leaves nothing exactly when every character is
+    a space — so a sweep can never tell the two apart and the line comes back a survivor
+    that no test could have pinned. `set(shown) <= {" "}` IS the decision: every character is
+    a space, empty included, and there is no second spelling of it to drift to.
+    """
+    shown = contain.escaped(str(text))
+    return contain.BLANK if set(shown) <= {" "} else shown
+
+
+def _words(command: Iterable[str]) -> str:
+    """A command as the prompt shows it, **contained word by word** (ruling 35), whole.
+
+    It comes out of a file a chat can write and it is about to be drawn on a terminal, so a
+    `\\r` or an ESC in it could otherwise redraw this very prompt to show a harmless command
+    while another one is approved. The `was` line gets the same treatment for the same
+    reason one level along: the record is under `.charter/`, which is as writable as the
+    file (ruling 13).
+    """
+    return " ".join(_whole(word) for word in command)
+
+
+def _names(env: Iterable[tuple[str, str]]) -> str:
+    """An environment as the prompt shows it — `NAME=value` a pair at a time, contained.
+
+    Pairs rather than a mapping, because the two callers hold it differently:
+    `profiles.Profile.env` is a tuple of pairs already sorted, and a record read back out of
+    `.charter/` is a `dict` whose `.items()` the caller sorts. Annotated as the pairs both
+    of them are, so a third caller cannot quietly hand it a third shape.
+    """
+    return " ".join(_whole(f"{name}={value}") for name, value in env)
+
+
+def _prompt(p: profiles.Profile, state: str, was: dict) -> str:
+    """The whole question as one block of text, ending in :data:`QUESTION`.
+
+    The command and the environment on rows of their own, because they are two different
+    decisions — which program, and which account — and a single line runs them together.
+    """
+    lines = [HEADLINE[state].format(name=_whole(p.name)),
+             f"  command  {_words(p.command)}"]
+    if p.env:
+        lines.append(f"  env      {_names(p.env)}")
+    if state == CHANGED:
+        # What it WAS, so the operator can read the change rather than only the new
+        # command: "is this the command you meant" is a different question from "did you
+        # mean to swap these two". One line, because it is the thing being compared against
+        # rather than the thing being approved.
+        #
+        # `dict.get` with a default and not `or`: *was* is a record a chat can write, so an
+        # entry missing either key is ordinary rather than exotic — and `if x` drops the
+        # half that is empty, because a `was` row that begins with a space reads as a
+        # command that begins with one.
+        lines.append("  was      " + " ".join(
+            x for x in (_names(sorted(was.get("env", {}).items())),
+                        _words(was.get("command", []))) if x))
+    return "\n".join([*lines, QUESTION])
+
+
+def ask_in_terminal(p: profiles.Profile, *, stdin, stdout) -> Answer:
+    """Show *p*'s command on *stdout*, read one line off *stdin*, and record a yes.
+
+    Streams rather than `input()`/`print()`, for `frame/picker.py`'s reason: a prompt is
+    exactly the shape of test this repo keeps getting wrong, and one that needed a real tty
+    to prove that `n` starts nothing would be testing the terminal instead of the rule.
+
+    End of input and `KeyboardInterrupt` both decline. A closed stdin is a launch driven
+    from a script, and ^C at a prompt means "not this" — neither may come out of here as a
+    traceback in a pane somebody is looking at.
+
+    **A profile that needs no approval by the time this runs is not asked about** (S1), and
+    that state is reachable rather than defensive: `launcher.refusal` read the record to
+    decide there was a question, this reads it again to build the prompt, and between the
+    two a second terminal, the pane a `+` opened, or the chat this module's docstring names
+    can have written it. A yes is the honest answer — the operator's approval is on disk —
+    and it is the only one that does not either crash on a headline for a state with no
+    question in it or put a question nobody needs on a screen.
+    """
+    state, was = _state_and_record(p)
+    if not state:
+        return Answer(True, "")
+    stdout.write(_prompt(p, state, was))
+    stdout.flush()
+    try:
+        line = stdin.readline()
+    except KeyboardInterrupt:
+        line = ""
+    if line.strip().lower() not in _YES:
+        # On the same stream the question went to, because it is the second half of one
+        # exchange — and in the words `_choose_workspace` already uses for a cancel.
+        stdout.write(f"\n{NOTHING_STARTED}\n")
+        stdout.flush()
+        return Answer(False, "")
+    return Answer(True, record_launched(p))
+
+
+def refusal(p: profiles.Profile, *, attended: bool) -> "launcher.Refusal | None":
+    """Why *p* may not start yet, or ``None`` — the last link in `launcher.refusal`'s chain.
+
+    Two kinds and never two sentences to tell apart (ruling 27): an **attended** open gets
+    :data:`launcher.KIND_ASK`, which the caller answers by asking if it has a terminal and
+    by printing this text if it has not; an unattended one gets
+    :data:`launcher.KIND_UNATTENDED`, because a reopen, a restore and a handoff have nobody
+    to put the question to and a pane that waits on one never starts and never says why.
+    """
+    from .frame import launcher
+
+    state = approval_needed(p)
+    if not state:
+        return None
+    said = {"name": contain.readable(p.name), "state": state}
+    if attended:
+        return launcher.Refusal(launcher.KIND_ASK, NEEDS_ASKING.format(**said),
+                                launcher.REFUSED_EXIT)
+    return launcher.Refusal(launcher.KIND_UNATTENDED, UNATTENDED.format(**said),
+                            launcher.REFUSED_EXIT)

--- a/docs/adr/0018-charter-may-run-the-harness-but-never-draws-it.md
+++ b/docs/adr/0018-charter-may-run-the-harness-but-never-draws-it.md
@@ -229,8 +229,11 @@ record.
   one command while another is approved. And **nothing is clipped**: a sentence bounds what
   it quotes, because a sentence ends in a remedy that a long value would push off the
   screen, but a prompt exists to be read before it is answered, and a command approved with
-  its tail unseen is what the ask is against. It wraps. A surface that must clip — a
-  selector row, a doctor row — says how much it kept back; this one never has to.
+  its tail unseen is what the ask is against. It wraps. The refusal sentences are the other
+  kind of surface: they quote a profile's name only to say which one, and bound it with
+  `contain.readable`'s fixed `...` marker, as every refusal Task 2 shipped does. A row the
+  operator chooses or approves from — a selector row, a doctor row — says how much it kept
+  back; the prompt never has to.
 * **The question is asked only where it can be answered.** Both of the pane's ends must be a
   terminal (`profiletrust.can_ask`), and the open must be an attended one. A pane that fails
   either test is refused with a sentence rather than asked, because a question nobody can
@@ -248,9 +251,15 @@ record.
   before `_refused_in_pane` runs, so nothing is said in the pane and nothing is written under
   the chat. Both are right: the operator answered this question themselves a moment ago and
   was told `charter: nothing started.` as they did, so there is no sentence they have not
-  read; and a decline is reachable only from an ATTENDED open, which is precisely the open
-  nobody is waiting on the record for — `_await_the_launcher` is asked by an unattended one.
-  A refusal charter decided still records; the one the operator decided does not need to.
+  read. On charter's own server nobody reads the record for it either: a decline is
+  reachable only from an ATTENDED open, and `_await_the_launcher` is asked only by an
+  unattended one. **In an operator's tmux it reads worse, and says so here:**
+  `_launch_in_operator_tmux` reads the record whether or not the open was attended, so a
+  decline there that races the eager check, or a press whose streams are `/dev/null`,
+  reports the window gone with charter's unknown-death code rather than "nothing started".
+  That is a less exact sentence, not a hole — nothing ran, and the decline was answered on
+  the terminal that asked. A refusal charter decided still records; the one the operator
+  decided does not need to.
 * **A line, not a keystroke.** Waiting on one keypress means putting the pane's terminal
   into raw mode, and a `tcsetattr` from a pane on a Linux CI runner left the launcher killed
   by a signal — an empty `#{pane_dead_status}` — so the refusal went with the window after

--- a/docs/adr/0018-charter-may-run-the-harness-but-never-draws-it.md
+++ b/docs/adr/0018-charter-may-run-the-harness-but-never-draws-it.md
@@ -157,27 +157,35 @@ trimming afterwards: the bound belongs where the memory is. Verified on tmux 3.7
 Harness profiles put a charter process in the pane. `charter frame-launch --profile <name>`
 is what tmux now starts in every chat pane, and it becomes the harness by `os.execvpe`
 replacing itself with the profile's command (`charter/frame/launcher.py`). Before that
-happens, charter may write on that screen, and there are exactly two things it writes.
+happens, charter may write on that screen, and there are exactly three things it writes.
 
 **A refusal** — the local file became committable since the pre-tmux check, the command is
-not on `PATH`, the profile is declared and nothing can ask the operator's approval yet, the
-`execvpe` itself raised — goes into the pane, and where somebody is at the keyboard the
-launcher **holds the pane open until they press Enter.**
+not on `PATH`, the `execvpe` itself raised — goes into the pane, and where somebody is at
+the keyboard the launcher **holds the pane open until they press Enter.**
 
-**A claim to a chat that cannot be proven** is the second, and it is not a refusal: the
-launch goes ahead. `launcher.framed_chat()` asks tmux whether this process's own pid is the
-`#{pane_pid}` of a live pane belonging to the chat it was handed, because `$TMUX_PANE` and
-`$CHARTER_SESSION_ID` are inherited by a model's tool shell and prove nothing. A claim that
-does not check prints one line saying so and returns `None`, and the launcher then runs as a
-launch with **no frame** — it records nothing for that chat, which is the point of the
+**A question** is the second, and it is the only one of the three that READS from the pane
+as well as writing to it. A profile whose command or environment is new or has changed
+since it last ran is not refused where somebody is in front of it: the launcher prints what
+it would run and reads one line, `run this? [y/N]` (`charter/profiletrust.py`, and the
+plan's *A new or changed command asks once*). A no starts nothing and exits on the
+workspace picker's own cancel code, saying nothing more — the operator has just answered.
+Where the question cannot be answered it is a refusal instead, which is the bound below.
+
+**A claim to a chat that cannot be proven** is the third, and it is not a refusal either:
+the launch goes ahead. `launcher.framed_chat()` asks tmux whether this process's own pid is
+the `#{pane_pid}` of a live pane belonging to the chat it was handed, because `$TMUX_PANE`
+and `$CHARTER_SESSION_ID` are inherited by a model's tool shell and prove nothing. A claim
+that does not check prints one line saying so and returns `None`, and the launcher then runs
+as a launch with **no frame** — it records nothing for that chat, which is the point of the
 proof. Silently downgrading would cost a chat its session id and its resume id with nothing
 said, so the sentence goes where the person watching is: the pane the harness is about to
 take over.
 
-That is charter writing in a chat's pane, which the rule above says it never does. The rule
-is right and this is not an exception to it, because of *when*: **no harness has ever run in
-that pane.** The `exec` has not happened — or it was attempted and raised, which leaves the
-same pane with the same charter process in it and no harness either way — so there is no
+All three are charter writing in a chat's pane — and the question reads from it too — which
+the rule above says it never does. The rule is right and this is not an exception to it,
+because of *when*: **no harness has ever run in that pane.** The `exec` has not happened —
+or it was attempted and raised, which leaves the same pane with the same charter process in
+it and no harness either way — so there is no
 harness process, no output of its own on that screen, nothing to draw over and nothing to
 parse. Every failure this ADR was written against needs a harness on the other side of the
 pane to occur at all — owning a terminal parser, deciding what somebody else's cursor means,
@@ -210,25 +218,50 @@ record.
   attempted. Neither leaves a harness in the pane, which is why the rule survives both and
   the pair did not. The bound is checkable from outside because there is one moment it
   turns: `state.record_launch`, written the instant the pane stops being charter's.
-* **Two sentences, and charter wrote both.** A refusal, plus `press Enter to close this
-  chat.` where the pane waits; or the one line an unproven chat prints before launching
-  anyway. No escape sequences of charter's own, no panel, no layout, and never a third thing
-  later.
-* **Every refusal is recorded, and only the WAIT is conditional.** `_refused_in_pane` writes
-  the sentence into the chat's state directory on every path (`state.record_launch`), the
-  attended one included, where the launch that opened the chat reports it. What an attended
-  open adds is the wait — and that needs two conditions rather than one: the open must be
-  ATTENDED **and** the pane's stdin must be a terminal, because `_wait_for_the_operator`
-  returns at once when `sys.stdin.isatty()` is false. So an attended launcher run out of a
-  pipe prints and exits, and a reopen, a handoff or a background open never stops at all.
+* **Three kinds of line, and charter wrote every one.** A refusal, plus `press Enter to
+  close this chat.` where the pane waits; the approval prompt, which is the profile's
+  command and environment on rows of their own and then `run this? [y/N]`; or the one line
+  an unproven chat prints before launching anyway. No escape sequences of charter's own, no
+  panel, no layout, and never a fourth thing later.
+* **The prompt is escaped AND whole, and those are two promises.** Every byte of it outside
+  printable ASCII comes out as a reversible escape (`contain.escaped`, ruling 35), because
+  it comes from a file a chat can write and an ESC in it could redraw the question to show
+  one command while another is approved. And **nothing is clipped**: a sentence bounds what
+  it quotes, because a sentence ends in a remedy that a long value would push off the
+  screen, but a prompt exists to be read before it is answered, and a command approved with
+  its tail unseen is what the ask is against. It wraps. A surface that must clip — a
+  selector row, a doctor row — says how much it kept back; this one never has to.
+* **The question is asked only where it can be answered.** Both of the pane's ends must be a
+  terminal (`profiletrust.can_ask`), and the open must be an attended one. A pane that fails
+  either test is refused with a sentence rather than asked, because a question nobody can
+  answer is a chat that never starts and never says why — which is the same failure the wait
+  below is bounded against, one moment earlier.
+* **Every refusal the pane SAYS is recorded, and only the WAIT is conditional.**
+  `_refused_in_pane` writes the sentence into the chat's state directory on every path it
+  runs (`state.record_launch`), the attended one included, where the launch that opened the
+  chat reports it. What an attended open adds is the wait — and that needs two conditions
+  rather than one: the open must be ATTENDED **and** the pane's stdin must be a terminal,
+  because `_wait_for_the_operator` returns at once when `sys.stdin.isatty()` is false. So an
+  attended launcher run out of a pipe prints and exits, and a reopen, a handoff or a
+  background open never stops at all.
+* **A decline is the one exception, and it is not a hole.** `cmd_frame_launch` returns on it
+  before `_refused_in_pane` runs, so nothing is said in the pane and nothing is written under
+  the chat. Both are right: the operator answered this question themselves a moment ago and
+  was told `charter: nothing started.` as they did, so there is no sentence they have not
+  read; and a decline is reachable only from an ATTENDED open, which is precisely the open
+  nobody is waiting on the record for — `_await_the_launcher` is asked by an unattended one.
+  A refusal charter decided still records; the one the operator decided does not need to.
 * **A line, not a keystroke.** Waiting on one keypress means putting the pane's terminal
   into raw mode, and a `tcsetattr` from a pane on a Linux CI runner left the launcher killed
   by a signal — an empty `#{pane_dead_status}` — so the refusal went with the window after
   all. The pane's own line discipline does the waiting instead: no mode change, nothing to
   restore, nothing of the terminal's state for charter to get wrong.
-* **Reading is untouched.** This amendment adds a WRITE before the harness exists; the two
-  reads the 2026-09-01 amendment allows are unchanged, and charter still never reads this
-  pane to react to what a harness printed in it.
+* **Reading the harness is untouched.** This amendment adds a WRITE before the harness
+  exists, and one READ OF THE KEYBOARD — a line off the pane's stdin, through its own line
+  discipline — which is not a reading of the pane at all: there is no output on that screen
+  but charter's own, and nothing is parsed. The two reads of the harness's pane that the
+  2026-09-01 amendment allows are unchanged, and charter still never reads this pane to
+  react to what a harness printed in it.
 
 Recorded here rather than in the records task that closes this phase, because the code that
 relies on it shipped in the same pull request
@@ -238,7 +271,14 @@ Task 6): otherwise `main` carries an unqualified prohibition while the code cont
 it, and the only thing telling a reader otherwise is a spec they have no reason to open.
 
 *Corrected 2026-09-12 by that records task, against the shipped
-`charter/frame/launcher.py`: the unproven-chat line named as the second thing charter writes
-there, the `execvpe`-that-raised case covered, "only before the `exec`" replaced by the
-distinguishing question, the wait's two conditions both stated, the record separated from
-the wait, and the measurement cited where a reader can open it.*
+`charter/frame/launcher.py`: the unproven-chat line named as one of the things charter
+writes there, the `execvpe`-that-raised case covered, "only before the `exec`" replaced by
+the distinguishing question, the wait's two conditions both stated, the record separated
+from the wait, and the measurement cited where a reader can open it.*
+
+*Extended 2026-09-12 by the task that added the approval
+([#992](https://github.com/diazoxide/charter/pull/992)), under the same rule: the launcher
+now ASKS in that pane as well as writing in it, so the question is named as the second thing
+it writes, its containment and the two conditions for putting it are bounded, and the read
+it makes is distinguished from the two reads of a harness's pane the 2026-09-01 amendment
+allows.*

--- a/docs/control-plane.md
+++ b/docs/control-plane.md
@@ -468,13 +468,11 @@ environment, declared in a file that stays on your machine. The decisions behind
 of this, and the reason each one rests on, are
 [ADR 0022](adr/0022-a-harness-profile-belongs-to-one-machine.md).
 
-**Every chat now starts through charter's own launcher, and launching a DECLARED profile
-arrives in a later release.** Charter reads the profiles, refuses the broken ones by name,
-and keeps the file out of git; `charter claude`, bare `charter`, the `+`, a workspace tab
-and a reopen all run the built-in profile of their harness and record it. A profile this
-file declares is refused, by name, with a sentence saying charter cannot yet ask before a
-declared command runs — the release that adds the asking is the one that lets it launch,
-because until then nothing stands for your approval of a command that runs on a click.
+**Every chat now starts through charter's own launcher.** Charter reads the profiles,
+refuses the broken ones by name, and keeps the file out of git; `charter claude-work`, bare
+`charter`, the `+`, a workspace tab and a reopen all run the profile they name and record
+it. A profile this file declares runs once you have seen its command and said so — see
+*A new or changed command asks once*, below.
 
 ### Profiles live in `charter.local.toml`, never in `charter.toml`
 
@@ -536,6 +534,71 @@ A broken profile is refused alone, by name, and every other profile still loads.
 | an `env` name containing `KEY`, `TOKEN`, `SECRET` or `PASSWORD` | a variable set on the harness reaches the model's shell, as the next section measures | log in inside the harness |
 | a key other than `kind`, `command` and `env` | a typo such as `enviroment` would drop `CLAUDE_CONFIG_DIR` and launch the default account without a word | remove or respell it |
 | a file that is not valid TOML | nothing in it can be read | fix the file; the built-ins still load |
+
+### A new or changed command asks once
+
+A profile's command runs on a click, and charter starts it with no shell and no harness
+permission prompt in between. So the first time charter is asked to run one it shows you
+what that is, and asks:
+
+```
+charter: profile 'claude-work' is new — it has not run on this machine before.
+  command  claude
+  env      CLAUDE_CONFIG_DIR=~/.claude-work
+run this? [y/N]
+```
+
+Anything but `y` or `yes` starts nothing and exits 130. A yes is written down — the profile's
+`kind`, `command` and `env`, exactly as the file spells them — and that profile then starts
+without a word until one of those three changes. A change asks again, with a `was` line
+showing what it ran last time:
+
+```
+charter: profile 'claude-work' has changed since it last ran.
+  command  /opt/claude-2.1/bin/claude
+  env      CLAUDE_CONFIG_DIR=~/.claude-work
+  was      CLAUDE_CONFIG_DIR=~/.claude-work claude
+run this? [y/N]
+```
+
+**Built-ins never ask.** `claude`, `codex` and `opencode` come out of charter's own
+registry rather than out of a file, so there is nothing about them a question could catch —
+and a question that never carries risk is one you learn to answer yes to without reading. A
+profile the file declares under a built-in's name (`[harness.claude]`) is a declaration, and
+asks with the rest.
+
+**Why ask at all**, when nothing else charter does stops to. Once `charter.local.toml` is
+ignored, an edit to it leaves no diff — no review, no `git status`, nothing on a branch for
+anybody to notice. Nothing stops a chat editing your plane's config, and a chat is an agent
+with a shell. And the command goes to tmux, so by the time a harness could ask about it,
+that harness *is* the command. Codex trusts its hooks by hash for the same reason.
+
+**Where it asks, and where it refuses instead.**
+
+| Opening a chat | What happens |
+|---|---|
+| `charter claude-work` at a terminal | asks before tmux: a no starts nothing, with no session and no window allocated |
+| `charter claude-work --no-frame` | asks on that same terminal, then becomes the harness |
+| `charter claude-work --no-frame > log` | refuses — there is nowhere to put the question, and it names the command to run where you can answer |
+| the `+`, a workspace tab, the palette's new chat | asks **in the chat's own pane**: the press itself has no terminal, and the pane has one on both ends. A no exits 130 and the window closes |
+| `charter reopen`, restoring a recorded plane | refuses that chat by name and leaves it in the record — a reopen has nobody to ask. Run it once yourself, then `charter reopen` again |
+| a chat handed off by another chat | refuses before anything is written: no chat directory, no window, no first message |
+
+**Saying yes answers this question and nothing else.** After a yes, every check runs again
+from the top before the harness starts — the file is still ignored, the command is still on
+`PATH`, the record now matches — and the pane runs all of them once more immediately before
+it becomes the harness. A yes is never a way past the check behind it.
+
+**The limit, said plainly.** The record lives in `.charter/harness-profiles-launched.json`,
+which is as writable by a chat as `charter.local.toml` is: both sit under paths no guard
+covers, and charter does not police paths (that is host policy). So this catches a command
+you did not change yourself **unless whatever changed it also forged the record**. It closes
+the accident and the careless edit, and it is the difference between a command that ran
+unseen and one that was read out loud first. It is not a boundary.
+
+If charter cannot write that record, the launch is refused rather than started: running it
+anyway would mean asking you the identical question at the next open, which is not something
+you can fix by answering.
 
 ### No credentials in a profile
 
@@ -603,10 +666,9 @@ of charter's own registry rather than a list in this page — or the name of a p
 `charter.local.toml` declares. A `default` in the local file wins over the committed one,
 which is how a machine chooses its own without touching what everybody else pulls.
 
-**A declared profile is a legal value here and does not launch yet**: bare `charter` on a
-plane whose default names one is refused with the launcher's own sentence — charter cannot
-yet ask before a declared command runs — rather than started. A built-in default starts
-exactly as it did.
+**A declared profile is a legal value here**: bare `charter` on a plane whose default names
+one is `charter <that profile>`, question and all — the first open shows its command and
+asks (*A new or changed command asks once*). A built-in default starts exactly as it did.
 
 **Charter does not pick one for you.** No default and you get the usage message, not
 "whatever is installed" (a machine with two of them has no answer, and the answer would

--- a/docs/frame.md
+++ b/docs/frame.md
@@ -22,10 +22,11 @@ plane places it*, below). The middle pane is the harness's and charter draws not
 `charter <profile>` names a **harness profile** — a kind, a command and an environment,
 declared in `charter.local.toml`
 ([control-plane.md](control-plane.md#harness--profiles-and-the-default)). `claude`, `codex`
-and `opencode` are themselves profiles, the built-in one per harness, and this release
-starts those. A profile the file declares does not run yet: it is refused with a sentence
-saying charter cannot yet ask before a declared command runs, because nothing stands for
-your approval of a command until the release that adds one.
+and `opencode` are themselves profiles, the built-in one per harness. The first time a
+profile the file declares is asked to run — and again whenever its command or environment
+changes — charter shows what it would run and asks `run this? [y/N]` before it does
+([control-plane.md](control-plane.md#a-new-or-changed-command-asks-once)). Built-ins never
+ask.
 
 `charter` on its own opens the frame once the plane says which harness it means —
 `[harness] default = "claude"` in `charter.toml`, documented in
@@ -821,6 +822,13 @@ frame-new-chat`, which is `charter <harness>` in this workspace with one differe
 builds the frame without becoming your terminal, because the process behind a click is not
 one.
 
+One thing it can still put to you, and it puts it **in the new chat's own pane**: a profile
+whose command is new or has changed asks `run this? [y/N]` there. The press has no terminal
+to ask on — that is what a click is — and the pane it opens has one on both ends, so the
+question goes where you can actually answer it. Answering no exits that chat and closes its
+window, exactly as any other exit does. A workspace tab opens a chat the same way and asks
+in the same place.
+
 **Pressing the `-` closes nothing.** It opens the menu about the chat you are in — the same
 one a right-click on that tab opens — whose `chat: close` row draws the warning naming the
 chat and what stopping it costs, and the keypress on *that* is what stops it. A pointer
@@ -1085,6 +1093,13 @@ caution: a profile can be a different account, where the conversation this chat 
 resume was never held and the workspace's code was never meant to go. Declaring it again
 and running `charter reopen` brings that chat back — which is what leaving it in the record
 is for.
+
+**A chat whose profile is new or has changed is skipped the same way, and for the same
+reason there is no substitute: a reopen has nobody to ask.** Charter shows a command and
+asks before it runs one — [*A new or changed command asks once*](control-plane.md#a-new-or-changed-command-asks-once)
+— and a restore is one command typed once for a plane-full of chats, with no moment in it
+to put a question. Run `charter <profile>` once yourself, answer it there, and
+`charter reopen` brings the chat back.
 
 **A chat comes back in its workspace, and is told when that is not where it had been.** The
 record stores the directory the harness was actually standing in; the restore lands in
@@ -1410,7 +1425,7 @@ directly. Only one reading differs, and nothing in charter reads it: until the `
 `#{pane_current_command}` names charter's interpreter rather than the harness.
 
 **A refusal in the pane waits for you.** A launcher that refuses — a command that is no
-longer on `PATH`, a profile this release cannot yet approve — prints its sentence in the
+longer on `PATH`, a local file git would now commit — prints its sentence in the
 pane and waits for you to press Enter, because a pane that printed and exited would have its window
 closed before anything could read it: measured, charter's own check for a chat that died
 early answers a few milliseconds before the launcher's first line has even run. A chat

--- a/docs/harnesses.md
+++ b/docs/harnesses.md
@@ -73,8 +73,10 @@ git would commit the file.
 chat can run a command as easily as it can edit a file, so a command could never stand for
 your approval of what a profile runs; it would only save typing.
 
-Launching a profile arrives in a later release. Today the list is what charter read, and
-every launch is the one it always was.
+**What does stand for your approval is the launch itself.** The first time charter is asked
+to run a profile you declared — and again whenever its command or environment changes — it
+shows you what that is and asks `run this? [y/N]` before it runs it. Built-ins never ask.
+See [*A new or changed command asks once*](control-plane.md#a-new-or-changed-command-asks-once).
 
 ## What each harness lets charter offer
 

--- a/docs/news/unreleased-harness-profiles.md
+++ b/docs/news/unreleased-harness-profiles.md
@@ -1,6 +1,6 @@
 ---
 version: unreleased
-headline: Charter reads harness profiles from charter.local.toml, a file it keeps out of git
+headline: A chat starts on the harness profile you name — its own command and config folder, never through tmux
 adopt: reinit
 ---
 
@@ -44,7 +44,21 @@ is **skipped by name** rather than moved onto another one — another profile ma
 account, where that conversation does not exist. It stays in the record, so declaring the
 profile again and running `charter reopen` brings it back.
 
-This release still does not launch a profile you declared: it is refused by name, with a
-sentence saying charter cannot yet ask before a declared command runs. Nothing a chat could
-have written into `charter.local.toml` runs until the release that adds the asking. The
-built-in profiles — `claude`, `codex`, `opencode` — start exactly as they did.
+`charter claude-work` runs that profile's command with its env. A profile whose command or
+environment is new or has changed since it last ran shows it and asks `run this? [y/N]`
+once; a reopen, a handoff, or a launch with no terminal to ask in refuses it instead.
+
+```
+charter: profile 'claude-work' is new — it has not run on this machine before.
+  command  claude
+  env      CLAUDE_CONFIG_DIR=~/.claude-work
+run this? [y/N]
+```
+
+A yes is written down and that profile starts without a word until one of those three
+changes. The built-in profiles — `claude`, `codex`, `opencode` — never ask: their command
+comes out of charter's own registry rather than out of a file. `charter <profile>` asks
+before tmux; the `+` and a workspace tab ask in the new chat's own pane, because the press
+behind them has no terminal and the pane has one. The record lives under `.charter/`, which
+a chat can write as easily as it can write `charter.local.toml` — so this catches a command
+you did not change yourself unless whatever changed it also forged the record.

--- a/docs/superpowers/plans/2026-09-11-harness-profiles.md
+++ b/docs/superpowers/plans/2026-09-11-harness-profiles.md
@@ -1549,6 +1549,16 @@ The measurement's L3 is not a test: nothing in `charter/` reads that format. Its
     and ask a second time (N2b nit).
   - With a terminal missing on either side it returns that refusal: its text is printed and
     `REFUSED_EXIT` returned (review 3).
+  - **As built, two additions the plan did not name.** A decline is its own kind,
+    `KIND_DECLINED`, carrying no text: `ask_in_terminal` has already said `charter: nothing
+    started.` on the terminal the question went to, so `start` and `cmd_frame_launch` both
+    stay quiet for it — repeating it under charter's red ✗ would report the operator's own
+    answer as a rule firing, and a pane must not wait for Enter under a question its operator
+    has just answered. And `_launch`'s `--no-frame` branch passes the OPEN's `attended`
+    rather than `sys.stdin.isatty() and sys.stdout.isatty()`, which Task 2 conflated: they
+    are different questions now that `can_ask` exists, and the old spelling made
+    `charter <profile> --no-frame > log` say "nobody is at this open" about a command
+    somebody had just typed instead of the `NEEDS_ASKING` this table's own row asks for.
 - `charter/commands_frame.py`:
   - `_launch`'s pre-tmux step 5: ask when `attended` and `profiletrust.can_ask(sys.stdin, sys.stdout)`. Defer to the pane
     only a `KIND_ASK` refusal, and only when attended with no terminal (`+`, a tab). Every other
@@ -1576,8 +1586,10 @@ def fingerprint(p: profiles.Profile) -> dict: ...
     # {"kind": p.kind, "command": list(p.command), "env": dict(p.env)} — as DECLARED, before
     # `~` expansion: the file is what an edit changes, and HOME is not something a chat moves
 def last_launched(name: str) -> dict | None: ...
-def record_launched(p: profiles.Profile) -> str: ...     # "" once written; the OSError's text otherwise. Never raises
-RECORD_NOT_WRITTEN = ("charter: you approved profile '{name}', but charter could not record that "
+def record_launched(p: profiles.Profile) -> str: ...     # "" once written; the OSError's own
+    # strerror otherwise, WITHOUT the path — every caller that quotes one already names it, so
+    # returning it here printed it twice (as built). Never raises
+RECORD_NOT_WRITTEN = ("you approved profile '{name}', but charter could not record that "
     "at {path} ({why}), so it will not start it — it would only ask you again. Nothing was "
     "started; fix that path and run it again.")
 def approval_needed(p: profiles.Profile) -> str: ...     # "" | "new" | "changed"; built-ins ""
@@ -1586,11 +1598,18 @@ def refusal(p: profiles.Profile, *, attended: bool) -> "launcher.Refusal | None"
     # attended — the caller asks if can_ask, and prints the text otherwise;
     # Refusal(KIND_UNATTENDED, UNATTENDED formatted, REFUSED_EXIT) when not. Callers branch
     # on kind, never on text (re-review N2)
-def ask_in_terminal(p: profiles.Profile, *, stdin, stdout) -> bool: ...
-    # prints the command and env, reads one line, True only for "y"/"yes"; records on True
-NEEDS_ASKING = ("charter: profile '{name}' is {state} since it last ran, and charter asks "
-    "before such a command runs — but there is no terminal here to ask in. Nothing was "
+class Answer(NamedTuple): yes: bool; why: str     # the fourth review's nit, as built: a yes
+    # has two outcomes and they are not the same launch — approved-and-recorded, and
+    # approved-and-NOT-recorded, which refuses (N2b). `why` is "" on every other path.
+def ask_in_terminal(p: profiles.Profile, *, stdin, stdout) -> Answer: ...
+    # prints the command and env, reads one line, yes only for "y"/"yes"; records on a yes,
+    # and says "charter: nothing started." on *stdout* for anything else — the terminal the
+    # question went to, in `_choose_workspace`'s own words for a cancel
+NEEDS_ASKING = ("profile '{name}' is {state}, and charter asks before it runs a command it "
+    "has not been shown before — but there is no terminal here to ask in, so nothing was "
     "started. Run it where you can answer: charter {name}")
+    # As built: "{state} since it last ran" read as false for the `new` state, which has
+    # never run at all. Same for UNATTENDED and REOPEN_UNAPPROVED below.
 def can_ask(stdin, stdout) -> bool: ...     # both isatty(); a terminal on one side only is not one
 ```
 

--- a/tests/_isolation.py
+++ b/tests/_isolation.py
@@ -390,6 +390,104 @@ def declare_profiles(case, text: str = DECLARED_PROFILES) -> Path:
     return local
 
 
+class Typed:
+    """A terminal somebody is sitting at, holding the lines they are about to type.
+
+    Replacing ``sys.stdin`` outright is how a test declares its terminal-ness to
+    `tests/_ttyguard` — the guard's own stream is not consulted at all — and it is the only
+    way to count the READS, which is what "asked exactly once" is an assertion about. A
+    read with nothing left is an error rather than an empty string, because a second
+    question is the failure two of those cases exist to catch.
+    """
+
+    def __init__(self, *lines: str) -> None:
+        self.lines = list(lines)
+        self.reads = 0
+
+    def isatty(self) -> bool:
+        return True
+
+    def readline(self) -> str:
+        self.reads += 1
+        if not self.lines:
+            raise AssertionError("nothing here was going to answer a second question")
+        return self.lines.pop(0)
+
+
+class APipe:
+    """The other end of the same question: not a terminal, and never read from or written
+    to — a read here is a launch waiting on something that cannot answer."""
+
+    def isatty(self) -> bool:
+        return False
+
+    def readline(self) -> str:
+        raise AssertionError("nobody is here to answer a question")
+
+    def write(self, text: str) -> None:
+        raise AssertionError("nothing may be asked of a stream that is not a terminal")
+
+
+class ATerminal(io.StringIO):
+    """A `StringIO` that says it is a terminal: the screen half of an ask, kept where a
+    test can read back what was drawn on it."""
+
+    def isatty(self) -> bool:
+        return True
+
+
+def approve_profile(case, name: str = "claude-work"):
+    """Seed *name*'s launch record, the way an operator who already said yes once has.
+
+    **A real-tmux test that launches a declared profile has to call this** (Global
+    Constraint, N6). `_launch` passes `--attended` for an open somebody is in front of,
+    and a real pane has a terminal on both of its ends — so a declared profile with no
+    record does exactly what it promises there: it prints its command and waits at
+    `run this? [y/N]` until the suite's own 600 s watchdog kills the run. A hang is not a
+    verdict, and this is the one line that keeps it from being one.
+
+    The profile, so a caller can assert about the very object the record was made from.
+    `profiletrust` is imported here rather than at the top for ruling 43's reason: this
+    module is imported by most of the suite, and profile code stays off that path.
+    """
+    from charter import profiles, profiletrust
+
+    p = profiles.current().profiles[name]
+    why = profiletrust.record_launched(p)
+    case.assertEqual(why, "", f"the launch record for '{name}' could not be written")
+    return p
+
+
+def approve_every_profile(case) -> None:
+    """:func:`approve_profile` for every profile this plane declares right now.
+
+    For a fixture whose cases are about something else entirely — which profile a `+`
+    carries, what a refusal says about `PATH` — where naming each one would be a list that
+    goes stale the next time the fixture grows a profile. Called AFTER a case rewrites
+    `charter.local.toml`, because it records what is declared at the moment it runs.
+    """
+    from charter import profiles
+
+    for name in profiles.current().profiles:
+        approve_profile(case, name)
+
+
+def assert_approved(name: str = "claude-work") -> None:
+    """Fail now, before tmux, if *name* has no launch record — :func:`approve_profile`'s
+    other half.
+
+    A missing record is a **hang** rather than a failure once a real pane is involved, and
+    a hang costs the whole run its verdict. Asked before the launch so the message names
+    the fixture's mistake instead of arriving as a watchdog kill fifteen minutes later.
+    """
+    from charter import profiles, profiletrust
+
+    p = profiles.current().profiles.get(name)
+    if p is None or profiletrust.approval_needed(p):
+        raise AssertionError(
+            f"no launch record for '{name}' — its pane would wait at run this? [y/N]")
+
+
 def isolate_state_dir(case) -> Path:
     """Point ``config.STATE_DIR`` at a throwaway dir for one test case, restoring after.
 

--- a/tests/test_a_chat_carries_its_profile.py
+++ b/tests/test_a_chat_carries_its_profile.py
@@ -25,9 +25,11 @@ from types import SimpleNamespace
 from unittest import mock
 
 from charter import commands_frame, config
-from charter.frame import chats, choose, launcher, leave, reopen as reopen_state, state
+from charter.frame import chats, choose, leave, reopen as reopen_state, state
 from tests import _gitguard
-from tests._isolation import PersonaIso, declare_profiles, make_plane
+from tests._isolation import (APipe as _APipe, PersonaIso,
+                              approve_every_profile, approve_profile,
+                              declare_profiles, make_plane)
 
 
 #: The real `subprocess.run`, captured before any fixture below patches the module
@@ -76,16 +78,23 @@ class _APressInAlpha(PersonaIso):
         for ws in ("alpha", "beta"):
             (config.WORKSPACES_DIR / ws).mkdir(parents=True, exist_ok=True)
         _a_chat(self.FID, ws="alpha", profile="claude-work")
+        # **A press has no terminal**, stated rather than inherited (`tests/_ttyguard`).
+        # `builtin_actions._spawn` runs `cmd_new_chat` detached with all three streams on
+        # `/dev/null`, which is what decides that the one question a profile can raise is
+        # deferred to the pane (`_the_pane_will_ask`) rather than asked here.
+        self.enterContext(mock.patch("sys.stdin", _APipe()))
         self.said = self.enterContext(
             mock.patch("charter.commands_frame._say_on_screen"))
         self.launched: list = []
 
     def _no_approval_needed(self) -> None:
-        """Task 2 refuses every declared profile (review B1), and these cases are about
-        which profile is CARRIED. The two that are about the refusal reaching the presser do
-        not stand it down."""
-        self.enterContext(mock.patch.object(launcher, "_approval_refusal",
-                                            return_value=None))
+        """Seed a launch record for every profile this plane declares.
+
+        These cases are about which profile is CARRIED by a press, a tab or a handoff, and
+        a profile charter has never run asks its own question first (Task 3). The cases
+        that are about that question do not seed one.
+        """
+        approve_every_profile(self)
 
     def _tmux(self, cmd, **kw):
         """Answer the two tmux questions a press asks, and let everything else through.
@@ -205,14 +214,24 @@ class ANewChatTakesThePressersProfile(_APressInAlpha, unittest.TestCase):
 class APressThatCannotLaunchSaysWhyOnTheFrame(_APressInAlpha, unittest.TestCase):
     """`cmd_new_chat` runs detached with its three streams on `/dev/null`, so a refusal
     `_launch` printed is read by nobody: without this the `+` would report only "the
-    launcher returned 3" for a profile the operator could have fixed. Review B1 makes this
-    reachable today — every declared profile is refused until Task 3."""
+    launcher returned 3" for a profile the operator could have fixed in a line."""
 
     def test_the_press_says_the_launchers_own_refusal(self):
-        self._press()
+        self._no_approval_needed()
+        with mock.patch("charter.commands_frame.shutil.which", return_value=None):
+            self._press()
         self.assertEqual(self.launched, [])
-        self.assertTrue(any("cannot yet ask before a declared command runs" in s
-                            for s in self._sentences()), self._sentences())
+        self.assertTrue(any("not on PATH" in s for s in self._sentences()),
+                        self._sentences())
+
+    def test_a_press_defers_the_one_question_the_pane_can_ask_itself(self):
+        """N2a's nit, on the surface it matters on. A profile nobody has approved is not a
+        refusal a `+` reports — the pane it opens has a terminal on both ends and asks
+        there. Reported here instead, the press would say "charter asks before it runs a
+        command it has not been shown before" and open no chat at all."""
+        self._press()
+        self.assertEqual(len(self.launched), 1, self._sentences())
+        self.assertEqual(self.launched[0].profile, "claude-work")
 
 
 class AWorkspaceTabOpensTheSameProfile(_APressInAlpha, unittest.TestCase):
@@ -266,10 +285,13 @@ class AHandoffTakesTheCallingChatsProfile(_APressInAlpha, unittest.TestCase):
         self.assertEqual(self.launched[0].profile, "claude-work")
         self.assertEqual(self.launched[0].harness, "claude")
 
-    def test_a_handoff_to_a_declared_profile_refuses_before_anything_is_written(self):
-        """Review B1: the refusal is the whole answer a handoff gets, before a chat
-        directory, a window or a first message exists anywhere."""
-        self.assertIn("cannot yet ask before a declared command runs", self._refusal())
+    def test_a_handoff_to_an_unapproved_profile_refuses_before_anything_is_written(self):
+        """Nobody is at a chat a handoff opens, so the question cannot be put and the
+        refusal is the whole answer — before a chat directory, a window or a first message
+        exists anywhere. It names the one command that would approve it."""
+        said = self._refusal()
+        self.assertIn("nobody is at this open to approve it", said)
+        self.assertIn("charter claude-work", said)
 
     def test_a_profile_whose_kind_this_charter_cannot_place_is_refused_not_raised(self):
         """The guard `_same_harness_as` carried before profiles, restored.
@@ -351,8 +373,9 @@ class AReopenNeverSubstitutes(PersonaIso, unittest.TestCase):
         self.local = declare_profiles(self)
         (config.WORKSPACES_DIR / "alpha").mkdir(parents=True, exist_ok=True)
         self.launched: list = []
-        self.enterContext(mock.patch.object(launcher, "_approval_refusal",
-                                            return_value=None))
+        # What an operator who has already run this profile once leaves behind: these cases
+        # are about which profile comes back, not about the question a new one asks.
+        approve_profile(self)
 
     def _chat(self, **kw):
         fields = dict(chat="alpha.1", workspace="alpha", persona="", harness="claude-code",

--- a/tests/test_a_chat_pane_starts_as_charter_and_becomes_the_harness.py
+++ b/tests/test_a_chat_pane_starts_as_charter_and_becomes_the_harness.py
@@ -38,8 +38,9 @@ from charter import commands_frame, config
 from charter.frame import launcher, state, tmuxctl
 
 from tests import _gitguard, _tmuxreap, _tmuxsocket, _ttyguard
-from tests._isolation import (PersonaIso, declare_profiles, make_plane,
-                              no_background_refresh, no_update_check_in)
+from tests._isolation import (PersonaIso, approve_profile, assert_approved,
+                              declare_profiles, make_plane, no_background_refresh,
+                              no_update_check_in)
 
 _HAS_TMUX = shutil.which("tmux") is not None
 
@@ -56,14 +57,23 @@ _SERVERS = itertools.count()
 #: happened.
 _REPO_ROOT = Path(__file__).resolve().parents[1]
 
-#: One declared profile whose command really resolves here: the recorder on this fixture's
-#: own `PATH` is `claude`, so what the pane refuses is the DECLARATION (review B1) rather
-#: than a command that was never going to run.
+#: One declared profile whose command really resolves here — the recorder on this fixture's
+#: own `PATH` is `claude` — so a pane that starts it really becomes it.
 _LOCAL = """
 [harness.claude-work]
 kind = "claude"
 command = ["claude"]
 env = { CLAUDE_CONFIG_DIR = "~/.cw" }
+"""
+
+#: And one whose command exists nowhere, for the pane that has to REFUSE. Since Task 3 an
+#: unapproved profile in an attended pane asks rather than refuses, so a refusal that
+#: reaches a real pane has to come from another link in the chain: this is `NOT_ON_PATH`,
+#: which is the one an operator actually meets (a harness uninstalled, a path typo).
+_NOWHERE = """
+[harness.claude-work]
+kind = "claude"
+command = ["charter-has-no-such-harness-here"]
 """
 
 
@@ -150,7 +160,20 @@ class _ARealChatOnARealServer(PersonaIso):
         return subprocess.run([self.tmux, "-L", self.socket, *args], capture_output=True,
                               text=True, timeout=20)
 
-    def _launch(self, **ns) -> int:
+    def _launch(self, *, unapproved: bool = False, **ns) -> int:
+        """The real `_launch`, against the real server this case started.
+
+        **A declared profile is checked for its launch record first** (Global Constraint,
+        N6): `_launch` passes `--attended` for an open somebody is in front of, and a real
+        pane has a terminal on both ends — so a profile with no record stops that pane at
+        `run this? [y/N]` and waits until the suite's own 600 s watchdog. That is a hang
+        rather than a failure, and a hang costs the whole run its verdict, so it is caught
+        here, before tmux, where it names the fixture's mistake. *unapproved* is how the
+        one case that is ABOUT that question says so.
+        """
+        name = ns.get("profile")
+        if name and not unapproved:
+            assert_approved(name)
         args = SimpleNamespace(**{"harness": "claude", "rest": [], "no_frame": False,
                                   "workspace": self.WS, "pick": False, "attach": False,
                                   "size": (120, 40), **ns})
@@ -237,6 +260,26 @@ class ThePaneCharterStartsIsThePaneTheHarnessRunsIn(_ARealChatOnARealServer,
             self.assertNotIn("CHARTER_HARNESS_PROFILE", said,
                              "the profile crossed tmux, where only its name may go")
 
+    def test_a_declared_profiles_env_reaches_the_harness_and_not_tmux(self):
+        """L6 for a profile the FILE declares, which is the case the constraint exists for:
+        `env` is set at the `exec` in the pane, so nothing of it joins `layout.CARRIABLE`
+        or crosses tmux's own argument parser — and tmux's environment holds no trace of
+        either the variable or its value."""
+        (self.tmp / "alt").mkdir()
+        declare_profiles(self, f'[harness.claude-work]\nkind = "claude"\n'
+                               f'command = ["claude"]\n'
+                               f'env = {{ CLAUDE_CONFIG_DIR = "{self.tmp / "alt"}" }}\n')
+        approve_profile(self)
+        self.assertEqual(self._launch(profile="claude-work"), 0)
+        harness = self._harness()
+        self.assertEqual(harness["env"].get("CLAUDE_CONFIG_DIR"), str(self.tmp / "alt"))
+        self.assertEqual(harness["env"].get("CHARTER_HARNESS_PROFILE"), "claude-work")
+        for scope in (("show-environment", "-g"),
+                      ("show-environment", "-t", state.workspace_prefix(self.WS))):
+            said = self._tmux(*scope).stdout
+            self.assertNotIn("CLAUDE_CONFIG_DIR", said)
+            self.assertNotIn(str(self.tmp / "alt"), said)
+
     def test_the_chat_is_framed_because_the_pane_proved_it(self):
         """Rulings 29 and 33 end to end: the launcher asked tmux whether its own pid was
         the `#{pane_pid}` of a live pane whose window is named for this chat, and kept the
@@ -270,9 +313,9 @@ class TheHarnessExitCodeTravelsAsItDid(_ARealChatOnARealServer, unittest.TestCas
 class ARefusalInThePaneReachesTheOperator(_ARealChatOnARealServer, unittest.TestCase):
     """Ruling 42, both halves, against a real pane.
 
-    The plane declares a profile, so the pane's own launcher refuses it (review B1) — while
-    the check this process makes before tmux is stood down, which is exactly the state the
-    two checks exist for: the plane can move between them.
+    The plane declares a profile whose command exists nowhere, so the pane's own launcher
+    refuses it — while the check this process makes before tmux is stood down, which is
+    exactly the state the two checks exist for: the plane can move between them.
     """
 
     SLUG = "pane-refusal"
@@ -283,7 +326,10 @@ class ARefusalInThePaneReachesTheOperator(_ARealChatOnARealServer, unittest.Test
         # ceiling that stops git's walk above this throwaway plane. It carries
         # `tests._gitguard.environment()` into the git it runs, which is what every other
         # module here does and what `tests._planeguard.AmbientGitConfig` holds them to.
-        self.local = declare_profiles(self, _LOCAL)
+        self.local = declare_profiles(self, _NOWHERE)
+        # Approved, so what the pane refuses is the missing command rather than the
+        # question `ThePaneAsksBeforeItRunsANewCommand` below is about.
+        approve_profile(self)
         # Only the pre-tmux call, in THIS process. The pane's launcher is another process
         # and runs the whole chain for itself, which is the half under test.
         self.enterContext(mock.patch.object(launcher, "refusal", return_value=None))
@@ -293,7 +339,7 @@ class ARefusalInThePaneReachesTheOperator(_ARealChatOnARealServer, unittest.Test
         fid = "beta.1"
         pane = state.harness_pane(fid)
         self.assertTrue(_eventually(
-            lambda: "cannot yet ask before a declared command runs" in self._pane_text(pane)),
+            lambda: "which is not on PATH" in self._pane_text(pane)),
             f"the pane never showed the refusal: {self._pane_text(pane)!r}")
         # **The property ruling 42 is about**: it is still there to be read. A launcher that
         # printed and exited would have had its window killed by the teardown hook 6-14 ms
@@ -334,10 +380,60 @@ class ARefusalInThePaneReachesTheOperator(_ARealChatOnARealServer, unittest.Test
         with mock.patch.object(commands_frame.util, "err", side_effect=said.append):
             rc = self._launch(profile="claude-work",
                               opening=commands_frame.Opening("fix the widget please"))
-        self.assertEqual(rc, launcher.REFUSED_EXIT)
-        self.assertTrue(
-            any("cannot yet ask before a declared command runs" in s for s in said),
-            f"the launch did not report what the pane refused: {said}")
+        # 127, the shell's own number for a command that is not there, and the launcher's
+        # for it — carried out of the pane by the record rather than reconstructed.
+        self.assertEqual(rc, launcher.MISSING_EXIT)
+        self.assertTrue(any("which is not on PATH" in s for s in said),
+                        f"the launch did not report what the pane refused: {said}")
+
+
+@unittest.skipUnless(_HAS_TMUX, "no tmux on this machine")
+class ThePaneAsksBeforeItRunsANewCommand(_ARealChatOnARealServer, unittest.TestCase):
+    """Task 3's question, in the place the plan says it is asked: the chat's own pane.
+
+    A `+`, a workspace tab and the palette's new chat are all a single press by a process
+    with `/dev/null` for streams, so charter cannot put the question where the press
+    happened — but the pane it opens has a terminal on both of its ends. This is that pane,
+    on a real server, with a real `y` sent to it.
+    """
+
+    SLUG = "pane-asks"
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.local = declare_profiles(self, _LOCAL)
+        # No `approve_profile`: this is the one case that is ABOUT the missing record, and
+        # `_launch(unapproved=True)` is how it says so to the guard that would fail fast.
+        self.enterContext(mock.patch.object(launcher, "refusal", return_value=None))
+
+    def test_the_pane_shows_the_command_and_waits_for_an_answer(self):
+        self.assertEqual(self._launch(profile="claude-work", unapproved=True), 0)
+        pane = state.harness_pane("beta.1")
+        self.assertTrue(_eventually(lambda: "run this? [y/N]" in self._pane_text(pane)),
+                        f"the pane never asked: {self._pane_text(pane)!r}")
+        drawn = self._pane_text(pane)
+        self.assertIn("command  claude", drawn)
+        self.assertIn("CLAUDE_CONFIG_DIR=~/.cw", drawn)
+        self.assertFalse((self.records / "harness.json").is_file(),
+                         "the command ran before anybody answered the question")
+
+    def test_a_yes_starts_the_harness_and_is_not_asked_again(self):
+        """And the record it leaves is what makes it *once*: the second launch of the same
+        profile runs the command with nothing to answer, which is the whole promise of the
+        feature's own title."""
+        self.assertEqual(self._launch(profile="claude-work", unapproved=True), 0)
+        pane = state.harness_pane("beta.1")
+        self.assertTrue(_eventually(lambda: "run this? [y/N]" in self._pane_text(pane)),
+                        f"the pane never asked: {self._pane_text(pane)!r}")
+        sent = self._tmux("send-keys", "-t", pane, "y", "Enter")
+        self.assertEqual(sent.returncode, 0, sent.stderr)
+        harness = self._harness()
+        self.assertEqual(harness["env"].get("CHARTER_HARNESS_PROFILE"), "claude-work")
+        self.assertEqual(harness["env"].get("CLAUDE_CONFIG_DIR"),
+                         str(self.home / ".cw"))
+        # Written by the PANE's own process, into this plane's state directory — which is
+        # what `assert_approved` reads and what every later open of this profile finds.
+        assert_approved("claude-work")
 
 
 @unittest.skipUnless(_HAS_TMUX, "no tmux on this machine")
@@ -360,7 +456,8 @@ class ARefusalInsideTheOperatorsOwnTmux(_ARealChatOnARealServer, unittest.TestCa
 
     def setUp(self) -> None:
         super().setUp()
-        self.local = declare_profiles(self, _LOCAL)
+        self.local = declare_profiles(self, _NOWHERE)
+        approve_profile(self)
         self.enterContext(mock.patch.object(launcher, "refusal", return_value=None))
         # An operator's own server: started by NAME so `tests._tmuxreap` can collect it,
         # and reached by PATH, which is what `tmuxctl.is_operator_socket` reads as "a tmux
@@ -390,13 +487,12 @@ class ARefusalInsideTheOperatorsOwnTmux(_ARealChatOnARealServer, unittest.TestCa
         with mock.patch.object(commands_frame.util, "err", side_effect=said.append):
             rc = self._launch(profile="claude-work",
                               opening=commands_frame.Opening("fix the widget please"))
-        self.assertTrue(
-            any("cannot yet ask before a declared command runs" in s for s in said),
-            f"the launch did not say what the pane refused: {said}")
+        self.assertTrue(any("which is not on PATH" in s for s in said),
+                        f"the launch did not say what the pane refused: {said}")
         # The launcher's own number, not tmux's reading of a pane that is no longer there:
         # in somebody else's tmux `#{pane_dead_status}` is empty or absent for exactly this
         # pane, and both read as `_UNKNOWN_DEATH_CODE`.
-        self.assertEqual(rc, launcher.REFUSED_EXIT, said)
+        self.assertEqual(rc, launcher.MISSING_EXIT, said)
 
     def test_the_window_it_opened_is_taken_back(self):
         """A window the operator never asked for, holding a chat that never started, is not

--- a/tests/test_a_new_or_changed_profile_asks_once.py
+++ b/tests/test_a_new_or_changed_profile_asks_once.py
@@ -1,0 +1,959 @@
+"""A profile whose command is new or has changed shows it and asks once, before it runs.
+
+Charter records each profile's `kind`, `command` and `env` as last launched, under
+`.charter/`. A profile with no record, or one that no longer matches, is shown to the
+operator and asked `run this? [y/N]` before anything starts. Built-ins never ask: their
+command comes out of charter's own registry rather than out of a file (spec, *What guards
+a launch*, item 2).
+
+**Why there is an ask at all.** Once `charter.local.toml` is ignored an edit to it leaves
+no diff; nothing stops a chat editing plane config; and the command goes to tmux rather
+than through a harness's own permission prompt. Codex trusts hooks by hash for the same
+reason.
+
+**And where there is nobody to ask, there is a refusal instead.** A reopen, a restore, a
+handoff and any open with no terminal on both stdin and stdout refuse where they would have
+asked (review 3, ruling 23) — a question nobody can see is a pane that hangs, which is the
+one outcome worse than a refusal.
+
+This module is also where the two lines Task 2's sweep could not measure are pinned, for
+the reason the sweep gives: each of those mutations hangs a real-tmux case instead of
+failing it, and a run that timed out is neither green nor red. Both are a second of test
+time here (:class:`ThePinsARealTmuxCaseCouldOnlyHangOn`).
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import os
+import shutil
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
+
+from charter import commands_frame, config, profiles, profiletrust
+from charter.frame import launcher, reopen as reopen_state, state
+from tests import _gitguard
+from tests._isolation import (APipe as _APipe, ATerminal as _ATerminal, PersonaIso,
+                              Typed as _Typed, approve_profile, assert_approved,
+                              declare_profiles, make_plane)
+from tests.test_a_profile_launch_is_refused_before_tmux import _ALaunchNamesAProfile
+
+
+class _ADeclaringPlane(PersonaIso):
+    """A plane declaring `claude-work`, in a git repository that ignores the local file."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        make_plane(self)
+        self.enterContext(mock.patch.dict(
+            os.environ,
+            {"PATH": os.environ.get("PATH", ""),
+             "CHARTER_ROOT": str(config.ROOT), **_gitguard.environment()}, clear=True))
+        # AFTER the clearing patch, so its `$HOME` and `$GIT_CEILING_DIRECTORIES` survive:
+        # the ignore check is a real `git status` and both decide what it answers.
+        self.local = declare_profiles(self)
+
+    def _profile(self, name: str = "claude-work") -> profiles.Profile:
+        return profiles.current().profiles[name]
+
+
+class TheRecord(_ADeclaringPlane, unittest.TestCase):
+    """What charter writes down when a profile runs, and what it makes of it next time."""
+
+    def test_a_built_in_never_needs_approval(self):
+        """The spec says so, and the reason is what the record is FOR: a built-in's
+        command comes out of charter's own registry, which no chat can edit. Asking about
+        it would train an operator to answer yes to a question that never carries risk."""
+        self.assertEqual(profiletrust.approval_needed(self._profile("codex")), "")
+
+    def test_a_declared_profile_with_no_record_is_new(self):
+        self.assertEqual(profiletrust.approval_needed(self._profile()), profiletrust.NEW)
+
+    def test_a_recorded_profile_is_approved(self):
+        profiletrust.record_launched(self._profile())
+        self.assertEqual(profiletrust.approval_needed(self._profile()), "")
+
+    def test_a_changed_command_is_changed(self):
+        profiletrust.record_launched(self._profile())
+        self.local.write_text('[harness.claude-work]\nkind = "claude"\n'
+                              'command = ["/opt/claude-2.1/bin/claude"]\n')
+        self.assertEqual(profiletrust.approval_needed(self._profile()),
+                         profiletrust.CHANGED)
+
+    def test_a_changed_env_value_is_changed(self):
+        """The `env` is half of what a profile IS — it is what moves the account — so a
+        record that compared only the command would approve a profile pointed at somebody
+        else's config folder."""
+        profiletrust.record_launched(self._profile())
+        self.local.write_text('[harness.claude-work]\nkind = "claude"\n'
+                              'command = ["claude"]\n'
+                              'env = { CLAUDE_CONFIG_DIR = "~/.someone-else" }\n')
+        self.assertEqual(profiletrust.approval_needed(self._profile()),
+                         profiletrust.CHANGED)
+
+    def test_a_changed_kind_is_changed(self):
+        profiletrust.record_launched(self._profile())
+        self.local.write_text('[harness.claude-work]\nkind = "codex"\n'
+                              'command = ["claude"]\n'
+                              'env = { CLAUDE_CONFIG_DIR = "~/.cw" }\n')
+        self.assertEqual(profiletrust.approval_needed(self._profile()),
+                         profiletrust.CHANGED)
+
+    def test_a_declared_replacement_of_a_built_in_asks(self):
+        """`[harness.claude]` is a declaration, whatever it is called: the name is the
+        built-in's and the command is the file's, and the command is what this is about."""
+        self.local.write_text('[harness.claude]\nkind = "claude"\n'
+                              'command = ["/opt/claude"]\n')
+        self.assertEqual(profiletrust.approval_needed(self._profile("claude")),
+                         profiletrust.NEW)
+
+    def test_the_record_is_private_state_under_charter(self):
+        """The name and the shape are spelled literally: a round trip through charter's own
+        writer and reader cannot pin a key that both halves would rename together."""
+        profiletrust.record_launched(self._profile())
+        path = config.STATE_DIR / "harness-profiles-launched.json"
+        self.assertEqual(path.stat().st_mode & 0o077, 0)
+        self.assertEqual(json.loads(path.read_text()),
+                         {"claude-work": {"kind": "claude", "command": ["claude"],
+                                          "env": {"CLAUDE_CONFIG_DIR": "~/.cw"}}})
+
+    def test_the_record_is_what_the_file_says_and_not_what_the_exec_gets(self):
+        """As DECLARED, before `~` is expanded. The file is what an edit changes, and
+        `$HOME` is not something a chat moves — a record of the expansion would read as
+        *changed* for every profile the day somebody's home directory moved."""
+        profiletrust.record_launched(self._profile())
+        raw = json.loads((config.STATE_DIR / "harness-profiles-launched.json").read_text())
+        self.assertEqual(raw["claude-work"]["env"]["CLAUDE_CONFIG_DIR"], "~/.cw")
+        self.assertNotIn(str(self.home), json.dumps(raw))
+
+    def test_recording_one_profile_leaves_the_others_recorded(self):
+        """One object keyed by name, so approving `codex-pinned` today does not make
+        `claude-work` ask again tomorrow."""
+        profiletrust.record_launched(self._profile())
+        profiletrust.record_launched(self._profile("codex-pinned"))
+        self.assertEqual(profiletrust.approval_needed(self._profile()), "")
+        self.assertEqual(profiletrust.approval_needed(self._profile("codex-pinned")), "")
+
+    def test_the_first_record_makes_the_state_directory_it_lives_in(self):
+        """A plane that has never written any state has no `.charter/` yet, and the first
+        profile somebody approves is allowed to be the thing that creates it — at 0700,
+        through `config.private_mkdir`, because the umask must not decide the mode of
+        charter's own state directory (#437)."""
+        shutil.rmtree(config.STATE_DIR, ignore_errors=True)
+        self.assertEqual(profiletrust.record_launched(self._profile()), "")
+        self.assertEqual(profiletrust.approval_needed(self._profile()), "")
+        self.assertEqual(config.STATE_DIR.stat().st_mode & 0o077, 0)
+
+    def test_an_unreadable_record_asks_again(self):
+        """It fails towards ASKING, never towards running: a file charter cannot read says
+        nothing about what the operator approved, and treating silence as a yes is exactly
+        the state this record exists to keep out."""
+        config.private_mkdir(config.STATE_DIR)
+        (config.STATE_DIR / "harness-profiles-launched.json").write_text("{nope")
+        self.assertEqual(profiletrust.approval_needed(self._profile()), profiletrust.NEW)
+
+    def test_a_record_of_the_wrong_shape_asks_again(self):
+        """Same rule one level down: the file is a plain JSON object a chat can write, so
+        an entry that is a string rather than a fingerprint is not an approval either."""
+        config.private_mkdir(config.STATE_DIR)
+        (config.STATE_DIR / "harness-profiles-launched.json").write_text(
+            '{"claude-work": "approved, honest"}')
+        self.assertEqual(profiletrust.approval_needed(self._profile()), profiletrust.NEW)
+
+    def test_a_record_that_is_not_an_object_at_all_asks_again(self):
+        """And one level up from that: the whole file is JSON a chat can write, so a list
+        where an object belongs reads as no records rather than as an `AttributeError` in
+        the middle of a launch."""
+        config.private_mkdir(config.STATE_DIR)
+        (config.STATE_DIR / profiletrust.RECORD).write_text("[]")
+        self.assertEqual(profiletrust.approval_needed(self._profile()), profiletrust.NEW)
+
+    def test_a_record_that_cannot_be_written_says_why_and_never_raises(self):
+        """`record_launched` is called from a launch that is about to `exec`, and from a
+        hook-reachable press: it hands back the reason instead of raising it."""
+        # Both shapes an `OSError` arrives in, because the sentence has to name something
+        # either way: the filesystem's own `strerror`, and one raised with a message and no
+        # errno at all — where an empty answer would read to `ask_in_terminal` as a write
+        # that worked, and the launch would go ahead on a record that is not there.
+        for raised, expected in ((OSError(28, "No space left on device"),
+                                  "No space left on device"),
+                                 (OSError("the disk is read-only"),
+                                  "the disk is read-only")):
+            with self.subTest(raised=raised):
+                with mock.patch.object(profiletrust.config, "replace_for",
+                                       side_effect=raised):
+                    why = profiletrust.record_launched(self._profile())
+                self.assertIn(expected, why)
+                self.assertEqual(profiletrust.approval_needed(self._profile()),
+                                 profiletrust.NEW)
+
+
+class TheAsk(_ADeclaringPlane, unittest.TestCase):
+    """The prompt itself: what it shows, what it accepts, and what it writes down."""
+
+    def _ask(self, answer: str = "y\n", name: str = "claude-work"):
+        stdin, out = _Typed(answer), io.StringIO()
+        got = profiletrust.ask_in_terminal(self._profile(name), stdin=stdin, stdout=out)
+        return got, out.getvalue(), stdin
+
+    def test_it_shows_the_command_and_the_env_before_asking(self):
+        _got, said, _stdin = self._ask()
+        self.assertIn("command  claude", said)
+        self.assertIn("CLAUDE_CONFIG_DIR=~/.cw", said)
+        self.assertTrue(said.rstrip().endswith("run this? [y/N]"), said)
+
+    def test_it_says_which_profile_and_why_it_is_asking(self):
+        _got, said, _stdin = self._ask()
+        self.assertIn("claude-work", said)
+        self.assertIn("has not run on this machine before", said)
+
+    def test_yes_records_and_runs(self):
+        got, _said, stdin = self._ask()
+        self.assertEqual(got, profiletrust.Answer(True, ""))
+        self.assertEqual(profiletrust.approval_needed(self._profile()), "")
+        self.assertEqual(stdin.reads, 1, "one question, read once")
+
+    def test_yes_spelled_out_and_in_capitals_is_still_yes(self):
+        for answer in ("yes\n", "Y\n", "  y  \n"):
+            with self.subTest(answer=answer):
+                # Back to a plane that has never run this profile: the previous answer
+                # recorded one, and a second question is never asked of an approved one.
+                (config.STATE_DIR / profiletrust.RECORD).unlink(missing_ok=True)
+                got, _said, _stdin = self._ask(answer)
+                self.assertTrue(got.yes)
+
+    def test_anything_else_declines_and_records_nothing(self):
+        """A default of no is the whole point, so end-of-input and a fat finger both land
+        on it. `""` is the closed stream: a launch driven from a script must decline rather
+        than loop asking."""
+        for answer in ("\n", "n\n", "no\n", "yess\n", ""):
+            with self.subTest(answer=answer):
+                got, _said, _stdin = self._ask(answer)
+                self.assertEqual(got, profiletrust.Answer(False, ""))
+                self.assertEqual(profiletrust.approval_needed(self._profile()),
+                                 profiletrust.NEW)
+
+    def test_a_profile_approved_since_the_question_was_settled_is_not_asked_about(self):
+        """**The two reads are two moments, and the record can move between them** (S1).
+        `refusal` reads it to decide there is a question; this reads it again to build the
+        prompt — and in between a second terminal, the pane a `+` opened, or the chat this
+        module's own docstring names can have written it. A profile that matches by then is
+        APPROVED: it starts, with no question and no prompt.
+
+        Both streams refuse to be touched, so this is "nothing was asked" rather than
+        "something was asked quickly" — and before the fix it was neither: `HEADLINE[""]`
+        raised `KeyError('')` out of a launcher, in a pane, which is the one thing this
+        function's own rule forbids.
+        """
+        profiletrust.record_launched(self._profile())
+        got = profiletrust.ask_in_terminal(self._profile(), stdin=_APipe(), stdout=_APipe())
+        self.assertEqual(got, profiletrust.Answer(True, ""))
+
+    def test_a_control_c_at_the_prompt_declines(self):
+        """^C at a question means "not this", and it must not come out of here as a
+        traceback in a pane the operator is looking at.
+
+        **Caught here rather than allowed to escape**, and that is a decision about the
+        SWEEP rather than about the prompt. `unittest` reads a `KeyboardInterrupt` out of a
+        test as the operator interrupting the run: it stops the whole run and the process
+        dies on SIGINT. So an escaping one is not a red — it is a run that ended — and
+        `tools/sweep.py` could not resolve this guard at all while it was: CI answered
+        `unresolved` for narrowing it, which is neither green nor red and leaves the line
+        with no verdict. Caught, the same mutation is an ordinary failing assertion.
+        """
+        stdin = mock.Mock(readline=mock.Mock(side_effect=KeyboardInterrupt))
+        try:
+            got = profiletrust.ask_in_terminal(self._profile(), stdin=stdin,
+                                               stdout=io.StringIO())
+        except KeyboardInterrupt:
+            self.fail("^C at the prompt came out as a traceback instead of a decline")
+        self.assertEqual(got, profiletrust.Answer(False, ""))
+        self.assertEqual(profiletrust.approval_needed(self._profile()), profiletrust.NEW)
+
+    def test_control_bytes_in_a_command_are_shown_escaped_in_the_prompt(self):
+        """Ruling 35, and the reason this prompt exists at all: `charter.local.toml` is a
+        file a chat can write, so a `\\r` or an ESC in a `command` could redraw this very
+        line to show a harmless command while the operator approves another one."""
+        self.local.write_text('[harness.sneaky]\nkind = "claude"\n'
+                              'command = ["rm\\r\\u001b[2Kclaude"]\n')
+        _got, said, _stdin = self._ask(name="sneaky")
+        self.assertNotIn("\r", said)
+        self.assertNotIn("\x1b", said)
+        # `contain.readable`'s own spelling for a byte that is not printable ASCII.
+        self.assertIn("\\u000d", said)
+
+    def test_a_control_byte_in_an_env_value_is_shown_escaped_too(self):
+        """The `env` is on the prompt beside the command, and it comes out of the same
+        file — so it is the same hazard and it gets the same containment."""
+        self.local.write_text('[harness.sneaky]\nkind = "claude"\n'
+                              'command = ["claude"]\n'
+                              'env = { CLAUDE_CONFIG_DIR = "~/a\\u001b[2Kb" }\n')
+        _got, said, _stdin = self._ask(name="sneaky")
+        self.assertNotIn("\x1b", said)
+        self.assertIn("\\u001b", said)
+
+    def test_a_new_profile_has_nothing_it_was(self):
+        """The `was` row belongs to a CHANGE. On a profile that has never run there is
+        nothing to compare against, and a row saying so — blank, or repeating the command
+        back — would make the first question look like the second one."""
+        _got, said, _stdin = self._ask()
+        self.assertNotIn("was ", said)
+
+    def test_a_profile_with_no_environment_gets_no_env_row(self):
+        """A blank `env` row is a question about nothing, and it is the row that decides
+        WHICH ACCOUNT a chat runs as — so an empty one reads as "no account set" on a
+        profile that genuinely has none, and as noise everywhere else."""
+        self.local.write_text('[harness.plain]\nkind = "claude"\ncommand = ["claude"]\n')
+        _got, said, _stdin = self._ask(name="plain")
+        self.assertIn("command  claude", said)
+        self.assertNotIn("env ", said)
+
+    def test_the_prompt_shows_a_long_command_whole(self):
+        """**A sentence clips; a prompt does not** (F1). `contain.readable` stops each word
+        at 160 characters, and a command approved with its tail unseen is the one outcome
+        this whole feature is against: `--settings <somewhere else>` past that clip reads as
+        an ordinary `claude`. It wraps rather than hiding anything, and nothing on this
+        prompt ends in the `...` that would mean charter kept some of it back."""
+        tail = "z" * 400
+        self.local.write_text('[harness.wordy]\nkind = "claude"\n'
+                              f'command = ["claude", "--settings", "/tmp/{tail}"]\n')
+        _got, said, _stdin = self._ask(name="wordy")
+        self.assertIn(f"command  claude --settings /tmp/{tail}", said)
+        self.assertNotIn("...", said)
+
+    def test_a_long_environment_value_is_whole_on_the_prompt_too(self):
+        """The `env` is the half that decides WHICH ACCOUNT, so a config folder clipped to
+        its first 160 characters is exactly the value an operator must be able to read to
+        the end before saying yes."""
+        tail = "z" * 400
+        self.local.write_text('[harness.wordy]\nkind = "claude"\n'
+                              'command = ["claude"]\n'
+                              f'env = {{ CLAUDE_CONFIG_DIR = "/tmp/{tail}" }}\n')
+        _got, said, _stdin = self._ask(name="wordy")
+        self.assertIn(f"env      CLAUDE_CONFIG_DIR=/tmp/{tail}", said)
+        self.assertNotIn("...", said)
+
+    def test_a_long_command_is_whole_and_still_escaped(self):
+        """Whole is not raw: every byte outside printable ASCII is still an escape, at any
+        length. Not clipping and not escaping are two different decisions and only one of
+        them was made."""
+        tail = "z" * 400
+        self.local.write_text('[harness.wordy]\nkind = "claude"\n'
+                              f'command = ["cl\\raude{tail}"]\n')
+        _got, said, _stdin = self._ask(name="wordy")
+        self.assertIn(f"command  cl\\u000daude{tail}", said)
+        self.assertNotIn("\r", said)
+
+    def test_the_profiles_name_on_the_prompt_is_whole_as_well(self):
+        """Same rule for the headline: the name is what the last line tells somebody to
+        type, so a clipped one is a remedy nobody can run. The one-line REFUSALS still clip
+        it — `TheRefusalsWhereNobodyCanBeAsked` pins that — because a sentence that ends in
+        its remedy is the surface a 200-character name really does spoil."""
+        long_name = "w" * 200
+        self.local.write_text(f'[harness.{long_name}]\nkind = "claude"\n'
+                              'command = ["claude"]\n')
+        _got, said, _stdin = self._ask(name=long_name)
+        self.assertIn(long_name, said)
+        self.assertNotIn("...", said)
+
+    def test_what_it_was_reads_in_a_settled_order(self):
+        """Two variables in one record come back in whatever order JSON kept them, and a
+        `was` line that reordered itself between two asks would read as a change the
+        operator did not make. Sorted by name, like `profiles.Profile.env` itself."""
+        config.private_mkdir(config.STATE_DIR)
+        (config.STATE_DIR / profiletrust.RECORD).write_text(json.dumps(
+            {"claude-work": {"kind": "claude", "command": ["claude"],
+                             "env": {"ZZ_LAST": "z", "AA_FIRST": "a"}}}))
+        _got, said, _stdin = self._ask()
+        self.assertIn("was      AA_FIRST=a ZZ_LAST=z claude", said)
+
+    def test_a_record_missing_half_its_fingerprint_still_shows_a_was_row(self):
+        """The record is a file a chat can write, so an entry with no `env` — or no
+        `command` — is ordinary rather than exotic, and neither may come out of here as a
+        `KeyError` in the middle of a launch. The row shows what is there, with no leading
+        or trailing space where the missing half would have been: a `was` line that begins
+        with one reads as a command that begins with one.
+
+        Both halves, because they are two lookups and a test that exercised one would leave
+        the other free to be written as `was["…"]`.
+        """
+        for entry, expected in (
+                ('{"kind": "claude", "command": ["elsewhere"]}', "  was      elsewhere\n"),
+                ('{"kind": "claude", "env": {"CLAUDE_CONFIG_DIR": "~/.old"}}',
+                 "  was      CLAUDE_CONFIG_DIR=~/.old\n")):
+            with self.subTest(entry=entry):
+                config.private_mkdir(config.STATE_DIR)
+                (config.STATE_DIR / profiletrust.RECORD).write_text(
+                    '{"claude-work": ' + entry + '}')
+                _got, said, _stdin = self._ask()
+                self.assertIn(expected, said)
+
+    def test_a_word_that_renders_as_nothing_is_still_shown_as_a_word(self):
+        """Not clipping is not the same as printing nothing. After the escape the prompt
+        holds only printable ASCII, so "renders as nothing" is exactly "is spaces" — and an
+        argument of three spaces that reached the screen as three spaces would be a word the
+        operator approved without being able to see that it was there at all."""
+        self.local.write_text('[harness.blankish]\nkind = "claude"\n'
+                              'command = ["claude", "   "]\n')
+        _got, said, _stdin = self._ask(name="blankish")
+        self.assertIn('command  claude ""', said)
+
+    def test_an_argument_that_merely_contains_a_space_is_shown_as_it_is(self):
+        """The other side of the same rule, and an ordinary profile rather than an odd one:
+        `command` is an argv list, so one element holding a space is a single argument with
+        a space in it — `--append-system-prompt "be terse"` — and it is exactly the argument
+        an operator most needs to read before saying yes. "Renders as nothing" is *every*
+        character is a space, not *any*."""
+        self.local.write_text('[harness.spaced]\nkind = "claude"\ncommand = '
+                              '["claude", "--append-system-prompt", "be terse"]\n')
+        _got, said, _stdin = self._ask(name="spaced")
+        self.assertIn("command  claude --append-system-prompt be terse", said)
+
+    def test_a_changed_profile_shows_what_it_was(self):
+        """A change is only readable against what it changed FROM: "is this the command
+        you meant" is a different question from "did you mean to swap these two"."""
+        profiletrust.record_launched(self._profile())
+        self.local.write_text('[harness.claude-work]\nkind = "claude"\n'
+                              'command = ["claude", "--elsewhere"]\n')
+        _got, said, _stdin = self._ask()
+        self.assertIn("has changed since it last ran", said)
+        self.assertIn("was ", said)
+        self.assertIn("CLAUDE_CONFIG_DIR=~/.cw", said)
+
+    def test_what_it_was_is_shown_escaped_as_well(self):
+        """The old fingerprint is read back out of `.charter/`, which is as writable by a
+        chat as the local file is (ruling 13) — so it reaches this terminal by the same
+        route and is contained by the same rule."""
+        config.private_mkdir(config.STATE_DIR)
+        (config.STATE_DIR / "harness-profiles-launched.json").write_text(json.dumps(
+            {"claude-work": {"kind": "claude", "command": ["rm\r[2Kclaude"],
+                             "env": {}}}))
+        _got, said, _stdin = self._ask()
+        self.assertNotIn("\r", said)
+        self.assertNotIn("\x1b", said)
+        self.assertIn("\\u000d", said)
+
+    def test_a_yes_that_cannot_be_recorded_comes_back_as_the_write_error(self):
+        """N2b's nit, and the reason this returns more than a `bool`: a yes charter could
+        not write down must refuse the launch rather than run it, because the very next
+        open would find no record and ask the same question again."""
+        with mock.patch.object(profiletrust.config, "replace_for",
+                               side_effect=OSError(28, "No space left on device")):
+            got, _said, _stdin = self._ask()
+        self.assertEqual(got, profiletrust.Answer(True, "No space left on device"))
+
+    def test_the_question_is_on_the_screen_before_anything_is_read(self):
+        """The prompt's last line ends WITHOUT a newline — `run this? [y/N] ` leaves the
+        cursor beside it, which is what makes it look like a question — so nothing flushes
+        it on its own. Unflushed, the operator is shown a blank pane and charter waits
+        there for an answer to a question they cannot see."""
+        flushed: list[int] = []
+
+        class _Screen(_ATerminal):
+            def flush(self) -> None:
+                flushed.append(len(self.getvalue()))
+
+        class _LooksBeforeItAnswers(_Typed):
+            def readline(self) -> str:
+                if not flushed:
+                    raise AssertionError("asked for an answer before the question was "
+                                         "flushed to the screen")
+                return super().readline()
+
+        got = profiletrust.ask_in_terminal(self._profile(), stdin=_LooksBeforeItAnswers("y\n"),
+                                           stdout=_Screen())
+        self.assertTrue(got.yes)
+
+    def test_the_two_states_are_the_words_the_sentences_use(self):
+        """`new` and `changed` are read straight into three sentences, so they are an
+        interface rather than two flags: spelled out here, and asserted IN the sentences,
+        so a rename is a red test rather than prose that stops making sense."""
+        self.assertEqual((profiletrust.NEW, profiletrust.CHANGED), ("new", "changed"))
+        for attended in (True, False):
+            self.assertIn("is new", profiletrust.refusal(self._profile(),
+                                                         attended=attended).text)
+        profiletrust.record_launched(self._profile())
+        self.local.write_text('[harness.claude-work]\nkind = "claude"\n'
+                              'command = ["elsewhere"]\n')
+        for attended in (True, False):
+            self.assertIn("is changed", profiletrust.refusal(self._profile(),
+                                                             attended=attended).text)
+
+    def test_a_decline_is_the_workspace_pickers_own_cancel_code(self):
+        """130, written out. Every neighbouring number already means something else to
+        whoever reads `$?` — 127 and 126 are the shell's words for a command that could not
+        be found or run, 2 is charter's usage error, 1 is a harness that ran and failed, 0
+        is one that ran and did not — and 130 is the shell's "ended by SIGINT", which is
+        what answering no to a question is. The same number `_choose_workspace` returns for
+        a cancelled picker, so one `$?` means one thing across both prompts."""
+        self.assertEqual(profiletrust.DECLINED_EXIT, 130)
+        self.assertEqual(profiletrust.DECLINED_EXIT, commands_frame._PICKER_CANCELLED)
+
+    def test_asking_needs_a_terminal_on_both_sides(self):
+        """Ruling 23: a terminal on one side only is not one. `charter claude-work > log`
+        has somebody at the keyboard and nowhere to print the question; `charter claude-work
+        < /dev/null` has the screen and nothing to read from. Both are a hang if asked."""
+        for stdin_tty, stdout_tty in ((True, False), (False, True), (False, False)):
+            with self.subTest(stdin=stdin_tty, stdout=stdout_tty):
+                self.assertFalse(profiletrust.can_ask(
+                    SimpleNamespace(isatty=lambda t=stdin_tty: t),
+                    SimpleNamespace(isatty=lambda t=stdout_tty: t)))
+        self.assertTrue(profiletrust.can_ask(SimpleNamespace(isatty=lambda: True),
+                                             SimpleNamespace(isatty=lambda: True)))
+
+
+class TheRefusalsWhereNobodyCanBeAsked(_ADeclaringPlane, unittest.TestCase):
+    """`profiletrust.refusal` — the seam the launcher's chain ends in."""
+
+    def test_an_approved_profile_is_not_refused(self):
+        profiletrust.record_launched(self._profile())
+        self.assertIsNone(profiletrust.refusal(self._profile(), attended=True))
+        self.assertIsNone(profiletrust.refusal(self._profile(), attended=False))
+
+    def test_an_attended_open_asks_and_an_unattended_one_refuses(self):
+        """Two kinds, not two sentences: the caller decides what to do by the KIND (ruling
+        27), because a sentence gets reworded and a branch on one stops branching."""
+        self.assertEqual(profiletrust.refusal(self._profile(), attended=True).kind,
+                         launcher.KIND_ASK)
+        self.assertEqual(profiletrust.refusal(self._profile(), attended=False).kind,
+                         launcher.KIND_UNATTENDED)
+
+    def test_each_refusal_names_the_command_that_would_approve_it(self):
+        for attended in (True, False):
+            with self.subTest(attended=attended):
+                r = profiletrust.refusal(self._profile(), attended=attended)
+                self.assertIn("charter claude-work", r.text)
+                self.assertEqual(r.exit, launcher.REFUSED_EXIT)
+
+    def test_a_refusal_repeats_the_profiles_name_back_bounded(self):
+        """`profiles.NAME_RE` bounds a declared name's shape and not its length, so this is
+        the one value in the sentence that arrives printable and as long as the file liked
+        — and each of these sentences ends in the remedy."""
+        long_name = "w" * 200
+        self.local.write_text(f'[harness.{long_name}]\nkind = "claude"\n'
+                              'command = ["claude"]\n')
+        for attended in (True, False):
+            with self.subTest(attended=attended):
+                r = profiletrust.refusal(self._profile(long_name), attended=attended)
+                self.assertIn("w" * 160 + "...", r.text)
+                self.assertNotIn(long_name, r.text)
+
+    def test_a_built_in_is_refused_nowhere(self):
+        self.assertIsNone(profiletrust.refusal(self._profile("codex"), attended=False))
+
+
+class WhereItAsks(_ALaunchNamesAProfile, unittest.TestCase):
+    """Every open charter has, and what each of them does with a profile nobody approved.
+
+    The table in the plan's Task 3, as cases: a terminal launch asks before tmux; a press
+    with no terminal defers to the pane, which has one on both ends; and a reopen, a
+    handoff or a launch with nowhere to ask refuses instead.
+    """
+
+    def test_a_terminal_launch_asks_before_anything_is_allocated(self):
+        """A refusal before tmux is a `return` with nothing to tear down — no session, no
+        window, no chat directory — which is why the question is asked here and not after
+        the frame is built."""
+        screen, said = _ATerminal(), []
+        with mock.patch.object(commands_frame.util, "err", side_effect=said.append):
+            rc = self._launch(profile="claude-work", stdin=_Typed("n\n"), stdout=screen)
+        self.assertEqual(rc, profiletrust.DECLINED_EXIT)
+        self.assertEqual(self.argvs, [], "tmux was asked for something anyway")
+        self.assertFalse((config.STATE_DIR / "frame" / "beta.1").exists())
+        # Said on the terminal the question went to, in `_choose_workspace`'s own words for
+        # a cancel — and said NOWHERE ELSE: an operator's own "no" reported a second time
+        # under charter's red ✗ reads as a rule firing on them.
+        self.assertIn("charter: nothing started.", screen.getvalue())
+        self.assertEqual(said, [])
+
+    def test_the_question_is_the_profiles_own_command(self):
+        screen = _ATerminal()
+        self._launch(profile="claude-work", stdin=_Typed("n\n"), stdout=screen)
+        self.assertIn("command  claude", screen.getvalue())
+        self.assertIn("CLAUDE_CONFIG_DIR=~/.cw", screen.getvalue())
+        self.assertIn("run this? [y/N]", screen.getvalue())
+
+    def test_a_yes_at_the_terminal_launches_and_is_not_asked_again_in_the_pane(self):
+        """The record is what the pane reads, so the second run of the chain — the one
+        immediately before the `exec` — finds an approval rather than a question. Asking
+        twice for one launch is the failure this pins."""
+        self.assertEqual(self._launch(profile="claude-work", stdin=_Typed("y\n")), 0)
+        self.assertTrue(any("new-window" in a for a in self.argvs), self.argvs)
+        assert_approved("claude-work")
+        # And the pane's own launcher, in this process, with a stdin that would raise if
+        # it were read: the approval is already there to be found.
+        self.assertEqual(launcher.start(self._profile(), [], fid=None, attended=True), 0)
+        self.assertEqual(len(self.execs), 1, self.execs)
+
+    def test_only_asking_is_deferred_to_the_pane(self):
+        """N2a's nit. A press has no terminal, so the ASK waits for the pane — but every
+        other refusal still happens here, where there is nothing to tear down. A `PATH`
+        refusal carried into tmux would open a window to say it in and close it again."""
+        rc, said = self._said(profile="claude-work", which=None, stdin=_APipe())
+        self.assertEqual(rc, launcher.MISSING_EXIT)
+        self.assertIn("not on PATH", said)
+        self.assertEqual(self.argvs, [])
+
+    def test_a_press_with_no_terminal_defers_to_the_pane(self):
+        """The `+`, a workspace tab, the palette's new chat: nobody typed anything, the
+        process behind the click has `/dev/null` for streams, and the pane it opens has a
+        terminal on both ends. So it launches, with `--attended`, and the pane asks."""
+        self.assertEqual(self._launch(profile="claude-work", stdin=_APipe()), 0)
+        start = next(a for a in self.argvs if "new-window" in a)
+        self.assertIn("--attended", start)
+
+    def test_a_press_says_the_refusal_it_is_not_deferring(self):
+        """The other half of the same rule, on the surface a press actually reports on:
+        `_launch_refusal` hands a `+` the sentence to put on the attention row, and it
+        must hand back nothing for the one question the pane is going to ask itself."""
+        with mock.patch("sys.stdin", _APipe()):
+            self.assertEqual(
+                commands_frame._launch_refusal(self._profile(), attended=True), "")
+            with mock.patch.object(launcher.shutil, "which", return_value=None):
+                self.assertIn("not on PATH", commands_frame._launch_refusal(
+                    self._profile(), attended=True))
+
+    def test_an_attended_launch_with_no_terminal_refuses_with_needs_asking(self):
+        """Review 3: somebody typed this, and there is nowhere to put the question. It is
+        refused with its own sentence rather than asked into a pipe — and stdin is never
+        read, which is the stronger claim: a read on a closed stream returns at once and
+        looks exactly like a guard that is there."""
+        said: list[str] = []
+        with mock.patch("sys.stdin", _APipe()), \
+                mock.patch("sys.stdout", io.StringIO()), \
+                mock.patch.object(launcher.util, "err", side_effect=said.append):
+            rc = launcher.start(self._profile(), [], fid=None, attended=True)
+        self.assertEqual(rc, launcher.REFUSED_EXIT)
+        self.assertTrue(any("no terminal here to ask in" in s for s in said), said)
+
+    def test_an_attended_launch_with_a_terminal_on_both_asks(self):
+        stdin = _Typed("y\n")
+        with mock.patch("sys.stdin", stdin), \
+                mock.patch("sys.stdout", _ATerminal()):
+            self.assertEqual(launcher.start(self._profile(), [], fid=None, attended=True),
+                             0)
+        self.assertEqual(len(self.execs), 1, self.execs)
+        self.assertEqual(stdin.reads, 1)
+
+    def test_a_decline_is_not_reported_a_second_time_as_a_refusal(self):
+        """The same rule one surface along — `launcher.start`, which is `--no-frame` and
+        every launch whose output is a pipe. `ask_in_terminal` has already answered on the
+        terminal the question went to; charter's red ✗ over the top of that would report
+        the operator's own answer as a rule they broke."""
+        said: list[str] = []
+        with mock.patch("sys.stdin", _Typed("n\n")), \
+                mock.patch("sys.stdout", (screen := _ATerminal())), \
+                mock.patch.object(launcher.util, "err", side_effect=said.append):
+            rc = launcher.start(self._profile(), [], fid=None, attended=True)
+        self.assertEqual(rc, profiletrust.DECLINED_EXIT)
+        self.assertEqual(said, [])
+        self.assertIn("charter: nothing started.", screen.getvalue())
+        self.assertEqual(self.execs, [])
+
+    def test_a_yes_runs_the_whole_chain_again_before_the_exec(self):
+        """Ruling 27: a yes answers the approval question and nothing else. The plane can
+        move while the operator is reading the prompt — and a yes that walked straight past
+        the checks behind it would be the one path in charter where saying yes to one
+        question waives the rest."""
+        gone: list[str] = []
+
+        def _which(program, path=None):
+            # On the ask's own read: the command leaves `PATH` while the question is on
+            # screen. The first call is the chain before the ask, the second is after it.
+            return None if gone else "/nowhere/claude"
+
+        class _TypesAndRemovesTheCommand(_Typed):
+            def readline(self) -> str:
+                gone.append("yes")
+                return super().readline()
+
+        said: list[str] = []
+        with mock.patch.object(launcher.shutil, "which", side_effect=_which), \
+                mock.patch("sys.stdin", _TypesAndRemovesTheCommand("y\n")), \
+                mock.patch("sys.stdout", _ATerminal()), \
+                mock.patch.object(launcher.util, "err", side_effect=said.append):
+            rc = launcher.start(self._profile(), [], fid=None, attended=True)
+        self.assertEqual(rc, launcher.MISSING_EXIT)
+        self.assertEqual(self.execs, [], "a yes walked past the check behind it")
+
+    def test_a_record_lost_between_the_yes_and_the_recheck_says_what_happened(self):
+        """S1's other half. After a yes the whole chain runs again (ruling 27), and the
+        record it just wrote is under `.charter/`, which a chat can write (ruling 13) — so
+        the re-run CAN come back asking. Asking a second time is what N2b rules out, and the
+        sentence that used to come out here was `NEEDS_ASKING` — *there is no terminal here
+        to ask in* — said on a terminal that plainly had one. It says what is true instead.
+        """
+        real = profiletrust.record_launched
+
+        def _records_it_then_loses_it(p):
+            why = real(p)
+            (config.STATE_DIR / profiletrust.RECORD).write_text("{}")
+            return why
+
+        stdin, said = _Typed("y\n"), []
+        with mock.patch("sys.stdin", stdin), \
+                mock.patch("sys.stdout", _ATerminal()), \
+                mock.patch.object(profiletrust, "record_launched",
+                                  side_effect=_records_it_then_loses_it), \
+                mock.patch.object(launcher.util, "err", side_effect=said.append):
+            rc = launcher.start(self._profile(), [], fid=None, attended=True)
+        self.assertEqual(rc, launcher.REFUSED_EXIT)
+        self.assertEqual(stdin.reads, 1, "the same question was asked twice")
+        self.assertEqual(self.execs, [], "a command nobody approved was started")
+        self.assertTrue(any("moved while that question was on screen" in s
+                            for s in said), said)
+        self.assertFalse(any("no terminal here to ask in" in s for s in said), said)
+
+    def test_the_moved_refusal_repeats_the_profiles_name_back_bounded(self):
+        """The fourth one-line sentence that quotes a name, and it ends in the remedy
+        `charter <name>` like its siblings — so it clips where the PROMPT does not. A
+        200-character name in the middle of it is a remedy nobody reads to."""
+        long_name = "w" * 200
+        self.local.write_text(f'[harness.{long_name}]\nkind = "claude"\n'
+                              'command = ["claude"]\n')
+        real = profiletrust.record_launched
+
+        def _records_it_then_loses_it(p):
+            why = real(p)
+            (config.STATE_DIR / profiletrust.RECORD).write_text("{}")
+            return why
+
+        said: list[str] = []
+        with mock.patch("sys.stdin", _Typed("y\n")), \
+                mock.patch("sys.stdout", _ATerminal()), \
+                mock.patch.object(profiletrust, "record_launched",
+                                  side_effect=_records_it_then_loses_it), \
+                mock.patch.object(launcher.util, "err", side_effect=said.append):
+            rc = launcher.start(self._profile(long_name), [], fid=None, attended=True)
+        self.assertEqual(rc, launcher.REFUSED_EXIT)
+        self.assertIn("w" * 160 + "...", said[0])
+        self.assertNotIn(long_name, said[0])
+
+    def test_a_record_that_cannot_be_written_refuses_and_never_asks_again(self):
+        """N2b's nit: re-running the chain after a yes charter could not write down would
+        find no record and ask the very same question a second time. It refuses instead,
+        naming the path and what the filesystem said."""
+        stdin = _Typed("y\n")
+        said: list[str] = []
+        with mock.patch("sys.stdin", stdin), \
+                mock.patch("sys.stdout", _ATerminal()), \
+                mock.patch.object(profiletrust.config, "replace_for",
+                                  side_effect=OSError(28, "No space left on device")), \
+                mock.patch.object(launcher.util, "err", side_effect=said.append):
+            rc = launcher.start(self._profile(), [], fid=None, attended=True)
+        self.assertEqual(rc, launcher.REFUSED_EXIT)
+        self.assertEqual(stdin.reads, 1, "the same question was asked twice")
+        self.assertTrue(any("No space left on device" in s for s in said), said)
+        self.assertTrue(any(str(config.STATE_DIR) in s for s in said), said)
+
+    def test_the_record_path_a_refusal_quotes_is_contained(self):
+        """Ruling 35 on the one value in this sentence charter did not mint: the path is
+        built from `config.STATE_DIR`, which is built from the plane root — a directory an
+        operator named and a chat may have made — and this sentence goes to a terminal."""
+        said: list[str] = []
+        with mock.patch("sys.stdin", _Typed("y\n")), \
+                mock.patch("sys.stdout", _ATerminal()), \
+                mock.patch.object(profiletrust.config, "STATE_DIR",
+                                  self.tmp / "pl\x1bane"), \
+                mock.patch.object(profiletrust.config, "replace_for",
+                                  side_effect=OSError(28, "no spa\x1b[2Kce left")), \
+                mock.patch.object(launcher.util, "err", side_effect=said.append):
+            rc = launcher.start(self._profile(), [], fid=None, attended=True)
+        self.assertEqual(rc, launcher.REFUSED_EXIT)
+        self.assertEqual(len(said), 1, said)
+        # Both halves: the path, and what the filesystem said about it — which is not
+        # charter's own words either, and arrives about a path the FILE chose.
+        self.assertNotIn("\x1b", said[0])
+        self.assertEqual(said[0].count("\\u001b"), 2, said[0])
+
+    def test_the_record_path_a_refusal_quotes_is_not_clipped_short(self):
+        """S2: the sentence ends in *fix that path and run it again*, so the path has to be
+        one the reader can act on. `contain.PATH_DISPLAY_LIMIT` (1024) and not
+        `DISPLAY_LIMIT` (160) — `contain` says why in as many words, and a plane's paths are
+        legitimately long: this one is under a temp directory and 200 characters of name."""
+        deep = self.tmp / ("d" * 200)
+        said: list[str] = []
+        with mock.patch("sys.stdin", _Typed("y\n")), \
+                mock.patch("sys.stdout", _ATerminal()), \
+                mock.patch.object(profiletrust.config, "STATE_DIR", deep), \
+                mock.patch.object(profiletrust.config, "replace_for",
+                                  side_effect=OSError(28, "No space left on device")), \
+                mock.patch.object(launcher.util, "err", side_effect=said.append):
+            rc = launcher.start(self._profile(), [], fid=None, attended=True)
+        self.assertEqual(rc, launcher.REFUSED_EXIT)
+        self.assertIn(str(deep / profiletrust.RECORD), said[0])
+
+    def test_the_pane_asks_and_a_no_exits_130(self):
+        """In the pane, whose stdin and stdout are its own tty. A no closes the window the
+        way any other exit does — there is nothing to read afterwards, because the operator
+        just answered the question themselves."""
+        state.frame_dir("beta.1", create=True)
+        waited: list[int] = []
+        with mock.patch("sys.stdin", _Typed("n\n")), \
+                mock.patch("sys.stdout", _ATerminal()), \
+                mock.patch.object(launcher, "framed_chat", return_value="beta.1"), \
+                mock.patch.object(launcher, "_wait_for_the_operator",
+                                  side_effect=lambda: waited.append(1)):
+            rc = launcher.cmd_frame_launch(SimpleNamespace(
+                profile="claude-work", attended=True, rest=[]))
+        self.assertEqual(rc, profiletrust.DECLINED_EXIT)
+        self.assertEqual(self.execs, [])
+        self.assertEqual(waited, [], "the operator answered; there is no key to wait for")
+
+    def test_an_unattended_pane_refuses_rather_than_asks(self):
+        """A reopen's pane and a handoff's pane carry no `--attended`, so the question is
+        never put: there is nobody there to see it, and a pane waiting on one is a chat
+        that never starts and never says why."""
+        state.frame_dir("beta.1", create=True)
+        said: list[str] = []
+        with mock.patch("sys.stdin", _APipe()), \
+                mock.patch.object(launcher, "framed_chat", return_value="beta.1"), \
+                mock.patch.object(launcher.util, "err", side_effect=said.append):
+            rc = launcher.cmd_frame_launch(SimpleNamespace(
+                profile="claude-work", attended=False, rest=[]))
+        self.assertEqual(rc, launcher.REFUSED_EXIT)
+        self.assertTrue(any("nobody is at this open" in s for s in said), said)
+
+    def test_a_built_in_never_asks_anywhere(self):
+        """With a stdin that raises on a read, so this is "never asked" rather than
+        "answered quickly".
+
+        **The command is stood in for**, because which harnesses a machine happens to have
+        installed is not what this case is about — and it decided it: with the real
+        `shutil.which` this passed here and came back 127 on CI, where `codex` is not
+        installed (`CONTRIBUTING.md`, *your machine is not the runner*).
+        """
+        with mock.patch("sys.stdin", _APipe()), \
+                mock.patch.object(launcher.shutil, "which", return_value="/nowhere/codex"):
+            self.assertEqual(launcher.start(self._profile("codex"), [], fid=None,
+                                            attended=True), 0)
+        self.assertEqual(len(self.execs), 1, self.execs)
+
+    def test_each_refusal_says_something_different(self):
+        """A reader has to be able to tell which rule fired. Four sentences for one
+        profile, one fixture — so a copied message is a red test rather than a shrug."""
+        p = self._profile()
+        sentences = {profiletrust.refusal(p, attended=True).text,
+                     profiletrust.refusal(p, attended=False).text}
+        with mock.patch.object(launcher.shutil, "which", return_value=None):
+            sentences.add(launcher.refusal(p, root=config.ROOT, attended=True,
+                                           env=dict(os.environ)).text)
+        (config.ROOT / ".gitignore").write_text("")
+        sentences.add(launcher.refusal(p, root=config.ROOT, attended=True,
+                                       env=dict(os.environ)).text)
+        self.assertEqual(len(sentences), 4, sentences)
+
+
+class AReopenAndAHandoffRefuseWhereTheyWouldHaveAsked(PersonaIso, unittest.TestCase):
+    """Nobody is at either of these, and both know it before they start anything."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        make_plane(self)
+        self.enterContext(mock.patch.dict(
+            os.environ,
+            {"PATH": os.environ.get("PATH", ""),
+             "CHARTER_ROOT": str(config.ROOT), **_gitguard.environment()}, clear=True))
+        self.local = declare_profiles(self)
+        (config.WORKSPACES_DIR / "alpha").mkdir(parents=True, exist_ok=True)
+        self.launched: list = []
+
+    def _chat(self, **kw):
+        fields = dict(chat="alpha.1", workspace="alpha", persona="", harness="claude-code",
+                      cwd="", resume="", transcript="", active=True, profile="claude-work")
+        return reopen_state.Chat(**{**fields, **kw})
+
+    def _reopen(self, c) -> str:
+        def fake_launch(args):
+            self.launched.append(args)
+            args.reopening.fid = "alpha.1"
+            return 0
+
+        said: list[str] = []
+        with mock.patch.object(commands_frame.util, "warn", side_effect=said.append), \
+                mock.patch("charter.commands_frame.cmd_launch", side_effect=fake_launch):
+            commands_frame._reopen_one(c)
+        return "\n".join(said)
+
+    def test_a_reopen_skips_an_unapproved_profile(self):
+        """A reopen has nobody to ask, and it says so by name rather than starting a chat
+        whose pane would refuse a moment later. The chat stays in the manifest, so
+        approving the profile once and running `charter reopen` again brings it back."""
+        said = self._reopen(self._chat())
+        self.assertEqual(self.launched, [])
+        self.assertIn("a reopen has nobody to ask", said)
+        self.assertIn("alpha.1", said)
+        self.assertIn("charter claude-work", said)
+
+    def test_the_skipped_chats_profile_is_repeated_back_bounded(self):
+        """`profiles.NAME_RE` bounds a declared name's shape and not its length, so this is
+        the one value in the sentence that arrives printable and as long as the file liked
+        — and the sentence ends in the remedy, `Run charter <name> once to approve it`,
+        which an unbounded name in the middle of it scrolls off the screen."""
+        long_name = "w" * 200
+        self.local.write_text(f'[harness.{long_name}]\nkind = "claude"\n'
+                              'command = ["claude"]\n')
+        said = self._reopen(self._chat(profile=long_name))
+        self.assertIn("w" * 160 + "...", said)
+        self.assertNotIn(long_name, said)
+        self.assertEqual(self.launched, [])
+
+    def test_a_reopen_of_an_approved_profile_goes_ahead(self):
+        approve_profile(self)
+        self.assertNotIn("nobody to ask", self._reopen(self._chat()))
+        self.assertEqual(len(self.launched), 1)
+
+    def test_a_reopen_of_a_built_in_is_never_stopped_by_this(self):
+        self.assertNotIn("nobody to ask", self._reopen(self._chat(profile="codex")))
+        self.assertEqual(len(self.launched), 1)
+
+
+class ThePinsARealTmuxCaseCouldOnlyHangOn(PersonaIso, unittest.TestCase):
+    """Two of Task 2's lines its own sweep could not measure, pinned in a second here.
+
+    Both mutations hang a real-tmux case rather than reddening it, and a sweep run that
+    timed out is neither green nor red — it is *unresolved*, so the line comes back with no
+    verdict at all (`tools/sweep.py`, `SUBSET_TIMEOUT`). Task 3 owns the attended path and
+    the ask, so each gets a pin that runs in this process with no tmux anywhere near it.
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+        make_plane(self)
+        state.frame_dir("beta.1", create=True)
+
+    def test_the_wait_for_a_launcher_is_bounded_by_a_deadline(self):
+        """**Line one: `_await_the_launcher`'s deadline.** A pane charter cannot prove a
+        chat for records nothing at all, so without the budget this wait never ends — and a
+        reopen of four chats stops on the first of them, forever. The sleep counter is the
+        bound: a loop with its deadline gone reaches it instead of hanging the run."""
+        slept: list[float] = []
+
+        def _sleep(seconds: float) -> None:
+            slept.append(seconds)
+            if len(slept) > 50:
+                raise AssertionError("the wait is not bounded by its deadline")
+
+        ticks = iter([0.0, 0.0, commands_frame._LAUNCHER_SECONDS + 1])
+        with mock.patch.object(commands_frame.time, "sleep", side_effect=_sleep), \
+                mock.patch.object(commands_frame.time, "monotonic",
+                                  side_effect=lambda: next(ticks)), \
+                mock.patch.object(commands_frame, "_pane_state",
+                                  return_value=(commands_frame._ALIVE, None)):
+            self.assertEqual(commands_frame._await_the_launcher("sock", "beta.1", "%1"),
+                             (None, ""))
+
+    def test_only_an_attended_open_puts_attended_on_the_argv(self):
+        """**Line two: `("--attended",) if attended else ()`.** Collapsed, every pane on
+        the plane is attended — including a reopen's and a handoff's, which have nobody in
+        front of them — and each of those panes then stops on a question until the suite's
+        own watchdog. Asserted in both directions, because only one of them is the hang."""
+        self.assertIn("--attended", launcher.argv("claude-work", [], attended=True))
+        self.assertNotIn("--attended", launcher.argv("claude-work", [], attended=False))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_a_profile_launch_is_refused_before_tmux.py
+++ b/tests/test_a_profile_launch_is_refused_before_tmux.py
@@ -6,11 +6,12 @@ immediately before the exec, because the plane can move in between (spec, *What 
 launch*). This module is the first half: what `_launch` refuses, what it hands tmux when it
 does not, and what never crosses tmux at all.
 
-**Every declared profile is refused here** (review B1). Nothing yet stands for the
-operator's approval of a `command`, and `charter.local.toml` is a file a chat can write
-with no diff to show for it — so between this merge and Task 3's, `main` runs no command
-that file declares, through `charter <profile>`, `+`, a tab, reopen or a handoff. The three
-cases that say so run without the stand-in the rest of the module uses.
+**No declared profile runs here until somebody has seen its command** (review B1, and
+Task 3's ask in place of Task 2's flat refusal). `charter.local.toml` is a file a chat can
+write with no diff to show for it, so a profile with no launch record shows what it would
+run and asks first — through `charter <profile>`, `+`, a tab, reopen and a handoff alike.
+The three cases that say so run without the record the rest of the module seeds, and every
+other case here seeds one because it is about something else entirely.
 """
 
 from __future__ import annotations
@@ -24,10 +25,12 @@ from pathlib import Path
 from types import SimpleNamespace
 from unittest import mock
 
-from charter import commands_frame, config, contain
+from charter import commands_frame, config, contain, profiletrust
 from charter.frame import launcher, layout, reopen as reopen_state, state, tmuxctl
 from tests import _gitguard, _tmuxsocket
-from tests._isolation import PersonaIso, declare_profiles, make_plane
+from tests._isolation import (APipe as _APipe, ATerminal as _ATerminal, PersonaIso,
+                              Typed as _Typed, approve_every_profile, declare_profiles,
+                              make_plane)
 
 #: The operator's own tmux, as `tmuxctl.operator_server` reads it out of `$TMUX`: a socket
 #: PATH, which is what `is_operator_socket` tells from charter's own `-L charter` name.
@@ -56,11 +59,23 @@ class _ALaunchNamesAProfile(PersonaIso):
         self.enterContext(mock.patch.object(launcher.os, "execvpe",
                                             side_effect=lambda *a: self.execs.append(a)))
 
+    def _profile(self, name: str = "claude-work"):
+        from charter import profiles
+
+        return profiles.current().profiles[name]
+
     def _no_approval_needed(self) -> None:
-        """Task 2 refuses every declared profile (review B1). A case that is about something
-        else stands that one refusal down; the three that are about it do not."""
-        self.enterContext(mock.patch.object(launcher, "_approval_refusal",
-                                            return_value=None))
+        """Seed a launch record for every profile this plane declares.
+
+        A declared profile charter has never run shows its command and asks (Task 3), so a
+        case about something else — which argv crosses tmux, what a `PATH` refusal says —
+        would otherwise be measuring that one question. This is what an operator who
+        already said yes once leaves behind, which is the state those cases mean.
+
+        Called again by a case that REWRITES `charter.local.toml`, because it records what
+        is declared at the moment it runs.
+        """
+        approve_every_profile(self)
 
     def _tmux_answer(self, action, argv, **kw):
         self.argvs.append(list(argv))
@@ -70,7 +85,8 @@ class _ALaunchNamesAProfile(PersonaIso):
         return subprocess.CompletedProcess(argv, 0, out, "")
 
     def _launch(self, *, which: str | None = "/nowhere/claude", dead_status=None,
-                verdict: tuple = (None, ""), operator=None, **ns) -> int:
+                verdict: tuple = (None, ""), operator=None, stdin=None, stdout=None,
+                **ns) -> int:
         """The real `_launch` with tmux stood in — and every answer a case might care about
         as a PARAMETER rather than a patch applied inside here.
 
@@ -78,14 +94,24 @@ class _ALaunchNamesAProfile(PersonaIso):
         are entered inside this helper, so they override anything a case set up outside it,
         and the case about a missing binary was answered "installed" along with everything
         else. A knob a case can state is the only way that stays honest.
+
+        *stdin* and *stdout* are the same knob for the ask (Task 3): a stream given here
+        REPLACES the interpreter's, which is how a case declares its terminal-ness to
+        `tests/_ttyguard` and the only way to count what was read. Given neither, this is
+        the open a press makes — a terminal for output, nothing to read from — which is
+        what every case written before the ask existed assumed.
         """
         args = SimpleNamespace(**{"harness": "claude", "rest": [], "no_frame": False,
                                   "workspace": "beta", "pick": False, "size": (120, 40),
                                   **ns})
+        streams = [mock.patch("sys.stdin", stdin) if stdin is not None
+                   else mock.patch("sys.stdin.isatty", return_value=False),
+                   mock.patch("sys.stdout", stdout) if stdout is not None
+                   else mock.patch("sys.stdout.isatty", return_value=True)]
+        for s in streams:
+            self.enterContext(s)
         with mock.patch("charter.commands_frame.shutil.which", return_value=which), \
                 mock.patch.object(launcher.shutil, "which", return_value=which), \
-                mock.patch("sys.stdout.isatty", return_value=True), \
-                mock.patch("sys.stdin.isatty", return_value=False), \
                 mock.patch.object(tmuxctl, "version", return_value=(3, 7)), \
                 mock.patch.object(tmuxctl, "operator_server", return_value=operator), \
                 mock.patch.object(commands_frame, "_live_sessions", return_value={"beta"}), \
@@ -124,28 +150,35 @@ class _ALaunchNamesAProfile(PersonaIso):
         return any("new-window" in a or "new-session" in a for a in self.argvs)
 
 
-class EveryDeclaredProfileIsRefusedUntilApprovalExists(_ALaunchNamesAProfile,
-                                                       unittest.TestCase):
-    """Review B1, and the three cases that run WITHOUT the stand-in. Delete the refusal and
-    these go red: `main` would run whatever a chat wrote into `charter.local.toml`."""
+class ADeclaredProfileAsksBeforeItRuns(_ALaunchNamesAProfile, unittest.TestCase):
+    """Review B1, now that Task 3 has put the ask where Task 2's flat refusal stood: the
+    three cases that run WITHOUT a launch record. Nothing a chat wrote into
+    `charter.local.toml` starts until somebody at the keyboard has seen the command.
+    """
 
-    def test_every_declared_profile_is_refused_until_approval_exists(self):
-        rc, said = self._said(profile="claude-work")
-        self.assertEqual(rc, launcher.REFUSED_EXIT)
-        self.assertIn("cannot yet ask before a declared command runs", said)
+    def test_a_declared_profile_with_no_record_asks_before_it_runs(self):
+        typed = _Typed("n\n")
+        rc = self._launch(profile="claude-work", stdin=typed,
+                          stdout=(screen := _ATerminal()))
+        self.assertEqual(rc, profiletrust.DECLINED_EXIT)
+        self.assertIn("run this? [y/N]", screen.getvalue())
+        self.assertIn("command  claude", screen.getvalue())
+        self.assertEqual(typed.reads, 1)
         self.assertFalse(self._started(), self.argvs)
         self.assertEqual(self.execs, [])
 
-    def test_a_declared_replacement_of_a_built_in_is_refused_until_approval_exists(self):
+    def test_a_declared_replacement_of_a_built_in_asks_before_it_runs(self):
+        """`[harness.claude]` is the file speaking, whatever the name on the table is —
+        and the command on it is the file's, which is the whole question."""
         self.local.write_text('[harness.claude]\nkind = "claude"\n'
                               'command = ["/opt/claude"]\n')
-        rc, said = self._said()
-        self.assertEqual(rc, launcher.REFUSED_EXIT)
-        self.assertIn("cannot yet ask before a declared command runs", said)
+        rc = self._launch(stdin=_Typed("n\n"), stdout=(screen := _ATerminal()))
+        self.assertEqual(rc, profiletrust.DECLINED_EXIT)
+        self.assertIn("command  /opt/claude", screen.getvalue())
         self.assertFalse(self._started(), self.argvs)
 
     def test_a_built_in_the_file_does_not_replace_still_launches(self):
-        self.assertEqual(self._launch(harness="codex"), 0)
+        self.assertEqual(self._launch(harness="codex", stdin=_Typed()), 0)
         self.assertTrue(self._started(), self.argvs)
 
 
@@ -326,14 +359,26 @@ class ALaunchWithNoFrameExecsTheProfile(_ALaunchNamesAProfile, unittest.TestCase
         self.assertEqual(env["CHARTER_WORKSPACE"], "alpha")
         self.assertEqual(env["CHARTER_ROOT"], str(config.ROOT))
 
-    def test_a_no_frame_launch_of_a_declared_profile_is_refused_like_any_other(self):
+    def test_a_no_frame_launch_of_a_declared_profile_is_asked_about_like_any_other(self):
         """The `--no-frame` harness gets the same checks — no flag launches a profile
-        unguarded."""
-        with mock.patch.object(launcher, "_approval_refusal",
-                               return_value=launcher.Refusal(launcher.KIND_NOT_YET, "no",
-                                                             launcher.REFUSED_EXIT)):
-            rc = self._launch(profile="claude-work", no_frame=True)
+        unguarded — and here the question is put on this process's own terminal, because
+        this process is the one that becomes the harness."""
+        # The record seeded in `setUp` is what a case about something else wants; this one
+        # is about the ask, so it starts from a plane that has never run this profile.
+        (config.STATE_DIR / profiletrust.RECORD).unlink()
+        rc = self._launch(profile="claude-work", no_frame=True, stdin=_Typed("n\n"),
+                          stdout=_ATerminal())
+        self.assertEqual(rc, profiletrust.DECLINED_EXIT)
+        self.assertEqual(self.execs, [])
+
+    def test_a_no_frame_launch_with_nowhere_to_ask_refuses_and_reads_nothing(self):
+        """Review 3: `charter claude-work --no-frame > log` has somebody at the keyboard
+        and no terminal to put the question on. It says so — rather than reading a pipe,
+        which returns at once and looks exactly like a question that was answered."""
+        (config.STATE_DIR / profiletrust.RECORD).unlink()
+        rc, said = self._said(profile="claude-work", no_frame=True, stdin=_APipe())
         self.assertEqual(rc, launcher.REFUSED_EXIT)
+        self.assertIn("no terminal here to ask in", said)
         self.assertEqual(self.execs, [])
 
 

--- a/tests/test_a_reopened_empty_chat_is_shown_its_brief.py
+++ b/tests/test_a_reopened_empty_chat_is_shown_its_brief.py
@@ -29,7 +29,7 @@ import unittest
 from types import SimpleNamespace
 from unittest import mock
 
-from charter import commands_frame, contain, hooks
+from charter import commands_frame, contain, hooks, profiles
 from charter.frame import leave
 from charter.frame import reopen as reopen_state
 from charter.frame import state
@@ -148,7 +148,16 @@ class AReopenOwesTheBriefOnlyWhenTheConversationIsGone(PersonaIso):
         empty, and the chat then gets its brief on top of its own transcript.
         """
         from charter.frame import launcher
-        profile = SimpleNamespace(kind="claude", name="claude")
+
+        # **`source` as well as `kind` and `name`**, because `launcher.resolve` answers with
+        # a `profiles.Profile` and a stand-in for it owes every field a reader of one may
+        # read. `_reopen_one` reads this one: a reopen has nobody to ask, so it checks
+        # `profiletrust.approval_needed` before it starts anything, and that answers `""`
+        # for a built-in — which is what this stand-in is — by looking at exactly this
+        # field. Without it the reopen raised `AttributeError` instead of reaching the one
+        # question this case is about.
+        profile = SimpleNamespace(kind="claude", name="claude",
+                                  source=profiles.BUILTIN)
         with mock.patch("charter.commands_frame._resumes", return_value=False), \
                 mock.patch.object(launcher, "resolve", return_value=(profile, "")):
             with mock.patch("charter.commands_frame.cmd_launch",

--- a/tests/test_the_launcher_becomes_the_profile.py
+++ b/tests/test_the_launcher_becomes_the_profile.py
@@ -35,7 +35,10 @@ from unittest import mock
 from charter import commands_frame, config, profiles
 from charter.frame import launcher, state, tmuxctl
 from tests import _gitguard, _tmuxsocket
-from tests._isolation import PersonaIso, declare_profiles, make_plane
+from tests._isolation import (APipe as _APipe, ATerminal as _ATerminal,
+                              PersonaIso, Typed as _Typed,
+                              approve_every_profile, declare_profiles,
+                              make_plane)
 
 #: The `list-panes -a` row `tmuxctl.live_pane_by_pid` parses: pid, dead, pane, session,
 #: window, `@charter_chat`. Spelled here rather than built from the format, so a change to
@@ -65,19 +68,21 @@ class _AProfileAndAPlane(PersonaIso):
         return profiles.current().profiles[name]
 
     def _no_approval_needed(self) -> None:
-        """Stand in for Task 2's B1 refusal, for a case that is about something else.
+        """Seed a launch record for every profile this plane declares.
 
-        Task 2 refuses every declared profile (review B1), so without this every case below
-        would be measuring that one sentence. Task 3 replaces the body it stands in for.
+        A declared profile charter has never run shows its command and asks (Task 3), so
+        without this every case below would be measuring that one question instead of the
+        thing it is about. This is what an operator who already said yes once leaves
+        behind. Called again by a case that REWRITES `charter.local.toml`, because it
+        records what is declared at the moment it runs.
         """
-        self.enterContext(mock.patch.object(launcher, "_approval_refusal",
-                                            return_value=None))
+        approve_every_profile(self)
 
 
 class TheLauncherBecomesTheProfile(_AProfileAndAPlane, unittest.TestCase):
-    def test_the_pane_refuses_a_declared_profile_until_approval_exists(self):
-        """Review B1: `main` must never run an unapproved declared command between two
-        merges, so Task 2 refuses every declared profile and Task 3 lifts it."""
+    def test_the_pane_refuses_a_declared_profile_nobody_has_approved(self):
+        """`main` never runs an unapproved declared command. Unattended — a reopen's pane,
+        a handoff's — so there is nobody to put the question to and it refuses instead."""
         rc = launcher.start(self._profile(), [], fid="beta.1", attended=False)
         self.assertEqual(rc, launcher.REFUSED_EXIT)
         self.assertEqual(self.execs, [])
@@ -189,14 +194,19 @@ class TheLauncherBecomesTheProfile(_AProfileAndAPlane, unittest.TestCase):
 
     def test_the_kinds_are_a_written_down_vocabulary(self):
         """Ruling 27: a caller branches on the KIND and never on the text, so the kinds are
-        an interface — Task 3 matches `KIND_NOT_YET` to decide which refusal a pane defers
-        to instead of prints. Spelled out here so a rename is a red test rather than a
+        an interface — `is_a_question` matches `KIND_ASK` to decide what a pane will ask
+        instead of this process, and `already_said` matches `KIND_DECLINED` to keep an
+        operator's own "no" out of charter's red ✗. Each of those two questions has ONE
+        home, which is what makes a new kind like `KIND_MOVED` an entry here rather than an
+        edit at six call sites. Spelled out here so a rename is a
         branch that quietly stops matching, and asserted DISTINCT because two kinds that
         collided would make that branch answer for both.
         """
-        kinds = (launcher.KIND_IGNORED, launcher.KIND_PATH, launcher.KIND_NOT_YET,
-                 launcher.KIND_EXEC)
-        self.assertEqual(kinds, ("ignored", "path", "not-yet", "exec"))
+        kinds = (launcher.KIND_IGNORED, launcher.KIND_PATH, launcher.KIND_ASK,
+                 launcher.KIND_UNATTENDED, launcher.KIND_RECORD, launcher.KIND_MOVED,
+                 launcher.KIND_DECLINED, launcher.KIND_EXEC)
+        self.assertEqual(kinds, ("ignored", "path", "ask", "unattended", "record", "moved",
+                                 "declined", "exec"))
         self.assertEqual(len(set(kinds)), len(kinds))
 
     def test_the_path_the_exec_will_use_is_the_path_that_is_asked(self):
@@ -213,6 +223,9 @@ class TheLauncherBecomesTheProfile(_AProfileAndAPlane, unittest.TestCase):
         program.chmod(0o755)
         self.local.write_text('[harness.own-path]\nkind = "claude"\n'
                               'command = ["harness-only-here"]\n')
+        # The file was rewritten, so the record is seeded again: this case is about which
+        # `PATH` the check asks, and an unapproved profile would answer it a link earlier.
+        self._no_approval_needed()
         p = self._profile("own-path")
         self.assertIsNone(launcher.refusal(p, root=config.ROOT, attended=False,
                                            env={"PATH": str(elsewhere)}))
@@ -306,9 +319,9 @@ class ARefusalNamesTheProfileWithoutBecomingIt(_AProfileAndAPlane, unittest.Test
         return launcher.refusal(self._profile(LONG_NAME), root=config.ROOT,
                                 attended=False, env=dict(os.environ), **kw)
 
-    def test_the_not_yet_refusal_clips_it(self):
+    def test_the_ask_refusal_clips_it(self):
         r = self._refusal()
-        self.assertEqual(r.kind, launcher.KIND_NOT_YET)
+        self.assertEqual(r.kind, launcher.KIND_UNATTENDED)
         self.assertIn(self.CLIPPED, r.text)
         self.assertNotIn(LONG_NAME, r.text)
 
@@ -335,18 +348,18 @@ class ARefusalNamesTheProfileWithoutBecomingIt(_AProfileAndAPlane, unittest.Test
         self.assertIn(self.CLIPPED, r.text)
         self.assertNotIn(LONG_NAME, r.text)
 
-    def test_the_not_yet_refusal_offers_only_profiles_the_file_does_not_declare(self):
-        """The other half of :data:`launcher.DECLARED_NOT_YET`: it names what the operator
-        CAN launch, and a list that repeated the declared profiles back would name the very
-        commands this refusal exists to not run."""
-        self.local.write_text(f'[harness.{LONG_NAME}]\nkind = "claude"\n'
-                              'command = ["claude"]\n\n'
-                              '[harness.claude]\nkind = "claude"\ncommand = ["elsewhere"]\n')
-        offered = self._refusal().text.rsplit(": ", 1)[1].rstrip(".").split(", ")
-        read = profiles.current()
-        self.assertTrue(offered)
-        for name in offered:
-            self.assertEqual(read.profiles[name].source, profiles.BUILTIN, name)
+    def test_the_record_that_could_not_be_written_clips_it_too(self):
+        """The fourth sentence that quotes a name, and the one an operator meets while they
+        are already having a bad day — a full disk. It ends in "run it again", which is a
+        remedy a 200-character name in the middle would push off the screen."""
+        with mock.patch("sys.stdin", _Typed("y\n")), \
+                mock.patch("sys.stdout", _ATerminal()), \
+                mock.patch.object(launcher.config, "replace_for",
+                                  side_effect=OSError(28, "No space left on device")):
+            r = launcher.attempt(self._profile(LONG_NAME), [], fid=None, attended=True)
+        self.assertEqual(r.kind, launcher.KIND_RECORD)
+        self.assertIn(self.CLIPPED, r.text)
+        self.assertNotIn(LONG_NAME, r.text)
 
 
 class OnlyThePanesOwnFirstProcessIsFramed(_AProfileAndAPlane, unittest.TestCase):
@@ -597,6 +610,10 @@ class ARefusalInThePaneReachesTheOperator(_AProfileAndAPlane, unittest.TestCase)
         state.frame_dir("beta.1", create=True)
         self.enterContext(mock.patch.object(launcher, "framed_chat",
                                             return_value="beta.1"))
+        # No terminal to ask on, stated rather than inherited (`tests/_ttyguard`): these
+        # cases are about what a pane does with a refusal it already has, and a pane that
+        # could ask would answer its own question instead of producing one.
+        self.enterContext(mock.patch("sys.stdin", _APipe()))
 
     def test_an_attended_pane_waits_for_a_key_before_it_exits(self):
         waited: list[int] = []

--- a/tests/test_the_profile_words_are_written_down.py
+++ b/tests/test_the_profile_words_are_written_down.py
@@ -124,11 +124,18 @@ class TestTheNewsEntryKeepsItsShape(unittest.TestCase):
     """
 
     #: `test_news_gate.test_no_test_opens_an_entry_by_its_staged_name` refuses a test that
-    #: hard-codes `unreleased-<slug>.md`, so the entry is found by its headline instead.
+    #: hard-codes `unreleased-<slug>.md`, so the entry is found by what it is ABOUT instead.
+    #:
+    #: **By the term and not by the headline**, which is the correction Task 3 made: this
+    #: looked for "harness profiles from charter.local.toml", a phrase out of the headline
+    #: Task 1 wrote — and the plan has Task 3 replace that headline, so the locator went
+    #: looking for words its own feature had moved on from and the class failed as "no news
+    #: entry announces harness profiles". The term this entry exists to introduce outlives
+    #: every task's rewrite of the sentence around it.
     def _entry_text(self) -> str:
         for path in sorted((ROOT / "docs" / "news").glob("*.md")):
             text = path.read_text()
-            if "harness profiles from charter.local.toml" in text:
+            if "harness profile" in text:
                 return text
         self.fail("no news entry announces harness profiles")
 


### PR DESCRIPTION
Task 3 of the harness-profiles plan (`docs/superpowers/plans/2026-09-11-harness-profiles.md`),
on top of Task 1 (`53ae334`) and Task 2 (`3b4b6a3`).

Task 2 launched profiles and **refused every one the local file declared**, because nothing
stood for the operator's approval of a `command` that runs on a click (review B1). This is
the thing that stands for it, and `DECLARED_NOT_YET` goes in the same commit that replaces
it — so between this merge and Task 2's, `main` never runs an unapproved declared command.

## What it does

Charter records each profile's `kind`, `command` and `env` as last launched, in
`.charter/harness-profiles-launched.json` (`charter/profiletrust.py`). A profile with no
record, or one that no longer matches, is shown and asked about once:

```
charter: profile 'claude-work' is new — it has not run on this machine before.
  command  claude
  env      CLAUDE_CONFIG_DIR=~/.claude-work
run this? [y/N]
```

Anything but `y`/`yes` starts nothing and exits 130 — the workspace picker's own cancel
code. A yes is recorded, and that profile then starts without a word until one of the three
changes; a change asks again with a `was` line showing what it ran last time. **Built-ins
never ask**: their command comes out of charter's own registry rather than out of a file,
and a question that never carries risk is one you learn to answer yes to without reading. A
declaration under a built-in's name (`[harness.claude]`) is a declaration and asks.

**Why ask at all.** Once `charter.local.toml` is ignored, an edit to it leaves no diff;
nothing stops a chat editing plane config; and the command goes to tmux, so by the time a
harness could ask about it, that harness *is* the command. Codex trusts its hooks by hash
for the same reason.

**Where it asks, and where it refuses instead** (ruling 23, review 3). Asking needs a
terminal on stdin **and** stdout; either half missing is a hang rather than a question.

| Opening a chat | What happens |
|---|---|
| `charter claude-work` at a terminal | asks before tmux — a no is a `return` with no session, no window and no chat directory allocated |
| `charter claude-work --no-frame` | asks on that same terminal, then becomes the harness |
| `charter claude-work --no-frame > log` | refuses with `NEEDS_ASKING`, and never reads the pipe |
| the `+`, a workspace tab, the palette's new chat | asks **in the chat's own pane**: the press runs detached on `/dev/null` and the pane has a terminal on both ends. A no exits 130 and the window closes |
| `charter reopen`, a restored plane | refuses that chat by name and leaves it in the manifest for a retry |
| a chat handed off by another chat | refuses before anything is written |

Only `KIND_ASK` defers to the pane (N2a); every other refusal still happens before tmux,
where there is nothing to tear down.

**After a yes, the whole chain runs again from the top** (ruling 27), on every path, and
the pane runs it a third time immediately before the `exec`. A yes charter could not write
down refuses rather than running (N2b) — going round again would find no record and ask the
identical question, which is the one thing answering cannot fix. Refusals are typed
(`KIND_ASK`, `KIND_UNATTENDED`, `KIND_RECORD`, `KIND_DECLINED`) and every caller branches on
the kind, never on a sentence that will be reworded.

**Everything the prompt shows is contained** (ruling 35): the command and `env` come out of
a file a chat can write, and the `was` line out of `.charter/`, which is as writable.

**The limit is stated at full volume** (ruling 13), in the module docstring, in
`docs/control-plane.md` and in the news entry: the record is as writable by a chat as
`charter.local.toml` is, so the ask catches a command the operator did not change themselves
unless whatever changed it also forged the record. It closes the accident and the careless
edit; it is not a boundary.

## ADR, and the docstrings that disagreed with the code

Rebased onto `08692fa`, so Task 6's records (`b13fcdc`) are underneath this. That task had
already rewritten `docs/adr/0018`'s amendment against the shipped launcher; this **extends**
it rather than replacing it. The question is named as the second of the three things charter
writes in that pane; its containment is bounded (every profile-derived byte through
`contain.readable` with `NO_CLIP` — escaped, never clipped); it is put only where both of the pane's ends are a terminal and
somebody is at the open; and the read it makes is distinguished from the two reads of a
HARNESS's pane the 2026-09-01 amendment allows. Ruling 44: the amendment ships with the code
that relies on it.

Reviewing that ADR turned up **two claims the launcher's own module docstring made that the
code does not do**, both corrected here: it said an attended pane "waits for a key" when it
waits for a LINE (`_wait_for_the_operator` measures why — raw mode discarded an early key,
and a CI runner killed the launcher inside the terminal-mode change), and that an
*unattended* pane records its refusal under the chat, when both paths record and only the
WAIT is conditional — a decline, which the operator answered themselves, being the one
refusal not recorded (ADR 0018 says where that reads worse). The same pair stood in `_refused_in_pane`'s docstring, in
`commands_frame`'s comment above the `_await_the_launcher` call, and on
`state._LAUNCH_FILE`. The module docstring now also describes the module as this task leaves
it — the approval, the ask, and who waits.

## Tests

`tests/test_a_new_or_changed_profile_asks_once.py` — 52 cases: the record, the prompt, the
refusals, and every open in the table above. Task 2's `_approval_refusal` stand-ins are
gone: those cases now seed a real launch record through
`tests._isolation.approve_profile` / `approve_every_profile`, so the mechanics run through
the real approval. `tests/test_a_profile_launch_is_refused_before_tmux.py`'s three B1 cases
became the three ask cases the plan names.

**Real tmux** (`tests/test_a_chat_pane_starts_as_charter_and_becomes_the_harness.py`): a new
`ThePaneAsksBeforeItRunsANewCommand` — the pane shows the command and waits, nothing runs
before an answer, and a real `y` sent with `send-keys` starts the harness and leaves a
record. Plus `test_a_declared_profiles_env_reaches_the_harness_and_not_tmux`, the plan's own
case. Every real-tmux launch of a declared profile now seeds its record through
`approve_profile` and goes through `assert_approved`, which fails **before tmux** when one
is missing (Global Constraint, N6) — without a record an attended real pane asks and waits
until the suite's 600 s watchdog, and a hang is not a verdict.

**The two lines Task 2's own sweep could not measure**, for exactly that reason, now have a
fast unit-level pin each in `ThePinsARealTmuxCaseCouldOnlyHangOn`:
`_await_the_launcher`'s deadline, and `("--attended",) if attended else ()`. A second of
test time, no tmux.

## Suite

**Targeted modules locally; CI's matrix is the full-suite evidence** (three agents share this
machine, and a local full run under that contention is redundant with the four CI jobs that
gate the merge). Every module this change touches, plus every module covering the source
files it changes:

```
tests/_isolation.py · test_a_chat_carries_its_profile ·
test_a_chat_pane_starts_as_charter_and_becomes_the_harness ·
test_a_new_or_changed_profile_asks_once · test_a_profile_launch_is_refused_before_tmux ·
test_a_reopened_empty_chat_is_shown_its_brief · test_the_launcher_becomes_the_profile ·
test_the_profile_words_are_written_down
  Ran 259 tests in 11.576s — OK

test_frame_launcher · test_charter_names_a_profile_on_the_command_line ·
test_the_chat_bars_plus_makes_a_chat · test_a_workspace_tab_opens_what_it_names ·
test_a_chat_opens_in_the_background_with_its_first_message ·
test_a_reopen_says_what_it_cannot_bring_back · test_bare_charter_opens_the_frame ·
test_a_handoff_refuses_before_it_changes_anything ·
test_harness_profiles_are_read_from_the_local_file · test_charter_harness_list_shows_profiles
  Ran 682 tests in 22.940s — OK
```

The real-tmux module is in the first batch, and its two new cases drive a real pane: it shows
the command and waits, and a real `y` sent with `send-keys` starts the harness and leaves a
record.

## Sweep

**66 mutations across the three files this branch touches**, 453 added lines charged. The
first run of it — CI's, five shards, and `python3 tools/sweep.py` locally alongside — came
back **53 pinned, 12 survivors, 1 unresolved**. Every survivor is addressed here rather
than argued away, and each was hand-checked by applying the sweep's own mutation and
watching the covering case go red:

| Survivor | What it was, and what was done |
|---|---|
| `profiletrust._prompt` — `last_launched(p.name) or {}`, `was.get("env") or {}`, `was.get("command") or []` | Three fallbacks, and the first was genuinely dead: `approval_needed` had already proved the record was there. **The code changed**, not the test — `_state_and_record` reads the record ONCE and hands it down, so there is nothing to fall back to, and the other two became `dict.get(k, default)` for a record a chat can write with half a fingerprint in it. Pinned by a case over both shapes |
| `profiletrust._prompt` — `contain.readable(p.name)` | A 200-character declared name scrolls the command it is asking about off the top. Pinned by the clip, the way Task 2 pins its four refusals |
| `profiletrust._prompt` — `sorted(...)`, and the `if x` that drops an empty half | A `was` line that reorders itself between two asks reads as a change nobody made; one that begins with a space reads as a command that does. Both pinned |
| `profiletrust.NEW` / `CHANGED` / `DECLINED_EXIT` | Three literals every test reached through the constant, so any spelling passed. Now asserted as their own values AND inside the sentences that read them; `DECLINED_EXIT` is asserted equal to `commands_frame._PICKER_CANCELLED`, which is the reason it is 130 |
| `launcher.answered` — `contain.readable(...)` on the record's path and on the `strerror` | Neither is charter's own text: the path is built from the plane root and the `strerror` comes back from the kernel about a path the FILE chose. Pinned by a case that puts an ESC in both |
| `commands_frame._reopen_one` — `contain.readable(p.name)` | The reopen refusal ends in `Run charter <name> once to approve it`, which an unbounded name pushes off the screen. Pinned by the clip |
| `profiletrust.ask_in_terminal` — `except KeyboardInterrupt` (**unresolved**, not a survivor) | The shard timed out rather than answering; measured by hand here, where narrowing it to `ZeroDivisionError` reddens `test_a_control_c_at_the_prompt_declines` |

**Three rounds, and the last two are worth reading together.** Round one — CI's five shards
and a local full run, which agreed exactly — reported **12 survivors**; all twelve are fixed.
Round two came back **`no survivors`**, 66 of 66 pinned. The review fixes then added code, so
round three swept 67 mutations and named **2 more survivors**, both in the new lines:

| Survivor | What was done |
|---|---|
| `launcher.answered` — `contain.readable(p.name)` in the new `KIND_MOVED` sentence | The fourth one-line refusal that quotes a name, and it ends in the remedy `charter <name>` like its siblings. Pinned by the clip, as those are |
| `profiletrust._whole` — `shown.strip(" ")` → `lstrip` | **Equivalent, and the code changed rather than the test.** Either strip leaves nothing exactly when every character is a space, so no test could ever have told them apart — a survivor by construction. `set(shown) <= {" "}` is the decision stated directly, and `<`, `>=`, `>` and dropping the stand-in all redden now. `>=`/`>` are the interesting ones: they blank a word that merely CONTAINS a space, which is `--append-system-prompt "be terse"` |

**And the one line that was `unresolved` is measurable now**, which is what made round two
`no survivors` rather than `no verdict`. It was `ask_in_terminal`'s `except
KeyboardInterrupt`: `unittest` reads one raised inside a test as the operator interrupting
the run, so the narrowed mutant did not fail the case — it **ended the run**, SIGINT, exit
`-2`. That is neither green nor red, which is exactly what `unresolved` means. The covering
case catches it and calls `self.fail`, and the same mutation is an ordinary
`FAILED (failures=1)`.

Every fix in every round was hand-checked as well as swept: the mutation applied to a scratch
copy, the covering case watched going red. Two of those hand-checks were wrong at first — a
`count=1` replace hit a backticked mention in prose rather than the call — which is worth
saying, because each briefly read as a survivor that was not one.

## Departures from the plan

- **`ask_in_terminal` returns an `Answer(yes, why)` rather than a `bool`** — the fourth
  review's carried nit, so `attempt` can return `KIND_RECORD` for a yes it could not write
  down.
- **`record_launched` returns the `OSError`'s own text without the path.** Every caller that
  quotes one already names it (`RECORD_NOT_WRITTEN`), so returning it here printed it twice.
- **A decline is its own kind, `KIND_DECLINED`, carrying no text.** `ask_in_terminal` has
  already said `charter: nothing started.` on the terminal the question went to — in
  `_choose_workspace`'s own words for a cancel — so `start`, `_launch` and
  `cmd_frame_launch` all stay quiet for it. Repeating it under charter's red ✗ would report
  the operator's own answer as a rule firing, and a pane must not wait for Enter under a
  question its operator has just answered.
- **`NEEDS_ASKING`, `UNATTENDED` and `REOPEN_UNAPPROVED` drop "since it last ran".** The
  plan's wording read as false for the `new` state, which has never run at all.
- **`_launch`'s `--no-frame` branch passes the OPEN's `attended`** rather than
  `sys.stdin.isatty() and sys.stdout.isatty()`, which Task 2 conflated. They are different
  questions now that `can_ask` exists, and the old spelling made
  `charter <profile> --no-frame > log` say "nobody is at this open" about a command somebody
  had just typed instead of the `NEEDS_ASKING` the plan's own table asks for.
- **`background_refusal` gained no new check**: Task 2's `_how_a_background_open_would_go`
  already calls `_launch_refusal(p, attended=False)` right after `_same_profile_as`, which
  is the check the plan asks for.
- The plan's `Produces` block and Task 3 `Files` list are amended to record all of the
  above, so Tasks 4 and 5 read what shipped.

## Proved false

- **`docs/harnesses.md` still said "Launching a profile arrives in a later release. Today
  the list is what charter read, and every launch is the one it always was."** Task 2 made
  the first half false and this makes the second half false; corrected here.
- **`charter/frame/launcher.py`'s module docstring said an attended pane "waits for a key"
  and that only an *unattended* one records its refusal.** Both false against Task 2's own
  code — it waits for a line, and both paths record (a decline excepted). Three more copies of the pair, in
  `_refused_in_pane`, `commands_frame` and `frame/state.py`, said the same. All corrected.
- **Task 6's `test_the_profile_words_are_written_down` found the news entry by a phrase out
  of the headline Task 1 wrote**, which the plan has this task replace — so the locator went
  looking for words its own feature had moved on from, and the class failed as "no news
  entry announces harness profiles" the moment the headline changed. It finds the entry by
  the term it exists to introduce instead.
- **`ARefusalInThePaneReachesTheOperator`'s premise no longer held.** It refused a declared
  profile in a real attended pane — which now *asks* there, because it has a terminal. The
  class keeps ruling 42's two halves against a `NOT_ON_PATH` refusal instead, which is the
  refusal an operator actually meets, and it carries 127 rather than 3 as its exit code.
- **ADR 0018's Task 2 amendment did not cover the ask.** Its bound reads "Only a refusal …
  one sentence charter wrote, plus `press Enter to close this chat.` … and never a second
  thing later", which the approval prompt is. Ruling 44 made that this PR's to fix.

No version bump, no tag. Not to be merged by me.

## Fix-up after verifying the fix round (`86dfef8`)

A read-only check of `e8c7558` → `6a59ebb` against both review sets found S1, S2, F3, F4 and
the structure items fixed, no path by which a declared command runs without a matching
record, and two rulings half done — both in what the records claim:

| Finding | Outcome |
|---|---|
| F1: ADR said a surface that must clip says how much it kept back, but this PR's refusal sentences bound a name with the fixed `...` | ADR now separates them: a sentence bounds a name it quotes; a row the operator chooses from counts what it hid; the prompt clips nothing |
| F2: "not a hole" reason false in an operator's tmux, where `_launch_in_operator_tmux` reads the record whatever the open | ADR states that a decline there can read as a window gone — a less exact sentence, nothing ran; `commands_frame`'s fourth "EVERY pane records" copy names the exception |
| `KIND_MOVED` read the record a third time for `{state}`, which could render "is  again" | The sentence no longer carries a state |
| `_whole` duplicated `contain.readable(x, contain.NO_CLIP)` | Replaced by it |
| Stale `_answered` name; stale "no `r is not None`" comment | Corrected |

Affected modules run locally on an isolated `TMUX_TMPDIR`: 664 + 97 tests, OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

