### PR TITLE
A pull request waits on one test matrix and up to sixteen sweep shards

### DIFF
--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -29,11 +29,18 @@ name: deletion sweep
 #     silently. The moment `push:` can also produce that check, its presence stops proving
 #     the pull-request-scoped sweep ran — a push-scoped run of a different tree satisfies it.
 #     The one-line fix reintroduces one level down the exact defect it was reached for.
-#   * **The cost is not the cost of `test.yml`.** That workflow carries both triggers, and
-#     every pull request there runs its matrix twice — once on the head sha, once on the
-#     merge commit. Four cheap jobs, twice, is affordable. This gate is eight parallel jobs
-#     and up to forty minutes on a large diff (#639: 443 mutations), and `push:` would spend
-#     that on every push of every branch, PR or not.
+#   * **The cost is not the cost of `test.yml`.** This bullet used to read "that workflow
+#     carries both triggers, and every pull request there runs its matrix twice — once on
+#     the head sha, once on the merge commit. Four cheap jobs, twice, is affordable." It no
+#     longer describes either workflow. `test.yml`'s `push:` is scoped to `main` now, so a
+#     branch with an open pull request runs that matrix once: cheap was being counted in
+#     runner-minutes, which a public repository is not billed for, and in wall clock — the
+#     thing actually being spent — a duplicate matrix was never cheap. The comparison it was
+#     making still holds and holds harder. This gate is up to SIXTEEN parallel jobs
+#     (`MAX_SHARDS`) of up to forty minutes each on a large diff (#639: 443 mutations), and
+#     `push:` would spend that on every push of every branch, PR or not — against an
+#     account-wide ceiling of 20 concurrent jobs, which those sixteen and `test.yml`'s four
+#     already exactly fill.
 #
 # `workflow_dispatch` stays. It has the same missing merge commit, and it is a hazard of
 # degree rather than of kind: somebody has to ask for it, once, on purpose — which is the

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,27 @@
 name: tests
 on:
+  # **`main` only, and the branch filter is the whole of it.** An unfiltered `push:` beside
+  # `pull_request:` runs this matrix twice on every pull request — once on the head sha,
+  # once on the merge commit. `sweep.yml`'s header waved that through since 0.54.0 as "four
+  # cheap jobs, twice, is affordable", and cheap was true in the currency it was counting:
+  # this repository is public, so GitHub bills nothing for standard runners. It is not the
+  # currency being spent. What a duplicate matrix costs is the wall clock somebody waits
+  # out before merging, and there it costs full price — eight jobs queueing where four
+  # would do, against an account-wide ceiling of 20 concurrent jobs.
+  #
+  # The two runs were never two answers either. `pull_request` tests the merge commit —
+  # the tree that will land — and the push run tests the head sha, the same code without
+  # main's latest. Branch protection requires `test (3.11)` … `test (3.14)`, and those are
+  # satisfied by the merge-commit run; the push run was four jobs nobody read.
+  #
+  # Scoped rather than deleted, because two things need a push to main to exist:
+  # `dev-install` below runs on exactly that ref, and a merge should still say whether
+  # main itself is green instead of inheriting a tick from the pull request it came from.
+  # `tests/test_workflows.py` pins this trigger set and checks the branch named here
+  # against the ref `dev-install` waits for, so narrowing it further fails loudly rather
+  # than stranding that job.
   push:
+    branches: ["main"]
   pull_request:
   workflow_dispatch:      # lets CI be re-triggered without a noise commit
 
@@ -13,8 +34,9 @@ permissions:
 
 # Every `uses:` is pinned to a full commit SHA with its tag in a trailing comment, for the
 # reason `release.yml`'s header gives at length. It applies here too and for the same
-# reason: this workflow runs on every push and pull request, so a moved tag executes here
-# first and on the widest trigger — with a token that is read-only, which bounds the damage
+# reason: this workflow runs on every pull request and on every push to main, which is
+# still the widest trigger in this repository, so a moved tag executes here first — with a
+# token that is read-only, which bounds the damage
 # without removing it. Dependabot moves these (`.github/dependabot.yml`);
 # `tests/test_workflows.py` reads these files as YAML and refuses any ref written here that
 # is not a full commit SHA, an image digest, or a file tracked in this repository — a
@@ -40,6 +62,13 @@ jobs:
     # Push to main only. On a pull request the branch does not exist under that name yet,
     # so the install below would be testing whatever main already says — a green tick for
     # code this run never saw.
+    #
+    # **Still load-bearing now that `push:` above is itself scoped to main**, and not
+    # redundant with it: `workflow_dispatch` also runs from main and carries the same
+    # `github.ref`, so the `event_name` half is what keeps a manual re-run of the matrix
+    # from installing out of a branch nobody pushed. `tests/test_workflows.py` checks this
+    # condition against the branches the trigger names, because a job that quietly stops
+    # running is worse than one that fails.
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     # This job is the whole value of "publish on every commit", without publishing

--- a/tests/test_sweep.py
+++ b/tests/test_sweep.py
@@ -4040,7 +4040,7 @@ class TheSweepIsSplitAcrossMachinesAndNothingIsDropped(unittest.TestCase):
             sweep.SHARD_FIXED = fixed
             self.assertEqual(sweep.per_shard_seconds(), 1, fixed)
             self.assertEqual(sweep.per_shard(), 1, fixed)
-            self.assertEqual(sweep.shards_for(self._costs(50)), 8, fixed)  # not a crash
+            self.assertEqual(sweep.shards_for(self._costs(50)), 16, fixed)  # not a crash
 
     def test_the_two_diffs_that_ran_out_of_time_now_fit(self):
         """#608's 62 mutations were cancelled twice and #626's 78 three times, at
@@ -4063,24 +4063,56 @@ class TheSweepIsSplitAcrossMachinesAndNothingIsDropped(unittest.TestCase):
         self.assertEqual(sweep.shards_for([]), 1)
 
     def test_the_fan_out_is_capped_and_the_sweep_is_not(self):
-        """`MAX_SHARDS` limits how much of the runner pool one branch may hold. It does
-        not limit what gets asked: past the ceiling the shards simply carry more."""
-        self.assertEqual(sweep.shards_for(self._costs(10_000)), 8)
+        """`MAX_SHARDS` limits how many machines one branch asks for at once. It does
+        not limit what gets asked: past the ceiling the shards simply carry more.
+
+        The cap was eight while it was read as a share of the runner pool. This repository
+        is public, so that pool is free and the scarce thing is the clock — hence sixteen.
+        The property under test is the one that did not change: a plan past the ceiling is
+        still dealt whole.
+        """
+        self.assertEqual(sweep.shards_for(self._costs(10_000)), 16)
         plan = self._plan(400)
-        dealt = [m for i in range(1, 9) for m in sweep.shard_of(plan, i, 8)]
+        dealt = [m for i in range(1, 17) for m in sweep.shard_of(plan, i, 16)]
         self.assertEqual(len(dealt), 400)
+
+    def test_doubling_the_fan_out_does_not_halve_the_wall_clock(self):
+        """The arithmetic `MAX_SHARDS`' comment states, held to the constants it states it
+        from — because a number a reader is shown is a number something should assert.
+
+        :data:`sweep.SHARD_FIXED` is paid **per shard** and not per plan: the checkout, the
+        selection map and the unmutated baseline are bought again by every machine. So the
+        half of a shard the fan-out divides is the mutation half only. Take the biggest plan
+        the old cap of eight fit — eight full hands — and the same plan on sixteen machines
+        is twelve minutes of fixed cost plus half of twenty-eight, which is twenty-six
+        minutes and not twenty. Raising the cap is worth doing and it is not worth
+        overselling, and the comment on the constant says so in these numbers.
+        """
+        self.assertEqual(sweep.MAX_SHARDS, 16)
+        half = sweep.MAX_SHARDS // 2
+        biggest = half * sweep.per_shard_seconds()       # what eight shards used to fit
+        at_half = sweep.SHARD_FIXED + biggest / half
+        at_full = sweep.SHARD_FIXED + biggest / sweep.MAX_SHARDS
+        self.assertEqual([round(at_half / 60), round(at_full / 60)], [40, 26])
+        self.assertGreater(at_full, at_half / 2,
+                           "the fixed cost is paid per shard, so twice the machines is "
+                           "less than half the wall clock — and the comment on MAX_SHARDS "
+                           "must not claim otherwise")
 
     def test_a_diff_past_the_ceiling_says_so_out_loud(self):
         """The spec is explicit that a cap the reader cannot see is worse than the cap.
 
-        224 and 225 are the same boundary this test held before #915 — eight shards of
-        twenty-eight *average* mutations — and it survives the change of unit intact,
-        because an unmeasured mutation is still priced at :data:`sweep.SECONDS_A_MUTATION`
-        and eight hands of 28 × 60 s are exactly the 1680 s a shard is sized for.
+        448 and 449 are the boundary 224 and 225 were before the cap went to sixteen, and
+        the boundary survived #915's change of unit before it survived this one: an
+        unmeasured mutation is still priced at :data:`sweep.SECONDS_A_MUTATION`, and a hand
+        of 28 × 60 s is exactly the 1680 s a shard is sized for, so the ceiling is
+        ``MAX_SHARDS`` such hands however many that is. Raising the cap moves where the
+        warning starts; it does not change what the warning is about, and a diff past
+        sixteen full shards still gets told so before a runner is spent.
         """
-        self.assertEqual(sweep.over_budget(self._costs(224)), "")
-        loud = sweep.over_budget(self._costs(225))
-        self.assertIn("225 mutations", loud)
+        self.assertEqual(sweep.over_budget(self._costs(448)), "")
+        loud = sweep.over_budget(self._costs(449))
+        self.assertIn("449 mutations", loud)
         self.assertIn("nothing here is dropped", loud.lower())
 
     def test_past_the_ceiling_the_warning_promises_a_short_answer_and_not_a_missing_one(
@@ -4561,9 +4593,17 @@ class TheWorkflowAsksTheToolAndNotTheOtherWayAround(unittest.TestCase):
     def test_a_diff_past_the_fan_out_ceiling_warns_on_the_pull_request(self):
         """A log line is not loud. `over_budget` reaching the plan's stdout as a workflow
         command is what puts it in the run's annotations instead of in a fold, and the
-        spec's rule is that a cap the reader cannot see is worse than the cap."""
+        spec's rule is that a cap the reader cannot see is worse than the cap.
+
+        The size of the plan is derived from `MAX_SHARDS` and not written as 300, which is
+        what it was while the cap was eight. A literal here is a claim about a particular
+        ceiling, and this test is not about where the ceiling is — it is about a diff on the
+        far side of it being *told so*, wherever it sits. Raising the cap to sixteen is what
+        found the literal, which is the argument for not writing another one.
+        """
+        past = sweep.MAX_SHARDS * sweep.per_shard() + 1
         plan = [sweep.Mutation("charter/m.py", n, n, "drop-if", "q?", "if x: pass",
-                               "", "f") for n in range(300)]
+                               "", "f") for n in range(past)]
         real = sweep.plan_for
         sweep.plan_for = lambda *a: (plan, {})
         self.addCleanup(lambda: setattr(sweep, "plan_for", real))
@@ -4573,10 +4613,10 @@ class TheWorkflowAsksTheToolAndNotTheOtherWayAround(unittest.TestCase):
         self.assertEqual(code, 0, said)
         self.assertIn("::warning title=The deletion sweep is over its budget::", said)
         self.assertIn("Nothing here is dropped", said)
-        # And it still asks about all three hundred, on the eight machines it is allowed.
-        self.assertEqual(self._read_outputs()["shards"], "8")
-        self.assertEqual(len([m for i in range(1, 9)
-                              for m in sweep.shard_of(plan, i, 8)]), 300)
+        # And it still asks about every one of them, on the machines it is allowed.
+        self.assertEqual(self._read_outputs()["shards"], str(sweep.MAX_SHARDS))
+        self.assertEqual(len([m for i in range(1, sweep.MAX_SHARDS + 1)
+                              for m in sweep.shard_of(plan, i, sweep.MAX_SHARDS)]), past)
 
     def test_a_diff_inside_the_ceiling_says_nothing_about_the_ceiling(self):
         code, said = self._cli("--plan", "--base", self.base,
@@ -6521,7 +6561,7 @@ class TheFanOutIsSizedAgainstTheHeaviestHandAndNotTheTotal(unittest.TestCase):
         self.assertLessEqual(sweep.heaviest_hand([heavy] * 3, 3),
                              sweep.per_shard_seconds())
 
-    def test_nothing_is_dropped_when_the_cost_wants_more_than_eight_shards(self):
+    def test_nothing_is_dropped_when_the_cost_wants_more_shards_than_the_cap(self):
         """The trade `MAX_SHARDS` forces, and the answer this file chose: **exceed the
         budget, loudly, and never drop.** A plan capped by dropping mutations would make
         the verdict's own name — `no survivors` — a claim about a sweep that never ran, and
@@ -6529,16 +6569,23 @@ class TheFanOutIsSizedAgainstTheHeaviestHandAndNotTheTotal(unittest.TestCase):
         still dealt, the shards carry more than they were sized for, they stop at
         `SHARD_REPORT_AT` and report what they measured, and `no verdict: N out of time`
         stays reachable and honest.
+
+        This used to say "more than eight shards" and to reach for it with a literal 9. The
+        cap is sixteen now, and 9 quietly became a plan that FITS — the assertion went on
+        passing for a while and then stopped meaning anything. So the one-past case is
+        derived from the constant below: the property is "one machine past the cap gets the
+        cap", and it is true of whatever the cap is.
         """
         costs = [float(sweep.per_shard_seconds())] * 40
         self.assertEqual(sweep.shards_for(costs), sweep.MAX_SHARDS)
-        # Nine mutations of exactly one budget each is the case that catches a fan-out
-        # allowed one machine past the cap: NINE shards would fit it perfectly, eight
-        # cannot fit it at all, and the answer has to be eight. `MAX_SHARDS` is a limit on
-        # how much of the runner pool one branch may hold, and a plan that wants more
-        # machines is exactly the plan that must not be given them.
-        self.assertEqual(sweep.shards_for([float(sweep.per_shard_seconds())] * 9),
-                         sweep.MAX_SHARDS)
+        # `MAX_SHARDS + 1` mutations of exactly one budget each is the case that catches a
+        # fan-out allowed one machine past the cap: that many shards would fit it perfectly,
+        # `MAX_SHARDS` cannot fit it at all, and the answer has to be `MAX_SHARDS`. A plan
+        # that wants one more machine than the ceiling allows is exactly the plan that must
+        # not be given it.
+        self.assertEqual(
+            sweep.shards_for([float(sweep.per_shard_seconds())] * (sweep.MAX_SHARDS + 1)),
+            sweep.MAX_SHARDS)
         plan = [_mutation("charter/m.py", n) for n in range(40)]
         dealt = [m for i in range(1, sweep.MAX_SHARDS + 1)
                  for m in sweep.shard_of(plan, i, sweep.MAX_SHARDS)]
@@ -6546,12 +6593,17 @@ class TheFanOutIsSizedAgainstTheHeaviestHandAndNotTheTotal(unittest.TestCase):
         self.assertEqual(sorted(m.line for m in dealt), sorted(m.line for m in plan))
 
     def test_the_warning_fires_on_the_heaviest_hand_and_not_on_a_count(self):
-        """The boundary again, on the other function that reads it. 224 average mutations
-        are eight hands of exactly 1680 s and say nothing; one more is 1740 s on the
-        heaviest hand and says so."""
+        """The boundary again, on the other function that reads it. `MAX_SHARDS` hands of
+        exactly 1680 s say nothing; one hand's worth more and the heaviest is 3360 s, which
+        says so.
+
+        Said in terms of the constant and not of 8 and 9. Those were the numbers while the
+        cap was eight, and the second of them turned into a plan that fits the moment the
+        cap moved — an assertion still green and no longer about anything.
+        """
         budget = float(sweep.per_shard_seconds())
         self.assertEqual(sweep.over_budget([budget / 8] * 8), "")
-        loud = sweep.over_budget([budget] * 9)
+        loud = sweep.over_budget([budget] * (sweep.MAX_SHARDS + 1))
         self.assertIn("PARTIAL answer", loud)
         self.assertIn(f"{sweep.per_shard_seconds()} s a shard is sized for", loud)
 

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -2586,6 +2586,74 @@ def requirable(workflow: object) -> dict[str, str]:
     return out
 
 
+class TheMatrixRunsOncePerPullRequestAndOnceOnMain(unittest.TestCase):
+    """`test.yml`'s triggers, and the sentence in `sweep.yml`'s header that used to excuse
+    them.
+
+    That header argues at length that `push:` does not belong on the SWEEP, and every word
+    of that still stands — the two events sweep different trees, and a required check
+    satisfied by a push-scoped run stops proving the pull-request-scoped sweep happened.
+    One bullet of the argument was a concession rather than part of it: *"That workflow
+    carries both triggers, and every pull request there runs its matrix twice — once on the
+    head sha, once on the merge commit. Four cheap jobs, twice, is affordable."*
+
+    Affordable in what. The repository is public, so the runner minutes were never the
+    price — the wall clock is, and a duplicated matrix is not cheap in the only currency
+    being spent. Both runs test the same four interpreters, and the merge-commit run is the
+    one branch protection reads. So `push:` here is scoped to `main`, which is the branch
+    where a push is not also a pull request, and a branch with an open PR runs the matrix
+    once.
+
+    Three things have to hold together for that to be safe, and they are asserted rather
+    than argued:
+
+    * The four required contexts — `test (3.11)` … `test (3.14)` — are reported by a job
+      no trigger-shaped condition gates, so `pull_request` still produces every one of
+      them. A required context nothing reports blocks forever.
+    * `dev-install` asks for `refs/heads/main` by hand, and a `push:` narrowed to some
+      OTHER branch would leave that condition permanently false: a job that silently stops
+      running is the failure this whole file is about. So the branch the filter names and
+      the ref the condition demands are checked against each other.
+    * `pull_request` and `workflow_dispatch` stay. Narrowing the push trigger must not
+      become "the matrix runs on main only".
+    """
+
+    def workflow(self) -> dict:
+        return load((GITHUB / "workflows" / "test.yml").read_text())
+
+    def test_a_branch_with_an_open_pull_request_runs_the_matrix_once(self):
+        on = self.workflow()["on"]
+        self.assertEqual(set(on), {"push", "pull_request", "workflow_dispatch"})
+        self.assertEqual(on["push"], {"branches": ["main"]},
+                         "an unfiltered `push:` runs this matrix a second time on every "
+                         "pull request, on the head sha, and nothing reads that run")
+        self.assertIsNone(on["pull_request"],
+                          "the merge-commit run is the one branch protection reads")
+
+    def test_the_contexts_branch_protection_requires_are_reported_on_pull_requests(self):
+        """`test (3.11)`…`test (3.14)` come from the matrix job, and it carries no `if:`.
+
+        A condition here mentioning `github.event_name` would be the same defect from the
+        other side: the check would stop appearing on the trigger that still needs it, and
+        a required context that never reports does not pass — it blocks.
+        """
+        test = self.workflow()["jobs"]["test"]
+        self.assertNotIn("if", test)
+        self.assertEqual(test["strategy"]["matrix"]["python-version"],
+                         ["3.11", "3.12", "3.13", "3.14"])
+
+    def test_the_dev_install_smoke_test_still_has_a_push_that_can_reach_it(self):
+        """It runs on pushes to main and nowhere else, and it says so in an `if:` rather
+        than in the trigger — so narrowing the trigger past it would strand it."""
+        branches = self.workflow()["on"]["push"]["branches"]
+        guard = self.workflow()["jobs"]["dev-install"]["if"]
+        self.assertEqual(guard,
+                         "github.event_name == 'push' && github.ref == 'refs/heads/main'")
+        self.assertTrue(any(f"refs/heads/{b}" in guard for b in branches),
+                        f"`push:` fires on {branches}, and `dev-install` waits for a ref "
+                        "none of them produces — the job would never run again")
+
+
 class TheSweepsAbsenceIsSomethingOnlyARequiredCheckCanSay(unittest.TestCase):
     """#646 and #561 are one defect seen from two heights, and this holds the code half.
 

--- a/tools/sweep.py
+++ b/tools/sweep.py
@@ -3242,9 +3242,48 @@ SECONDS_A_MUTATION_FIXED = 25
 SECONDS_A_SUITE_RUN = 960
 
 #: The most jobs one pull request may fan out to. Not a limit on what gets swept — every
-#: mutation is still dealt to a shard past this point, they just get more each — but a
-#: limit on how much of the runner pool one branch may hold at once.
-MAX_SHARDS = 8
+#: mutation is still dealt to a shard past this point, they just get more each.
+#:
+#: **It was eight, and what made eight the number has stopped being true.** That figure was
+#: written down as "a limit on how much of the runner pool one branch may hold at once",
+#: which prices a shard in runner-minutes and rations them. This repository is public, so
+#: GitHub bills nothing for standard runners: minutes were never the scarce thing here. The
+#: two things that are scarce are the wall clock a reviewer waits out on a pull request, and
+#: :data:`SHARD_TIMEOUT` — the hard hour past which a machine is cancelled, which is what
+#: turns a plan that is merely large into an answer that arrives PARTIAL.
+#:
+#: **The arithmetic, said out loud, because doubling the machines does not halve the wait.**
+#: :data:`SHARD_FIXED` is twelve minutes paid *per shard*, not per plan: the checkout, the
+#: selection map and the unmutated baseline are bought again by every machine that joins,
+#: and the sixteenth buys them too. Only the mutation half of a hand divides. So the biggest
+#: plan eight shards fit — eight full hands, 8 × :func:`per_shard_seconds` — costs
+#: 12 + 28 = 40 minutes on each of eight, and the very same plan on sixteen costs
+#: 12 + 14 = **26**. A third off the clock, not a half, and the fixed cost is why. Every
+#: further doubling buys less than the one before it, which is one of the two reasons the
+#: number below is sixteen and not thirty-two; the concurrency ceiling is the other.
+#:
+#: What it buys outright is the ceiling, and that is the half worth having: 16 × 1,680 s of
+#: predicted test time fits where 8 × 1,680 s did, so a diff that used to be told to expect
+#: a partial answer now gets a whole one. :func:`over_budget` still says so past even this.
+#:
+#: **Measured on a real plan and not on an example.** PR #981: 151 mutations, 203 minutes of
+#: predicted test time. At eight there was no fitting count at all — the heaviest of eight
+#: hands was 2,207 s against the 1,680 s a shard is sized for, `over_budget` said PARTIAL out
+#: loud before a runner was spent, and the run bore it out — 47 minutes on the slowest shard
+#: and a verdict of `no verdict: 2 not measured`. At sixteen the same plan sizes to
+#: **fourteen** shards with a heaviest hand of 1,597 s, inside the budget. Fourteen and not
+#: sixteen because :func:`shards_for` asks for the FEWEST that fit: raising this ceiling does
+#: not spend it. The answer goes from partial to complete, which is worth more than the ten
+#: minutes that come with it.
+#:
+#: **Two ceilings it must not be raised past without measuring again.** A job matrix may
+#: generate 256 jobs per run, which is not close. The binding one is account-wide: GitHub
+#: Free allows 20 concurrent jobs on standard runners, so sixteen shards plus `test.yml`'s
+#: four-version matrix is exactly 20 — and that fits only because `test.yml`'s `push:` is
+#: scoped to `main`, so a pull request runs that matrix once instead of twice. Past sixteen
+#: the shards start queueing on each other, which buys nothing and reports as a slow run
+#: rather than as a limit anybody can see.
+MAX_SHARDS = 16
 
 
 def per_shard_seconds() -> int:
@@ -3415,10 +3454,17 @@ def over_budget(costs: list[float]) -> str:
     **What it says the ceiling IS changed with #915.** It used to be a count — 224
     mutations, eight shards of twenty-eight — and a count is exactly the thing that could
     not see #914 coming: 22 mutations, comfortably inside 224, and five of them measured.
-    The ceiling is now the heaviest of the eight hands this plan would produce, in seconds
-    — the number that actually decides whether the answer arrives. Seconds and not minutes,
-    because #914 is 1707 against 1680 and rounding those to minutes prints "28 of 28",
-    which is a warning that reads like a fit.
+    The ceiling is now the heaviest of the :data:`MAX_SHARDS` hands this plan would
+    produce, in seconds — the number that actually decides whether the answer arrives.
+    Seconds and not minutes, because #914 is 1707 against 1680 and rounding those to
+    minutes prints "28 of 28", which is a warning that reads like a fit.
+
+    **Where the ceiling sits is a number this function reads and never one it argues.**
+    `MAX_SHARDS` went from eight to sixteen, so the diff that trips this is now about twice
+    the diff that used to — and the sentence below did not have to change a word, because
+    it was written against the constant rather than against 224. What did not move is what
+    happens past it: nothing is dropped, every mutation is still dealt, and a shard that
+    cannot finish reports what it measured.
     """
     heaviest = heaviest_hand(costs, MAX_SHARDS)
     if heaviest <= per_shard_seconds():


### PR DESCRIPTION
Two changes to how long a pull request waits, both measured rather than argued.

The framing behind both: **this repository is public, so GitHub bills nothing for standard runners.** Minutes were never the scarce thing here, and both constants below were sized as though they were. What is scarce is wall clock, and the 60-minute per-shard timeout.

## 1. `MAX_SHARDS` 8 → 16

Its comment read *"a limit on how much of the runner pool one branch may hold at once"* — a ration of a free resource. Rewritten against what is actually scarce, and made honest about what doubling does **not** buy.

`SHARD_FIXED` is twelve minutes paid **per shard**: the checkout, the selection map and the unmutated baseline are bought again by every machine that joins. Only the mutation half of a hand divides. So the biggest plan eight shards fit costs `12 + 28 = 40` minutes on each of eight, and the same plan on sixteen costs `12 + 14 = 26`. **A third off the clock, not a half.**

### Measured, on PR #981's diff

Re-run locally through `tools/sweep.py --plan --warm-map` against the same commit range. The "before" run reproduces #981's CI plan job byte for byte (run `34677248505`), which is what makes the "after" comparable:

| | shards | predicted test time | heaviest hand | verdict |
|---|---|---|---|---|
| **before** (`MAX_SHARDS = 8`) | 8 | 203 min | **2,207 s** vs 1,680 s sized for | over budget → `::warning`, PARTIAL |
| **after** (`MAX_SHARDS = 16`) | **14** | 203 min | **1,597 s** vs 1,680 s sized for | fits, no warning |

And #981's real run bore the warning out: **47 minutes** on its slowest shard, concluding `no verdict: 2 not measured`. At sixteen that plan comes back whole.

Fourteen and not sixteen because `shards_for` asks for the **fewest** shards that fit — raising the ceiling does not spend it.

### What it does not buy

- Not 2× — see the arithmetic above. Roughly 49 min → 39 min on this plan's heaviest shard.
- Not unlimited. The binding ceiling is account-wide: **GitHub Free allows 20 concurrent jobs** on standard runners. Sixteen shards plus a four-version matrix is exactly 20 — past sixteen the shards start queueing on each other, which buys nothing and shows up as a slow run rather than as a limit anyone can see. (A job matrix may generate 256 jobs per run, so that one is not close.)

## 2. `test.yml`'s `push:` scoped to `main`

It carried `push:` unfiltered beside `pull_request:`, so **every pull request ran the four-version matrix twice** — once on the head sha, once on the merge commit. Branch protection reads the merge-commit run; the other four jobs were nobody's.

`sweep.yml`'s header argued at length that the *sweep* must not carry `push:` — every word of that still stands and is untouched. One bullet of it was a concession rather than part of the argument: *"Four cheap jobs, twice, is affordable."* Cheap in runner-minutes, which is not the currency being spent. That bullet now says what actually happens, and `test.yml` carries the reasoning for the filter.

### Branch protection, checked before claiming safety

`gh api repos/diazoxide/charter/branches/main/protection` returned (no 403). Required contexts:

```
test (3.11)  test (3.12)  test (3.13)  test (3.14)  Add up what the shards found
```

The four come from `test.yml`'s matrix job, which carries no `if:` and so is reached by `pull_request` exactly as before. The fifth comes from `sweep.yml`, which is untouched. **No required check comes only from a push-triggered run.**

`dev-install` keeps `if: github.event_name == 'push' && github.ref == 'refs/heads/main'`, so it still runs on pushes to main and nowhere else — and that condition is still load-bearing rather than redundant with the new filter, because `workflow_dispatch` also runs from main and carries the same `github.ref`.

### The two changes are coupled

Sixteen shards fit under the 20-job ceiling only because the matrix now runs once per PR instead of twice.

## Tests

Test-first, each failing before its change. Beyond the pins the plan named, the full suite found **three more** that reached for the old cap with a literal — a `9` meaning "one past eight" and a `300` meaning "past 224" — both of which quietly became *fitting* plans at sixteen, i.e. assertions still green and no longer about anything. Those are derived from `MAX_SHARDS` now.

Full suite locally: `Ran 13007 tests in 1148.569s` — `OK (skipped=9)`.

No news entry: CI configuration is not user-visible, and `CONTRIBUTING.md` asks for one only for user-visible change.

**This PR's own run is the demonstration** for half of it: one `tests` workflow run instead of two. It is not a demonstration of the fan-out — the sweep charges `charter/` only, and this diff touches `tools/`, `tests/` and `.github/`, so its own sweep has nothing to shard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
