### PR TITLE
Harness profiles are written down: the ADR, the 0017 and 0018 amendments, and the words

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -20,6 +20,27 @@ same invariants on every harness; what differs is what it can *offer*, and `char
 names each gap rather than leaving it to be found (ADR 0015).
 _Avoid_: host, client, runner, IDE, platform
 
+**Harness profile**:
+A named way to launch one harness kind — its kind, its command, its environment — declared
+in the plane's `charter.local.toml`, which charter keeps out of git because a profile's
+command runs on a click with no permission prompt in between. Every registered kind is also
+a profile named after itself. Never an *alias*, which is a shell feature charter never sees,
+and not an *account*: a profile need not be a different one (ADR 0022).
+_Avoid_: alias, account
+
+**Kind**:
+Which harness program a profile launches, written as the word typed after `charter`:
+`claude`, `codex`, `opencode`. `$CHARTER_HARNESS` still holds the registry's name for it —
+`claude-code` — because hooks compare that value; the profile's own name rides beside it in
+`$CHARTER_HARNESS_PROFILE`.
+_Avoid_: type, flavour
+
+**Profile selector**:
+What a new chat's pane shows before any harness has run in it; the harness starts in that
+pane once a profile is picked. Not the workspace *picker*, which runs before tmux exists
+because a workspace is a tmux session and charter has to know which one first.
+_Avoid_: menu, dropdown, picker
+
 **Host**:
 A forge host — `github.com`, a self-hosted GitLab. Never the agent runtime: both senses of
 this word were load-bearing at once until ADR 0015 split them.

--- a/docs/adr/0017-charter-ignores-what-carries-credentials.md
+++ b/docs/adr/0017-charter-ignores-what-carries-credentials.md
@@ -72,3 +72,33 @@ but the missing reasoning.
 - This does not license charter to manage a plane's `.gitignore` generally. The trigger is
   narrow — charter's command created the path, and the path carries credentials. A path
   that fails either half gets a sentence, not a write.
+
+## Amendment, 2026-09-12: a file whose whole meaning is "not committed"
+
+`charter init` writes `/charter.local.toml` into a new plane's `.gitignore`, and
+`charter reinit` adds the line to a plane made before harness profiles existed. That file
+fails the second half of rule 1 as written: it holds `[harness]` tables — a kind, a command,
+an environment — and a variable named like a credential is **refused** in one, so by
+construction it carries none.
+
+The line is written anyway, because the trigger was never the word "credentials". It was
+*whether the plane has a defensible second posture*, and credential material was the only
+category where the answer had reliably been no. This file is the second: a harness profile
+is one machine's account and one machine's install path, and **the file exists only to hold
+what must not be shared** ([ADR 0022](0022-a-harness-profile-belongs-to-one-machine.md)).
+Committing it is not a choice with a cost on each side, the way committing
+`.claude/skills/playwright-cli/` is. It is the file's purpose, inverted.
+
+What is new, and what makes this worth recording rather than filing under "close enough":
+**charter does not trust the line it wrote.** A trace committed by accident is a disclosure —
+bad, and over. A profile in a committed file is a *command that runs on a click, on every
+machine that pulls it*, which is a failure with a future. So the line is a claim charter
+re-checks: while git tracks `charter.local.toml`, or would commit it, every profile declared
+there is refused by name with its own fix, and `charter doctor` warns. A plane that is no git
+repository has nothing to commit to and passes; any other answer git cannot give refuses too,
+because an unknown is not a pass ([ADR 0009](0009-errors-classify-they-do-not-guess.md)).
+
+The narrowness above survives intact, with the first half of the trigger unchanged and the
+second half stated as what it always meant: **charter's own command created the path, and the
+path has no posture but "untracked"**. A path a plane could reasonably commit still gets a
+sentence, not a write.

--- a/docs/adr/0018-charter-may-run-the-harness-but-never-draws-it.md
+++ b/docs/adr/0018-charter-may-run-the-harness-but-never-draws-it.md
@@ -156,18 +156,33 @@ trimming afterwards: the bound belongs where the memory is. Verified on tmux 3.7
 
 Harness profiles put a charter process in the pane. `charter frame-launch --profile <name>`
 is what tmux now starts in every chat pane, and it becomes the harness by `os.execvpe`
-replacing itself with the profile's command (`charter/frame/launcher.py`). A launcher that
-refuses — the local file became committable since the pre-tmux check, the command is not on
-`PATH`, the profile is declared and nothing can ask the operator's approval yet — **prints
-that refusal in the pane and holds the pane open until somebody presses Enter.**
+replacing itself with the profile's command (`charter/frame/launcher.py`). Before that
+happens, charter may write on that screen, and there are exactly two things it writes.
 
-That is charter drawing in a chat's pane, which the rule above says it never does. The rule
+**A refusal** — the local file became committable since the pre-tmux check, the command is
+not on `PATH`, the profile is declared and nothing can ask the operator's approval yet, the
+`execvpe` itself raised — goes into the pane, and where somebody is at the keyboard the
+launcher **holds the pane open until they press Enter.**
+
+**A claim to a chat that cannot be proven** is the second, and it is not a refusal: the
+launch goes ahead. `launcher.framed_chat()` asks tmux whether this process's own pid is the
+`#{pane_pid}` of a live pane belonging to the chat it was handed, because `$TMUX_PANE` and
+`$CHARTER_SESSION_ID` are inherited by a model's tool shell and prove nothing. A claim that
+does not check prints one line saying so and returns `None`, and the launcher then runs as a
+launch with **no frame** — it records nothing for that chat, which is the point of the
+proof. Silently downgrading would cost a chat its session id and its resume id with nothing
+said, so the sentence goes where the person watching is: the pane the harness is about to
+take over.
+
+That is charter writing in a chat's pane, which the rule above says it never does. The rule
 is right and this is not an exception to it, because of *when*: **no harness has ever run in
-that pane.** The `exec` has not happened, so there is no harness process, no output of its
-own on that screen, nothing to draw over and nothing to parse. Every failure this ADR was
-written against needs a harness on the other side of the pane to occur at all — owning a
-terminal parser, deciding what somebody else's cursor means, painting over somebody else's
-frame — and none of them is reachable before the process that would produce them exists.
+that pane.** The `exec` has not happened — or it was attempted and raised, which leaves the
+same pane with the same charter process in it and no harness either way — so there is no
+harness process, no output of its own on that screen, nothing to draw over and nothing to
+parse. Every failure this ADR was written against needs a harness on the other side of the
+pane to occur at all — owning a terminal parser, deciding what somebody else's cursor means,
+painting over somebody else's frame — and none of them is reachable before the process that
+would produce them exists.
 
 **The distinguishing question, in the same shape as the one above:** *has a harness ever run
 in this pane, and is charter's own process still the one in it?* No and yes is this
@@ -176,7 +191,8 @@ the harness's, `state.record_launch` says so, and nothing charter owns writes th
 
 **Why the refusal cannot simply be printed and exited on, which is the whole reason this is
 a decision and not a detail.** Measured 2026-09-11 on tmux 3.7c and at the 3.2 floor, 40
-runs, in `workspaces/harness-profiles/refs/task2-measure/`: `_launch`'s eager
+runs, in the pull request that shipped this launcher
+([#981](https://github.com/diazoxide/charter/pull/981)): `_launch`'s eager
 `#{pane_dead_status}` ask completes **6-14 ms** after the start while a Python launcher's
 first line runs at **19-22 ms**, so the ask is always too early to catch a refusal — and by
 the time anything else could look, the chat-teardown hook has killed the window.
@@ -187,13 +203,24 @@ record.
 
 **Bounded, and each bound is checkable from outside.**
 
-* **Only a refusal, and only before the `exec`.** One sentence charter wrote, plus
-  `press Enter to close this chat.` — no escape sequences of charter's own, no panel, no
-  layout, and never a second thing later.
-* **Only where somebody is there to read it.** An ATTENDED open waits; a reopen, a handoff
-  and a background open write the same sentence into the chat's state directory instead
-  (`state.record_launch`), where the launch that opened the chat reports it. A pane nobody
-  is at never stops on anything.
+* **Only while no harness has ever run in that pane** — the distinguishing question above,
+  and not the pair this amendment first wrote, *only a refusal, and only before the `exec`*.
+  Each half of that pair is wrong exactly once: an unproven chat prints a line that is **not
+  a refusal**, and an `execvpe` that RAISES prints its refusal **after** the exec was
+  attempted. Neither leaves a harness in the pane, which is why the rule survives both and
+  the pair did not. The bound is checkable from outside because there is one moment it
+  turns: `state.record_launch`, written the instant the pane stops being charter's.
+* **Two sentences, and charter wrote both.** A refusal, plus `press Enter to close this
+  chat.` where the pane waits; or the one line an unproven chat prints before launching
+  anyway. No escape sequences of charter's own, no panel, no layout, and never a third thing
+  later.
+* **Every refusal is recorded, and only the WAIT is conditional.** `_refused_in_pane` writes
+  the sentence into the chat's state directory on every path (`state.record_launch`), the
+  attended one included, where the launch that opened the chat reports it. What an attended
+  open adds is the wait — and that needs two conditions rather than one: the open must be
+  ATTENDED **and** the pane's stdin must be a terminal, because `_wait_for_the_operator`
+  returns at once when `sys.stdin.isatty()` is false. So an attended launcher run out of a
+  pipe prints and exits, and a reopen, a handoff or a background open never stops at all.
 * **A line, not a keystroke.** Waiting on one keypress means putting the pane's terminal
   into raw mode, and a `tcsetattr` from a pane on a Linux CI runner left the launcher killed
   by a signal — an empty `#{pane_dead_status}` — so the refusal went with the window after
@@ -204,6 +231,14 @@ record.
   pane to react to what a harness printed in it.
 
 Recorded here rather than in the records task that closes this phase, because the code that
-relies on it ships in the same pull request (`workspaces/harness-profiles/workspace.md`,
-ruling 44): otherwise `main` carries an unqualified prohibition while the code contradicts
+relies on it shipped in the same pull request
+([#981](https://github.com/diazoxide/charter/pull/981); the rule is *an ADR amendment ships
+with the code that first relies on it*, `docs/superpowers/plans/2026-09-11-harness-profiles.md`,
+Task 6): otherwise `main` carries an unqualified prohibition while the code contradicts
 it, and the only thing telling a reader otherwise is a spec they have no reason to open.
+
+*Corrected 2026-09-12 by that records task, against the shipped
+`charter/frame/launcher.py`: the unproven-chat line named as the second thing charter writes
+there, the `execvpe`-that-raised case covered, "only before the `exec`" replaced by the
+distinguishing question, the wait's two conditions both stated, the record separated from
+the wait, and the measurement cited where a reader can open it.*

--- a/docs/adr/0022-a-harness-profile-belongs-to-one-machine.md
+++ b/docs/adr/0022-a-harness-profile-belongs-to-one-machine.md
@@ -15,8 +15,10 @@ A **harness profile** answers both: a name, a kind, a command and an environment
 the operator, and a chat that starts on the one somebody picked. This record holds the
 decisions that were expensive to reverse and the reason each rests on. The mechanics — every
 key of the table, every refusal and its fix — are in
-[`docs/control-plane.md`](../control-plane.md), and the grill that settled them, ruling by
-ruling, is `workspaces/harness-profiles/workspace.md` in the plane this was built on.
+[`docs/control-plane.md`](../control-plane.md). What the grill settled is
+`docs/superpowers/specs/2026-09-11-harness-profiles.md`, and the rulings taken on the way are
+that plan's own `## Controller rulings`
+(`docs/superpowers/plans/2026-09-11-harness-profiles.md`).
 
 Written while the feature lands in stages
 (`docs/superpowers/plans/2026-09-11-harness-profiles.md`): the decisions below are settled,

--- a/docs/adr/0022-a-harness-profile-belongs-to-one-machine.md
+++ b/docs/adr/0022-a-harness-profile-belongs-to-one-machine.md
@@ -1,0 +1,227 @@
+# A harness profile belongs to one machine
+
+`Harness.binary` is a class attribute and `launch_argv` returns `[binary, *extra]`. Nothing
+overrides either, so charter has run one program per harness kind, one way, and an operator
+with a work Claude Code account in one `CLAUDE_CONFIG_DIR` and a personal one in another has
+had nowhere to say so. A shell alias is no answer: charter runs the binary with no shell —
+`execvp` where there is no frame, tmux's own exec in a pane, `shutil.which` only as a
+pre-check — so an rc-file alias never resolves.
+
+A second failure sits beside it. Bare `charter` launched `[harness] default`, and `+`
+launched the kind of the chat it was pressed from, so opening charter on an empty workspace
+started a harness session before anybody had said which one they wanted.
+
+A **harness profile** answers both: a name, a kind, a command and an environment, declared by
+the operator, and a chat that starts on the one somebody picked. This record holds the
+decisions that were expensive to reverse and the reason each rests on. The mechanics — every
+key of the table, every refusal and its fix — are in
+[`docs/control-plane.md`](../control-plane.md), and the grill that settled them, ruling by
+ruling, is `workspaces/harness-profiles/workspace.md` in the plane this was built on.
+
+Written while the feature lands in stages
+(`docs/superpowers/plans/2026-09-11-harness-profiles.md`): the decisions below are settled,
+and the code for each arrives with the task that owns it.
+
+## The click is the reason for most of what follows
+
+A profile's `command` runs on a click. Between pressing `+` and `os.execvpe` there is no
+harness permission prompt, no tool call a guard could deny, nothing that shows a human the
+words about to be run — the command goes to tmux, and tmux runs it. Everything in this
+record that looks like suspicion of the operator's own file is that sentence, applied.
+
+**So profiles live only in `charter.local.toml`, beside `charter.toml` and out of git.**
+Accounts and install paths belong to one person's machine, and a command in the committed
+file could be changed by a merged pull request, or by a chat writing the file it is running
+in, and then run on every machine that pulls it. A `[harness.<name>]` table in `charter.toml`
+is refused with a pointer to the local file. The committed `[harness]` keeps `default` and
+nothing else changes there.
+
+**The local file carries `[harness]` and nothing else**, refusing every other section by
+name. A general overlay would let an ignored file change plane policy with no trace in git —
+`[[forge]]` hosts steer the one-credential guard (`charter/gitpolicy.py`) — and "override"
+has no definite meaning for a list table anyway. `[frame]`'s look keys are the likely next
+section to be admitted, each on its own reason.
+
+**"Ignored" is guaranteed rather than hoped for.** `charter init` writes
+`/charter.local.toml` into a new plane's `.gitignore` and `charter reinit` backfills it —
+which needed an amendment to [ADR 0017](0017-charter-ignores-what-carries-credentials.md),
+whose rule covers a path charter creates that carries credentials, and this file carries
+none. Charter does not then trust its own line: while git tracks the file, or would commit
+it, the profiles in it are refused by name and `doctor` warns. A plane that is not a git
+repository has nothing to commit to and passes; any other answer git cannot give — git
+missing, a timeout, output that does not parse — refuses too, because an unknown is not a
+pass ([ADR 0009](0009-errors-classify-they-do-not-guess.md)). The check is one
+`git --no-optional-locks status`, so it takes no `index.lock` from a `charter save` running
+beside it, and it runs where a person asked — a launch, the selector, `charter harness list`,
+`charter harness install`, `charter doctor` — never on a config read, so no hook pays a git
+call per tool call. One hook pays one per session: SessionStart runs `charter doctor`, so a
+plane that has a `charter.local.toml` makes that single `git status` at each session start.
+Named here rather than left to be found.
+
+**A new or changed command asks once.** Charter records each profile's `kind`, `command` and
+`env` as last launched, under `.charter/`; a profile with no record, or with a different one,
+shows its command and asks `run this? [y/N]` before it runs. Built-ins never ask. Why an ask
+and not a rule: once the file is ignored, an edit to it leaves no diff for a reviewer to
+catch, and nothing stops a chat editing plane config. Codex trusts its hooks by hash for the
+same reason. After a yes, the whole chain of checks runs again from the top before the
+`exec`, so a yes never walks past a refusal standing behind it; an open nobody is at refuses
+where it would have asked, rather than waiting on a question nobody can see.
+
+## No credential goes in `env`
+
+A variable set on the harness process reaches the shell the model runs. Measured on Claude
+Code — the grill's own tool shell saw `CLAUDE_CODE_MESSAGING_TOKEN` — and on Codex, whose
+default `shell_environment_policy` passed a `*_TOKEN` probe straight through (`codex
+sandbox`, 0.147.0). So an `env` name containing `KEY`, `TOKEN`, `SECRET` or `PASSWORD` is
+refused, and the refusal names the harness's own login in the config folder the profile
+already moves: `CLAUDE_CONFIG_DIR` and `/login`, `CODEX_HOME` and `codex login`,
+`XDG_DATA_HOME` and `opencode auth login`.
+
+A vault reference was considered and rejected on the same measurement: resolving
+`vault:work/token` at launch puts the value on the harness process, which is where the model's
+shell reads it — the key would only rest somewhere else first. **Charter declines to hold a
+credential in a profile, and cannot prevent one**: a wrapper script named in `command` can
+export whatever it likes, and charter sees a program name.
+
+## Unwired refuses to launch, built-ins included
+
+Measured on claude 2.1.268, codex-cli 0.147.0 and opencode 1.18.23, in throwaway folders with
+no login: **a harness pointed at another config folder loads none of charter's wiring.**
+Claude Code lists no charter plugin — not even "enabled but not installed" — even in a
+directory whose `.claude/settings.json` enables it, because the `charter` marketplace is
+known only to `~/.claude/settings.json`. An empty `CODEX_HOME` holds no plugin, no hook trust
+and no `shell_environment_policy.set` line. opencode under another `XDG_CONFIG_HOME` loads no
+shim, and its shells are handed no `CHARTER_HARNESS`.
+
+A chat in that state looks guarded and is not. So a profile whose wiring charter cannot find
+refuses to launch and prints the fix, and no flag launches one unguarded. **The refusal
+covers the built-ins too** — `charter codex` where nobody wired Codex, `charter opencode`
+where `init` never wrote the shim, both of which run today — because a chat that looks
+guarded and is not is the same failure whichever profile started it.
+
+Wiring is detected by **asking the harness under the profile's own environment**, never
+inferred from which variables the profile sets: one account is reachable through variables
+that do and do not move the plugin. Claude Code's `CLAUDE_SECURESTORAGE_CONFIG_DIR` moves the
+login alone by its own binary's code, and opencode's login follows `XDG_DATA_HOME` while its
+plugins follow `XDG_CONFIG_HOME`. Codex is the exception that cannot be asked — `codex plugin
+list` answers the same for an empty home and a wired one — so charter reads that home's
+`config.toml` instead, and counts it wired only with all three marks present.
+
+A probe that cannot answer — a timeout, a non-zero exit, output that does not parse —
+refuses the launch and names the probe to run by hand. Same rule as the git answer above, and
+the same ADR 0009 behind it.
+
+## `CHARTER_HARNESS` stays the kind, and the profile rides beside it
+
+The obvious move is to put the profile's name in `CHARTER_HARNESS`, where every hook would
+find it. It is wrong: hooks compare that variable to `claude-code` for session ids, resume
+and the working spinner (`hooks._turn_begin`, `hooks._record_harness_session`), and a value
+of `claude-work` would make each of them quietly answer "not Claude Code". `CHARTER_HARNESS`
+keeps the registry's name for the kind. The profile is a field of its own —
+`CHARTER_HARNESS_PROFILE` — set by the launcher at the `exec` rather than through tmux, and
+recorded in the chat's state and in the reopen manifest. It never joins
+`commands_frame._FRAME_IDENTITY`, because that would put it on a tmux `-e`.
+
+**Every chat pane starts as a charter launcher that `exec`s the profile.** Three reasons, the
+first a constraint: a profile's `env` reaches the harness without being added to
+`layout.CARRIABLE`, which raises on every name it does not know, and without passing through
+tmux's own argument parser, which has already cost this repo #957 and #961; one process runs
+the checks for every open — the CLI, the selector, `+`, a reopen, a handoff; and `exec` keeps
+the launcher's pid, so the harness is the process the launcher was, and the pane id charter
+recorded, `remain-on-exit` and the `pane-died` path all see what they see today. What that
+launcher may put on the screen before the `exec`, and why it has to hold the pane rather than
+print and exit, is [ADR 0018](0018-charter-may-run-the-harness-but-never-draws-it.md)'s
+2026-09-12 amendment.
+
+## No harness starts until somebody picks a profile
+
+Opening charter on a workspace with no running chat, and `+`, show a **profile selector** in
+the chat's own pane; the harness starts there once a row is picked. It shows even when one
+profile is available, because skipping it would bring back the harness nobody picked on a
+one-harness machine, and one profile costs one Enter. Esc closes that window having started
+nothing — which is what #518 could not offer when it put the workspace picker *before* tmux,
+because cancelling there meant tearing down a launch that had half happened. Here nothing has
+happened: no harness ran, and no identity was recorded.
+
+The workspace prompt stays before tmux for the reason it was put there: a workspace *is* a
+tmux session, so charter has to know which one before a frame exists. A profile belongs to
+one chat, so choosing it belongs in that chat's pane.
+
+Every open that nobody is at names its profile instead: `charter <profile>`, a reopen, a
+restored plane, a chat handed off by another chat. **A reopened chat whose profile is gone is
+skipped by name, never given another.** Another profile may be another account, where that
+chat's resume id does not exist and where its workspace's code was never meant to go. It stays
+in the manifest, so declaring the profile again and running `charter reopen` brings it back.
+
+**There is no `charter harness add`.** A chat can run a command as easily as it can edit a
+file, so the command could never stand for the operator's approval of what it wrote — it
+would buy typing and nothing else. `charter harness list` shows every profile charter read,
+the file it came from, and why any was refused.
+
+## Refused by name, and the name stays refused
+
+A broken profile is refused alone and the rest still load, because a missing profile is a row
+that is not in the selector — easy to miss in a way a missing panel is not, which is why
+`[[frame.component]]` makes the opposite trade and refuses its whole arrangement.
+
+Two refusals are worth recording with their reasons, because both look like fussiness:
+
+- **A key inside a profile other than `kind`, `command` and `env` refuses that profile.** A
+  typo such as `enviroment` would otherwise drop `CLAUDE_CONFIG_DIR` and launch the default
+  account without a word — the failure the feature exists to prevent, arrived at by spelling.
+- **A declared profile that replaces a built-in and is refused takes the name down with it**,
+  rather than letting the built-in stand in. The operator said how `claude` runs on this
+  machine; running the default in its place runs the command they replaced.
+
+## What was considered and rejected
+
+- **One `"kind: command args"` string.** It has nowhere to put environment variables, which
+  is how a second account is usually selected in the first place, and it would make charter
+  split a string the way a shell does. Every later option would have been more invented
+  syntax.
+- **A per-user `~/.config/charter` file.** The operator's call: profiles are per plane and
+  per machine, and a plane's own directory is where its other configuration is.
+- **A full overlay in the local file.** An ignored file that could restate `[[forge]]` would
+  move plane policy with no trace in git.
+- **A vault reference in `env`.** The value lands on the harness process either way.
+- **Setup at launch.** A click would write a plugin into a second account unasked, and Codex
+  ignores hooks nobody approved, so the click would not even work.
+- **The selector before tmux, beside the workspace prompt.** A profile belongs to one chat,
+  and there is no chat yet at that point.
+- **A `charter harness add` command.** Above: it cannot be approval.
+
+## Consequences, including what this costs
+
+- **The launch record and the wiring cache live under `.charter/`, which is as writable by a
+  chat as `charter.local.toml` is.** The ask catches a changed command only where whatever
+  changed it did not also forge the record, and a launch therefore never trusts the cached
+  wiring answer — it probes fresh, and the selector's cache draws rows and decides nothing.
+  Charter adds no guard for either path: a path pattern is host policy
+  ([ADR 0014](0014-policy-that-fits-a-pattern-belongs-to-the-host.md)).
+- **A launcher's claim to be in a frame is a guard rail, not a boundary.** It proves the claim
+  by being its pane's first process — its own pid equal to the `#{pane_pid}` of a live pane
+  that belongs to the chat it names, read from tmux — because `$TMUX_PANE` and
+  `$CHARTER_SESSION_ID` are inherited by a model's tool shell and prove nothing. Measured
+  2026-09-11: a framed chat's Bash tool saw `TMUX_PANE=%3195`, the harness pane of its own
+  chat, so a pane-id proof would have passed for a model running `charter frame-launch` by
+  hand. A process that deliberately starts its own tmux pane in a window named like a chat
+  still passes the pid proof. It stops an accident, not an attempt.
+- **The `env` refusal is a pattern match, so it can refuse an innocent name** —
+  `KEYBOARD_LAYOUT` contains `KEY` — and a wrapper script on `PATH` can still export a key
+  charter never sees. This is a refusal to hold one, not a barrier against one.
+- **Asking a harness is not free and not read-only.** A probe costs about 215–281 ms for
+  `claude plugin list --json` and 720–750 ms for `opencode debug config`, and
+  `claude plugin list --json` writes `.claude.json` into the config folder it runs against
+  (measured). That is why no probe runs on a hook path, SessionStart's preflight included,
+  and why `doctor` spends a subprocess per profile only when a person ran it.
+- **A one-harness machine pays one more keypress** at every bare `charter` and every `+`.
+  Bought deliberately: the alternative is the harness nobody picked, which is one of the two
+  failures this record opens with.
+- **`[harness] default` launches nothing any more.** It chooses the row the selector starts
+  on, and a `default` naming a profile this machine lacks marks no row and makes `doctor`
+  warn, rather than refusing a launch.
+- **The proof this is checked against is one account in two Claude Code config folders, not
+  two accounts.** Two accounts is what an operator will actually do, and nothing here has
+  been run against it.
+- **opencode also reads `~/.opencode/` whatever `XDG_CONFIG_HOME` says** — a possible home
+  for a shim that would survive a profile switch, and it is unmeasured.

--- a/docs/control-plane.md
+++ b/docs/control-plane.md
@@ -464,7 +464,9 @@ Two Claude Code accounts, work in one config folder and personal in another, or 
 pinned to an older release: charter ran one program per harness, one way, and had no way to
 be told otherwise. A shell alias does not help — charter runs the harness with no shell, so
 the alias never resolves. A **harness profile** is the way: a kind, a command and an
-environment, declared in a file that stays on your machine.
+environment, declared in a file that stays on your machine. The decisions behind the shape
+of this, and the reason each one rests on, are
+[ADR 0022](adr/0022-a-harness-profile-belongs-to-one-machine.md).
 
 **Every chat now starts through charter's own launcher, and launching a DECLARED profile
 arrives in a later release.** Charter reads the profiles, refuses the broken ones by name,

--- a/docs/news/unreleased-harness-profiles.md
+++ b/docs/news/unreleased-harness-profiles.md
@@ -21,7 +21,9 @@ named after it, and yours — with the file each came from and why any was refus
 charter cannot launch, a command written as a shell string, a name `charter` already uses, a
 variable named like a credential. Charter holds no credential in a profile, because anything
 set on the harness reaches the model's own shell; that refusal names the harness's own login
-instead.
+instead. It is a refusal to hold one and not a barrier against one: the pattern can catch an
+innocent name — `KEYBOARD_LAYOUT` contains `KEY` — and a wrapper script named in `command`
+can export whatever it likes.
 
 A profile's command will run on a click, so the file must never be committed. `charter init`
 writes `/charter.local.toml` into a new plane's `.gitignore` and `charter reinit` adds it to

--- a/docs/superpowers/specs/2026-08-28-phase5-workspace-and-chat-tabs.md
+++ b/docs/superpowers/specs/2026-08-28-phase5-workspace-and-chat-tabs.md
@@ -329,6 +329,15 @@ side.
 2. **The harness's auth.** Every harness authenticates itself, entirely outside the abstraction.
    Two chats on the same harness share that harness's credentials. Charter cannot separate them
    and does not pretend to (§4).
+
+   > *Superseded 2026-09-11 by harness profiles
+   > (`docs/superpowers/specs/2026-09-11-harness-profiles.md`,
+   > [ADR 0022](../../adr/0022-a-harness-profile-belongs-to-one-machine.md)): two profiles of
+   > one kind can hold two logins, because a profile carries the environment — a
+   > `CLAUDE_CONFIG_DIR`, a `CODEX_HOME` — that points the harness at another config folder.
+   > Charter still holds no credential of its own: the login is the harness's, made by running
+   > `/login` inside that folder. The sentence above stays because this spec is the record of
+   > what was decided in August.*
 3. **Anything drawn in the harness pane.** ADR 0018, enforced by construction: `_surface_argvs`
    never takes the harness pane as an argument.
 

--- a/tests/test_the_profile_words_are_written_down.py
+++ b/tests/test_the_profile_words_are_written_down.py
@@ -1,0 +1,138 @@
+"""The profile decisions are written down where a reader without the plan can find them.
+
+Harness profiles were settled in a grill and then built over seven tasks, and the reasons
+lived in a workspace file that ships with nobody. This is the tripwire for the three places
+that carry them into the repo: `CONTEXT.md` for the words, `docs/adr/` for the decisions,
+and the phase-5 spec's own credentials sentence, which profiles made false.
+
+The ADR is pinned **by slug, not by number**. The chat-handoff plan claims 0021 and pins
+that number in its own test, so whichever of the two merges first must not break the other
+(`workspaces/harness-profiles/workspace.md`, controller ruling 2).
+
+These read files off the tree, never through `config`: a test that resolved the plane would
+be answering about whatever plane it ran in.
+"""
+
+from __future__ import annotations
+
+import re
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+ADR = ROOT / "docs" / "adr"
+
+
+def _entry(text: str, term: str) -> str:
+    """The body of one `**Term**:` entry in `CONTEXT.md`, up to the next bold term.
+
+    Sliced rather than line-counted because an entry's definition runs to as many lines as
+    it needs, and `_Avoid_` is the last of them.
+    """
+    start = text.index(f"**{term}**:")
+    rest = text[start + len(term) + 5:]
+    end = rest.find("\n**")
+    return rest if end < 0 else rest[:end]
+
+
+class TestTheWordsAreDefined(unittest.TestCase):
+    def test_context_defines_the_three_terms(self):
+        """A word charter refuses on (`account`, `alias`) has to be in the glossary that
+        says why, or the next writer reaches for it again."""
+        text = (ROOT / "CONTEXT.md").read_text()
+        for term in ("Harness profile", "Kind", "Profile selector"):
+            self.assertIn(f"**{term}**:", text, f"CONTEXT.md defines no {term!r}")
+            body = _entry(text, term)
+            self.assertRegex(body, r"(?m)^_Avoid_:",
+                             f"{term!r} names nothing it is not")
+
+    def test_the_profile_glossary_refuses_alias_and_account(self):
+        """The two words the spec's Language section rules out by name — a shell alias
+        charter never sees, and an account a profile need not change."""
+        body = _entry((ROOT / "CONTEXT.md").read_text(), "Harness profile").lower()
+        avoid = body[body.index("_avoid_:"):]
+        for word in ("alias", "account"):
+            self.assertIn(word, avoid, f"'harness profile' still permits {word!r}")
+
+
+class TestTheDecisionsAreRecorded(unittest.TestCase):
+    def test_the_profile_adr_exists_once(self):
+        """Pinned by slug. Two plans were numbering ADRs at the same time, and the number
+        is whichever one merged first."""
+        found = sorted(ADR.glob("*-a-harness-profile-belongs-to-one-machine.md"))
+        self.assertEqual(1, len(found),
+                         f"expected one profile ADR, found {[p.name for p in found]}")
+        self.assertTrue(found[0].read_text().startswith("# "),
+                        f"{found[0].name} does not open with its claim as a title")
+
+    def test_the_profile_adr_states_its_limits(self):
+        """ADR 0022's costs are the half a decision record is usually missing. Three of
+        them are the reason the guard rails are guard rails: the launch record and the
+        wiring cache sit under `.charter/`, a wrapper script can still carry a key, and
+        the proof was one account in two folders."""
+        text = next(ADR.glob("*-a-harness-profile-belongs-to-one-machine.md")).read_text()
+        for claim in (".charter/", "wrapper script", "guard rail"):
+            self.assertIn(claim, text, f"the profile ADR states no limit about {claim!r}")
+
+    def test_adr_0017_is_amended_for_the_local_file(self):
+        """0017 ignores a path charter creates that carries credentials. This one carries
+        none and is ignored anyway, so the amendment has to say why."""
+        text = (ADR / "0017-charter-ignores-what-carries-credentials.md").read_text()
+        self.assertIn("charter.local.toml", text)
+
+    def test_adr_0018_is_amended_for_a_pane_before_its_harness(self):
+        """Written in Task 2's own pull request, not here (ruling 44): the launcher that
+        holds a refusal in a chat's pane shipped with it. This pins the sentence the whole
+        amendment turns on, which the profile selector rests on too."""
+        text = (ADR / "0018-charter-may-run-the-harness-but-never-draws-it.md").read_text()
+        self.assertIn("no harness has ever run", text)
+
+    def test_the_phase5_credentials_line_carries_its_supersession(self):
+        """That spec is the record of what was decided in August, so the sentence stays
+        and is marked rather than rewritten."""
+        spec = (ROOT / "docs" / "superpowers" / "specs"
+                / "2026-08-28-phase5-workspace-and-chat-tabs.md").read_text()
+        self.assertIn("Superseded 2026-09-11 by harness profiles", spec)
+        line = next(l for l in spec.splitlines()
+                    if "Superseded 2026-09-11 by harness profiles" in l)
+        self.assertIn("2026-09-11-harness-profiles.md", line + spec,
+                      "the supersession names no spec to read instead")
+
+
+class TestTheNewsEntryKeepsItsShape(unittest.TestCase):
+    """CONTRIBUTING's frontmatter rules, asked of the one entry this feature ships.
+
+    `test_news_gate` already asks them of every entry in the tree; this asks them by
+    *slug*, because five tasks each append to this file and the release stamp renames it.
+    """
+
+    #: `test_news_gate.test_no_test_opens_an_entry_by_its_staged_name` refuses a test that
+    #: hard-codes `unreleased-<slug>.md`, so the entry is found by its headline instead.
+    def _entry_text(self) -> str:
+        for path in sorted((ROOT / "docs" / "news").glob("*.md")):
+            text = path.read_text()
+            if "harness profiles from charter.local.toml" in text:
+                return text
+        self.fail("no news entry announces harness profiles")
+
+    def test_the_frontmatter_is_flat_and_unquoted(self):
+        body = self._entry_text()
+        block = re.match(r"---\n(.*?)\n---\n", body, re.S)
+        self.assertIsNotNone(block, "the entry opens with no frontmatter block")
+        keys = {}
+        for line in block.group(1).splitlines():
+            key, _, value = line.partition(":")
+            keys[key] = value.strip()
+            self.assertIn(":", line, f"frontmatter line is not key: value — {line!r}")
+            self.assertNotRegex(value.strip(), r"""^['"].*['"]$""",
+                                f"{key}: is quoted, and charter unquotes nothing")
+        self.assertLessEqual(set(keys), {"version", "headline", "check", "adopt",
+                                         "lead", "security"},
+                             "a key charter does not read renders as nothing at all")
+        self.assertEqual("unreleased", keys.get("version"))
+        self.assertEqual("reinit", keys.get("adopt"),
+                         "the ignore line is what a plane adopts")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_the_profile_words_are_written_down.py
+++ b/tests/test_the_profile_words_are_written_down.py
@@ -7,7 +7,7 @@ and the phase-5 spec's own credentials sentence, which profiles made false.
 
 The ADR is pinned **by slug, not by number**. The chat-handoff plan claims 0021 and pins
 that number in its own test, so whichever of the two merges first must not break the other
-(`workspaces/harness-profiles/workspace.md`, controller ruling 2).
+(`docs/superpowers/plans/2026-09-11-harness-profiles.md`, *Controller rulings* 2).
 
 These read files off the tree, never through `config`: a test that resolved the plane would
 be answering about whatever plane it ran in.
@@ -86,6 +86,23 @@ class TestTheDecisionsAreRecorded(unittest.TestCase):
         amendment turns on, which the profile selector rests on too."""
         text = (ADR / "0018-charter-may-run-the-harness-but-never-draws-it.md").read_text()
         self.assertIn("no harness has ever run", text)
+
+    def test_adr_0018_bounds_are_the_ones_the_launcher_keeps(self):
+        """The records task read that amendment against `charter/frame/launcher.py` and
+        found its bounds narrower than the code in two places and looser in two more. The
+        code was right and the record was corrected, so these pin the corrections:
+
+        * `framed_chat()` prints a line that is **not** a refusal and lets the launch go on;
+        * the wait needs a terminal as well as an attended open (`sys.stdin.isatty()`);
+        * `state.record_launch` runs on every refusal — only the wait is conditional.
+
+        Asked of the words rather than of the code because the code already behaves this
+        way; what drifted, and what would drift again, is the sentence describing it.
+        """
+        text = (ADR / "0018-charter-may-run-the-harness-but-never-draws-it.md").read_text()
+        for claim in ("unproven", "not a refusal", "isatty", "state.record_launch"):
+            self.assertIn(claim, text,
+                          f"0018's amendment no longer accounts for {claim!r}")
 
     def test_the_phase5_credentials_line_carries_its_supersession(self):
         """That spec is the record of what was decided in August, so the sentence stays


### PR DESCRIPTION
Task 6 of the harness-profiles plan
(`docs/superpowers/plans/2026-09-11-harness-profiles.md`). **Docs only — no behaviour
changes, no guard is added, and `python3 tools/sweep.py` had nothing to charge** (below).

The reasons behind harness profiles have lived in
`workspaces/harness-profiles/workspace.md` — rulings 1–44, in the plane this was built on,
which ships with nobody. This is the pull request that moves them into the repo.

## What is here

**`docs/adr/0022-a-harness-profile-belongs-to-one-machine.md`.** Numbered 0022 and not
0021: the chat-handoff plan claims 0021 and pins that number in its own test, so this one
is pinned **by slug** and neither plan's test breaks whichever merges first (ruling 2).

The record opens with the sentence most of the rest descends from: **a profile's command
runs on a click.** Between the `+` and `os.execvpe` there is no harness permission prompt,
no tool call a guard could deny, and nothing that shows a person the words about to run. So
the file is gitignored rather than committed (a command in the committed file could be
changed by a merged PR, or by a chat, and then run on every machine that pulls it); so
"ignored" is a claim charter re-checks rather than a line it trusts; and so a new or changed
command asks once. Also recorded, each with the reason it rests on:

- no credential-shaped name in `env`, with the measurement behind it — a variable set on the
  harness process reaches the shell the model runs, seen on Claude Code
  (`CLAUDE_CODE_MESSAGING_TOKEN` in the grill's own tool shell) and on Codex (a `*_TOKEN`
  probe through the default `shell_environment_policy`), which is also why a vault reference
  was rejected: the key would only rest somewhere else first;
- unwired refuses to launch, **built-ins included** (ruling 10) — a chat that looks guarded
  and is not is the same failure whichever profile started it — and a probe that cannot
  answer refuses too, because an unknown is not a pass (ruling 12, ADR 0009);
- `CHARTER_HARNESS` stays the kind, because hooks compare it to `claude-code` for session
  ids, resume and the working spinner; the profile rides beside it as
  `CHARTER_HARNESS_PROFILE`, set at the `exec` rather than through tmux;
- the launcher and its `exec`, the selector, reopen never substituting, and no
  `charter harness add`.

The limits are at full volume, in `## Consequences, including what this costs`: the launch
record and the wiring cache sit under `.charter/`, **as writable by a chat as
`charter.local.toml` is** (ruling 13); a wrapper script named in `command` can still export
a key, so the `env` refusal is a refusal to hold one and not a barrier against one; the
frame-identity pid proof **stops an accident, not an attempt** (ruling 29, with the
2026-09-11 `TMUX_PANE=%3195` measurement that killed the pane-id proof); asking a harness
costs 215–750 ms and writes `.claude.json`; a one-harness machine pays one more keypress;
the proof is one account in two folders, not two accounts.

**`docs/adr/0017` — amended.** Its rule covers a path charter's own command creates *and
that carries credentials*, and `charter.local.toml` carries none — a credential-shaped `env`
name is refused. The line is written anyway, because the trigger was never the word
"credentials": it was whether the plane has a defensible second posture, and this file's
whole meaning is "not committed". The amendment also records what is genuinely new —
**charter does not trust the line it wrote.** A trace committed by accident is a disclosure,
which is over; a profile in a committed file is a command that runs on a click on every
machine that pulls it, which has a future. 0017's narrowness survives: a path a plane could
reasonably commit still gets a sentence, not a write.

**`CONTEXT.md`** gains `harness profile`, `kind` and `profile selector` in the file's own
entry shape, each with its `_Avoid_` line as a bare list like every other entry, the reasons
moved into the definition where the `Host` entry puts them. They keep the two words charter
refuses out of the next draft: a shell *alias* charter never sees, and an *account* a profile
need not change.

**The phase-5 spec's credentials line** is marked superseded where it stands, with a pointer
to the profiles spec and to ADR 0022, rather than deleted or rewritten — that spec is the
record of what was decided in August.

**`docs/control-plane.md`** gains one sentence pointing at ADR 0022 from the `[harness]`
section, so a reader of the mechanics can reach the reasons.

## ADR 0018 — reviewed, then corrected

Task 2 shipped 0018's amendment in its own pull request, with the launcher that relies on it
(ruling 44), which is the right order. I reviewed it against `charter/frame/launcher.py`
rather than rewriting it, and found five places where the text does not describe the code.
**The controller ruled that the code is right and the record is wrong**, so the five are
fixed here — that is what this task owns. Each one, and what it became:

1. **"Only a refusal, and only before the `exec`" is gone**, because each half of that pair
   is wrong exactly once: `framed_chat()` prints a line that is *not* a refusal, and a
   `KIND_EXEC` refusal is printed *after* `os.execvpe` raised. Neither leaves a harness in
   the pane, so the rule survives both and the pair does not. The bound is now the
   amendment's own distinguishing question — *has a harness ever run in this pane, and is
   charter's own process still the one in it?* — with the one moment it turns named:
   `state.record_launch`.
2. **`UNPROVEN_CHAT` is named as the second thing charter writes there**, with its reason.
   It is correct behaviour, not a refusal: ruling 29 makes a launch that cannot prove its
   chat a no-frame launch that writes no chat record, because `$TMUX_PANE` and
   `$CHARTER_SESSION_ID` are inherited by a model's tool shell and prove nothing — and
   downgrading in silence would cost a chat its session id and its resume id with nothing
   said.
3. **The `execvpe`-that-raised case is covered** by the "no harness has ever run" bound,
   which is true of it, rather than by "before the `exec`", which is not.
4. **Holding the pane needs two conditions and the text named one.** The open must be
   attended **and** the pane's stdin must be a terminal: `_wait_for_the_operator` returns at
   once when `sys.stdin.isatty()` is false, so an attended launcher run out of a pipe prints
   and exits. Both are stated.
5. **"instead" no longer reads as though the recording were conditional.**
   `_refused_in_pane` calls `state.record_launch` on every path, the attended one included;
   what an attended open adds is the wait.

**And the citation now resolves for a public reader.**
`workspaces/harness-profiles/refs/task2-measure/` is a plane path this repo does not carry,
so the numbers stay inline — tmux 3.7c and the 3.2 floor, 40 runs, the eager
`#{pane_dead_status}` ask at **6-14 ms** against a Python launcher's first line at
**19-22 ms**, `_pane_last_words` empty in all 40 on charter's own server — and the citation
is **#981**, where they were measured. The same correction is applied to the two other
plane-path citations this branch added: ADR 0022 and the new test's docstring now point at
`docs/superpowers/specs/2026-09-11-harness-profiles.md` and at the plan's own
`## Controller rulings`.

The amendment carries a dated line saying it was corrected by this task and what changed, so
the next reader sees the drift rather than only its repair.

**One drift left alone, and reported rather than patched.**
`charter/frame/launcher.py`'s module docstring still says an attended launcher "waits for a
key" (it waits for a LINE — `_wait_for_the_operator`'s own docstring is correct and explicit
about why) and that "an **unattended** one records it under the chat" (both paths record).
That is under `charter/`, and editing it would stop this being a docs-only change and put
lines in front of the sweep, so it belongs to whoever next touches that module.

## The news entry

Reviewed against `main` and against CONTRIBUTING's rules rather than restructured — each
task owns its own lines in it.

- Frontmatter is flat `key: value`, unquoted, and uses three of the six allowed keys:
  `version: unreleased`, `headline:`, `adopt: reinit`. `adopt: reinit` stays — the ignore
  line is what a plane adopts.
- Every claim in it is checkable against `main` today: the file name, the TOML block,
  `charter harness list`, the refusal categories, `charter init`/`charter reinit`, the
  launcher, `CHARTER_HARNESS_PROFILE`, reopen skipping a missing profile, and the closing
  paragraph saying a declared profile does not launch yet.
- **One edit**, and it is a limit rather than a restructure: the credential paragraph said
  what charter refuses without saying what the refusal does not reach. It now states both in
  the same breath — the pattern can catch `KEYBOARD_LAYOUT`, and a wrapper script named in
  `command` can export whatever it likes. Both are true of `main` today (Task 1 shipped the
  `env` refusal), so nothing here describes unshipped behaviour.

Ruling 10's built-ins sentence and the `.charter/` writability limit are **not** added: the
wiring refusal and the trust record are Tasks 4 and 3, and those tasks own those lines.

## Scope, deliberately

Task 3 (#992), Task 4 and Task 5 are not on `main`. Nothing here describes the selector, the
approval prompt or the wiring check as something an operator can use today:

- ADR 0022 is a decision record and says so in its own header — "Written while the feature
  lands in stages… the code for each arrives with the task that owns it";
- the `profile selector` entry in `CONTEXT.md` defines the word, which is what that file is
  for;
- `docs/control-plane.md` keeps Task 2's standing "launching a DECLARED profile arrives in a
  later release" paragraph untouched;
- the plan's Task 6 also listed two *selector* bullets for ADR 0018. They are not added:
  the task brief says review rather than rewrite, and the selector's decision is recorded in
  ADR 0022 instead. The amendment's existing sentence — "no harness has ever run in that
  pane" — is already the one the selector rests on, which is what the test pins.

One deliberate deviation from the plan's test list: the case the plan names
`test_adr_0018_is_amended_for_the_selector` is here as
`test_adr_0018_is_amended_for_a_pane_before_its_harness`, because the assertion is on the
sentence Task 2 shipped and a test name is a claim like any other. The assertion itself is
the plan's, unchanged.

## Verification

- `tests/test_the_profile_words_are_written_down.py` — 9 cases, stdlib `unittest`, reading
  files off `Path(__file__).resolve().parents[1]` and never through `config`. **Red first:**
  6 of 8 failed before the docs were written; the two that passed are pins of what Tasks 1
  and 2 already shipped (0018's amendment, the news frontmatter). The news entry is found by
  its **headline**, not by its staged filename, because
  `test_news_gate.test_no_test_opens_an_entry_by_its_staged_name` refuses the latter. The
  ninth case, `test_adr_0018_bounds_are_the_ones_the_launcher_keeps`, pins the four
  corrections above — asked of the words, because the code already behaves this way and what
  drifted is the sentence describing it.
- Whole suite, the way CI runs it — `python3 -m unittest discover -s tests`:

  ```
  Ran 12862 tests in 1222.514s

  OK (skipped=9)
  ```

- `python3 tools/sweep.py`:

  ```
  0 mutations across 0 file(s)
  NOTHING TO SWEEP — not one mutation was applied…
  ```

  Expected, and it is the honest reading: the sweep mutates `charter/`, and this pull request
  changes no line under it. **No guard is added here**, so there is nothing for the sweep to
  charge and no hand-deletion check to report either.

No version bump, no tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
