### PR TITLE
A harness profile that does not carry charter's plugin refuses to start and names the command that wires it

### DIFF
--- a/charter/cli.py
+++ b/charter/cli.py
@@ -122,6 +122,14 @@ def build_parser() -> argparse.ArgumentParser:
         help="Preflight: check python/git/glab/auth/ssh/inventory before working.",
     )
     doc_check.add_argument("--json", action="store_true", help="Emit machine-readable results.")
+    # What the SessionStart hook runs, and the reason it needs a flag at all: a hook runs
+    # the same words a person types, so nothing in the process can tell the two apart — and
+    # a tty test would misread `charter doctor --json` and `charter doctor | less` as the
+    # hook. With it, no harness profile is probed (ruling 11) and no git call is made for
+    # one: both are paid at every session start otherwise.
+    doc_check.add_argument("--preflight", action="store_true",
+                           help="Run as the SessionStart hook does: no harness-profile "
+                                "probe and no git call for one. Every other check runs.")
     # The second of the two doors an install may come through (#881); `charter init` is the
     # first. A flag rather than a behaviour, because a preflight that installed software
     # every time it ran would be doing it as a side effect of a question — and `doctor` runs

--- a/charter/commands.py
+++ b/charter/commands.py
@@ -2221,6 +2221,67 @@ def _provision_harnesses(root: Path) -> list[tuple[str, str]]:
     return out
 
 
+def _wire_profiles(root: Path, *, install: bool) -> list[tuple[str, str]]:
+    """Wire each DECLARED profile's own config folder. ``(status, label)`` pairs.
+
+    Beside :func:`_wire_harnesses`, which writes the default folder's wiring, because a
+    profile names another folder and every kind loses charter's wiring when its folder
+    moves (measured; `charter/wiring.py`). Built-ins are skipped here: their folder is the
+    default one those two loops already cover.
+
+    **`reinit` installs no software** (ruling 9, `docs/harnesses.md`'s standing rule): with
+    ``install=False`` it wires the file-only kinds — opencode's shim — and for a Claude Code
+    profile it REPORTS the gap and names `charter harness install <name>`. `init` and
+    `charter harness install <profile>` are the two doors an install may come through
+    (#881), and Codex stays opt-in through neither.
+
+    A profile charter may not yet run a command for is reported and not touched (ruling 1),
+    and while git would carry `charter.local.toml` nothing here runs at all — every profile
+    in it is refused, which `charter harness list` and `doctor`'s `harness profiles` row
+    already say with the fix.
+    """
+    from . import profiles, wiring
+    from .harness import codex as _codex, opencode as _opencode
+
+    if profiles.ignore_check(root).reason:
+        return []
+    out: list[tuple[str, str]] = []
+    for p in profiles.current().profiles.values():
+        if p.source == profiles.BUILTIN:
+            continue
+        label = f"profile '{contain.readable(p.name)}'"
+        why = wiring.approval_needed(p)
+        if why:
+            out.append(("skipped", f"{label} is {contain.readable(why)}"))
+            continue
+        if p.harness == _codex.NAME:
+            # The same restraint `cmd_harness_install`'s docstring states for Codex today:
+            # its config file is machine-wide, so arming it reaches every repo on the
+            # machine, and running that command IS the consent (ADR 0003's shape).
+            out.append(("opt-in", f"{label}: charter harness install "
+                                  f"{contain.readable(p.name)}"))
+            continue
+        if install or p.harness == _opencode.NAME:
+            out += [(status, f"{label}: {detail}")
+                    for status, detail in wiring.install(p, root)]
+            continue
+        w = wiring.detect(p, cwd=root)
+        if w.state != wiring.WIRED:
+            out.append(("missing", f"{label}: not wired — {w.detail}; {w.fix}"))
+    return out
+
+
+def _say_profile_wiring(pairs: list[tuple[str, str]]) -> None:
+    """Print what :func:`_wire_profiles` did, one line each. A gap is a warning and the rest
+    are notes: nothing here fails `init` or `reinit`, because a profile's own account folder
+    is not what those two commands are for."""
+    for status, label in pairs:
+        if status in ("skipped", "missing", "opt-in", "unvouched", "failed", "unknown"):
+            util.warn(f"  {label}")
+        else:
+            util.info(f"  {label}")
+
+
 # --------------------------------------------------------------------------- #
 # init's one offer: the repo you are standing in                               #
 #                                                                              #
@@ -2632,6 +2693,10 @@ def cmd_init(args) -> int:
         else:
             (created if status == "created" else present).append(label)
 
+    # After `_provision_harnesses`, which installs for the DEFAULT folder: a profile names
+    # another one, and every kind loses charter's wiring when its folder moves.
+    _say_profile_wiring(_wire_profiles(root, install=True))
+
     fd = _ensure_front_door(root, getattr(args, "front_door", None))
     if fd:
         created.append(fd[1])
@@ -2770,6 +2835,10 @@ def cmd_reinit(args) -> int:
         elif status == "unvouched":
             unvouched.append(label)
 
+    # `install=False` (ruling 9): `reinit` wires the file-only kinds per profile and names
+    # `charter harness install <name>` for a Claude Code plugin that is missing.
+    _say_profile_wiring(_wire_profiles(config.ROOT, install=False))
+
     gh_status, gh_detail = _ensure_guard_hook(config.ROOT)
     if gh_status == "created":
         created.append(".claude/settings.json (plane-root guard)")
@@ -2864,8 +2933,9 @@ def cmd_doctor(args) -> int:
     still naming what to do."""
     if getattr(args, "fix", False):
         _run_doctor_fix()
+    preflight = getattr(args, "preflight", False)
     if getattr(args, "json", False):
-        results = doctor.run_all()
+        results = doctor.run_all(preflight=preflight)
         print(json.dumps(
             [{"name": r.name, "status": r.status, "detail": r.detail, "hint": r.hint}
              for r in results],
@@ -2885,9 +2955,9 @@ def cmd_doctor(args) -> int:
         # report. (`doctor._checks` is an eager list today, so nothing actually streams
         # yet; sizing from the results would make that unfixable rather than merely
         # unfixed — see `_FIXED_CHECK_NAMES`.)
-        name_w = doctor.name_width()
+        name_w = doctor.name_width(preflight=preflight)
         results = []
-        for r in doctor.iter_all():
+        for r in doctor.iter_all(preflight=preflight):
             results.append(r)
             print(r.render(name_w), flush=True)
         print()

--- a/charter/commands.py
+++ b/charter/commands.py
@@ -2222,7 +2222,8 @@ def _provision_harnesses(root: Path) -> list[tuple[str, str]]:
 
 
 def _wire_profiles(root: Path, *, install: bool) -> list[tuple[str, str]]:
-    """Wire each DECLARED profile's own config folder. ``(status, label)`` pairs.
+    """Wire each DECLARED profile's own config folder. ``(status, label)`` pairs, each label
+    already contained.
 
     Beside :func:`_wire_harnesses`, which writes the default folder's wiring, because a
     profile names another folder and every kind loses charter's wiring when its folder
@@ -2235,12 +2236,12 @@ def _wire_profiles(root: Path, *, install: bool) -> list[tuple[str, str]]:
     `charter harness install <profile>` are the two doors an install may come through
     (#881), and Codex stays opt-in through neither.
 
-    A profile charter may not yet run a command for is reported and not touched (ruling 1),
-    and while git would carry `charter.local.toml` nothing here runs at all — every profile
-    in it is refused, which `charter harness list` and `doctor`'s `harness profiles` row
-    already say with the fix.
+    A profile the operator has not approved is reported and not touched (ruling 1): nothing
+    here can ask, and wiring runs the profile's own command. While git would carry
+    `charter.local.toml` nothing here runs at all — every profile in it is refused, which
+    `charter harness list` and `doctor`'s `harness profiles` row already say with the fix.
     """
-    from . import profiles, wiring
+    from . import profiles, profiletrust, wiring
     from .harness import codex as _codex, opencode as _opencode
 
     if profiles.ignore_check(root).reason:
@@ -2249,37 +2250,42 @@ def _wire_profiles(root: Path, *, install: bool) -> list[tuple[str, str]]:
     for p in profiles.current().profiles.values():
         if p.source == profiles.BUILTIN:
             continue
-        label = f"profile '{contain.readable(p.name)}'"
-        why = wiring.approval_needed(p)
-        if why:
-            out.append(("skipped", f"{label} is {contain.readable(why)}"))
+        name = contain.readable(p.name)
+        label = f"profile '{name}'"
+        state = profiletrust.approval_needed(p)
+        if state:
+            out.append(("skipped", f"{label} is {state} and not approved yet — run charter "
+                                   f"{name} once to approve its command"))
             continue
         if p.harness == _codex.NAME:
             # The same restraint `cmd_harness_install`'s docstring states for Codex today:
             # its config file is machine-wide, so arming it reaches every repo on the
             # machine, and running that command IS the consent (ADR 0003's shape).
-            out.append(("opt-in", f"{label}: charter harness install "
-                                  f"{contain.readable(p.name)}"))
+            out.append(("opt-in", f"{label}: charter harness install {name}"))
             continue
         if install or p.harness == _opencode.NAME:
-            out += [(status, f"{label}: {contain.readable(detail)}")
-                    for status, detail in wiring.install(p, root)]
+            out += [(status, f"{label}: {detail}") for status, detail in wiring.install(p, root)]
             continue
         w = wiring.detect(p, cwd=root)
         if w.state != wiring.WIRED:
-            out.append(("missing", f"{label}: not wired — {w.detail}; {w.fix}"))
+            out.append(("missing", f"{label}: not wired — {wiring.said(w.detail)}; "
+                                   f"{wiring.said(w.fix)}"))
     return out
 
 
+#: The statuses that are charter reporting what it DID. Everything else — `missing`,
+#: `skipped`, `opt-in`, `unavailable`, `unknown`, `unvouched`, `failed`, `refused`, and any
+#: status a harness adds later — is something the operator has to act on, so it is a
+#: warning. Listed this way round so a new status fails loud rather than quiet.
+_WIRED_NOTES = frozenset({"created", "installed", "present", "refreshed", "current", "added"})
+
+
 def _say_profile_wiring(pairs: list[tuple[str, str]]) -> None:
-    """Print what :func:`_wire_profiles` did, one line each. A gap is a warning and the rest
-    are notes: nothing here fails `init` or `reinit`, because a profile's own account folder
+    """Print what :func:`_wire_profiles` did, one line each. A gap is a warning and a write
+    is a note: nothing here fails `init` or `reinit`, because a profile's own account folder
     is not what those two commands are for."""
     for status, label in pairs:
-        if status in ("skipped", "missing", "opt-in", "unvouched", "failed", "unknown"):
-            util.warn(f"  {label}")
-        else:
-            util.info(f"  {label}")
+        (util.info if status in _WIRED_NOTES else util.warn)(f"  {label}")
 
 
 # --------------------------------------------------------------------------- #

--- a/charter/commands.py
+++ b/charter/commands.py
@@ -2262,7 +2262,7 @@ def _wire_profiles(root: Path, *, install: bool) -> list[tuple[str, str]]:
                                   f"{contain.readable(p.name)}"))
             continue
         if install or p.harness == _opencode.NAME:
-            out += [(status, f"{label}: {detail}")
+            out += [(status, f"{label}: {contain.readable(detail)}")
                     for status, detail in wiring.install(p, root)]
             continue
         w = wiring.detect(p, cwd=root)

--- a/charter/commands_frame.py
+++ b/charter/commands_frame.py
@@ -8060,7 +8060,7 @@ def _the_pane_will_ask(r) -> bool:
             and not profiletrust.can_ask(sys.stdin, sys.stdout))
 
 
-def _launch_refusal(p, *, attended: bool, cwd=None) -> str:
+def _launch_refusal(p, *, attended: bool, cwd=None, probe: bool = True) -> str:
     """The launcher's own refusal for *p* as a sentence, or ``""`` when it may start.
 
     **Asked by the presses, because a press has no other surface.** `_launch` runs this same
@@ -8078,7 +8078,7 @@ def _launch_refusal(p, *, attended: bool, cwd=None) -> str:
     a command it has not been shown before" on the attention row and open no chat — for a
     profile the operator is one keypress away from approving in the pane.
     """
-    r = _profile_refusal(p, attended=attended, cwd=cwd)
+    r = _profile_refusal(p, attended=attended, cwd=cwd, probe=probe)
     if r is None or _the_pane_will_ask(r):
         return ""
     return r.text
@@ -11242,7 +11242,8 @@ def background_refusal(ws: str, *, caller: str, first_message: str) -> str:
         ws, caller=caller, first_message=first_message)[0]
 
 
-def _how_a_background_open_would_go(ws: str, *, caller: str, first_message: str):
+def _how_a_background_open_would_go(ws: str, *, caller: str, first_message: str,
+                                    probe: bool = True):
     """``(refusal, profile, harness)`` — every reason an open would refuse, and what it
     resolved on the way to finding none.
 
@@ -11277,7 +11278,7 @@ def _how_a_background_open_would_go(ws: str, *, caller: str, first_message: str)
     # that cannot start is refused while there is still nothing to undo: no chat directory,
     # no window, no first message anywhere. Unattended, because nobody is in front of the
     # chat this would open: a check that would ask refuses here instead (review 3).
-    refused = _launch_refusal(p, attended=False, cwd=_chat_dir_of(ws))
+    refused = _launch_refusal(p, attended=False, cwd=_chat_dir_of(ws), probe=probe)
     if refused:
         return f"cannot open a chat in '{ws}': {refused}", None, None
     h = _harness_of(p)
@@ -11331,8 +11332,13 @@ def open_in_background(ws: str, *, caller: str, first_message: str,
     harness starts. A caller writing it afterwards would be writing the file the new chat's
     SessionStart is already looking for.
     """
+    # **Everything again but the wiring probe.** `charter handoff` — this seam's one caller
+    # — asked `background_refusal` a moment ago, probe included, so its refusal could be
+    # said before anything was written; the pane probes again before its `exec`. A third
+    # probe here bought nothing the pane's does not (A3: a start pays two). The cheap checks
+    # still run, for the race `background_refusal`'s docstring names.
     refusal, p, h = _how_a_background_open_would_go(
-        ws, caller=caller, first_message=first_message)
+        ws, caller=caller, first_message=first_message, probe=False)
     if refusal:
         return Opened(False, "", refusal)
     socket = state.frame_server(caller) or SOCKET

--- a/charter/commands_frame.py
+++ b/charter/commands_frame.py
@@ -7985,7 +7985,7 @@ def _harness_of(p):
     return next((x for x in harness.all() if x.name == p.harness), None)
 
 
-def _profile_refusal(p, *, attended: bool):
+def _profile_refusal(p, *, attended: bool, cwd=None):
     """The launcher's own chain for *p* as THIS process sees the world — the `Refusal`, or
     ``None`` when it may start.
 
@@ -7996,7 +7996,7 @@ def _profile_refusal(p, *, attended: bool):
     """
     from .frame import launcher
 
-    return launcher.refusal(p, root=config.ROOT, attended=attended,
+    return launcher.refusal(p, root=config.ROOT, attended=attended, cwd=cwd,
                             env=launcher.environment(p, os.environ, framed=True))
 
 
@@ -8039,7 +8039,7 @@ def _the_pane_will_ask(r) -> bool:
             and not profiletrust.can_ask(sys.stdin, sys.stdout))
 
 
-def _launch_refusal(p, *, attended: bool) -> str:
+def _launch_refusal(p, *, attended: bool, cwd=None) -> str:
     """The launcher's own refusal for *p* as a sentence, or ``""`` when it may start.
 
     **Asked by the presses, because a press has no other surface.** `_launch` runs this same
@@ -8057,10 +8057,27 @@ def _launch_refusal(p, *, attended: bool) -> str:
     a command it has not been shown before" on the attention row and open no chat — for a
     profile the operator is one keypress away from approving in the pane.
     """
-    r = _profile_refusal(p, attended=attended)
+    r = _profile_refusal(p, attended=attended, cwd=cwd)
     if r is None or _the_pane_will_ask(r):
         return ""
     return r.text
+
+
+def _chat_dir_of(ws: str):
+    """Where a chat opened in *ws* would stand, for a check that must write nothing.
+
+    NOT :func:`_launch_root`, which calls `workspace.ensure` and creates the directory:
+    these three callers are refusals asked before anything is written, and a handoff that
+    made a workspace directory as a side effect of deciding not to open a chat there would
+    be the half-done open `background_refusal` exists to prevent. A workspace that has no
+    directory yet also has no mirrored `enabledPlugins`, so the plane root is the honest
+    answer — it is what `workspace.ensure` will copy from a moment later.
+    """
+    from pathlib import Path
+    from . import workspace
+
+    d = workspace.workspace_dir(ws)
+    return d if d.is_dir() else Path(config.ROOT)
 
 
 def _launch_root(ws: str):
@@ -8199,7 +8216,7 @@ def _open_workspace(fid: str, ws: str, *, socket: str,
         return None
     # Attended, because this open ends with the operator's client switched onto the new
     # window: somebody is in front of whatever it says.
-    refused = _launch_refusal(p, attended=True)
+    refused = _launch_refusal(p, attended=True, cwd=_chat_dir_of(ws))
     if refused:
         _say_on_screen(fid, f"cannot open '{ws}': {refused}")
         return None
@@ -11033,7 +11050,7 @@ def cmd_new_chat(args) -> int:
     # The launcher's own chain, asked here so its refusal reaches the frame's attention row
     # rather than `/dev/null` — see :func:`_launch_refusal`. Attended: the new window is
     # selected, so the operator is looking at whatever it says.
-    refused = _launch_refusal(p, attended=True)
+    refused = _launch_refusal(p, attended=True, cwd=_chat_dir_of(ws))
     if refused:
         _say_on_screen(fid, f"cannot open another chat: {refused}")
         return 0
@@ -11228,7 +11245,7 @@ def _how_a_background_open_would_go(ws: str, *, caller: str, first_message: str)
     # that cannot start is refused while there is still nothing to undo: no chat directory,
     # no window, no first message anywhere. Unattended, because nobody is in front of the
     # chat this would open: a check that would ask refuses here instead (review 3).
-    refused = _launch_refusal(p, attended=False)
+    refused = _launch_refusal(p, attended=False, cwd=_chat_dir_of(ws))
     if refused:
         return f"cannot open a chat in '{ws}': {refused}", None, None
     h = _harness_of(p)

--- a/charter/commands_frame.py
+++ b/charter/commands_frame.py
@@ -5374,7 +5374,12 @@ def _launch(args) -> int:
     # is the refusal's own — 127 for a command that is not on `PATH`, the shell's number
     # for it, so `charter <profile> && …` behaves the way `<command> && …` would have.
     if p is not None:
-        r = _profile_refusal(p, attended=attended)
+        # **The wiring probe is left to the pane for an open whose caller asked it already**
+        # — a `+`, a tab, a reopen, a handoff, each of which ran this chain for itself so its
+        # refusal had somewhere to be said (`_launch_refusal`, `_reopen_one`). Asked here
+        # too it was a THIRD probe for one start; the plan prices a start at two, one before
+        # tmux and one in the pane, and the pane's is never skipped.
+        r = _profile_refusal(p, attended=attended, probe=not _caller_asked(args))
         if launcher.is_a_question(r):
             # **The question is put HERE, before anything is allocated.** A no is a
             # `return` with no session, no window and no chat directory to tear down —
@@ -7985,22 +7990,35 @@ def _harness_of(p):
     return next((x for x in harness.all() if x.name == p.harness), None)
 
 
-def _profile_refusal(p, *, attended: bool, cwd=None):
+def _profile_refusal(p, *, attended: bool, cwd=None, probe: bool = True):
     """The launcher's own chain for *p* as THIS process sees the world — the `Refusal`, or
     ``None`` when it may start.
 
-    One spelling of its four arguments, because the two callers ask it identically: the
-    launch itself, before tmux, and a press that has a surface to say it on
+    One spelling of its arguments, because the two callers ask it identically: the launch
+    itself, before tmux, and a press that has a surface to say it on
     (:func:`_launch_refusal`). Two copies of a call whose `env` decides what `PATH` a
     command is looked up on is two answers waiting to drift.
     """
     from .frame import launcher
 
-    return launcher.refusal(p, root=config.ROOT, attended=attended, cwd=cwd,
+    return launcher.refusal(p, root=config.ROOT, attended=attended, cwd=cwd, probe=probe,
                             env=launcher.environment(p, os.environ, framed=True))
 
 
-def _asked_here(p, ask, *, attended: bool):
+def _caller_asked(args) -> bool:
+    """Did whoever built *args* run the launcher's chain — wiring probe included — for this
+    open already?
+
+    Every caller of `cmd_launch` that does not attach does: `_open_workspace` and
+    `cmd_new_chat` through :func:`_launch_refusal`, :func:`open_in_background` through
+    `background_refusal`, and :func:`_reopen_one` by name. They have to — each runs where
+    `_launch`'s own `util.err` reaches nobody. A launch that attaches is somebody at a
+    terminal, and that one is asked here.
+    """
+    return not _wants_attach(args)
+
+
+def _asked_here(p, ask, *, attended: bool, cwd=None):
     """Put *ask*'s question on this process's own terminal. The refusal left over, or
     ``None`` when the launch may go ahead.
 
@@ -8013,7 +8031,10 @@ def _asked_here(p, ask, *, attended: bool):
     """
     from .frame import launcher
 
-    return launcher.answered(p, ask, again=lambda: _profile_refusal(p, attended=attended))
+    # The WHOLE chain again, wiring probe included, and about the same directory the first
+    # pass asked about (ruling 27): a yes answers the approval question and no other.
+    return launcher.answered(p, ask, again=lambda: _profile_refusal(p, attended=attended,
+                                                                   cwd=cwd))
 
 
 def _the_pane_will_ask(r) -> bool:
@@ -10682,6 +10703,17 @@ def _reopen_one(c, *, quiet: bool = False) -> "Reopening | None":
     # every chat, and the only warning a deleted workspace gets would vanish silently.
     homeless = workspace.valid_name(c.workspace) and not workspace.exists(c.workspace)
     where = _restore_root(c)
+    # **Unwired, by name, for the approval check's reason** (ruling 10): without this the
+    # chat is started, its launcher refuses in a pane nobody is at, and the operator reads
+    # "did not come back (launcher returned 3)". Asked of the directory the chat comes back
+    # in, which is what Claude Code resolves `enabled` at. It stays in the manifest, so
+    # wiring the profile and running `charter reopen` again brings it back.
+    from . import wiring
+
+    unwired = wiring.refusal(p, cwd=where)
+    if unwired:
+        _report(quiet, util.warn, f"charter reopen: {c.chat} is not reopened — {unwired}")
+        return None
     if not _same_directory(where, c.cwd):
         # "its workspace directory" is a claim, so it is only made where it is true: the
         # branch of `_restore_root` that has no workspace to name lands somewhere for a

--- a/charter/commands_harness.py
+++ b/charter/commands_harness.py
@@ -101,9 +101,15 @@ def _resolve(name: str):
         return found, ""
     h = registry.get(name)
     if h is not None:
-        by_kind = {p.harness: p for p in read.profiles.values()}
-        if h.name in by_kind:
-            return by_kind[h.name], ""
+        # The BUILT-IN of that kind, and not merely the last profile of it this plane
+        # declares: a registry name asks for the harness charter knows, and answering it
+        # with somebody's `codex-pinned` would wire a folder they did not name. A built-in
+        # is named after its kind, so this is `read.profiles[<kind>]` whenever a declared
+        # profile has not replaced it — and a replacement IS what that name runs, so it is
+        # the right answer when it has.
+        for q in read.profiles.values():
+            if q.harness == h.name and q.name == q.kind:
+                return q, ""
     shown = contain.readable(name)
     return None, next((r.reason for r in read.refused if r.name == shown), "")
 
@@ -159,6 +165,10 @@ def cmd_harness_install(args) -> int:
         return 1
 
     for status, detail in wiring.install(p, config.ROOT):
+        # Contained here rather than at every `return` inside the harnesses: a `detail` is a
+        # path built out of the profile's own `env`, which is a file a chat can write, and
+        # this line goes to a terminal (ruling 35).
+        detail = contain.readable(detail)
         if status == "malformed":
             util.err(f"{detail} is not valid TOML — left it completely untouched.")
             util.info("  Fix it by hand, then re-run. charter never repairs this file.")

--- a/charter/commands_harness.py
+++ b/charter/commands_harness.py
@@ -120,9 +120,8 @@ def _say_codex_steps(home) -> None:
 
     util.info("  Codex installs the plugin and trusts its hooks itself — charter writes "
               "only the line that names the harness. The rest, in this profile's home:")
-    for step in wiring.CODEX_STEPS:
-        util.info(f"      CODEX_HOME={contain.readable(str(home))} {step}"
-                  if step.startswith("codex ") else f"      {step}")
+    for step in wiring.codex_steps(home).split("; "):
+        util.info(f"      {step}")
 
 
 def cmd_harness_install(args) -> int:

--- a/charter/commands_harness.py
+++ b/charter/commands_harness.py
@@ -83,34 +83,103 @@ def cmd_harness_list(args) -> int:
     return 0
 
 
+def _resolve(name: str):
+    """*name* as a profile, then as a registry NAME. ``(profile, why it was refused)``.
+
+    Ruling 8, and the order is the whole ruling: a profile named `codex` is what
+    `charter codex` runs, so it has to be what `charter harness install codex` wires. The
+    registry name (`claude-code`) is looked up second so a plane whose operator typed that
+    still reaches the built-in of that kind — nobody's muscle memory is broken by the
+    lookup gaining a first half.
+    """
+    from . import profiles
+    from .harness import registry
+
+    read = profiles.current()
+    found = read.profiles.get(name)
+    if found is not None:
+        return found, ""
+    h = registry.get(name)
+    if h is not None:
+        by_kind = {p.harness: p for p in read.profiles.values()}
+        if h.name in by_kind:
+            return by_kind[h.name], ""
+    shown = contain.readable(name)
+    return None, next((r.reason for r in read.refused if r.name == shown), "")
+
+
+def _say_codex_steps(home) -> None:
+    """The Codex-side commands, with `CODEX_HOME=` in front of each (ruling 7).
+
+    Printed and never run: they install software into an account folder and end in a trust
+    prompt only a person can answer, and charter's own consent rule is that running the
+    command IS the consent. Pinned against codex-cli 0.147.0 by running them (D4,
+    2026-09-12) — `codex plugin` has add / list / marketplace / remove and no `install`.
+    """
+    from . import wiring
+
+    util.info("  Codex installs the plugin and trusts its hooks itself — charter writes "
+              "only the line that names the harness. The rest, in this profile's home:")
+    for step in wiring.CODEX_STEPS:
+        util.info(f"      CODEX_HOME={contain.readable(str(home))} {step}"
+                  if step.startswith("codex ") else f"      {step}")
+
+
 def cmd_harness_install(args) -> int:
-    """Arm a harness that `init` deliberately will not arm."""
+    """Wire one profile's own config folder — the command every wiring refusal names.
+
+    Five steps, and the order is what keeps charter from running something nobody approved:
+    resolve the name, refuse a declared profile git would carry, refuse one whose command
+    may not be run yet, wire it, then ASK whether that worked. The last step is why this
+    exits non-zero on a Codex profile it has just written to: charter can write the
+    `shell_environment_policy` line and nothing else, and a command that reports success
+    over a profile that will still refuse to launch is the "remedy that ends the
+    investigation" `opencode.unvouched` was written against.
+    """
+    from . import profiles, wiring
+
     name = (getattr(args, "name", "") or "").strip()
-    if registry.get(name) is None:
-        util.err(f"unknown harness {name!r} — known: {', '.join(sorted(registry.KINDS))}")
+    p, refused = _resolve(name)
+    if p is None:
+        known = ", ".join(profiles.current().profiles)
+        if refused:
+            util.err(f"profile {contain.readable(name)!r} is refused — {refused}")
+        else:
+            util.err(f"no harness or profile named {contain.readable(name)!r} — have: "
+                     f"{known}")
         return 2
-    if name != codex.NAME:
-        util.info(f"'{name}' needs no opt-in — `charter init` (or `charter reinit`) writes "
-                  f"its wiring into the plane, because it is scoped to the plane.")
-        return 0
-
-    status, detail = codex.install()
-    if status == "malformed":
-        util.err(f"{detail} is not valid TOML — left it completely untouched.")
-        util.info("  Fix it by hand, then re-run. charter never repairs this file.")
+    shown = contain.readable(p.name)
+    if p.source != profiles.BUILTIN:
+        why = profiles.ignored_refusal(config.ROOT)
+        if why:
+            util.err(f"profile '{shown}' is refused — {why}")
+            return 1
+    why = wiring.approval_needed(p)
+    if why:
+        util.err(f"profile '{shown}' is {why} — nothing was installed.")
         return 1
-    if status == "doubled":
-        util.err(f"{detail}")
-        util.info("  Both sets are trusted and both run: charter fires twice on every "
-                  "SessionStart, UserPromptSubmit and Bash call. Nothing is wrong; "
-                  "everything is doubled, which is harder to notice.")
-        return 1
-    if status == "present":
-        util.ok(f"Already named: {detail}.")
-        return 0
 
-    util.ok(f"Named the harness in {detail}.")
-    util.info("  Codex's hooks come from the charter plugin — `codex plugin` installs the "
-              "same artifact Claude Code uses. This only sets $CHARTER_HARNESS, which the "
-              "plugin cannot do, so a Codex shell can say which harness it is.")
-    return 0
+    for status, detail in wiring.install(p, config.ROOT):
+        if status == "malformed":
+            util.err(f"{detail} is not valid TOML — left it completely untouched.")
+            util.info("  Fix it by hand, then re-run. charter never repairs this file.")
+            return 1
+        if status == "doubled":
+            util.err(f"{detail}")
+            util.info("  Both sets are trusted and both run: charter fires twice on every "
+                      "SessionStart, UserPromptSubmit and Bash call. Nothing is wrong; "
+                      "everything is doubled, which is harder to notice.")
+            return 1
+        if status == "unvouched":
+            util.warn(f"  {detail}")
+        else:
+            util.info(f"  {status}: {detail}")
+
+    w = wiring.detect(p, cwd=config.ROOT)
+    if w.state == wiring.WIRED:
+        util.ok(f"profile '{shown}' is wired — {w.detail}")
+        return 0
+    if p.harness == codex.NAME:
+        _say_codex_steps(codex.config_path(wiring.environment(p)).parent)
+    util.err(f"charter: {wiring.refusal(p, cwd=config.ROOT)}")
+    return 1

--- a/charter/commands_harness.py
+++ b/charter/commands_harness.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 import sys
 
 from . import config, contain, tui, util
-from .harness import codex, registry
+from .harness import registry
 
 
 def _list_profiles() -> None:
@@ -114,44 +114,32 @@ def _resolve(name: str):
     return None, next((r.reason for r in read.refused if r.name == shown), "")
 
 
-def _say_codex_steps(home) -> None:
-    """The Codex-side commands, with `CODEX_HOME=` in front of each (ruling 7).
-
-    Printed and never run: they install software into an account folder and end in a trust
-    prompt only a person can answer, and charter's own consent rule is that running the
-    command IS the consent. Pinned against codex-cli 0.147.0 by running them (D4,
-    2026-09-12) — `codex plugin` has add / list / marketplace / remove and no `install`.
-    """
-    from . import wiring
-
-    util.info("  Codex installs the plugin and trusts its hooks itself — charter writes "
-              "only the line that names the harness. The rest, in this profile's home:")
-    for step in wiring.codex_steps(home).split("; "):
-        util.info(f"      {step}")
-
-
 def cmd_harness_install(args) -> int:
     """Wire one profile's own config folder — the command every wiring refusal names.
 
     Five steps, and the order is what keeps charter from running something nobody approved:
-    resolve the name, refuse a declared profile git would carry, refuse one whose command
-    may not be run yet, wire it, then ASK whether that worked. The last step is why this
-    exits non-zero on a Codex profile it has just written to: charter can write the
-    `shell_environment_policy` line and nothing else, and a command that reports success
-    over a profile that will still refuse to launch is the "remedy that ends the
-    investigation" `opencode.unvouched` was written against.
+    resolve the name, refuse a declared profile git would carry, ASK before a command the
+    operator has not approved, wire it, then ask the harness whether that worked. The last
+    step is why this exits non-zero on a Codex profile it has just written to: charter can
+    write the `shell_environment_policy` line and nothing else, and a command that reports
+    success over a profile that will still refuse to launch is the "remedy that ends the
+    investigation" `opencode.unvouched` was written against. What is left for Codex is
+    Codex's own commands, and the refusal it ends on names them.
     """
-    from . import profiles, wiring
+    from . import profiles, profiletrust, wiring
+    from .frame import launcher
 
     name = (getattr(args, "name", "") or "").strip()
     p, refused = _resolve(name)
     if p is None:
-        known = ", ".join(profiles.current().profiles)
+        # Quoted by hand and not with `!r`: `contain.readable` has already escaped the name,
+        # and `repr` would escape its backslashes a second time (`\\u001b`).
+        shown = contain.readable(name)
         if refused:
-            util.err(f"profile {contain.readable(name)!r} is refused — {refused}")
+            util.err(f"profile '{shown}' is refused — {refused}")
         else:
-            util.err(f"no harness or profile named {contain.readable(name)!r} — have: "
-                     f"{known}")
+            known = ", ".join(profiles.current().profiles)
+            util.err(f"no harness or profile named '{shown}' — have: {known}")
         return 2
     shown = contain.readable(p.name)
     if p.source != profiles.BUILTIN:
@@ -159,16 +147,28 @@ def cmd_harness_install(args) -> int:
         if why:
             util.err(f"profile '{shown}' is refused — {why}")
             return 1
-    why = wiring.approval_needed(p)
-    if why:
-        util.err(f"profile '{shown}' is {why} — nothing was installed.")
-        return 1
+    state = profiletrust.approval_needed(p)
+    if state:
+        # **Installing runs the profile's own command** (`claude plugin install`), so it is
+        # asked about exactly as a launch is — Task 3's question and Task 3's sentences.
+        # With nobody at a terminal to ask, it is refused the way an open nobody is at is.
+        if not profiletrust.can_ask(sys.stdin, sys.stdout):
+            util.err(f"charter: {profiletrust.UNATTENDED.format(name=shown, state=state)}")
+            return 1
+        r = launcher.answered(p, profiletrust.refusal(p, attended=True),
+                              again=lambda: profiletrust.refusal(p, attended=True))
+        if r is not None:
+            # Branched on the KIND (ruling 27). A decline was answered on the terminal it
+            # was asked on, and exits with the picker's cancel code; a yes charter could not
+            # record (`KIND_RECORD`) or a record that moved under the question refuses.
+            if launcher.already_said(r):
+                return r.exit
+            util.err(f"charter: {r.text}")
+            return 1
 
     for status, detail in wiring.install(p, config.ROOT):
-        # Contained here rather than at every `return` inside the harnesses: a `detail` is a
-        # path built out of the profile's own `env`, which is a file a chat can write, and
-        # this line goes to a terminal (ruling 35).
-        detail = contain.readable(detail)
+        # Already contained by `wiring.install` — a label is a path built out of the
+        # profile's own `env`, which is a file a chat can write (ruling 35).
         if status == "malformed":
             util.err(f"{detail} is not valid TOML — left it completely untouched.")
             util.info("  Fix it by hand, then re-run. charter never repairs this file.")
@@ -179,16 +179,17 @@ def cmd_harness_install(args) -> int:
                       "SessionStart, UserPromptSubmit and Bash call. Nothing is wrong; "
                       "everything is doubled, which is harder to notice.")
             return 1
-        if status == "unvouched":
+        if status == "refused":
+            util.err(f"charter: {detail}")
+            return 1
+        if status in ("unvouched", "unavailable", "unknown", "failed"):
             util.warn(f"  {detail}")
         else:
             util.info(f"  {status}: {detail}")
 
     w = wiring.detect(p, cwd=config.ROOT)
     if w.state == wiring.WIRED:
-        util.ok(f"profile '{shown}' is wired — {w.detail}")
+        util.ok(f"profile '{shown}' is wired — {wiring.said(w.detail)}")
         return 0
-    if p.harness == codex.NAME:
-        _say_codex_steps(codex.config_path(wiring.environment(p)).parent)
-    util.err(f"charter: {wiring.refusal(p, cwd=config.ROOT)}")
+    util.err(f"charter: {wiring.sentence(p, w)}")
     return 1

--- a/charter/dispatch.py
+++ b/charter/dispatch.py
@@ -382,7 +382,14 @@ BACKFILL_SUFFIX = ".backfill.jsonl"
 
 def _transcript_dir() -> Path:
     """Claude Code stores a project's transcripts under ~/.claude/projects/<slug>, where
-    the slug is the project path with every separator replaced by '-'."""
+    the slug is the project path with every separator replaced by '-'.
+
+    **The DEFAULT config folder, and not a harness profile's** (ruling 16). A profile can
+    point Claude Code at another folder, which keeps its own `projects/`; this answers for
+    the plane rather than for one chat, so following one chat's folder would make the count
+    depend on which chat happened to ask. `~/.claude` and not `claude_code.config_home()`
+    for the same reason: this is a question about the machine's own Claude Code.
+    """
     slug = str(config.ROOT).replace("/", "-").replace("\\", "-")
     return Path.home() / ".claude" / "projects" / slug
 

--- a/charter/doctor.py
+++ b/charter/doctor.py
@@ -7,6 +7,7 @@ Nothing here changes the system.
 
 from __future__ import annotations
 
+import concurrent.futures as cf
 import json
 import os
 import platform
@@ -712,19 +713,19 @@ def check_plane_root() -> Result:
     )
 
 
-def check_harness_profiles() -> Result:
+def check_harness_profiles(*, preflight: bool = False) -> Result:
     """This machine's harness profiles, as `charter.local.toml` declares them now — and
     whether git would carry that file.
 
     Through `profiles.current()`, the one reader (ruling 43): it reads the file as it is now,
     and applies the refusals every surface sees, a name that clashes with a command included.
 
-    The git check lives here and not in `profiles.current()` because a person runs `doctor` —
-    though `charter doctor` is also what the SessionStart hook runs, so until doctor has a
-    preflight mode, a session start on a plane with the file pays this one lock-free
-    `git status`. `profiles.ignore_check` never raises, so one slow
-    git costs this row and nothing more: `_checks` builds every row in one list with no
-    per-check guard.
+    The git check lives here and not in `profiles.current()` because a person runs `doctor`.
+    **`charter doctor --preflight` — what the SessionStart hook runs — skips it** (re-review
+    N8): every git call on a hook path is paid at every session start, and what is left
+    costs one file read, so a refused profile and a missing `default` are still reported
+    there. `profiles.ignore_check` never raises, so one slow git costs this row and nothing
+    more: `_checks` builds every row in one list with no per-check guard.
 
     Each state's hint is that state's own fix (F3): `charter reinit` adds the ignore line, and
     that fixes a committable file only. WARN rather than FAIL even for a tracked file: its
@@ -738,7 +739,7 @@ def check_harness_profiles() -> Result:
     # committable file would be the one surface that reached the operator's own profiles with
     # no read the suite's guard could see (`tests/_planeguard`, ruling 43).
     profile_set = profiles.current()
-    check = profiles.ignore_check(_config.ROOT)
+    check = profiles.IgnoreCheck("", "") if preflight else profiles.ignore_check(_config.ROOT)
     if check.reason:
         return Result(name, WARN, detail=check.reason, hint=check.fix)
     names = ", ".join(profile_set.profiles)
@@ -754,6 +755,78 @@ def check_harness_profiles() -> Result:
                                                              names=names),
                       hint=profiles.DEFAULT_FIX.format(names=names))
     return Result(name, OK, detail=f"{len(profile_set.profiles)} profile(s): {names}")
+
+
+def check_profile_wiring(*, preflight: bool = False) -> list[Result]:
+    """One row per profile the selector would list: does charter's guard run in the folder
+    that profile names?
+
+    **No probe on a hook path** (ruling 11). `preflight=True` returns no rows and calls
+    nothing: a probe costs 137-718 ms per profile and writes into that profile's config
+    folder, and the SessionStart hook's whole budget is 20 s. Only a `charter doctor` a
+    person types probes.
+
+    **A profile whose command charter may not run yet is never probed** (ruling 1). Its row
+    says so and names what to run; asking the harness would mean running a command out of a
+    file a chat can write.
+
+    Concurrently, because the answers are independent and each is a subprocess: measured on
+    this plane, three declared profiles and three built-ins add well under the 2 s budget
+    ruling 11 sets. Each probe keeps its own `plugincache.LIST_TIMEOUT`.
+
+    **A row's exception costs that row, not the report** — `check_plugin_install`'s
+    catch-all shape. A `claude` that segfaults for one profile must not take the other rows,
+    or the checks after them, down with it.
+    """
+    from . import config as _config, profiles, wiring
+
+    if preflight:
+        return []
+    rows = wiring.listed()
+    out: list[Result] = []
+    with cf.ThreadPoolExecutor(max_workers=4) as pool:
+        answers = {p.name: pool.submit(_probe_one, wiring, p, _config.ROOT) for p in rows
+                   if not wiring.approval_needed(p)}
+        for p in rows:
+            name = f"profile {contain.readable(p.name)}"
+            why = wiring.approval_needed(p)
+            if why:
+                out.append(Result(name, WARN, detail=contain.readable(why),
+                                  hint=f"charter {contain.readable(p.name)}"))
+                continue
+            try:
+                w = answers[p.name].result()
+            except Exception as e:                      # noqa: BLE001 — one row, not the run
+                out.append(Result(name, WARN, detail=f"{type(e).__name__}: {e}",
+                                  hint=_NOT_CHECKED_HINT))
+                continue
+            if w.state == wiring.WIRED:
+                out.append(Result(name, OK, detail=w.detail))
+            elif w.state == wiring.UNWIRED:
+                out.append(Result(name, WARN, detail=w.detail, hint=w.fix))
+            else:
+                out.append(Result(name, WARN, detail=w.detail, hint=_NOT_CHECKED_HINT))
+    return out
+
+
+def _probe_one(wiring, p, root):
+    """One profile's probe, in its own thread. Separate so the executor holds a plain
+    callable and the loop above reads as the table it is."""
+    return wiring.detect(p, cwd=root)
+
+
+def profile_row_names(*, preflight: bool = False) -> list[str]:
+    """The names :func:`check_profile_wiring` will produce, without probing anything.
+
+    The same reader (`wiring.listed`), so `check_names` and `run_all` cannot disagree about
+    how many rows there are — the pin `_FIXED_CHECK_NAMES` already keeps for every other
+    check, applied to a list this plane's own `charter.local.toml` decides.
+    """
+    from . import profiles, wiring
+
+    if preflight:
+        return []
+    return [f"profile {contain.readable(p.name)}" for p in wiring.listed()]
 
 
 def check_index_lock() -> Result:
@@ -3769,7 +3842,7 @@ def check_mcp_launchers() -> Result:
 CHECK_TIMEOUT = 5.0
 
 
-def iter_all():
+def iter_all(*, preflight: bool = False):
     """Yield each :class:`Result` as it completes.
 
     A generator rather than a list because `cmd_doctor` collected everything before
@@ -3778,11 +3851,11 @@ def iter_all():
     "got as far as `vaults`, then stopped" — which names the culprit without charter
     having to guess at it.
     """
-    for r in _checks():
+    for r in _checks(preflight=preflight):
         yield r
 
 
-def _checks():
+def _checks(*, preflight: bool = False):
     """Order: cheap/local checks first, network checks last. The forge cli/auth pair is
     NOT fixed (it used to be exactly one hardcoded GitLab pair) — it's one pair PER
     FORGE this control plane actually declares (`declared_or_default_forges`), so a
@@ -3792,7 +3865,9 @@ def _checks():
     for forge in declared_or_default_forges():
         results.append(check_forge_cli(forge))
         results.append(check_forge_auth(forge))
-    results += [check_ssh(), check_control_plane_config(), check_harness_profiles(),
+    results += [check_ssh(), check_control_plane_config(),
+                check_harness_profiles(preflight=preflight),
+                *check_profile_wiring(preflight=preflight),
                 check_control_plane_schema(),
                 check_plane_root(), check_index_lock(),
                 check_session_root(), check_session_layer(),
@@ -3847,14 +3922,22 @@ _FIXED_CHECK_NAMES = (
     "credential paths", "mcp", "plugin install", "plugin", "plugin files",
 )
 
+#: The row the per-profile rows follow, in `_FIXED_CHECK_NAMES` and in `_checks`. A name
+#: rather than an index, so renaming the row above them moves them with it or fails loudly.
+_PROFILE_NAMES_AFTER = "harness profiles"
+
 #: Where the forge pair goes in `_FIXED_CHECK_NAMES` — after `git identity`, which is
 #: where `_checks` runs it. A number rather than a marker entry so the tuple holds only
 #: names and the pin below compares like with like.
 _FORGE_NAMES_AT = 3
 
 
-def check_names() -> list[str]:
+def check_names(*, preflight: bool = False) -> list[str]:
     """Every name this plane's preflight will print, **without running a single check**.
+
+    The profile rows are spliced after `harness profiles`, the forge pair's shape, because
+    which profiles this plane has is a property of one machine's `charter.local.toml` rather
+    than of this list — and `preflight` removes them, the way it removes them from the run.
 
     The forge pair is asked of `declared_or_default_forges` — the same call `_checks`
     makes, so the two cannot disagree about which forge this plane declares. A GitHub-only
@@ -3864,11 +3947,18 @@ def check_names() -> list[str]:
     pair = []
     for forge in declared_or_default_forges():
         pair += [forge.cli, f"{forge.cli} auth"]
-    return (list(_FIXED_CHECK_NAMES[:_FORGE_NAMES_AT]) + pair
-            + list(_FIXED_CHECK_NAMES[_FORGE_NAMES_AT:]))
+    names = (list(_FIXED_CHECK_NAMES[:_FORGE_NAMES_AT]) + pair
+             + list(_FIXED_CHECK_NAMES[_FORGE_NAMES_AT:]))
+    # `in` before `index`, because a test that stands in for `_FIXED_CHECK_NAMES` to prove
+    # the column is measured rather than guessed replaces the whole tuple — and a splice that
+    # raised there would take the width down over a row it was not asked about.
+    if _PROFILE_NAMES_AFTER not in names:
+        return names
+    at = names.index(_PROFILE_NAMES_AFTER) + 1
+    return names[:at] + profile_row_names(preflight=preflight) + names[at:]
 
 
-def name_width() -> int:
+def name_width(*, preflight: bool = False) -> int:
     """The NAME column of `charter doctor`, measured in cells from the names it holds.
 
     In cells rather than characters because cells are what a terminal lays out — the unit
@@ -3877,10 +3967,10 @@ def name_width() -> int:
     it is the same distinction that drew an 8-glyph CJK name 8 columns wide of every other
     row in `persona stats` (#508), and it is not something to get right later.
     """
-    return tui.column("", check_names())
+    return tui.column("", check_names(preflight=preflight))
 
 
-def run_all() -> list[Result]:
+def run_all(*, preflight: bool = False) -> list[Result]:
     """Every check, collected. Kept for callers that want them all at once (`--json`,
     tests); `iter_all` is what an interactive preflight should use."""
-    return list(iter_all())
+    return list(iter_all(preflight=preflight))

--- a/charter/doctor.py
+++ b/charter/doctor.py
@@ -766,9 +766,12 @@ def check_profile_wiring(*, preflight: bool = False) -> list[Result]:
     folder, and the SessionStart hook's whole budget is 20 s. Only a `charter doctor` a
     person types probes.
 
-    **A profile whose command charter may not run yet is never probed** (ruling 1). Its row
-    says so and names what to run; asking the harness would mean running a command out of a
-    file a chat can write.
+    **A profile charter may not run a command for is never probed** (ruling 1), and there
+    are two reasons it may not: git would carry `charter.local.toml` — the `harness profiles`
+    row above says why, with the fix — or the operator has not approved this command
+    (`profiletrust`). Its row says which and names what to run; asking the harness would
+    mean running a command out of a file a chat can write. `wiring.detect` keeps the same
+    gate for itself, so a row that forgot to ask would still not probe.
 
     Concurrently, because the answers are independent and each is a subprocess: measured on
     this plane, three declared profiles and three built-ins add well under the 2 s budget
@@ -777,42 +780,93 @@ def check_profile_wiring(*, preflight: bool = False) -> list[Result]:
     **A row's exception costs that row, not the report** — `check_plugin_install`'s
     catch-all shape. A `claude` that segfaults for one profile must not take the other rows,
     or the checks after them, down with it.
+
+    Every row is bounded by :func:`_counted` and never by a bare ``...`` (ruling 45): these
+    are rows an operator acts on, and a fix clipped without saying so reads as the whole fix.
     """
     from . import config as _config, profiles, wiring
 
     if preflight:
         return []
     rows = wiring.listed()
+    # ONE git call however many profiles are declared, and none for a plane that declares
+    # none — the same lock-free `git status` the `harness profiles` row makes.
+    ignored = (profiles.ignore_check(_config.ROOT)
+               if any(p.source != profiles.BUILTIN for p in rows)
+               else profiles.IgnoreCheck("", ""))
     out: list[Result] = []
     with cf.ThreadPoolExecutor(max_workers=4) as pool:
-        answers = {p.name: pool.submit(_probe_one, wiring, p, _config.ROOT) for p in rows
-                   if not wiring.approval_needed(p)}
+        held = {p.name: _not_probed(p, ignored) for p in rows}
+        answers = {p.name: pool.submit(wiring.detect, p, cwd=_config.ROOT)
+                   for p in rows if held[p.name] is None}
         for p in rows:
-            name = f"profile {contain.readable(p.name)}"
-            why = wiring.approval_needed(p)
-            if why:
-                out.append(Result(name, WARN, detail=contain.readable(why),
-                                  hint=f"charter {contain.readable(p.name)}"))
+            name = _profile_row_name(p)
+            if held[p.name] is not None:
+                detail, hint = held[p.name]
+                out.append(Result(name, WARN, detail=_counted(detail), hint=_counted(hint)))
                 continue
             try:
                 w = answers[p.name].result()
             except Exception as e:                      # noqa: BLE001 — one row, not the run
-                out.append(Result(name, WARN, detail=f"{type(e).__name__}: {e}",
-                                  hint=_NOT_CHECKED_HINT))
+                # Contained (ruling 35): an exception's text is whatever the code that raised
+                # it put there, and here that is a path or an argv built from the profile.
+                out.append(Result(name, WARN, detail=_counted(contain.readable(
+                    f"{type(e).__name__}: {e}", contain.NO_CLIP)), hint=_NOT_CHECKED_HINT))
                 continue
             if w.state == wiring.WIRED:
-                out.append(Result(name, OK, detail=w.detail))
+                out.append(Result(name, OK, detail=_counted(w.detail)))
             elif w.state == wiring.UNWIRED:
-                out.append(Result(name, WARN, detail=w.detail, hint=w.fix))
+                out.append(Result(name, WARN, detail=_counted(w.detail),
+                                  hint=_counted(w.fix)))
             else:
-                out.append(Result(name, WARN, detail=w.detail, hint=_NOT_CHECKED_HINT))
+                out.append(Result(name, WARN, detail=_counted(w.detail),
+                                  hint=_NOT_CHECKED_HINT))
     return out
 
 
-def _probe_one(wiring, p, root):
-    """One profile's probe, in its own thread. Separate so the executor holds a plain
-    callable and the loop above reads as the table it is."""
-    return wiring.detect(p, cwd=root)
+def _not_probed(p, ignored) -> tuple[str, str] | None:
+    """``(detail, hint)`` for a profile whose command charter may not run, else ``None``.
+
+    Both already escaped: the only profile-derived text in either is the name, contained
+    whole so :func:`_counted` can say how much of it a row hid.
+    """
+    from . import profiles, profiletrust
+
+    if p.source == profiles.BUILTIN:
+        return None
+    if ignored.reason:
+        return ("not probed — git would carry charter.local.toml, so every profile in it is "
+                "refused (the harness profiles row says why)", ignored.fix)
+    state = profiletrust.approval_needed(p)
+    if state:
+        return (f"{state}, and not approved yet — charter asks before it runs a command it "
+                f"has not been shown", f"charter {contain.readable(p.name, contain.NO_CLIP)}")
+    return None
+
+
+#: What a doctor row says about what it hid (ruling 45) — the selector's marker
+#: (`frame/overlay._HIDDEN`), because it is the same promise to the same operator. An
+#: ellipsis marks a cut and not its size, and on a row whose hint is a command to run, a
+#: reader cannot tell a clipped command from a whole one without the size.
+_HIDDEN = "… +{n} not shown"
+
+
+def _counted(text: str, limit: int = contain.DISPLAY_LIMIT) -> str:
+    """*text* — already escaped — within *limit* characters, saying how many it did not show.
+
+    Not `contain.readable`, which clips with a FIXED marker and would escape an escaped
+    value a second time: every caller here hands over text `contain` has already made safe
+    and left whole, so what is left to decide is only how much of it a row shows.
+    """
+    if len(text) <= limit:
+        return text
+    return text[:limit] + _HIDDEN.format(n=len(text) - limit)
+
+
+def _profile_row_name(p) -> str:
+    """A profile's row name — one spelling, because :func:`profile_row_names` sizes the
+    column from exactly these strings and a row whose name differed would push its own row."""
+    return f"profile {_counted(contain.readable(p.name, contain.NO_CLIP))}"
 
 
 def profile_row_names(*, preflight: bool = False) -> list[str]:
@@ -822,11 +876,11 @@ def profile_row_names(*, preflight: bool = False) -> list[str]:
     how many rows there are — the pin `_FIXED_CHECK_NAMES` already keeps for every other
     check, applied to a list this plane's own `charter.local.toml` decides.
     """
-    from . import profiles, wiring
+    from . import wiring
 
     if preflight:
         return []
-    return [f"profile {contain.readable(p.name)}" for p in wiring.listed()]
+    return [_profile_row_name(p) for p in wiring.listed()]
 
 
 def check_index_lock() -> Result:

--- a/charter/frame/launcher.py
+++ b/charter/frame/launcher.py
@@ -266,7 +266,8 @@ def display_command(p: profiles.Profile, rest: list[str]) -> list[str]:
 
 
 def refusal(p: profiles.Profile, *, root: Path, attended: bool,
-            env: Mapping[str, str], cwd: Path | None = None) -> Refusal | None:
+            env: Mapping[str, str], cwd: Path | None = None,
+            probe: bool = True) -> Refusal | None:
     """Why *p* may not start, or ``None``.
 
     The spec's order, and it is the order the checks cost in: the file is ignored, the
@@ -280,8 +281,8 @@ def refusal(p: profiles.Profile, *, root: Path, attended: bool,
     decides nothing about it. A declared replacement of a built-in (`[harness.claude]`) is
     declared, so `charter claude` is refused with the rest and never falls back (ruling 19).
 
-    *attended* decides what the last link answers: an open somebody is in front of gets the
-    question (`KIND_ASK`), and one nobody is at gets a refusal in its place.
+    *attended* decides what the approval link answers: an open somebody is in front of gets
+    the question (`KIND_ASK`), and one nobody is at gets a refusal in its place.
 
     **The wiring probe is last, and that is the order it costs in.** It runs the profile's
     own command (137-718 ms measured) and writes into the folder it asks about, so a profile
@@ -289,6 +290,13 @@ def refusal(p: profiles.Profile, *, root: Path, attended: bool,
     not run yet is never probed at all (ruling 1). Every call is a FRESH probe: a launch
     never reads `wiring.cached`, because that file is as writable by a chat as
     `charter.local.toml` is (ruling 21).
+
+    *probe* ``False`` leaves the wiring link off, and exactly one caller passes it:
+    `commands_frame._launch` for an open whose caller has just asked this whole chain for
+    itself — a `+`, a tab, a reopen, a handoff — so that a start pays the probe twice (once
+    before tmux, once in the pane), as the plan prices it, and not three times. It is never
+    a way past the check: the pane runs this chain with *probe* at its default before the
+    `exec`, whoever opened it.
     """
     if p.source != profiles.BUILTIN:
         why = profiles.ignored_refusal(root)
@@ -306,13 +314,14 @@ def refusal(p: profiles.Profile, *, root: Path, attended: bool,
                                           cmd=contain.readable(program)),
                        MISSING_EXIT)
     asked = _approval_refusal(p, attended=attended)
-    if asked is not None:
+    if asked is not None or not probe:
         return asked
     # The directory the CHAT will start in, because that is what the question is about:
-    # Claude Code resolves `enabledPlugins` at the session's own working directory and does
-    # not walk up (measured), and charter mirrors the plane's into `workspaces/<ws>/`. A
-    # caller that knows the workspace says so; the launcher in the pane, and `_launch`
-    # before tmux, are already standing there, which is what `Path.cwd()` means here.
+    # Claude Code resolves `enabledPlugins` at the session's own working directory (and the
+    # git root's `settings.local.json` above it — measured), and charter mirrors the
+    # plane's into `workspaces/<ws>/`. A caller that knows the workspace says so; the
+    # launcher in the pane, and `_launch` before tmux, are already standing there, which is
+    # what `Path.cwd()` means here.
     why = wiring.refusal(p, cwd=Path.cwd() if cwd is None else cwd)
     if why:
         return Refusal(KIND_WIRING, why, REFUSED_EXIT)
@@ -320,7 +329,10 @@ def refusal(p: profiles.Profile, *, root: Path, attended: bool,
 
 
 def _approval_refusal(p: profiles.Profile, *, attended: bool) -> Refusal | None:
-    """The last link: has the operator seen this command? (`profiletrust`)
+    """The approval link: has the operator seen this command? (`profiletrust`)
+
+    Before the wiring probe and never after it: the probe runs the profile's own command,
+    and only a yes here stands for the operator's approval of that command (ruling 1).
 
     **`main` never runs an unapproved declared command.** `charter.local.toml` is a file a
     chat can write with no diff to show for it, and its `command` goes to tmux rather than

--- a/charter/frame/launcher.py
+++ b/charter/frame/launcher.py
@@ -266,7 +266,7 @@ def display_command(p: profiles.Profile, rest: list[str]) -> list[str]:
 
 
 def refusal(p: profiles.Profile, *, root: Path, attended: bool,
-            env: Mapping[str, str]) -> Refusal | None:
+            env: Mapping[str, str], cwd: Path | None = None) -> Refusal | None:
     """Why *p* may not start, or ``None``.
 
     The spec's order, and it is the order the checks cost in: the file is ignored, the
@@ -308,10 +308,12 @@ def refusal(p: profiles.Profile, *, root: Path, attended: bool,
     asked = _approval_refusal(p, attended=attended)
     if asked is not None:
         return asked
-    # `Path.cwd()`: the directory `_launch` stands in before tmux, and the pane's own start
-    # directory after. Claude Code resolves `enabledPlugins` there, so it is the directory
-    # the question is actually about.
-    why = wiring.refusal(p, cwd=Path.cwd())
+    # The directory the CHAT will start in, because that is what the question is about:
+    # Claude Code resolves `enabledPlugins` at the session's own working directory and does
+    # not walk up (measured), and charter mirrors the plane's into `workspaces/<ws>/`. A
+    # caller that knows the workspace says so; the launcher in the pane, and `_launch`
+    # before tmux, are already standing there, which is what `Path.cwd()` means here.
+    why = wiring.refusal(p, cwd=Path.cwd() if cwd is None else cwd)
     if why:
         return Refusal(KIND_WIRING, why, REFUSED_EXIT)
     return None

--- a/charter/frame/launcher.py
+++ b/charter/frame/launcher.py
@@ -72,7 +72,7 @@ import sys
 from pathlib import Path
 from typing import Callable, Mapping, NamedTuple
 
-from .. import config, contain, profiles, util
+from .. import config, contain, profiles, util, wiring
 from . import state, tmuxctl
 
 #: What a launcher that refused in the pane exits with, after printing why.
@@ -103,6 +103,9 @@ KIND_MOVED = "moved"
 #: The operator read the command and said no. Not a rule firing: their own answer.
 KIND_DECLINED = "declined"
 KIND_EXEC = "exec"
+#: `wiring.KIND_WIRING`, named here so a reader of this list sees every kind a launch can
+#: refuse with. The constant lives beside the check that produces it.
+KIND_WIRING = wiring.KIND_WIRING
 
 
 class Refusal(NamedTuple):
@@ -279,6 +282,13 @@ def refusal(p: profiles.Profile, *, root: Path, attended: bool,
 
     *attended* decides what the last link answers: an open somebody is in front of gets the
     question (`KIND_ASK`), and one nobody is at gets a refusal in its place.
+
+    **The wiring probe is last, and that is the order it costs in.** It runs the profile's
+    own command (137-718 ms measured) and writes into the folder it asks about, so a profile
+    refused for any earlier reason is never probed — and a profile whose command charter may
+    not run yet is never probed at all (ruling 1). Every call is a FRESH probe: a launch
+    never reads `wiring.cached`, because that file is as writable by a chat as
+    `charter.local.toml` is (ruling 21).
     """
     if p.source != profiles.BUILTIN:
         why = profiles.ignored_refusal(root)
@@ -295,7 +305,16 @@ def refusal(p: profiles.Profile, *, root: Path, attended: bool,
                        NOT_ON_PATH.format(name=contain.readable(p.name),
                                           cmd=contain.readable(program)),
                        MISSING_EXIT)
-    return _approval_refusal(p, attended=attended)
+    asked = _approval_refusal(p, attended=attended)
+    if asked is not None:
+        return asked
+    # `Path.cwd()`: the directory `_launch` stands in before tmux, and the pane's own start
+    # directory after. Claude Code resolves `enabledPlugins` there, so it is the directory
+    # the question is actually about.
+    why = wiring.refusal(p, cwd=Path.cwd())
+    if why:
+        return Refusal(KIND_WIRING, why, REFUSED_EXIT)
+    return None
 
 
 def _approval_refusal(p: profiles.Profile, *, attended: bool) -> Refusal | None:

--- a/charter/harness/claude_code.py
+++ b/charter/harness/claude_code.py
@@ -11,6 +11,7 @@ import json
 import os
 import unicodedata
 from pathlib import Path
+from typing import Mapping
 
 from .base import Harness, LayerPart
 
@@ -188,7 +189,7 @@ def _restrictive(doc) -> dict[str, list[str]]:
     return {b: rules for b, rules in found.items() if rules}
 
 
-def config_home() -> Path:
+def config_home(env: Mapping[str, str] | None = None) -> Path:
     """The folder Claude Code keeps its user-level state in — ``settings.json`` and the
     ``plugins/`` manifest among it — resolved the way the binary resolves it (#969).
 
@@ -212,12 +213,12 @@ def config_home() -> Path:
     moves the plugin manifest out of this folder, and the cowork switch
     (`$CLAUDE_CODE_USE_COWORK_PLUGINS`) renames ``plugins/`` and ``settings.json`` inside it.
     """
-    named = os.environ.get("CLAUDE_CONFIG_DIR")
+    named = (os.environ if env is None else env).get("CLAUDE_CONFIG_DIR")
     raw = os.path.join(Path.home(), ".claude") if named is None else named
     return Path(unicodedata.normalize("NFC", raw))
 
 
-def global_config_file() -> Path:
+def global_config_file(env: Mapping[str, str] | None = None) -> Path:
     """Claude Code's ``.claude.json`` for the folder in use — where `mcpServers` live (#969).
 
     Its own rule, not :func:`config_home`'s, read off the same binary: a legacy
@@ -233,10 +234,11 @@ def global_config_file() -> Path:
 
     Not followed: `$CLAUDE_CODE_CUSTOM_OAUTH_URL` renames the file ``.claude-custom-oauth.json``.
     """
-    legacy = config_home() / ".config.json"
+    src = os.environ if env is None else env
+    legacy = config_home(env) / ".config.json"
     if os.path.exists(legacy):
         return legacy
-    return Path(os.environ.get("CLAUDE_CONFIG_DIR") or Path.home()) / ".claude.json"
+    return Path(src.get("CLAUDE_CONFIG_DIR") or Path.home()) / ".claude.json"
 
 
 class ClaudeCodeHarness(Harness):

--- a/charter/harness/codex.py
+++ b/charter/harness/codex.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 import os
 import tomllib
 from pathlib import Path
+from typing import Mapping
 
 from .base import WORKSPACE_SCOPE, Deficit, Harness
 
@@ -52,7 +53,7 @@ PLUGIN_UPDATE_CMD = ("codex plugin marketplace upgrade charter && "
                      "codex plugin add charter@charter")
 
 
-def config_path() -> Path:
+def config_path(env: Mapping[str, str] | None = None) -> Path:
     """Codex's config file. There is no project-level **config**: a `.codex/config.toml`
     or `codex.toml` planted in a project directory is ignored, checked by putting a
     deliberate type error in each and watching the config load anyway.
@@ -68,8 +69,13 @@ def config_path() -> Path:
     ``$CODEX_HOME`` is honoured — verified by pointing it at a throwaway directory and
     watching `codex mcp list` read that directory's config. Writing to `~/.codex`
     unconditionally would silently miss anyone who sets it.
+
+    *env* is the environment to resolve against, defaulting to this process's, so a harness
+    profile's own `$CODEX_HOME` is read and written by the same rule. **The home is the one
+    charter can SEE**: one a wrapper script exports on its way to `codex` is invisible here,
+    and `docs/harnesses.md` states that limit.
     """
-    home = os.environ.get("CODEX_HOME")
+    home = (os.environ if env is None else env).get("CODEX_HOME")
     return (Path(home) if home else Path.home() / ".codex") / "config.toml"
 
 
@@ -91,7 +97,7 @@ def _block() -> str:
         'set = { CHARTER_HARNESS = "codex" }', ""])
 
 
-def install() -> tuple[str, str]:
+def install(env: Mapping[str, str] | None = None) -> tuple[str, str]:
     """Arm charter's hooks in Codex's config. ``(status, detail)``.
 
     Not called by `init`, and that is the decision rather than an oversight: this file is
@@ -108,7 +114,7 @@ def install() -> tuple[str, str]:
     `trusted_hash`, and a `--dangerously-bypass-hook-trust` flag exist), so the caller is
     told to approve it rather than left believing the wiring is live.
     """
-    p = config_path()
+    p = config_path(env)
     raw = ""
     if p.exists():
         try:

--- a/charter/harness/opencode.py
+++ b/charter/harness/opencode.py
@@ -26,6 +26,7 @@ import json
 import os
 import re
 from pathlib import Path
+from typing import Mapping
 
 from .. import __version__
 from .base import WORKSPACE_SCOPE, Deficit, Harness
@@ -172,7 +173,7 @@ def _shadowed_builtins(name: str) -> tuple[str, ...]:
     return tuple(b for b in BUILTIN_PERMISSIONS if matcher.fullmatch(b))
 
 
-def global_dir() -> Path:
+def global_dir(env: Mapping[str, str] | None = None) -> Path:
     """Where opencode reads plugins, commands and config for EVERY project.
 
     Verified by putting a probe in `~/.config/opencode/plugin/` and booting `opencode
@@ -182,8 +183,14 @@ def global_dir() -> Path:
 
     `$XDG_CONFIG_HOME` first, for the same reason `$CODEX_HOME` is honoured: writing to a
     path the tool does not read is indistinguishable from not installing at all.
+
+    *env* is the environment to resolve against, defaulting to this process's, so a harness
+    profile's own `$XDG_CONFIG_HOME` is wired and asked about by one rule. Note what this
+    is NOT: opencode's ACCOUNT moves with `$XDG_DATA_HOME`, so a profile that switches
+    accounts need not move the plugin at all — which is exactly why wiring is detected by
+    asking rather than by reading variable names.
     """
-    xdg = os.environ.get("XDG_CONFIG_HOME")
+    xdg = (os.environ if env is None else env).get("XDG_CONFIG_HOME")
     return (Path(xdg) if xdg else Path.home() / ".config") / "opencode"
 
 
@@ -904,7 +911,7 @@ class OpenCodeHarness(Harness):
             return "current", __version__
         return "moved", f"opencode {SHIM_PATH} → {__version__}"
 
-    def wire(self, root: Path) -> list[tuple[str, str]]:
+    def wire(self, root: Path, *, env: Mapping[str, str] | None = None) -> list[tuple[str, str]]:
         """Install once, where opencode reads for every project.
 
         *root* is ignored: nothing is written into the plane. A plane is somebody's repo,
@@ -912,7 +919,7 @@ class OpenCodeHarness(Harness):
         per-tree design cost, along with a `.git/info/exclude` entry per checkout to hide
         the evidence.
         """
-        g = global_dir()
+        g = global_dir(env)
         # Labels are RELATIVE to the config dir, and say which harness they belong to.
         # An absolute path here is unbounded — a deep home directory turned `init`'s
         # summary into a 130-column line, which is the readability budget #231 set.

--- a/charter/persona.py
+++ b/charter/persona.py
@@ -1458,6 +1458,12 @@ def _skill_roots() -> list:
     The lint's own justification is that a declared skill costs context on every dispatch, so
     a dead entry is paid forever for nothing. That argues for accuracy about what EXISTS, not
     about what happens to be packaged.
+
+    **These are the DEFAULT config folder's, and not a harness profile's** (ruling 16). A
+    profile can point Claude Code at another folder with its own `plugins/` and `skills/`;
+    a persona belongs to the plane and is declared once for every chat on it, so an answer
+    that followed one chat's profile would lint the same persona differently depending on
+    which account asked.
     """
     from pathlib import Path as _P
     home = _P.home() / ".claude"

--- a/charter/plugincache.py
+++ b/charter/plugincache.py
@@ -370,7 +370,9 @@ def install(project, scope: str = INSTALL_SCOPE, *, env: dict | None = None,
     installing software because some unrelated command ran is #857's surprise, and the same
     reason charter refuses to write `~/.claude/settings.json` unasked.
     """
-    if not available(command):
+    # The PATH the steps below will run under, as `_claude_json` asks it (A2): a profile
+    # whose program lives only on its own `PATH` is installed for, not called unavailable.
+    if not available(command, path=(env or {}).get("PATH")):
         return "unavailable", (f"`{command[0]}` is not on PATH, so there is no Claude "
                                f"Code to install a plugin into")
     entry = installed_for(project, env=env, command=command)

--- a/charter/plugincache.py
+++ b/charter/plugincache.py
@@ -131,14 +131,21 @@ MARKETPLACE_SOURCE = "diazoxide/charter"
 INSTALL_SCOPE = "project"
 
 
-def available() -> bool:
-    """True when the `claude` CLI is on PATH. False is an ordinary answer, not a fault —
+#: The program every read here runs, when the caller names none. A profile names its own
+#: (`["/opt/claude-wrap"]`, a pinned binary), and a wrapper script's answer is the one that
+#: matters for a chat that will be started through it.
+DEFAULT_COMMAND = ("claude",)
+
+
+def available(command: tuple[str, ...] | list[str] = DEFAULT_COMMAND) -> bool:
+    """True when *command*'s program is on PATH. False is an ordinary answer, not a fault —
     charter supports opencode and Codex, and a plane on either has no Claude Code plugin
     to be stale."""
-    return bool(shutil.which("claude"))
+    return bool(shutil.which(command[0]))
 
 
-def _claude_json(args: list[str], cwd=None, timeout: float = LIST_TIMEOUT):
+def _claude_json(args: list[str], cwd=None, timeout: float = LIST_TIMEOUT, *,
+                 env: dict | None = None, command=DEFAULT_COMMAND):
     """Run ``claude plugin <args> --json`` and parse it. ``None`` on any failure.
 
     ``None`` and ``[]`` are different answers and both are load-bearing downstream: "I
@@ -162,11 +169,11 @@ def _claude_json(args: list[str], cwd=None, timeout: float = LIST_TIMEOUT):
       and a `claude` removed between them is a `FileNotFoundError` that would otherwise
       reach the crash reporter.
     """
-    if not available():
+    if not available(command):
         return None
     try:
-        proc = util.run(["claude", "plugin", *args, "--json"], cwd=cwd, check=False,
-                        timeout=timeout)
+        proc = util.run([*command, "plugin", *args, "--json"], cwd=cwd, check=False,
+                        timeout=timeout, env=env)
     except (util.ProcTimeout, OSError):
         return None
     if proc.returncode != 0:
@@ -177,15 +184,22 @@ def _claude_json(args: list[str], cwd=None, timeout: float = LIST_TIMEOUT):
         return None
 
 
-def _our_entries():
+def _our_entries(*, env: dict | None = None, command=DEFAULT_COMMAND, cwd=None):
     """Every ``claude plugin list`` row that IS charter's plugin, or :data:`UNKNOWN`.
+
+    *cwd* is not a nicety. Measured 2026-09-12 on 2.1.269: the rows are install records and
+    are listed whatever the directory, while each row's ``enabled`` is the EFFECTIVE
+    ``enabledPlugins`` value for the id resolved at the working directory — local over
+    project over user. So a caller that wants to know whether charter runs in a particular
+    directory has to ask from it. Today's callers pass none and keep this process's own,
+    which is what they have always asked.
 
     Split out of :func:`installed_charter_plugin` when :func:`installed_for` needed the
     same rows asked a different question. One reader, because two of them would eventually
     disagree about which rows count as charter's — and the id check below is the only thing
     standing between `charter doctor --fix` and a plugin that is not charter's to touch.
     """
-    entries = _claude_json(["list"])
+    entries = _claude_json(["list"], cwd=cwd, env=env, command=command)
     # ONE test, and it used to be two. `_claude_json` answers `None` for every way a read
     # can fail, and the line above it — `if entries is None: return UNKNOWN` — was carried
     # here from `installed_charter_plugin` and is strictly subsumed by this one: `None` is
@@ -245,7 +259,7 @@ def covers(entry: dict, project) -> bool:
     return _same_dir(entry.get("projectPath"), project)
 
 
-def installed_for(project):
+def installed_for(project, *, env: dict | None = None, command=DEFAULT_COMMAND):
     """The charter plugin install that covers *project* — or :data:`UNKNOWN`, or ``None``.
 
     :func:`installed_charter_plugin` answers a different question and keeps answering it:
@@ -253,7 +267,7 @@ def installed_for(project):
     same versioned cache directory, so any one of them will do. This one answers *is this
     plane covered*, where they are not interchangeable at all.
     """
-    ours = _our_entries()
+    ours = _our_entries(env=env, command=command)
     if ours is UNKNOWN:
         return UNKNOWN
     for e in ours:
@@ -262,8 +276,34 @@ def installed_for(project):
     return None
 
 
+def covering_entries(project, *, root=None, env: dict | None = None,
+                     command=DEFAULT_COMMAND):
+    """EVERY install of charter's plugin that applies to a session in *project*, asked from
+    *project* — or :data:`UNKNOWN`. Beside :func:`installed_for`, which answers with the
+    first one it finds.
+
+    Every one of them, because this machine lists user, project and local entries side by
+    side and the caller decides between them (review 6); the first that `covers` is an
+    arbitrary choice among answers that can disagree.
+
+    *root* is the PLANE, and it is why this is not `installed_for` with a loop.
+    `charter init` installs at project scope for the plane root, while a chat stands in
+    `workspaces/<ws>/` — a different `projectPath`, which `covers` alone reads as somebody
+    else's checkout. Charter mirrors the plane's `enabledPlugins` into that directory
+    (`claude_code.WORKSPACE_KEYS`), so the record that covers the plane is the one that
+    answers for the chat, and the `enabled` this returns was resolved by the binary in
+    *project* itself (D3, measured 2026-09-12).
+    """
+    ours = _our_entries(env=env, command=command, cwd=project)
+    if ours is UNKNOWN:
+        return UNKNOWN
+    return [e for e in ours
+            if covers(e, project) or (root is not None and covers(e, root))]
+
+
 def install_argvs(scope: str = INSTALL_SCOPE,
-                  source: str = MARKETPLACE_SOURCE) -> list[list[str]] | None:
+                  source: str = MARKETPLACE_SOURCE,
+                  *, command=DEFAULT_COMMAND) -> list[list[str]] | None:
     """The two commands that put charter's plugin on a machine, in order.
 
     ``None`` if *scope* is not one charter will install at, so a caller cannot run half a
@@ -283,16 +323,16 @@ def install_argvs(scope: str = INSTALL_SCOPE,
     if not isinstance(source, str) or not source or source.startswith("-"):
         return None
     return [
-        ["claude", "plugin", "marketplace", "add", source],
-        ["claude", "plugin", "install", PLUGIN_ID, "--scope", scope, "-y"],
+        [*command, "plugin", "marketplace", "add", source],
+        [*command, "plugin", "install", PLUGIN_ID, "--scope", scope, "-y"],
     ]
 
 
-def _step(argv: list[str], cwd) -> tuple[bool, str]:
+def _step(argv: list[str], cwd, *, env: dict | None = None) -> tuple[bool, str]:
     """Run one `claude plugin` step. ``(ok, why)``, never raising — same reasons as
     :func:`force_refresh`, which this sits beside."""
     try:
-        proc = util.run(argv, cwd=cwd, check=False, timeout=REFRESH_TIMEOUT)
+        proc = util.run(argv, cwd=cwd, check=False, timeout=REFRESH_TIMEOUT, env=env)
     except (util.ProcTimeout, OSError) as e:
         return False, str(e) or type(e).__name__
     if proc.returncode != 0:
@@ -301,7 +341,8 @@ def _step(argv: list[str], cwd) -> tuple[bool, str]:
     return True, ""
 
 
-def install(project, scope: str = INSTALL_SCOPE) -> tuple[str, str]:
+def install(project, scope: str = INSTALL_SCOPE, *, env: dict | None = None,
+            command=DEFAULT_COMMAND) -> tuple[str, str]:
     """Install charter's own Claude Code plugin for *project*. ``(status, detail)``.
 
     Five statuses, because five different things are true and only one of them is a fault:
@@ -320,23 +361,23 @@ def install(project, scope: str = INSTALL_SCOPE) -> tuple[str, str]:
     installing software because some unrelated command ran is #857's surprise, and the same
     reason charter refuses to write `~/.claude/settings.json` unasked.
     """
-    if not available():
-        return "unavailable", ("the `claude` CLI is not on PATH, so there is no Claude "
-                               "Code to install a plugin into")
-    entry = installed_for(project)
+    if not available(command):
+        return "unavailable", (f"`{command[0]}` is not on PATH, so there is no Claude "
+                               f"Code to install a plugin into")
+    entry = installed_for(project, env=env, command=command)
     if entry is UNKNOWN:
         return "unknown", ("could not read `claude plugin list --json`, so charter does "
                            "not know what is installed and will not install over it")
     if entry is not None:
         return "present", (f"{entry.get('id')} is already installed "
                            f"({entry.get('scope')} scope)")
-    argvs = install_argvs(scope)
+    argvs = install_argvs(scope, command=command)
     if argvs is None:
         return "failed", f"{scope!r} is not a scope charter will install at"
     add, put = argvs
     cwd = str(project) if project is not None and Path(project).is_dir() else None
-    added, why_add = _step(add, cwd)
-    ok, why = _step(put, cwd)
+    added, why_add = _step(add, cwd, env=env)
+    ok, why = _step(put, cwd, env=env)
     if ok:
         return "installed", f"{PLUGIN_ID} installed at {scope} scope"
     # The marketplace step is allowed to fail and the install still to be attempted: a

--- a/charter/plugincache.py
+++ b/charter/plugincache.py
@@ -137,11 +137,17 @@ INSTALL_SCOPE = "project"
 DEFAULT_COMMAND = ("claude",)
 
 
-def available(command: tuple[str, ...] | list[str] = DEFAULT_COMMAND) -> bool:
-    """True when *command*'s program is on PATH. False is an ordinary answer, not a fault —
-    charter supports opencode and Codex, and a plane on either has no Claude Code plugin
-    to be stale."""
-    return bool(shutil.which(command[0]))
+def available(command: tuple[str, ...] | list[str] = DEFAULT_COMMAND,
+              path: str | None = None) -> bool:
+    """True when *command*'s program is on *path* — this process's `PATH` when ``None``.
+    False is an ordinary answer, not a fault — charter supports opencode and Codex, and a
+    plane on either has no Claude Code plugin to be stale.
+
+    *path* is the `PATH` the command will actually be run under. A profile may set its own
+    in `env`, and the launcher looks its command up on that one (`launcher.refusal`); a
+    probe that looked on this process's instead would refuse a profile the launch would
+    have found, and call the harness "could not be asked" when it was never looked for."""
+    return bool(shutil.which(command[0], path=path))
 
 
 def _claude_json(args: list[str], cwd=None, timeout: float = LIST_TIMEOUT, *,
@@ -161,20 +167,23 @@ def _claude_json(args: list[str], cwd=None, timeout: float = LIST_TIMEOUT, *,
     **zero rows** and a scary line, which is the precise failure `iter_all`'s streaming and
     :data:`~charter.doctor.CHECK_TIMEOUT` were introduced to prevent.
 
-    Two exceptions get out of `util.run` and both are real:
+    Three exceptions get out of `util.run` and all are real:
 
     * `util.ProcTimeout` — a `claude` that hangs. `util.run` raises it regardless of
       ``check``, so ``check=False`` does not cover it.
     * `OSError` — `shutil.which` in :func:`available` and the exec here are two moments,
       and a `claude` removed between them is a `FileNotFoundError` that would otherwise
       reach the crash reporter.
+    * `ValueError` — below.
     """
-    if not available(command):
+    if not available(command, path=(env or {}).get("PATH")):
         return None
     try:
         proc = util.run([*command, "plugin", *args, "--json"], cwd=cwd, check=False,
                         timeout=timeout, env=env)
-    except (util.ProcTimeout, OSError):
+    except (util.ProcTimeout, OSError, ValueError):
+        # `ValueError` is a NUL byte in the argv, the cwd or an environment value, which
+        # `exec` refuses before anything runs — and a profile is a file a chat can write.
         return None
     if proc.returncode != 0:
         return None

--- a/charter/wiring.py
+++ b/charter/wiring.py
@@ -53,6 +53,7 @@ from __future__ import annotations
 import hashlib
 import json
 import os
+import re
 import shlex
 import shutil
 import time
@@ -82,12 +83,19 @@ MAX_AGE = 24 * 3600
 #: The key prefix Codex writes its hook-trust ledger under, per plugin.
 CODEX_TRUST_PREFIX = f"{plugincache.PLUGIN_ID}:hooks/hooks.json:"
 
-#: The Codex hook event every one of charter's guards is declared on. **A trusted hook is
-#: not a trusted guard**: Codex asks about each hook separately, and an approved
-#: `session_start` reconcile says nothing about whether `charter hook pretooluse` will run
-#: before a shell command (ruling 7 — "charter's guard actually runs"). Charter declares no
-#: other hook on this event, so a trusted entry under it is a trusted guard.
-CODEX_GUARD_EVENT = "pre_tool_use"
+#: The handler of charter's GUARD — `charter hook pretooluse`, the hook on `Bash` that
+#: refuses a command. **A trusted hook is not a trusted guard**: Codex asks about each hook
+#: separately, and neither an approved SessionStart reconcile nor an approved `Task|Agent`
+#: dispatch hook (`pretooluse-dispatch`, a `pre_tool_use` hook too) says anything about
+#: whether this one runs before a shell command (ruling 7 — "charter's guard actually
+#: runs"). Named by HANDLER and not by position: Codex keys trust by
+#: `<event>:<group>:<hook>` within the installed plugin's own `hooks/hooks.json`, and a
+#: position is a fact about one version of that file (:func:`_codex_guard_keys`).
+CODEX_GUARD_HANDLER = "pretooluse"
+
+#: Where Codex keeps an installed plugin, under its home: `plugins/cache/<marketplace>/
+#: <plugin>/<version>/` (D4, codex-cli 0.147.0).
+CODEX_PLUGIN_CACHE = Path("plugins") / "cache"
 
 #: How a Codex plugin is installed, pinned against codex-cli 0.147.0 by running it
 #: (D4, 2026-09-12): `codex plugin` has add / list / marketplace / remove and no `install`.
@@ -399,8 +407,9 @@ def _codex(p: profiles.Profile, cwd: Path, env: Mapping[str, str]) -> Wiring:
     against a real hash on 2026-09-12 and none matched. And Codex writes an entry per hook
     **lazily**, as each first fires — the operator's own wired home held 12 of the plugin's
     18 keys — so "an entry for every hook key" would call a wired machine unwired. What is
-    left is honest and weaker, and `docs/harnesses.md` says so: one of charter's GUARD hooks
-    (:data:`CODEX_GUARD_EVENT`) was approved in this home at least once.
+    left is honest and weaker, and `docs/harnesses.md` says so: charter's GUARD hook
+    (:data:`CODEX_GUARD_HANDLER`, at the position the installed plugin gives it) was
+    approved in this home at least once.
 
     The home is the one charter can see. One a wrapper script exports on its way to `codex`
     is invisible here, and the docs state that limit.
@@ -414,7 +423,10 @@ def _codex(p: profiles.Profile, cwd: Path, env: Mapping[str, str]) -> Wiring:
         doc = {}
     except (OSError, UnicodeDecodeError, tomllib.TOMLDecodeError) as e:
         return Wiring(UNKNOWN_STATE, f"{where} could not be read ({_whole(e)})", fix)
-    marks = _codex_marks(doc)
+    guards = _codex_guard_keys(path.parent)
+    if isinstance(guards, str):
+        return Wiring(UNKNOWN_STATE, guards, fix)
+    marks = _codex_marks(doc, guards)
     if isinstance(marks, str):
         return Wiring(UNKNOWN_STATE, CODEX_SHAPE.format(path=where, key=marks), fix)
     plugin, policy, trusted = marks
@@ -423,7 +435,11 @@ def _codex(p: profiles.Profile, cwd: Path, env: Mapping[str, str]) -> Wiring:
         missing.append(f"{plugincache.PLUGIN_ID} is not an enabled plugin")
     if policy.get("CHARTER_HARNESS") != codex.NAME:
         missing.append('shell_environment_policy.set has no CHARTER_HARNESS = "codex"')
-    if not trusted:
+    if not guards:
+        missing.append(f"no copy of {plugincache.PLUGIN_ID} under "
+                       f"{_whole(path.parent / CODEX_PLUGIN_CACHE)} places charter's guard "
+                       f"hook, so there is no guard to trust")
+    elif not trusted:
         missing.append("no guard hook of charter's is trusted — approve them in a codex "
                        "session")
     if not missing:
@@ -444,9 +460,70 @@ def _codex(p: profiles.Profile, cwd: Path, env: Mapping[str, str]) -> Wiring:
     return Wiring(UNWIRED, f"{where}: " + "; ".join(missing), fix)
 
 
-def _codex_marks(doc: dict):
+def _codex_guard_keys(home: Path):
+    """The trust-ledger keys that are charter's guard in *home* — or why charter could not
+    read where the guard is.
+
+    Read out of the INSTALLED plugin's `hooks/hooks.json`, because that file is what Codex
+    numbers its `<event>:<group>:<hook>` keys against: charter's own `hooks.json` has moved
+    groups between releases (0.42.0 had three `PreToolUse` groups, 0.60.0 has four), so a
+    hard-coded index is right for one version and silently names the dispatch hook in
+    another. A key is the guard when its hook runs :data:`CODEX_GUARD_HANDLER`.
+
+    Every cached version must agree, and a key only one of them calls the guard is not one:
+    Codex can keep an older copy beside the current one, and charter cannot tell which of
+    them it numbered the ledger by — so the rule is the one that fails closed. No copy at
+    all is an empty set, which reads as nothing to trust; a copy charter cannot read is an
+    UNKNOWN, because it may be the one that places the guard.
+    """
+    marketplace = plugincache.PLUGIN_ID.split("@", 1)[-1]
+    plugin = plugincache.PLUGIN_ID.split("@", 1)[0]
+    root = home / CODEX_PLUGIN_CACHE / marketplace / plugin
+    try:
+        versions = sorted(d for d in root.iterdir() if d.is_dir())
+    except (FileNotFoundError, NotADirectoryError):
+        return frozenset()
+    except (OSError, ValueError) as e:
+        return f"{_whole(root)} could not be read ({_whole(e)})"
+    found = []
+    for version in versions:
+        f = version / "hooks" / "hooks.json"
+        try:
+            doc = json.loads(f.read_text())
+        except FileNotFoundError:
+            found.append(frozenset())
+            continue
+        except (OSError, UnicodeDecodeError, ValueError) as e:
+            return f"{_whole(f)} could not be read ({_whole(e)})"
+        found.append(_guard_positions(doc))
+    return frozenset.intersection(*found) if found else frozenset()
+
+
+def _guard_positions(doc) -> frozenset:
+    """Every `<prefix><event>:<group>:<hook>` in a plugin `hooks.json` whose command runs
+    :data:`CODEX_GUARD_HANDLER`. Codex spells the event in snake case (`PreToolUse` →
+    `pre_tool_use`, measured on its ledger). Anything not in the file's documented shape
+    places no guard."""
+    from . import hooks
+
+    events = doc.get("hooks") if isinstance(doc, dict) else None
+    out = set()
+    for event, groups in (events.items() if isinstance(events, dict) else ()):
+        snake = re.sub(r"(?<!^)(?=[A-Z])", "_", str(event)).lower()
+        for g, group in enumerate(groups if isinstance(groups, list) else ()):
+            entries = group.get("hooks") if isinstance(group, dict) else None
+            for h, hook in enumerate(entries if isinstance(entries, list) else ()):
+                command = hook.get("command") if isinstance(hook, dict) else None
+                if (isinstance(command, str)
+                        and CODEX_GUARD_HANDLER in hooks._HOOK_CMD_RE.findall(command)):
+                    out.add(f"{CODEX_TRUST_PREFIX}{snake}:{g}:{h}")
+    return frozenset(out)
+
+
+def _codex_marks(doc: dict, guards: frozenset):
     """``(plugin table, policy set, trusted guard keys)`` out of *doc* — or the dotted KEY
-    that has a shape Codex never writes.
+    that has a shape Codex never writes. A trusted key counts only if it is one of
+    *guards*.
 
     Every level is checked for being a table before it is read, because each is a line a
     chat can write: `plugins."charter@charter" = true` parses, and so does a trust entry
@@ -481,8 +558,8 @@ def _codex_marks(doc: dict):
             continue
         if not isinstance(entry, dict):
             return f'hooks.state."{_whole(key)}"'
-        guard = str(key).startswith(f"{CODEX_TRUST_PREFIX}{CODEX_GUARD_EVENT}:")
-        if guard and isinstance(entry.get("trusted_hash"), str) and entry["trusted_hash"]:
+        if key in guards and isinstance(entry.get("trusted_hash"), str) \
+                and entry["trusted_hash"]:
             trusted.append(key)
     return plugin, policy, trusted
 
@@ -611,7 +688,11 @@ def _up_to_the_plane(cwd: Path) -> list[Path]:
 
 
 def _codex_stamps(env: Mapping[str, str], cwd: Path) -> list[Path]:
-    return [codex.config_path(env)]
+    """The config file, and the plugin cache directory whose versions place the guard."""
+    home = codex.config_path(env).parent
+    marketplace = plugincache.PLUGIN_ID.split("@", 1)[-1]
+    plugin = plugincache.PLUGIN_ID.split("@", 1)[0]
+    return [codex.config_path(env), home / CODEX_PLUGIN_CACHE / marketplace / plugin]
 
 
 def _opencode_stamps(env: Mapping[str, str], cwd: Path) -> list[Path]:

--- a/charter/wiring.py
+++ b/charter/wiring.py
@@ -1,0 +1,566 @@
+"""Is a harness profile wired — does charter's guard actually run in the folder it names?
+
+A profile exists to point a harness at another config folder, and **every kind loses
+charter's wiring when its folder moves**. Measured 2026-09-11 and again on 2026-09-12
+against claude 2.1.269, codex-cli 0.147.0 and opencode 1.18.23, in throwaway folders:
+
+* Claude Code under an empty `$CLAUDE_CONFIG_DIR` has no charter plugin at all — not even
+  "enabled but not installed" — because the `charter` marketplace is known only to the
+  folder it was added in.
+* Codex under an empty `$CODEX_HOME` has no plugin, no hook trust and no
+  `shell_environment_policy.set`.
+* opencode under a throwaway `$XDG_CONFIG_HOME` has no shim, loads no plugin, and its
+  shells get no `$CHARTER_HARNESS`.
+
+So a chat started on such a profile *looks* guarded and is not, which is the failure this
+module exists to stop. A profile that is not wired refuses to launch and prints the fix —
+**built-ins included** (ruling 10): `charter codex` on a plane where nobody wired Codex now
+refuses where it used to start, because a chat that looks guarded and is not is the same
+failure whichever profile started it.
+
+**Wiring is detected by ASKING the harness under the profile's own environment**, never by
+reading the profile's variable names. One account can be reached through variables that do
+or do not move the plugin — `$XDG_DATA_HOME` moves opencode's login and leaves its plugins
+where they are — so a rule written from variable names is a rule about the wrong thing.
+`claude plugin list --json` and `opencode debug config` follow the environment they are
+given; Codex's three marks are all in one file.
+
+**An unknown is never a pass** (ADR 0009, ruling 12). A probe that times out, exits
+non-zero or answers something unparseable refuses the launch with a sentence naming the
+probe to run by hand. No flag launches a profile unguarded.
+
+**Nothing here runs on a hook path** (ruling 11). A probe costs 137-718 ms and writes into
+the folder it asks about; `hooks/hooks.json` fires `charter doctor --preflight` at every
+session start, and that mode builds no profile row and calls nothing here.
+
+**A launch never trusts the cache** (review B2, ruling 21). :func:`cached` is for the
+selector's rows and nothing else: the file sits under `.charter/`, which no path guard
+covers (ADR 0014 — a path pattern is host policy), so a chat can write it, compute its key,
+and date an entry ahead. :func:`refusal` always probes.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import shlex
+import time
+import tomllib
+from pathlib import Path
+from typing import Mapping, NamedTuple
+
+from . import config, contain, plugincache, profiles, util
+from .harness import claude_code, codex, opencode
+
+#: The three answers. `UNKNOWN_STATE` rather than `UNKNOWN`, because `plugincache.UNKNOWN`
+#: is a sentinel object and these are strings that end up in a JSON cache.
+WIRED, UNWIRED, UNKNOWN_STATE = "wired", "unwired", "unknown"
+
+#: The launcher refusal kind this module produces. Callers branch on the KIND and never on
+#: the text (ruling 27): a sentence gets reworded, and a comparison against one is a guard
+#: that stops guarding on the day it does.
+KIND_WIRING = "wiring"
+
+#: Under `config.STATE_DIR`.
+CACHE = "cache/harness-wiring.json"
+
+#: How long a remembered answer may be reused by the selector. Both bounds matter: without
+#: the lower one, an entry a chat dated into the future passes the age test forever.
+MAX_AGE = 24 * 3600
+
+#: The key prefix Codex writes its hook-trust ledger under, per plugin.
+CODEX_TRUST_PREFIX = f"{plugincache.PLUGIN_ID}:hooks/hooks.json:"
+
+#: How a Codex plugin is installed, pinned against codex-cli 0.147.0 by running it
+#: (D4, 2026-09-12): `codex plugin` has add / list / marketplace / remove and no `install`.
+#: Printed with `CODEX_HOME=` in front of it, never run — it installs software into an
+#: account folder, and running this command IS the consent for the one line charter writes.
+CODEX_STEPS = ("codex plugin marketplace add https://github.com/diazoxide/charter",
+               f"codex plugin add {plugincache.PLUGIN_ID}",
+               "start codex once and approve charter's hooks when it asks")
+
+# Every sentence says the rule worked and names the fix in the same breath (CONTEXT.md,
+# *A refusal is the rule working*). No "charter:" prefix — each caller says it its own way,
+# the way `launcher`'s own texts do. Every profile-derived value is contained first
+# (ruling 35): `charter.local.toml` is a file a chat can write, and a `\r` or an ESC in a
+# command could redraw the line above to show a harmless command while another one runs.
+NOT_WIRED = ("profile '{name}' is not wired — {detail}, so a chat on it would run without "
+             "charter's guard. Nothing was started. Wire it: {fix}")
+CANNOT_TELL = ("charter could not ask {kind} whether profile '{name}' is wired ({detail}), "
+               "so it will not start it unguarded. Nothing was started. Run "
+               "charter harness install {name}, or check by hand: {probe}")
+
+#: Why charter may not run a declared profile's own command yet. **Task 3's launch record
+#: is what replaces this**; see :func:`approval_needed`.
+NOT_APPROVED_YET = ("not approved yet — this charter cannot ask before a declared "
+                    "command runs, so it runs none")
+
+CODEX_POLICY_BY_HAND = (
+    "{path} already has a [shell_environment_policy] table without charter's line, and "
+    "charter does not edit TOML it did not write — nothing was changed. Add this line "
+    'inside that table:\n  set = {{ CHARTER_HARNESS = "codex" }}\n'
+    'or, if the table already has a `set`, add CHARTER_HARNESS = "codex" to it.')
+
+#: Most specific first. Claude Code 2.1.269 resolves `enabled` itself — measured
+#: 2026-09-12, every listed entry of one plugin id carries the same effective value, merged
+#: local > project > user at the probe's own cwd — so this order decides nothing today. It
+#: is here for the day that stops being true, and it is the order that fails CLOSED: a chat
+#: that disables charter in `.claude/settings.local.json` is unwired whatever the user
+#: entry says (ruling 28).
+_SCOPE_ORDER = ("local", "project", "user")
+
+
+class Wiring(NamedTuple):
+    """What was asked, what it answered, and what to do about it."""
+
+    #: WIRED | UNWIRED | UNKNOWN_STATE.
+    state: str
+    #: What was asked and what it answered, already contained — it is displayed.
+    detail: str
+    #: The command that would fix it; ``""`` when wired.
+    fix: str
+
+
+def approval_needed(p: profiles.Profile) -> str:
+    """Why charter may not run *p*'s own command yet — ``""`` when it may.
+
+    Detection runs `[*command, "plugin", "list", "--json"]` and `[*command, "debug",
+    "config"]`: a probe is a launch of the profile's command by another name, so it is
+    gated by the same rule (ruling 1, and the Global Constraint *No profile's command runs
+    before that profile passes the ignored check and the trust check*).
+
+    **Today that rule is Task 2's standing refusal of every declared profile.** Nothing on
+    `main` yet stands for the operator's approval of a `command`, and `charter.local.toml`
+    is a file a chat can write with no diff to show for it. Task 3's merge replaces this
+    body with `profiletrust.approval_needed(p)` — one line, and
+    `NothingUnapprovedIsRun.test_the_launcher_and_the_gate_agree_about_every_profile` is
+    what fails if only one of the two places moves.
+    """
+    return "" if p.source == profiles.BUILTIN else NOT_APPROVED_YET
+
+
+def environment(p: profiles.Profile) -> dict[str, str]:
+    """The environment *p*'s command would be exec'd with, for a probe to run under.
+
+    `launcher.environment` and not a second merge of the same three things: a probe that
+    asked under a different environment than the launch would use is asking about a session
+    nobody is about to start. ``framed=True`` because that is the merge that drops nothing —
+    the unframed one removes `$CHARTER_SESSION_ID`, and `util.run`'s ``env`` is an overlay
+    that cannot express a removal anyway.
+
+    Imported at call time. `launcher` imports this module at the top, and ruling 43 keeps
+    profile code off every `charter hook …` process's import path.
+    """
+    from .frame import launcher
+
+    return launcher.environment(p, os.environ, framed=True)
+
+
+def probe_argv(p: profiles.Profile) -> list[str]:
+    """What charter runs to ask *p*'s harness whether it is wired — ``[]`` for Codex, whose
+    three marks are a file read."""
+    command = profiles.expanded_command(p)
+    if p.harness == claude_code.NAME:
+        return [*command, "plugin", "list", "--json"]
+    if p.harness == opencode.NAME:
+        return [*command, "debug", "config"]
+    return []
+
+
+def by_hand(p: profiles.Profile) -> str:
+    """The probe as an operator would type it: the profile's variables, then the command.
+
+    Contained piece by piece, `profiles.display`'s rule — this goes to a terminal, and both
+    halves come out of a file a chat can write.
+    """
+    pieces = [contain.readable(f"{name}={value}") for name, value in p.env]
+    argv = probe_argv(p)
+    pieces.append(contain.readable(shlex.join(argv) if argv
+                                   else f"read {codex.config_path(environment(p))}"))
+    return " ".join(pieces)
+
+
+def detect(p: profiles.Profile, *, cwd) -> Wiring:
+    """Ask *p*'s harness, under *p*'s environment, whether charter's guard runs there.
+
+    *cwd* is the directory the chat would start in — Claude Code resolves `enabled` there,
+    and an install record is bound to the directory it was installed from, so this is not a
+    detail that can be defaulted.
+
+    Never cached and never memoised: the whole point of :func:`cached` living beside this
+    is that only one of them may start a chat.
+
+    **The approval gate is here and not only in the callers** (ruling 1). A probe IS a run of
+    the profile's command, and there are four callers — the launcher, the selector, `harness
+    install` and `doctor`. A gate each of them has to remember is a gate one of them will not,
+    and the thing it lets through is a command out of a file a chat can write.
+    """
+    why = approval_needed(p)
+    if why:
+        return Wiring(UNKNOWN_STATE, contain.readable(why),
+                      f"charter {contain.readable(p.name)}")
+    env = environment(p)
+    if p.harness == claude_code.NAME:
+        return _claude(p, cwd=cwd, env=env)
+    if p.harness == codex.NAME:
+        return _codex(p, env=env)
+    if p.harness == opencode.NAME:
+        return _opencode(p, env=env)
+    # A kind charter has no wiring check for is an UNKNOWN and therefore a refusal, not a
+    # pass: the day a kind joins the registry without one, this is the row that says so.
+    return Wiring(UNKNOWN_STATE, f"charter has no wiring check for {contain.readable(p.kind)}",
+                  f"charter harness install {contain.readable(p.name)}")
+
+
+def refusal(p: profiles.Profile, *, cwd) -> str:
+    """Why *p* may not start, or ``""``. Always a fresh probe (review B2).
+
+    An UNKNOWN refuses with its own sentence (ruling 12) rather than sharing the unwired
+    one: "charter looked and the guard is absent" and "charter could not look" are
+    different things to be told, and only one of them has `charter harness install` as its
+    whole answer.
+    """
+    w = detect(p, cwd=cwd)
+    name = contain.readable(p.name)
+    if w.state == WIRED:
+        return ""
+    if w.state == UNWIRED:
+        return NOT_WIRED.format(name=name, detail=w.detail, fix=w.fix)
+    return CANNOT_TELL.format(kind=contain.readable(p.kind), name=name, detail=w.detail,
+                              probe=by_hand(p))
+
+
+# --------------------------------------------------------------------------- #
+# Per kind                                                                     #
+# --------------------------------------------------------------------------- #
+
+
+def _claude(p: profiles.Profile, *, cwd, env: Mapping[str, str]) -> Wiring:
+    """Claude Code: `claude plugin list --json`, run as *p* would run `claude`.
+
+    Two facts out of the same answer, and they are resolved differently — measured
+    2026-09-12 on 2.1.269 in throwaway folders:
+
+    * the ENTRIES are install records, listed whatever the cwd, each bound to the directory
+      it was installed from (`plugincache.covers`);
+    * `enabled` is the EFFECTIVE `enabledPlugins` value for the plugin id resolved at the
+      probe's own cwd — local over project over user — and every entry of that id carries
+      the same value.
+
+    So the probe is given *cwd*, and charter reads no settings file of its own (ruling 36's
+    "unless"): a disable written ONLY to `<cwd>/.claude/settings.local.json`, and only to
+    `<cwd>/.claude/settings.json`, each flipped the listed entry to `enabled: false` beside
+    an enabled user-scope install. A second reader would answer for a different merge than
+    the binary's — measured, `<ancestor>/.claude/settings.json` does NOT reach a session
+    below it while `settings.local.json` does — and a wrong UNWIRED refuses a chat that
+    would have been guarded.
+
+    **An install covering the PLANE covers a chat in that plane's workspace** (D3). `charter
+    init` installs at project scope for the plane root, and a chat's directory is
+    `workspaces/<ws>/` — a different `projectPath`, which `covers` alone reads as not this
+    plane's. Charter mirrors the plane's `enabledPlugins` into that directory
+    (`claude_code.WORKSPACE_KEYS`), and the probe's own `enabled` is resolved there, so the
+    record that covers the plane is the one that answers for the chat. Measured end to end:
+    an alternate `$CLAUDE_CONFIG_DIR`, `charter init`, `charter workspace create w`, and
+    `claude plugin list --json` in `workspaces/w` answering `enabled: true`.
+    """
+    folder = claude_code.config_home(env)
+    entries = plugincache.covering_entries(cwd, root=config.ROOT, env=dict(env),
+                                           command=profiles.expanded_command(p))
+    where = f"{contain.readable(str(folder))} for {contain.readable(str(cwd))}"
+    if entries is plugincache.UNKNOWN:
+        return Wiring(UNKNOWN_STATE,
+                      f"claude plugin list --json could not be read in {where}",
+                      f"charter harness install {contain.readable(p.name)}")
+    if not entries:
+        return Wiring(UNWIRED, f"{plugincache.PLUGIN_ID} is not installed in {where}",
+                      f"charter harness install {contain.readable(p.name)}")
+    best = min(entries, key=lambda e: _SCOPE_ORDER.index(e.get("scope"))
+               if e.get("scope") in _SCOPE_ORDER else len(_SCOPE_ORDER))
+    scope = contain.readable(str(best.get("scope")))
+    if best.get("enabled") is True:
+        return Wiring(WIRED,
+                      f"claude plugin list: {plugincache.PLUGIN_ID} enabled at {scope} "
+                      f"scope in {where}", "")
+    # NOT `charter harness install`: `plugincache.install` answers `present` for an install
+    # that exists, so pointing back at it would print a fix that changes nothing and loops
+    # — review 7's objection, one harness over. The enable is the command that moves this.
+    fix = " ".join([*(contain.readable(f"{n}={v}") for n, v in p.env),
+                    contain.readable(shlex.join([*profiles.expanded_command(p), "plugin",
+                                                 "enable", plugincache.PLUGIN_ID]))])
+    return Wiring(UNWIRED,
+                  f"{plugincache.PLUGIN_ID} is installed at {scope} scope and reads as "
+                  f"disabled in {where}", fix)
+
+
+def _codex(p: profiles.Profile, *, env: Mapping[str, str]) -> Wiring:
+    """Codex: three marks in `$CODEX_HOME/config.toml`, and it needs all three (ruling 7).
+
+    The plugin declares the hooks, the policy line is the only thing that can tell a Codex
+    shell which harness it is, and **a hook Codex has not trusted is inert** — so a plugin
+    nobody approved is installed and does nothing, which reads exactly like wired to
+    anything that stops at the plugin table.
+
+    The trust rule is the measured one, not the planned one. `trusted_hash` cannot be
+    recomputed from the plugin's `hooks/hooks.json`: the command string, the hook object as
+    JSON in three spellings, the whole matcher group and the joined commands were all tried
+    against a real hash on 2026-09-12 and none matched. And Codex writes an entry per hook
+    **lazily**, as each first fires — the operator's own wired home held 12 of the plugin's
+    18 keys — so "an entry for every hook key" would call a wired machine unwired. What is
+    left is honest and weaker, and `docs/harnesses.md` says so: charter's hooks were
+    approved in this home at least once.
+
+    The home is the one charter can see. One a wrapper script exports on its way to `codex`
+    is invisible here, and the docs state that limit.
+    """
+    path = codex.config_path(env)
+    name = contain.readable(p.name)
+    fix = f"charter harness install {name}"
+    try:
+        doc = tomllib.loads(path.read_text())
+    except FileNotFoundError:
+        doc = {}
+    except (OSError, UnicodeDecodeError, tomllib.TOMLDecodeError) as e:
+        return Wiring(UNKNOWN_STATE,
+                      f"{contain.readable(str(path))} could not be read "
+                      f"({contain.readable(str(e))})", fix)
+    where = contain.readable(str(path))
+    plugin = (doc.get("plugins") or {}).get(plugincache.PLUGIN_ID) or {}
+    policy = ((doc.get("shell_environment_policy") or {}).get("set") or {})
+    trusted = [k for k, v in ((doc.get("hooks") or {}).get("state") or {}).items()
+               if str(k).startswith(CODEX_TRUST_PREFIX) and (v or {}).get("trusted_hash")]
+    missing = []
+    if plugin.get("enabled") is not True:
+        missing.append(f"{plugincache.PLUGIN_ID} is not an enabled plugin")
+    if policy.get("CHARTER_HARNESS") != codex.NAME:
+        missing.append('shell_environment_policy.set has no CHARTER_HARNESS = "codex"')
+    if not trusted:
+        missing.append("no hook of charter's is trusted — approve them in a codex session")
+    if not missing:
+        return Wiring(WIRED, f"{where}: plugin enabled, harness named, "
+                             f"{len(trusted)} trusted hook(s)", "")
+    if ("shell_environment_policy" in doc
+            and policy.get("CHARTER_HARNESS") != codex.NAME):
+        # `codex.install()` answers `present` for ANY `[shell_environment_policy]` table,
+        # so `charter harness install` here would print a fix that changes nothing.
+        fix = CODEX_POLICY_BY_HAND.format(path=where)
+    return Wiring(UNWIRED, f"{where}: " + "; ".join(missing), fix)
+
+
+def _opencode(p: profiles.Profile, *, env: Mapping[str, str]) -> Wiring:
+    """opencode: `debug config`, and all three marks (ruling 26).
+
+    The entry has to name charter's shim, the shim's bytes have to be charter's, **and no
+    foreign plugin may share its realm**. The third is not tidiness. opencode imports the
+    whole plugin directory into ONE module realm and hands every plugin the same globals:
+    reproduced against 1.18.21 and the real shim, a byte-perfect `charter.ts` beside
+    `plugin/aaa_boot.ts` containing ``Object.hasOwn = () => false`` turns every guard lookup
+    into `undefined`, so a vault read routes to the Bash guard and is allowed — while
+    `shim_is_charters` says True throughout (`opencode.foreign_plugins`, ADR 0015's
+    amendment). Measured 2026-09-12: `debug config` lists the foreign file too.
+
+    `unvouched()` is not the test either — it answers ``()`` when the shim is missing, so an
+    entry naming a deleted file would read as wired.
+    """
+    home = opencode.global_dir(env)
+    name = contain.readable(p.name)
+    fix = f"charter harness install {name}"
+    argv = probe_argv(p)
+    where = contain.readable(str(home))
+    try:
+        proc = util.run(argv, check=False, env=dict(env), timeout=plugincache.LIST_TIMEOUT)
+    except (util.ProcTimeout, OSError) as e:
+        return Wiring(UNKNOWN_STATE,
+                      f"{contain.readable(shlex.join(argv))} did not answer "
+                      f"({contain.readable(str(e))})", fix)
+    if proc.returncode != 0:
+        return Wiring(UNKNOWN_STATE,
+                      f"{contain.readable(shlex.join(argv))} exited {proc.returncode}", fix)
+    try:
+        doc = json.loads(proc.stdout or "")
+    except (ValueError, TypeError):
+        return Wiring(UNKNOWN_STATE,
+                      f"{contain.readable(shlex.join(argv))} answered something that is "
+                      f"not JSON", fix)
+    entries = doc.get("plugin") if isinstance(doc, dict) else None
+    if isinstance(entries, str):
+        entries = [entries]
+    want = _resolved(home / opencode.SHIM_PATH)
+    named = any(_resolved(_unprefixed(e)) == want for e in (entries or [])
+                if isinstance(e, str))
+    if not named:
+        return Wiring(UNWIRED, f"opencode loads no plugin from {where}", fix)
+    if not opencode.shim_is_charters(home):
+        return Wiring(UNWIRED, f"{where}/{opencode.SHIM_PATH} is not the file charter "
+                               f"writes — charter cannot vouch for it", fix)
+    foreign = opencode.foreign_plugins(home)
+    if foreign:
+        return Wiring(UNWIRED,
+                      f"{where}/{opencode.PLUGIN_DIR} also holds "
+                      f"{contain.readable(', '.join(foreign))}, which shares one module "
+                      f"realm with charter's shim", "remove it, or move it out of "
+                                                   f"{where}/{opencode.PLUGIN_DIR}")
+    return Wiring(WIRED, f"opencode debug config: {opencode.SHIM_PATH} under {where}, and "
+                         f"nothing else in its realm", "")
+
+
+def _unprefixed(entry: str) -> str:
+    """A `plugin` entry as a path. Measured: opencode answers `file:///…` and keeps the
+    un-resolved spelling, so both halves of the comparison are resolved below."""
+    return entry[len("file://"):] if entry.startswith("file://") else entry
+
+
+def _resolved(p) -> str:
+    try:
+        return str(Path(p).resolve())
+    except (OSError, RuntimeError, ValueError):
+        return str(p)
+
+
+# --------------------------------------------------------------------------- #
+# The cache — the selector's rows, and never a launch                          #
+# --------------------------------------------------------------------------- #
+
+
+def _fingerprint(p: profiles.Profile) -> dict:
+    """What makes this the same profile as the one that was asked about.
+
+    Task 3's `profiletrust.fingerprint` answers exactly this question for the launch
+    record, and this becomes a call to it when that is on `main`. The `env` NAMES and their
+    values both count: a profile whose `CLAUDE_CONFIG_DIR` moved is a different folder to
+    ask about, and reusing an answer across that is the whole failure.
+    """
+    return {"name": p.name, "kind": p.kind, "command": list(p.command),
+            "env": [list(pair) for pair in p.env]}
+
+
+def _key(p: profiles.Profile, cwd) -> str:
+    return hashlib.sha256(
+        json.dumps({**_fingerprint(p), "cwd": str(cwd)}, sort_keys=True).encode()).hexdigest()
+
+
+def _stamp_paths(p: profiles.Profile, cwd) -> list[Path]:
+    """The files whose change accompanied every flip of this kind's answer (D2).
+
+    `.claude.json` is deliberately absent: the probe itself writes it, so stamping it would
+    invalidate the entry the probe just wrote. The chat DIRECTORY's settings files are here
+    and not only the plane root's — that is the file Claude Code reads for that chat, and a
+    stamp that missed it would keep saying `wired` after a chat wrote a `false` into it.
+    """
+    env = environment(p)
+    if p.harness == claude_code.NAME:
+        folder = claude_code.config_home(env)
+        return [folder / "plugins" / "installed_plugins.json", folder / "settings.json",
+                Path(cwd) / ".claude" / "settings.json",
+                Path(cwd) / ".claude" / "settings.local.json"]
+    if p.harness == codex.NAME:
+        return [codex.config_path(env)]
+    if p.harness == opencode.NAME:
+        home = opencode.global_dir(env)
+        return [home / opencode.PLUGIN_DIR, home / opencode.SHIM_PATH,
+                home / "opencode.json"]
+    return []
+
+
+def _stamp(p: profiles.Profile, cwd) -> dict:
+    out = {}
+    for path in _stamp_paths(p, cwd):
+        try:
+            st = path.stat()
+            out[str(path)] = [st.st_mtime_ns, st.st_size]
+        except OSError:
+            # Absent is a state like any other: a shim that appears has to be a miss.
+            out[str(path)] = None
+    return out
+
+
+def _read_cache() -> dict:
+    try:
+        doc = json.loads((Path(config.STATE_DIR) / CACHE).read_text())
+    except (OSError, UnicodeDecodeError, ValueError):
+        return {}
+    return doc if isinstance(doc, dict) else {}
+
+
+def cached(p: profiles.Profile, *, cwd) -> Wiring | None:
+    """A remembered answer whose stamp still matches, or ``None``. **Display only.**
+
+    `charter/frame/selector.py` draws its rows from this and probes on a miss; picking a row
+    probes again. A launch never reads it (ruling 21): this file is as writable by a chat as
+    `charter.local.toml` is, and a chat can compute the key, write the stamp and date the
+    entry ahead — which is why the age test has two bounds.
+    """
+    entry = _read_cache().get(_key(p, cwd))
+    if not isinstance(entry, dict):
+        return None
+    age = time.time() - (entry.get("checked_at") or 0)
+    if not 0 <= age < MAX_AGE:
+        return None
+    if entry.get("stamp") != _stamp(p, cwd):
+        return None
+    try:
+        return Wiring(entry["state"], entry["detail"], entry["fix"])
+    except (KeyError, TypeError):
+        return None
+
+
+def remember(p: profiles.Profile, *, cwd, w: Wiring) -> None:
+    """Record *w* for *p* at *cwd*. Best effort: a display cache is never worth a row."""
+    doc = _read_cache()
+    doc[_key(p, cwd)] = {"state": w.state, "detail": w.detail, "fix": w.fix,
+                         "checked_at": time.time(), "stamp": _stamp(p, cwd)}
+    path = Path(config.STATE_DIR) / CACHE
+    try:
+        config.private_mkdir(path.parent)
+        config.write_for(path, json.dumps(doc, indent=2) + "\n")
+    except OSError:
+        pass
+
+
+# --------------------------------------------------------------------------- #
+# Installing                                                                   #
+# --------------------------------------------------------------------------- #
+
+
+def install(p: profiles.Profile, root: Path) -> list[tuple[str, str]]:
+    """Wire *p*'s kind under *p*'s own environment. ``(status, label)`` pairs, `Harness.wire`'s
+    shape.
+
+    Codex is the one that cannot be finished from here, and that is a fact about Codex
+    rather than a gap: charter writes the `shell_environment_policy` line — the one thing
+    the plugin cannot write, because it is what tells a Codex shell which harness it is —
+    and the plugin install and the hook approval are Codex's own commands, printed with
+    `CODEX_HOME=` in front of them by the caller.
+    """
+    env = environment(p)
+    if p.harness == claude_code.NAME:
+        status, detail = plugincache.install(root, env=env,
+                                             command=profiles.expanded_command(p))
+        return [(status, detail)]
+    if p.harness == codex.NAME:
+        status, detail = codex.install(env=env)
+        return [(status, detail)]
+    if p.harness == opencode.NAME:
+        return opencode.OpenCodeHarness().wire(root, env=env)
+    return [("unavailable", f"charter has no wiring for {contain.readable(p.kind)}")]
+
+
+def listed(read: profiles.ProfileSet | None = None) -> list[profiles.Profile]:
+    """Every profile a selector would show, in the order `charter harness list` shows them.
+
+    Declared profiles always; a built-in only when its program is installed, because a row
+    about a harness this machine does not have is a row nobody can act on. One reader, so
+    `doctor.check_names` and `doctor.check_profile_wiring` cannot disagree about how many
+    rows there are — the pin `_FIXED_CHECK_NAMES` already keeps for every other check.
+    """
+    import shutil
+
+    read = read if read is not None else profiles.current()
+    order = list(profiles.builtins())
+    rows = [p for p in read.profiles.values()
+            if p.source != profiles.BUILTIN
+            or shutil.which(profiles.expanded_command(p)[0]) is not None]
+    return sorted(rows, key=lambda p: (p.name not in order,
+                                       order.index(p.name) if p.name in order else 0,
+                                       p.name))

--- a/charter/wiring.py
+++ b/charter/wiring.py
@@ -25,9 +25,14 @@ where they are — so a rule written from variable names is a rule about the wro
 `claude plugin list --json` and `opencode debug config` follow the environment they are
 given; Codex's three marks are all in one file.
 
+**Nothing is asked of a profile charter may not run yet** (ruling 1). A probe runs the
+profile's own command, so it passes the same two checks a launch does first: git would not
+carry `charter.local.toml`, and the operator approved this command (`profiletrust`).
+
 **An unknown is never a pass** (ADR 0009, ruling 12). A probe that times out, exits
-non-zero or answers something unparseable refuses the launch with a sentence naming the
-probe to run by hand. No flag launches a profile unguarded.
+non-zero, answers something unparseable, or reads a file a chat left in a shape the harness
+never writes, refuses the launch with a sentence naming the probe to run by hand. No flag
+launches a profile unguarded.
 
 **Nothing here runs on a hook path** (ruling 11). A probe costs 137-718 ms and writes into
 the folder it asks about; `hooks/hooks.json` fires `charter doctor --preflight` at every
@@ -37,6 +42,10 @@ session start, and that mode builds no profile row and calls nothing here.
 selector's rows and nothing else: the file sits under `.charter/`, which no path guard
 covers (ADR 0014 — a path pattern is host policy), so a chat can write it, compute its key,
 and date an entry ahead. :func:`refusal` always probes.
+
+**What a :class:`Wiring` carries is escaped and never clipped.** Every surface that shows
+one bounds it its own way (ruling 45): a refusal sentence with a fixed marker, a `doctor`
+row by saying how much it hid — and a row cannot count what was already cut before it saw it.
 """
 
 from __future__ import annotations
@@ -45,10 +54,11 @@ import hashlib
 import json
 import os
 import shlex
+import shutil
 import time
 import tomllib
 from pathlib import Path
-from typing import Mapping, NamedTuple
+from typing import Callable, Mapping, NamedTuple
 
 from . import config, contain, plugincache, profiles, util
 from .harness import claude_code, codex, opencode
@@ -72,13 +82,27 @@ MAX_AGE = 24 * 3600
 #: The key prefix Codex writes its hook-trust ledger under, per plugin.
 CODEX_TRUST_PREFIX = f"{plugincache.PLUGIN_ID}:hooks/hooks.json:"
 
+#: The Codex hook event every one of charter's guards is declared on. **A trusted hook is
+#: not a trusted guard**: Codex asks about each hook separately, and an approved
+#: `session_start` reconcile says nothing about whether `charter hook pretooluse` will run
+#: before a shell command (ruling 7 — "charter's guard actually runs"). Charter declares no
+#: other hook on this event, so a trusted entry under it is a trusted guard.
+CODEX_GUARD_EVENT = "pre_tool_use"
+
 #: How a Codex plugin is installed, pinned against codex-cli 0.147.0 by running it
 #: (D4, 2026-09-12): `codex plugin` has add / list / marketplace / remove and no `install`.
 #: Printed with `CODEX_HOME=` in front of it, never run — it installs software into an
 #: account folder, and running this command IS the consent for the one line charter writes.
-CODEX_STEPS = ("codex plugin marketplace add https://github.com/diazoxide/charter",
-               f"codex plugin add {plugincache.PLUGIN_ID}",
-               "start codex once and approve charter's hooks when it asks")
+CODEX_COMMANDS = (("codex", "plugin", "marketplace", "add",
+                   "https://github.com/diazoxide/charter"),
+                  ("codex", "plugin", "add", plugincache.PLUGIN_ID))
+#: The step no command can take: Codex asks a person, in a session, to trust each hook.
+CODEX_APPROVE = "start codex once and approve charter's hooks when it asks"
+
+#: What a refusal sentence repeats of a detail or a fix: a PATH's budget, because both name
+#: paths and a clipped path is one the reader cannot act on — and still a fixed number,
+#: because a budget the input can grow is not a budget (`contain.DISPLAY_LIMIT`).
+SAID_LIMIT = contain.PATH_DISPLAY_LIMIT
 
 # Every sentence says the rule worked and names the fix in the same breath (CONTEXT.md,
 # *A refusal is the rule working*). No "charter:" prefix — each caller says it its own way,
@@ -91,23 +115,22 @@ CANNOT_TELL = ("charter could not ask {kind} whether profile '{name}' is wired (
                "so it will not start it unguarded. Nothing was started. Run "
                "charter harness install {name}, or check by hand: {probe}")
 
-#: Why charter may not run a declared profile's own command yet. **Task 3's launch record
-#: is what replaces this**; see :func:`approval_needed`.
-NOT_APPROVED_YET = ("not approved yet — this charter cannot ask before a declared "
-                    "command runs, so it runs none")
-
 CODEX_POLICY_BY_HAND = (
     "{path} already has a [shell_environment_policy] table without charter's line, and "
     "charter does not edit TOML it did not write — nothing was changed. Add this line "
     'inside that table:\n  set = {{ CHARTER_HARNESS = "codex" }}\n'
     'or, if the table already has a `set`, add CHARTER_HARNESS = "codex" to it.')
 
+#: A Codex config a chat left in a shape Codex itself never writes. Unknown, not unwired:
+#: charter cannot say what Codex makes of it, and a guess in either direction is a guess.
+CODEX_SHAPE = "{path} holds {key} as something other than a table, which Codex never writes"
+
 #: Most specific first. Claude Code 2.1.269 resolves `enabled` itself — measured
 #: 2026-09-12, every listed entry of one plugin id carries the same effective value, merged
 #: local > project > user at the probe's own cwd — so this order decides nothing today. It
-#: is here for the day that stops being true, and it is the order that fails CLOSED: a chat
-#: that disables charter in `.claude/settings.local.json` is unwired whatever the user
-#: entry says (ruling 28).
+#: is here for the day that stops being true, and it is the order that fails CLOSED between
+#: install records: a local-scope record that reads disabled outranks a user-scope one that
+#: reads enabled (ruling 28).
 _SCOPE_ORDER = ("local", "project", "user")
 
 
@@ -116,28 +139,46 @@ class Wiring(NamedTuple):
 
     #: WIRED | UNWIRED | UNKNOWN_STATE.
     state: str
-    #: What was asked and what it answered, already contained — it is displayed.
+    #: What was asked and what it answered — escaped, never clipped (see the module).
     detail: str
-    #: The command that would fix it; ``""`` when wired.
+    #: The command that would fix it; ``""`` when wired. Escaped, never clipped.
     fix: str
 
 
-def approval_needed(p: profiles.Profile) -> str:
-    """Why charter may not run *p*'s own command yet — ``""`` when it may.
+def _whole(value) -> str:
+    """*value* escaped for a terminal and not clipped (ruling 35; see the module docstring)."""
+    return contain.readable(value, contain.NO_CLIP)
 
-    Detection runs `[*command, "plugin", "list", "--json"]` and `[*command, "debug",
-    "config"]`: a probe is a launch of the profile's command by another name, so it is
-    gated by the same rule (ruling 1, and the Global Constraint *No profile's command runs
-    before that profile passes the ignored check and the trust check*).
 
-    **Today that rule is Task 2's standing refusal of every declared profile.** Nothing on
-    `main` yet stands for the operator's approval of a `command`, and `charter.local.toml`
-    is a file a chat can write with no diff to show for it. Task 3's merge replaces this
-    body with `profiletrust.approval_needed(p)` — one line, and
-    `NothingUnapprovedIsRun.test_the_launcher_and_the_gate_agree_about_every_profile` is
-    what fails if only one of the two places moves.
+def said(text: str) -> str:
+    """A :class:`Wiring` field bounded for a SENTENCE, with contain's fixed marker.
+
+    Its own clip rather than `contain.readable` again: the field is escaped already, and a
+    second pass would double every backslash the first one wrote (`\\u001b` would read as
+    `\\\\u001b`). Ruling 45: a sentence may keep the fixed marker; a row must count.
     """
-    return "" if p.source == profiles.BUILTIN else NOT_APPROVED_YET
+    return text if len(text) <= SAID_LIMIT else text[:SAID_LIMIT] + "..."
+
+
+def _install_fix(p: profiles.Profile) -> str:
+    """The one sentence every "wire it with charter" answer ends in."""
+    return f"charter harness install {_whole(p.name)}"
+
+
+def _typed(p: profiles.Profile, argv, *, cwd=None) -> str:
+    """*argv* as an operator would paste it: `cd` first when *cwd* matters, then the
+    profile's variables, then the words — **each one shell-quoted, then escaped**.
+
+    Quoted because a home with a space in it, or a `;`, is a fix that cannot be pasted
+    otherwise; escaped after the quoting and not before, because the escape is for the
+    terminal the line is shown on and the quoting is for the shell it is pasted into.
+    The variables as the launch EXPANDS them: a quoted `~` is a directory named `~`.
+    """
+    pieces = [] if cwd is None else ["cd", shlex.quote(str(cwd)), "&&"]
+    pieces += [f"{name}={shlex.quote(value)}"
+               for name, value in sorted(profiles.expanded_env(p).items())]
+    pieces += [shlex.quote(str(word)) for word in argv]
+    return _whole(" ".join(pieces))
 
 
 def environment(p: profiles.Profile) -> dict[str, str]:
@@ -159,26 +200,56 @@ def environment(p: profiles.Profile) -> dict[str, str]:
 
 def probe_argv(p: profiles.Profile) -> list[str]:
     """What charter runs to ask *p*'s harness whether it is wired — ``[]`` for Codex, whose
-    three marks are a file read."""
-    command = profiles.expanded_command(p)
-    if p.harness == claude_code.NAME:
-        return [*command, "plugin", "list", "--json"]
-    if p.harness == opencode.NAME:
-        return [*command, "debug", "config"]
-    return []
+    three marks are a file read, and for a kind charter has no check for."""
+    kind = _KINDS.get(p.harness)
+    if kind is None or not kind.probe:
+        return []
+    return [*profiles.expanded_command(p), *kind.probe]
 
 
 def by_hand(p: profiles.Profile) -> str:
-    """The probe as an operator would type it: the profile's variables, then the command.
-
-    Contained piece by piece, `profiles.display`'s rule — this goes to a terminal, and both
-    halves come out of a file a chat can write.
-    """
-    pieces = [contain.readable(f"{name}={value}") for name, value in p.env]
+    """The probe as an operator would type it: the profile's variables, then the command —
+    or, for a kind whose answer is a file, the command that shows that file."""
     argv = probe_argv(p)
-    pieces.append(contain.readable(shlex.join(argv) if argv
-                                   else f"read {codex.config_path(environment(p))}"))
-    return " ".join(pieces)
+    if argv:
+        return _typed(p, argv)
+    return _whole(shlex.join(["cat", str(codex.config_path(environment(p)))]))
+
+
+def _not_asked(p: profiles.Profile) -> tuple[str, str]:
+    """Why charter may not run *p*'s command to ask it anything — ``("", "")`` when it may.
+
+    ``(sentence, fix)``. **The same two checks a launch makes before its own**, in the same
+    order (ruling 1, and the Global Constraint *No profile's command runs before that
+    profile passes the ignored check and the trust check*): a probe IS a run of the
+    profile's command, and there are four callers of it — the launcher, the selector,
+    `harness install` and `doctor`. A gate each of them has to remember is a gate one of
+    them will not, and the thing it lets through is a command out of a file a chat can
+    write.
+
+    **The ignore check first**: an approved profile in a file git would commit is still a
+    declaration charter has refused, and a record saying the operator once approved it says
+    nothing about the file it now sits in. Built-ins skip both — their command is charter's
+    own, out of the registry.
+
+    The sentence is Task 3's own and the launcher's own, never a paraphrase: nothing asks
+    here, so an unapproved profile is told what an open nobody is at is told
+    (:data:`profiletrust.UNATTENDED`).
+    """
+    from . import profiletrust
+    from .frame import launcher
+
+    if p.source == profiles.BUILTIN:
+        return "", ""
+    name = contain.readable(p.name)
+    check = profiles.ignore_check(config.ROOT)
+    if check.reason:
+        return launcher.IGNORED.format(name=name, why=check.reason), check.fix
+    state = profiletrust.approval_needed(p)
+    if state:
+        return (profiletrust.UNATTENDED.format(name=name, state=state),
+                f"charter {_whole(p.name)}")
+    return "", ""
 
 
 def detect(p: profiles.Profile, *, cwd) -> Wiring:
@@ -189,28 +260,35 @@ def detect(p: profiles.Profile, *, cwd) -> Wiring:
     detail that can be defaulted.
 
     Never cached and never memoised: the whole point of :func:`cached` living beside this
-    is that only one of them may start a chat.
-
-    **The approval gate is here and not only in the callers** (ruling 1). A probe IS a run of
-    the profile's command, and there are four callers — the launcher, the selector, `harness
-    install` and `doctor`. A gate each of them has to remember is a gate one of them will not,
-    and the thing it lets through is a command out of a file a chat can write.
+    is that only one of them may start a chat. A profile :func:`_not_asked` stops is an
+    UNKNOWN whose detail is that sentence — charter did not look, which is not a pass.
     """
-    why = approval_needed(p)
+    why, fix = _not_asked(p)
     if why:
-        return Wiring(UNKNOWN_STATE, contain.readable(why),
-                      f"charter {contain.readable(p.name)}")
-    env = environment(p)
-    if p.harness == claude_code.NAME:
-        return _claude(p, cwd=cwd, env=env)
-    if p.harness == codex.NAME:
-        return _codex(p, env=env)
-    if p.harness == opencode.NAME:
-        return _opencode(p, env=env)
-    # A kind charter has no wiring check for is an UNKNOWN and therefore a refusal, not a
-    # pass: the day a kind joins the registry without one, this is the row that says so.
-    return Wiring(UNKNOWN_STATE, f"charter has no wiring check for {contain.readable(p.kind)}",
-                  f"charter harness install {contain.readable(p.name)}")
+        return Wiring(UNKNOWN_STATE, why, fix)
+    return _asked(p, cwd=cwd)
+
+
+def _asked(p: profiles.Profile, *, cwd) -> Wiring:
+    """:func:`detect` past its gate: the kind's own question, and nothing that raises.
+
+    **Never a traceback** (A1): the config files and answers read here are the profile's,
+    and a profile is a file a chat can write. `ValueError` is what a NUL byte in a path or
+    an environment value raises out of `stat`, `open` and `exec` alike, so it is the one
+    exception every kind can meet that is not already its own UNKNOWN.
+    """
+    kind = _KINDS.get(p.harness)
+    if kind is None:
+        # A kind charter has no wiring check for is an UNKNOWN and therefore a refusal, not
+        # a pass: the day a kind joins the registry without one, this is the row that says so.
+        return Wiring(UNKNOWN_STATE, f"charter has no wiring check for {_whole(p.kind)}",
+                      _install_fix(p))
+    try:
+        return kind.ask(p, Path(cwd), environment(p))
+    except ValueError as e:
+        return Wiring(UNKNOWN_STATE,
+                      f"charter could not ask under this profile's environment "
+                      f"({_whole(e)})", _install_fix(p))
 
 
 def refusal(p: profiles.Profile, *, cwd) -> str:
@@ -219,16 +297,25 @@ def refusal(p: profiles.Profile, *, cwd) -> str:
     An UNKNOWN refuses with its own sentence (ruling 12) rather than sharing the unwired
     one: "charter looked and the guard is absent" and "charter could not look" are
     different things to be told, and only one of them has `charter harness install` as its
-    whole answer.
+    whole answer. A profile charter may not ask about at all is told why in the launcher's
+    and Task 3's own words, and nothing else.
     """
-    w = detect(p, cwd=cwd)
+    why, _fix = _not_asked(p)
+    if why:
+        return why
+    return sentence(p, _asked(p, cwd=cwd))
+
+
+def sentence(p: profiles.Profile, w: Wiring) -> str:
+    """*w* said as a refusal of *p* — ``""`` when it is wired. For a caller that already
+    holds an answer and must not pay for a second probe to word it (`harness install`)."""
     name = contain.readable(p.name)
     if w.state == WIRED:
         return ""
     if w.state == UNWIRED:
-        return NOT_WIRED.format(name=name, detail=w.detail, fix=w.fix)
-    return CANNOT_TELL.format(kind=contain.readable(p.kind), name=name, detail=w.detail,
-                              probe=by_hand(p))
+        return NOT_WIRED.format(name=name, detail=said(w.detail), fix=said(w.fix))
+    return CANNOT_TELL.format(kind=contain.readable(p.kind), name=name,
+                              detail=said(w.detail), probe=said(by_hand(p)))
 
 
 # --------------------------------------------------------------------------- #
@@ -236,7 +323,7 @@ def refusal(p: profiles.Profile, *, cwd) -> str:
 # --------------------------------------------------------------------------- #
 
 
-def _claude(p: profiles.Profile, *, cwd, env: Mapping[str, str]) -> Wiring:
+def _claude(p: profiles.Profile, cwd: Path, env: Mapping[str, str]) -> Wiring:
     """Claude Code: `claude plugin list --json`, run as *p* would run `claude`.
 
     Two facts out of the same answer, and they are resolved differently — measured
@@ -252,49 +339,53 @@ def _claude(p: profiles.Profile, *, cwd, env: Mapping[str, str]) -> Wiring:
     "unless"): a disable written ONLY to `<cwd>/.claude/settings.local.json`, and only to
     `<cwd>/.claude/settings.json`, each flipped the listed entry to `enabled: false` beside
     an enabled user-scope install. A second reader would answer for a different merge than
-    the binary's — measured, `<ancestor>/.claude/settings.json` does NOT reach a session
-    below it while `settings.local.json` does — and a wrong UNWIRED refuses a chat that
-    would have been guarded.
+    the binary's, and a wrong UNWIRED refuses a chat that would have been guarded.
 
     **An install covering the PLANE covers a chat in that plane's workspace** (D3). `charter
     init` installs at project scope for the plane root, and a chat's directory is
     `workspaces/<ws>/` — a different `projectPath`, which `covers` alone reads as not this
-    plane's. Charter mirrors the plane's `enabledPlugins` into that directory
-    (`claude_code.WORKSPACE_KEYS`), and the probe's own `enabled` is resolved there, so the
-    record that covers the plane is the one that answers for the chat. Measured end to end:
-    an alternate `$CLAUDE_CONFIG_DIR`, `charter init`, `charter workspace create w`, and
-    `claude plugin list --json` in `workspaces/w` answering `enabled: true`.
+    plane's. It is safe to count because of the fact above and only because of it: the
+    `enabled` on that record is what the binary resolved at *cwd*, so a plane install the
+    chat's own directory disables reads as disabled here
+    (`test_a_plane_install_the_chats_directory_disables_is_not_wired`).
     """
     folder = claude_code.config_home(env)
     entries = plugincache.covering_entries(cwd, root=config.ROOT, env=dict(env),
                                            command=profiles.expanded_command(p))
-    where = f"{contain.readable(str(folder))} for {contain.readable(str(cwd))}"
+    where = f"{_whole(folder)} for {_whole(cwd)}"
     if entries is plugincache.UNKNOWN:
         return Wiring(UNKNOWN_STATE,
                       f"claude plugin list --json could not be read in {where}",
-                      f"charter harness install {contain.readable(p.name)}")
+                      _install_fix(p))
     if not entries:
         return Wiring(UNWIRED, f"{plugincache.PLUGIN_ID} is not installed in {where}",
-                      f"charter harness install {contain.readable(p.name)}")
+                      _install_fix(p))
     best = min(entries, key=lambda e: _SCOPE_ORDER.index(e.get("scope"))
                if e.get("scope") in _SCOPE_ORDER else len(_SCOPE_ORDER))
-    scope = contain.readable(str(best.get("scope")))
+    scope = _whole(best.get("scope"))
     if best.get("enabled") is True:
         return Wiring(WIRED,
                       f"claude plugin list: {plugincache.PLUGIN_ID} enabled at {scope} "
                       f"scope in {where}", "")
     # NOT `charter harness install`: `plugincache.install` answers `present` for an install
     # that exists, so pointing back at it would print a fix that changes nothing and loops
-    # — review 7's objection, one harness over. The enable is the command that moves this.
-    fix = " ".join([*(contain.readable(f"{n}={v}") for n, v in p.env),
-                    contain.readable(shlex.join([*profiles.expanded_command(p), "plugin",
-                                                 "enable", plugincache.PLUGIN_ID]))])
+    # — review 7's objection, one harness over.
+    #
+    # `--scope local`, run FROM the chat's directory, because that is the enable measured
+    # to undo every disable that reaches it (claude 2.1.270, 2026-09-13, throwaway folders):
+    # a `false` in `<dir>/.claude/settings.local.json`, in `<dir>/.claude/settings.json`,
+    # and — in a git plane — in the plane root's `settings.local.json`. `--scope project`
+    # and `--scope user` each exited 1 over a local disable and changed nothing, which is
+    # review 7's loop again; and a scope-less enable run from anywhere else writes where
+    # the chat does not read.
+    fix = _typed(p, [*profiles.expanded_command(p), "plugin", "enable",
+                     plugincache.PLUGIN_ID, "--scope", "local"], cwd=cwd)
     return Wiring(UNWIRED,
                   f"{plugincache.PLUGIN_ID} is installed at {scope} scope and reads as "
                   f"disabled in {where}", fix)
 
 
-def _codex(p: profiles.Profile, *, env: Mapping[str, str]) -> Wiring:
+def _codex(p: profiles.Profile, cwd: Path, env: Mapping[str, str]) -> Wiring:
     """Codex: three marks in `$CODEX_HOME/config.toml`, and it needs all three (ruling 7).
 
     The plugin declares the hooks, the policy line is the only thing that can tell a Codex
@@ -308,45 +399,44 @@ def _codex(p: profiles.Profile, *, env: Mapping[str, str]) -> Wiring:
     against a real hash on 2026-09-12 and none matched. And Codex writes an entry per hook
     **lazily**, as each first fires — the operator's own wired home held 12 of the plugin's
     18 keys — so "an entry for every hook key" would call a wired machine unwired. What is
-    left is honest and weaker, and `docs/harnesses.md` says so: charter's hooks were
-    approved in this home at least once.
+    left is honest and weaker, and `docs/harnesses.md` says so: one of charter's GUARD hooks
+    (:data:`CODEX_GUARD_EVENT`) was approved in this home at least once.
 
     The home is the one charter can see. One a wrapper script exports on its way to `codex`
     is invisible here, and the docs state that limit.
     """
     path = codex.config_path(env)
-    name = contain.readable(p.name)
-    fix = f"charter harness install {name}"
+    where = _whole(path)
+    fix = _install_fix(p)
     try:
         doc = tomllib.loads(path.read_text())
     except FileNotFoundError:
         doc = {}
     except (OSError, UnicodeDecodeError, tomllib.TOMLDecodeError) as e:
-        return Wiring(UNKNOWN_STATE,
-                      f"{contain.readable(str(path))} could not be read "
-                      f"({contain.readable(str(e))})", fix)
-    where = contain.readable(str(path))
-    plugin = (doc.get("plugins") or {}).get(plugincache.PLUGIN_ID) or {}
-    policy = ((doc.get("shell_environment_policy") or {}).get("set") or {})
-    trusted = [k for k, v in ((doc.get("hooks") or {}).get("state") or {}).items()
-               if str(k).startswith(CODEX_TRUST_PREFIX) and (v or {}).get("trusted_hash")]
+        return Wiring(UNKNOWN_STATE, f"{where} could not be read ({_whole(e)})", fix)
+    marks = _codex_marks(doc)
+    if isinstance(marks, str):
+        return Wiring(UNKNOWN_STATE, CODEX_SHAPE.format(path=where, key=marks), fix)
+    plugin, policy, trusted = marks
     missing = []
     if plugin.get("enabled") is not True:
         missing.append(f"{plugincache.PLUGIN_ID} is not an enabled plugin")
     if policy.get("CHARTER_HARNESS") != codex.NAME:
         missing.append('shell_environment_policy.set has no CHARTER_HARNESS = "codex"')
     if not trusted:
-        missing.append("no hook of charter's is trusted — approve them in a codex session")
+        missing.append("no guard hook of charter's is trusted — approve them in a codex "
+                       "session")
     if not missing:
         return Wiring(WIRED, f"{where}: plugin enabled, harness named, "
-                             f"{len(trusted)} trusted hook(s)", "")
+                             f"{len(trusted)} trusted guard hook(s)", "")
     if policy.get("CHARTER_HARNESS") == codex.NAME:
         # Charter's own half is already written, so what is left is Codex's own commands and
         # a trust prompt only a person can answer. Naming `charter harness install` here
         # would name the command that has already done everything it can — review 7's
         # objection is about a fix that changes nothing, and this is the same fix one mark
         # further on.
-        fix = codex_steps(path.parent)
+        steps = codex_steps(path.parent)
+        fix = f"{'; '.join(steps[:-1])}; then {steps[-1]}"
     elif "shell_environment_policy" in doc:
         # `codex.install()` answers `present` for ANY `[shell_environment_policy]` table,
         # so `charter harness install` here would print a fix that changes nothing.
@@ -354,19 +444,63 @@ def _codex(p: profiles.Profile, *, env: Mapping[str, str]) -> Wiring:
     return Wiring(UNWIRED, f"{where}: " + "; ".join(missing), fix)
 
 
-def codex_steps(home) -> str:
-    """:data:`CODEX_STEPS` with ``CODEX_HOME=`` in front of each command it can prefix.
+def _codex_marks(doc: dict):
+    """``(plugin table, policy set, trusted guard keys)`` out of *doc* — or the dotted KEY
+    that has a shape Codex never writes.
 
-    Printed and never run: they install software into an account folder and end in a trust
-    prompt only a person can answer, and charter's own consent rule is that running the
-    command IS the consent.
+    Every level is checked for being a table before it is read, because each is a line a
+    chat can write: `plugins."charter@charter" = true` parses, and so does a trust entry
+    that is a string. Read without the check either one is an `AttributeError` in a
+    launch; read with it, it is an UNKNOWN that says which key (A1).
     """
-    where = contain.readable(str(home))
-    return "; ".join(f"CODEX_HOME={where} {step}" if step.startswith("codex ") else step
-                     for step in CODEX_STEPS)
+    def table(parent: dict, key: str, shown: str):
+        got = parent.get(key, {})
+        return got if isinstance(got, dict) else shown
+
+    plugins = table(doc, "plugins", "plugins")
+    if isinstance(plugins, str):
+        return plugins
+    plugin = table(plugins, plugincache.PLUGIN_ID, f'plugins."{plugincache.PLUGIN_ID}"')
+    if isinstance(plugin, str):
+        return plugin
+    policy_table = table(doc, "shell_environment_policy", "shell_environment_policy")
+    if isinstance(policy_table, str):
+        return policy_table
+    policy = table(policy_table, "set", "shell_environment_policy.set")
+    if isinstance(policy, str):
+        return policy
+    hooks = table(doc, "hooks", "hooks")
+    if isinstance(hooks, str):
+        return hooks
+    ledger = table(hooks, "state", "hooks.state")
+    if isinstance(ledger, str):
+        return ledger
+    trusted = []
+    for key, entry in ledger.items():
+        if not str(key).startswith(CODEX_TRUST_PREFIX):
+            continue
+        if not isinstance(entry, dict):
+            return f'hooks.state."{_whole(key)}"'
+        guard = str(key).startswith(f"{CODEX_TRUST_PREFIX}{CODEX_GUARD_EVENT}:")
+        if guard and isinstance(entry.get("trusted_hash"), str) and entry["trusted_hash"]:
+            trusted.append(key)
+    return plugin, policy, trusted
 
 
-def _opencode(p: profiles.Profile, *, env: Mapping[str, str]) -> Wiring:
+def codex_steps(home) -> list[str]:
+    """:data:`CODEX_COMMANDS` with ``CODEX_HOME=`` in front of each, then
+    :data:`CODEX_APPROVE`. One line per step, each one pasteable on its own.
+
+    A list, so no caller has to split a sentence back into steps — a home whose name holds
+    the separator would come apart in the wrong place (A11). Printed and never run: they
+    install software into an account folder and end in a trust prompt only a person can
+    answer, and charter's own consent rule is that running the command IS the consent.
+    """
+    prefix = f"CODEX_HOME={shlex.quote(str(home))}"
+    return [_whole(f"{prefix} {shlex.join(argv)}") for argv in CODEX_COMMANDS] + [CODEX_APPROVE]
+
+
+def _opencode(p: profiles.Profile, cwd: Path, env: Mapping[str, str]) -> Wiring:
     """opencode: `debug config`, and all three marks (ruling 26).
 
     The entry has to name charter's shim, the shim's bytes have to be charter's, **and no
@@ -382,25 +516,20 @@ def _opencode(p: profiles.Profile, *, env: Mapping[str, str]) -> Wiring:
     entry naming a deleted file would read as wired.
     """
     home = opencode.global_dir(env)
-    name = contain.readable(p.name)
-    fix = f"charter harness install {name}"
+    fix = _install_fix(p)
     argv = probe_argv(p)
-    where = contain.readable(str(home))
+    asked = _whole(shlex.join(argv))
+    where = _whole(home)
     try:
         proc = util.run(argv, check=False, env=dict(env), timeout=plugincache.LIST_TIMEOUT)
     except (util.ProcTimeout, OSError) as e:
-        return Wiring(UNKNOWN_STATE,
-                      f"{contain.readable(shlex.join(argv))} did not answer "
-                      f"({contain.readable(str(e))})", fix)
+        return Wiring(UNKNOWN_STATE, f"{asked} did not answer ({_whole(e)})", fix)
     if proc.returncode != 0:
-        return Wiring(UNKNOWN_STATE,
-                      f"{contain.readable(shlex.join(argv))} exited {proc.returncode}", fix)
+        return Wiring(UNKNOWN_STATE, f"{asked} exited {proc.returncode}", fix)
     try:
-        doc = json.loads(proc.stdout or "")
+        doc = json.loads(proc.stdout)
     except (ValueError, TypeError):
-        return Wiring(UNKNOWN_STATE,
-                      f"{contain.readable(shlex.join(argv))} answered something that is "
-                      f"not JSON", fix)
+        return Wiring(UNKNOWN_STATE, f"{asked} answered something that is not JSON", fix)
     entries = doc.get("plugin") if isinstance(doc, dict) else None
     if isinstance(entries, str):
         entries = [entries]
@@ -416,7 +545,7 @@ def _opencode(p: profiles.Profile, *, env: Mapping[str, str]) -> Wiring:
     if foreign:
         return Wiring(UNWIRED,
                       f"{where}/{opencode.PLUGIN_DIR} also holds "
-                      f"{contain.readable(', '.join(foreign))}, which shares one module "
+                      f"{_whole(', '.join(foreign))}, which shares one module "
                       f"realm with charter's shim", "remove it, or move it out of "
                                                    f"{where}/{opencode.PLUGIN_DIR}")
     return Wiring(WIRED, f"opencode debug config: {opencode.SHIM_PATH} under {where}, and "
@@ -441,53 +570,66 @@ def _resolved(p) -> str:
 # --------------------------------------------------------------------------- #
 
 
-def _fingerprint(p: profiles.Profile) -> dict:
-    """What makes this the same profile as the one that was asked about.
-
-    Task 3's `profiletrust.fingerprint` answers exactly this question for the launch
-    record, and this becomes a call to it when that is on `main`. The `env` NAMES and their
-    values both count: a profile whose `CLAUDE_CONFIG_DIR` moved is a different folder to
-    ask about, and reusing an answer across that is the whole failure.
-    """
-    return {"name": p.name, "kind": p.kind, "command": list(p.command),
-            "env": [list(pair) for pair in p.env]}
-
-
 def _key(p: profiles.Profile, cwd) -> str:
-    return hashlib.sha256(
-        json.dumps({**_fingerprint(p), "cwd": str(cwd)}, sort_keys=True).encode()).hexdigest()
+    """What makes this the same question as the one that was asked: the profile as the
+    operator approved it (`profiletrust.fingerprint` — its NAME rides beside it, because the
+    record is keyed by name and this is not), and the directory it was asked about."""
+    from . import profiletrust
+
+    return hashlib.sha256(json.dumps(
+        {**profiletrust.fingerprint(p), "name": p.name, "cwd": str(cwd)},
+        sort_keys=True).encode()).hexdigest()
 
 
-def _stamp_paths(p: profiles.Profile, cwd) -> list[Path]:
-    """The files whose change accompanied every flip of this kind's answer (D2).
+def _claude_stamps(env: Mapping[str, str], cwd: Path) -> list[Path]:
+    """The config folder's two files, and every settings file that can reach *cwd*.
 
-    `.claude.json` is deliberately absent: the probe itself writes it, so stamping it would
-    invalidate the entry the probe just wrote. The chat DIRECTORY's settings files are here
-    and not only the plane root's — that is the file Claude Code reads for that chat, and a
-    stamp that missed it would keep saying `wired` after a chat wrote a `false` into it.
+    **Every directory from *cwd* up to the plane root, inclusive** (A6). Measured on claude
+    2.1.270 (2026-09-13): in a git plane, a disable in the ROOT's `settings.local.json`
+    reads as disabled in `workspaces/<ws>/` below it — so a stamp of the chat's own
+    directory alone would keep answering `wired` after the plane root changed. Stamping a
+    file that turns out not to reach is only a spurious miss; missing one that does is a
+    display that stays green.
     """
-    env = environment(p)
-    if p.harness == claude_code.NAME:
-        folder = claude_code.config_home(env)
-        return [folder / "plugins" / "installed_plugins.json", folder / "settings.json",
-                Path(cwd) / ".claude" / "settings.json",
-                Path(cwd) / ".claude" / "settings.local.json"]
-    if p.harness == codex.NAME:
-        return [codex.config_path(env)]
-    if p.harness == opencode.NAME:
-        home = opencode.global_dir(env)
-        return [home / opencode.PLUGIN_DIR, home / opencode.SHIM_PATH,
-                home / "opencode.json"]
-    return []
+    folder = claude_code.config_home(env)
+    return [folder / "plugins" / "installed_plugins.json", folder / "settings.json",
+            *(d / ".claude" / name for d in _up_to_the_plane(cwd)
+              for name in ("settings.json", "settings.local.json"))]
+
+
+def _up_to_the_plane(cwd: Path) -> list[Path]:
+    """*cwd*, then each parent up to and including `config.ROOT` — or *cwd* alone when it is
+    not inside the plane. Resolved, because `os.getcwd()` answers `/private/var/…` for a
+    plane `config.ROOT` spells `/var/…` on macOS."""
+    try:
+        here, root = Path(os.path.realpath(cwd)), Path(os.path.realpath(config.ROOT))
+    except ValueError:
+        return [Path(cwd)]
+    if here != root and root not in here.parents:
+        return [here]
+    return [here, *(d for d in here.parents if d == root or root in d.parents)]
+
+
+def _codex_stamps(env: Mapping[str, str], cwd: Path) -> list[Path]:
+    return [codex.config_path(env)]
+
+
+def _opencode_stamps(env: Mapping[str, str], cwd: Path) -> list[Path]:
+    home = opencode.global_dir(env)
+    return [home / opencode.PLUGIN_DIR, home / opencode.SHIM_PATH, home / "opencode.json"]
 
 
 def _stamp(p: profiles.Profile, cwd) -> dict:
+    """``{path: [mtime_ns, size] | None}`` for the files whose change accompanied every flip
+    of this kind's answer (D2). `.claude.json` is deliberately absent: the probe itself
+    writes it, so stamping it would invalidate the entry the probe just wrote."""
+    kind = _KINDS.get(p.harness)
     out = {}
-    for path in _stamp_paths(p, cwd):
+    for path in ([] if kind is None else kind.stamped(environment(p), Path(cwd))):
         try:
             st = path.stat()
             out[str(path)] = [st.st_mtime_ns, st.st_size]
-        except OSError:
+        except (OSError, ValueError):
             # Absent is a state like any other: a shim that appears has to be a miss.
             out[str(path)] = None
     return out
@@ -504,27 +646,35 @@ def _read_cache() -> dict:
 def cached(p: profiles.Profile, *, cwd) -> Wiring | None:
     """A remembered answer whose stamp still matches, or ``None``. **Display only.**
 
-    `charter/frame/selector.py` draws its rows from this and probes on a miss; picking a row
-    probes again. A launch never reads it (ruling 21): this file is as writable by a chat as
-    `charter.local.toml` is, and a chat can compute the key, write the stamp and date the
-    entry ahead — which is why the age test has two bounds.
+    Nothing on `main` reads this yet: Task 5's selector will, drawing its rows from it and
+    probing on a miss, and picking a row probes again. A launch never reads it (ruling 21):
+    this file is as writable by a chat as `charter.local.toml` is, and a chat can compute
+    the key, write the stamp and date the entry ahead — which is why the age test has two
+    bounds, and why every field is checked for its type before it is believed (A1).
     """
     entry = _read_cache().get(_key(p, cwd))
     if not isinstance(entry, dict):
         return None
-    age = time.time() - (entry.get("checked_at") or 0)
-    if not 0 <= age < MAX_AGE:
+    at = entry.get("checked_at")
+    if isinstance(at, bool) or not isinstance(at, (int, float)):
+        return None
+    if not 0 <= time.time() - at < MAX_AGE:
         return None
     if entry.get("stamp") != _stamp(p, cwd):
         return None
-    try:
-        return Wiring(entry["state"], entry["detail"], entry["fix"])
-    except (KeyError, TypeError):
+    got = [entry.get(field) for field in ("state", "detail", "fix")]
+    if got[0] not in (WIRED, UNWIRED, UNKNOWN_STATE) or not all(isinstance(g, str)
+                                                                  for g in got):
         return None
+    return Wiring(*got)
 
 
 def remember(p: profiles.Profile, *, cwd, w: Wiring) -> None:
-    """Record *w* for *p* at *cwd*. Best effort: a display cache is never worth a row."""
+    """Record *w* for *p* at *cwd*. Best effort: a display cache is never worth a row.
+
+    Task 5's selector will call this on the miss it probes; nothing on `main` does yet, and
+    `doctor` deliberately does not (a suite reaching `run_all()` would write the cache).
+    """
     doc = _read_cache()
     doc[_key(p, cwd)] = {"state": w.state, "detail": w.detail, "fix": w.fix,
                          "checked_at": time.time(), "stamp": _stamp(p, cwd)}
@@ -543,38 +693,80 @@ def remember(p: profiles.Profile, *, cwd, w: Wiring) -> None:
 
 def install(p: profiles.Profile, root: Path) -> list[tuple[str, str]]:
     """Wire *p*'s kind under *p*'s own environment. ``(status, label)`` pairs, `Harness.wire`'s
-    shape.
+    shape with every label contained — or one ``("refused", why)`` when charter may not act
+    for *p* at all.
+
+    The gate is :func:`detect`'s, and it is here for detect's reason: an install runs the
+    profile's own command (`claude plugin install`) or writes into the folder its `env`
+    names, and a file git would commit is never acted on.
 
     Codex is the one that cannot be finished from here, and that is a fact about Codex
     rather than a gap: charter writes the `shell_environment_policy` line — the one thing
     the plugin cannot write, because it is what tells a Codex shell which harness it is —
-    and the plugin install and the hook approval are Codex's own commands, printed with
-    `CODEX_HOME=` in front of them by the caller.
+    and the plugin install and the hook approval are Codex's own commands, which the
+    unwired answer after it names with `CODEX_HOME=` in front.
     """
-    env = environment(p)
-    if p.harness == claude_code.NAME:
-        status, detail = plugincache.install(root, env=env,
-                                             command=profiles.expanded_command(p))
-        return [(status, detail)]
-    if p.harness == codex.NAME:
-        status, detail = codex.install(env=env)
-        return [(status, detail)]
-    if p.harness == opencode.NAME:
-        return opencode.OpenCodeHarness().wire(root, env=env)
-    return [("unavailable", f"charter has no wiring for {contain.readable(p.kind)}")]
+    why, _fix = _not_asked(p)
+    if why:
+        return [("refused", why)]
+    kind = _KINDS.get(p.harness)
+    if kind is None:
+        return [("unavailable", f"charter has no wiring for {_whole(p.kind)}")]
+    try:
+        # Contained HERE, once, for every caller: a label is a path built out of the
+        # profile's own `env` — a file a chat can write — and both `harness install` and
+        # `init` print it to a terminal (ruling 35).
+        return [(status, _whole(label)) for status, label in kind.wire(p, root, environment(p))]
+    except ValueError as e:
+        return [("failed", f"charter could not wire under this profile's environment "
+                           f"({_whole(e)})")]
 
 
-def listed(read: profiles.ProfileSet | None = None) -> list[profiles.Profile]:
+def _claude_wire(p: profiles.Profile, root: Path, env: dict) -> list[tuple[str, str]]:
+    return [plugincache.install(root, env=env, command=profiles.expanded_command(p))]
+
+
+def _codex_wire(p: profiles.Profile, root: Path, env: dict) -> list[tuple[str, str]]:
+    return [codex.install(env=env)]
+
+
+def _opencode_wire(p: profiles.Profile, root: Path, env: dict) -> list[tuple[str, str]]:
+    return opencode.OpenCodeHarness().wire(root, env=env)
+
+
+class _Kind(NamedTuple):
+    """Everything this module knows about one harness kind, in one row (C: one table in
+    place of four `p.harness ==` ladders, which had to agree and were free not to)."""
+
+    #: The words after the profile's command that ask; ``()`` when the answer is a file.
+    probe: tuple[str, ...]
+    #: ``(profile, cwd, env) -> Wiring``.
+    ask: Callable[[profiles.Profile, Path, Mapping[str, str]], Wiring]
+    #: ``(env, cwd) -> paths`` whose change can flip the answer.
+    stamped: Callable[[Mapping[str, str], Path], list[Path]]
+    #: ``(profile, root, env) -> (status, label) pairs``.
+    wire: Callable[[profiles.Profile, Path, dict], list[tuple[str, str]]]
+
+
+_KINDS: dict[str, _Kind] = {
+    claude_code.NAME: _Kind(("plugin", "list", "--json"), _claude, _claude_stamps,
+                            _claude_wire),
+    codex.NAME: _Kind((), _codex, _codex_stamps, _codex_wire),
+    opencode.NAME: _Kind(("debug", "config"), _opencode, _opencode_stamps, _opencode_wire),
+}
+
+
+def listed() -> list[profiles.Profile]:
     """Every profile a selector would show, in the order `charter harness list` shows them.
 
-    Declared profiles always; a built-in only when its program is installed, because a row
-    about a harness this machine does not have is a row nobody can act on. One reader, so
-    `doctor.check_names` and `doctor.check_profile_wiring` cannot disagree about how many
-    rows there are — the pin `_FIXED_CHECK_NAMES` already keeps for every other check.
+    Declared profiles always — one whose command is not installed is still a row, because it
+    is still somebody's declaration and `doctor` is where they find out; a built-in only
+    when its program is installed, because a row about a harness this machine does not have
+    is a row nobody can act on. One reader, so `doctor.check_names` and
+    `doctor.check_profile_wiring` cannot disagree about how many rows there are — the pin
+    `_FIXED_CHECK_NAMES` already keeps for every other check.
     """
-    import shutil
-
-    read = read if read is not None else profiles.current()
+    read = profiles.current()
     order = list(profiles.builtins())
     rows = [p for p in read.profiles.values()
             if p.source != profiles.BUILTIN

--- a/charter/wiring.py
+++ b/charter/wiring.py
@@ -480,7 +480,8 @@ def _codex_guard_keys(home: Path):
     plugin = plugincache.PLUGIN_ID.split("@", 1)[0]
     root = home / CODEX_PLUGIN_CACHE / marketplace / plugin
     try:
-        versions = sorted(d for d in root.iterdir() if d.is_dir())
+        # No `sorted`: the copies are intersected, and an intersection has no order.
+        versions = [d for d in root.iterdir() if d.is_dir()]
     except (FileNotFoundError, NotADirectoryError):
         return frozenset()
     except (OSError, ValueError) as e:
@@ -554,12 +555,15 @@ def _codex_marks(doc: dict, guards: frozenset):
         return ledger
     trusted = []
     for key, entry in ledger.items():
-        if not str(key).startswith(CODEX_TRUST_PREFIX):
+        # Only the guard's own entries are read. A prefix test used to stand here, and
+        # membership in *guards* implies it — every guard key is built on the prefix — so it
+        # was a second spelling of the same filter; another hook's entry, in any shape, says
+        # nothing about the guard.
+        if key not in guards:
             continue
         if not isinstance(entry, dict):
             return f'hooks.state."{_whole(key)}"'
-        if key in guards and isinstance(entry.get("trusted_hash"), str) \
-                and entry["trusted_hash"]:
+        if isinstance(entry.get("trusted_hash"), str) and entry["trusted_hash"]:
             trusted.append(key)
     return plugin, policy, trusted
 
@@ -677,13 +681,16 @@ def _claude_stamps(env: Mapping[str, str], cwd: Path) -> list[Path]:
 def _up_to_the_plane(cwd: Path) -> list[Path]:
     """*cwd*, then each parent up to and including `config.ROOT` — or *cwd* alone when it is
     not inside the plane. Resolved, because `os.getcwd()` answers `/private/var/…` for a
-    plane `config.ROOT` spells `/var/…` on macOS."""
+    plane `config.ROOT` spells `/var/…` on macOS.
+
+    One filter and no "outside the plane" branch: a parent is kept only when it IS the root
+    or lies below it, and no parent of a directory outside the plane — its own parent
+    included — is either. The branch that used to say so first answered the same list for
+    every input, and the sweep was right that nothing could tell it from its absence."""
     try:
         here, root = Path(os.path.realpath(cwd)), Path(os.path.realpath(config.ROOT))
     except ValueError:
         return [Path(cwd)]
-    if here != root and root not in here.parents:
-        return [here]
     return [here, *(d for d in here.parents if d == root or root in d.parents)]
 
 

--- a/charter/wiring.py
+++ b/charter/wiring.py
@@ -340,12 +340,30 @@ def _codex(p: profiles.Profile, *, env: Mapping[str, str]) -> Wiring:
     if not missing:
         return Wiring(WIRED, f"{where}: plugin enabled, harness named, "
                              f"{len(trusted)} trusted hook(s)", "")
-    if ("shell_environment_policy" in doc
-            and policy.get("CHARTER_HARNESS") != codex.NAME):
+    if policy.get("CHARTER_HARNESS") == codex.NAME:
+        # Charter's own half is already written, so what is left is Codex's own commands and
+        # a trust prompt only a person can answer. Naming `charter harness install` here
+        # would name the command that has already done everything it can — review 7's
+        # objection is about a fix that changes nothing, and this is the same fix one mark
+        # further on.
+        fix = codex_steps(path.parent)
+    elif "shell_environment_policy" in doc:
         # `codex.install()` answers `present` for ANY `[shell_environment_policy]` table,
         # so `charter harness install` here would print a fix that changes nothing.
         fix = CODEX_POLICY_BY_HAND.format(path=where)
     return Wiring(UNWIRED, f"{where}: " + "; ".join(missing), fix)
+
+
+def codex_steps(home) -> str:
+    """:data:`CODEX_STEPS` with ``CODEX_HOME=`` in front of each command it can prefix.
+
+    Printed and never run: they install software into an account folder and end in a trust
+    prompt only a person can answer, and charter's own consent rule is that running the
+    command IS the consent.
+    """
+    where = contain.readable(str(home))
+    return "; ".join(f"CODEX_HOME={where} {step}" if step.startswith("codex ") else step
+                     for step in CODEX_STEPS)
 
 
 def _opencode(p: profiles.Profile, *, env: Mapping[str, str]) -> Wiring:

--- a/docs/control-plane.md
+++ b/docs/control-plane.md
@@ -650,7 +650,9 @@ profile this machine has.
 
 Charter's guard lives in the harness's own config folder, and a profile names another one.
 **A profile whose folder does not carry charter's wiring refuses to launch**, prints what is
-missing and names the command that fixes it:
+missing and names the command that fixes it. Asking runs the profile's own command, so it
+is asked only once you have approved that command — a new `claude-alt` shows
+`run this? [y/N]` first, and a yes is followed by this, not by a chat:
 
 ```
 charter: profile 'claude-alt' is not wired — charter@charter is not installed in
@@ -666,9 +668,10 @@ profile started it.
 A probe that cannot answer — it timed out, exited non-zero, or said something charter could
 not read — refuses too, and prints the probe to run by hand. An unknown is not a pass.
 
-Every launch asks freshly, before tmux and again in the pane. It never reads the remembered
-answer under `.charter/`: that file is as writable by a chat as `charter.local.toml` is, and
-it exists to draw rows, not to start chats.
+Every launch asks freshly, before tmux and again in the pane — a `+`, a tab, `charter
+reopen` and a handoff ask before they open anything, and the pane asks again. It never
+reads the remembered answer under `.charter/`: that file is as writable by a chat as
+`charter.local.toml` is, and it exists to draw rows, not to start chats.
 
 What "wired" means per kind, what each of `init`, `reinit` and `charter harness install`
 does about it, and the measured cost of each probe are in

--- a/docs/control-plane.md
+++ b/docs/control-plane.md
@@ -641,10 +641,38 @@ charter.local.toml`, beside what git said.
 
 The check is one `git --no-optional-locks status`, which takes no `index.lock` from a commit
 running beside it. It runs when a person asks — `charter harness list`, `charter doctor` —
-and not when charter merely reads its config. One hook does pay it: the SessionStart hook
-runs `charter doctor`, so on a plane that has `charter.local.toml`, each session start makes
-that one `git status`. `charter doctor`'s `harness profiles` row warns for each refusal
-above, with each state's own fix, and for a `default` that names no profile this machine has.
+and not when charter merely reads its config, and not on a hook path: the SessionStart hook
+runs `charter doctor --preflight`, which skips it. `charter doctor`'s `harness profiles` row
+warns for each refusal above, with each state's own fix, and for a `default` that names no
+profile this machine has.
+
+### The profile is wired
+
+Charter's guard lives in the harness's own config folder, and a profile names another one.
+**A profile whose folder does not carry charter's wiring refuses to launch**, prints what is
+missing and names the command that fixes it:
+
+```
+charter: profile 'claude-alt' is not wired — charter@charter is not installed in
+/Users/you/.claude-alt for /plane/workspaces/w, so a chat on it would run without charter's
+guard. Nothing was started. Wire it: charter harness install claude-alt
+```
+
+**No flag launches one unguarded**, and the rule covers the built-ins: `charter codex` on a
+plane where nobody wired Codex, and `charter opencode` where `init` never wrote the shim,
+refuse the same way. A chat that looks guarded and is not is the same failure whichever
+profile started it.
+
+A probe that cannot answer — it timed out, exited non-zero, or said something charter could
+not read — refuses too, and prints the probe to run by hand. An unknown is not a pass.
+
+Every launch asks freshly, before tmux and again in the pane. It never reads the remembered
+answer under `.charter/`: that file is as writable by a chat as `charter.local.toml` is, and
+it exists to draw rows, not to start chats.
+
+What "wired" means per kind, what each of `init`, `reinit` and `charter harness install`
+does about it, and the measured cost of each probe are in
+[harnesses.md](harnesses.md#per-profile--wired-or-it-refuses-to-start).
 
 ### `default` — bare `charter`
 

--- a/docs/harnesses.md
+++ b/docs/harnesses.md
@@ -226,7 +226,7 @@ plugins where they are; `$CLAUDE_CONFIG_DIR` and `$CODEX_HOME` move both.
 | kind | what charter asks | what "wired" means |
 |---|---|---|
 | Claude Code | `<command> plugin list --json`, run in the chat's own directory with the profile's `env` | an install record of `charter@charter` covering that directory or the plane, whose `enabled` is true |
-| Codex | reads `$CODEX_HOME/config.toml` — no subprocess | all three: `plugins."charter@charter".enabled`, `shell_environment_policy.set.CHARTER_HARNESS = "codex"`, and at least one trusted **guard** hook of charter's (`pre_tool_use`) |
+| Codex | reads `$CODEX_HOME/config.toml` — no subprocess | all three: `plugins."charter@charter".enabled`, `shell_environment_policy.set.CHARTER_HARNESS = "codex"`, and a trusted entry for charter's **guard** hook — `charter hook pretooluse`, at the position the installed plugin's `hooks.json` gives it |
 | opencode | `<command> debug config` with the profile's `env` | all three: a `plugin` entry naming charter's shim, the shim byte-identical to what charter writes, and no other file in `plugin/` |
 
 Measured costs, five runs each: `claude plugin list --json` 137 ms against an empty folder
@@ -253,10 +253,14 @@ Three details that decide answers, all measured on 2026-09-12:
 - **Codex records hook trust lazily**, one entry per hook as each first fires — a machine
   that has been running charter under Codex for weeks held 12 of the plugin's 18 keys — and
   a `trusted_hash` cannot be recomputed from the plugin's `hooks/hooks.json`. So charter
-  asks whether one of charter's **guard** hooks — a `pre_tool_use` entry — was approved in
-  that home at all. An approved SessionStart hook is not enough: Codex asks about each hook
-  on its own, and that one guards nothing. An old entry survives a change to a hook's
-  command.
+  asks whether charter's **guard** hook — `charter hook pretooluse`, the one on `Bash` that
+  refuses a command — was approved in that home at all. Neither an approved SessionStart
+  hook nor the approved `Task|Agent` dispatch hook is enough: Codex asks about each hook on
+  its own, and neither of those refuses a command. Codex numbers its trust entries by
+  position in the installed plugin's own `hooks/hooks.json`
+  (`$CODEX_HOME/plugins/cache/charter/charter/<version>/`), and those positions move between
+  releases, so charter reads the guard's position there; when two cached versions disagree,
+  it is not wired. An old entry survives a change to a hook's command.
 - **A disabled plugin's fix is `claude plugin enable charter@charter --scope local`, run in
   the chat's own directory**, and charter prints it with that `cd` in front. Measured on
   claude 2.1.270 (2026-09-13): it undid a disable in that directory's `settings.local.json`,

--- a/docs/harnesses.md
+++ b/docs/harnesses.md
@@ -196,6 +196,92 @@ is **capability** — agents, skills, commands — and three things are delibera
 - **`CLAUDE.md` or any equivalent**, because a guest hides its own files and does not
   narrate the host's.
 
+### Per profile — wired, or it refuses to start
+
+A profile points a harness at another config folder, and **every kind loses charter's wiring
+when its folder moves**. Measured in throwaway folders against claude 2.1.269, codex-cli
+0.147.0 and opencode 1.18.23: under an empty `$CLAUDE_CONFIG_DIR` charter's plugin is not
+merely disabled, it is unknown to that folder, because the marketplace is known only to the
+folder it was added in. Under an empty `$CODEX_HOME` there is no plugin, no hook trust and
+no `shell_environment_policy`. Under a throwaway `$XDG_CONFIG_HOME` opencode has no shim.
+
+So a chat started on such a profile would look guarded and not be, and charter refuses it:
+
+```
+charter: profile 'claude-alt' is not wired — charter@charter is not installed in
+/Users/you/.claude-alt for /plane/workspaces/w, so a chat on it would run without charter's
+guard. Nothing was started. Wire it: charter harness install claude-alt
+```
+
+**This includes the built-ins.** `charter codex` on a plane where nobody wired Codex, and
+`charter opencode` where `init` never wrote the shim, now refuse where they used to start:
+a chat that looks guarded and is not is the same failure whichever profile started it. No
+flag launches one unguarded.
+
+**Wiring is detected by asking the harness under the profile's own environment**, never
+inferred from the profile's variable names — one account can be reached through variables
+that do or do not move the plugin. `$XDG_DATA_HOME` moves opencode's login and leaves its
+plugins where they are; `$CLAUDE_CONFIG_DIR` and `$CODEX_HOME` move both.
+
+| kind | what charter asks | what "wired" means |
+|---|---|---|
+| Claude Code | `<command> plugin list --json`, run in the chat's own directory with the profile's `env` | an install record of `charter@charter` covering that directory or the plane, whose `enabled` is true |
+| Codex | reads `$CODEX_HOME/config.toml` — no subprocess | all three: `plugins."charter@charter".enabled`, `shell_environment_policy.set.CHARTER_HARNESS = "codex"`, and at least one trusted hook of charter's |
+| opencode | `<command> debug config` with the profile's `env` | all three: a `plugin` entry naming charter's shim, the shim byte-identical to what charter writes, and no other file in `plugin/` |
+
+Measured costs, five runs each: `claude plugin list --json` 137 ms against an empty folder
+and 178 ms against a full one; `opencode debug config` 631 ms and 718 ms; Codex parses one
+file. A launch pays it twice — once before tmux and once in the pane — and always freshly.
+
+Three details that decide answers, all measured on 2026-09-12:
+
+- **`enabled` is the effective setting at the directory charter asks from**, merged local >
+  project > user, and every listed entry of the plugin carries the same value. A disable
+  written only to `<dir>/.claude/settings.local.json` — or only to that directory's
+  `.claude/settings.json` — flips it, so charter reads no settings file of its own.
+- **An install covering the plane covers a chat in its workspace.** `charter init` installs
+  at `project` scope for the plane root, while a chat stands in `workspaces/<ws>/`; charter
+  mirrors the plane's `enabledPlugins` into that directory, so the record that covers the
+  plane is the one that answers there.
+- **Codex records hook trust lazily**, one entry per hook as each first fires — a machine
+  that has been running charter under Codex for weeks held 12 of the plugin's 18 keys — and
+  a `trusted_hash` cannot be recomputed from the plugin's `hooks/hooks.json`. So charter
+  asks whether charter's hooks were approved in that home *at all*, and an old entry
+  survives a change to a hook's command.
+
+**Charter cannot tell** — a probe that times out, exits non-zero or answers something
+unparseable — is also a refusal, with the probe to run by hand printed beside it. An unknown
+is not a pass.
+
+**What each command does per profile:**
+
+- `charter init` installs for every approved Claude Code and opencode profile, the same two
+  doors an install may come through. A Codex profile is reported as opt-in.
+- `charter reinit` installs nothing. It writes the opencode shim into each opencode
+  profile's own config home, and for a Claude Code profile it reports the gap and names
+  `charter harness install <name>`.
+- `charter harness install <name>` resolves a profile first and a registry name second, so
+  `charter harness install codex` still means what it always did. It wires that profile's
+  own folder and then asks the harness whether that worked — and exits non-zero when it did
+  not, which is the ordinary outcome for Codex, whose plugin install and hook approval are
+  Codex's own commands. Charter prints them with `CODEX_HOME=` in front.
+- `charter doctor` shows a row per profile and probes them concurrently.
+  `charter doctor --preflight`, which the SessionStart hook runs, probes nothing and shows
+  no profile row: a probe costs a subprocess and writes into somebody's account folder, and
+  a hook's whole budget is 20 seconds.
+
+**Limits, stated rather than designed around:**
+
+- `claude plugin list --json` **writes** `.claude.json` and a `backups/` directory into the
+  folder it asks about. Charter's probe is otherwise a read.
+- **Codex's home is the one charter can see.** One a wrapper script exports on its way to
+  `codex` is invisible here, and charter will report on the wrong file without knowing it.
+- `charter dispatch`'s transcript lookup and charter's persona skill lookup answer for the
+  **default** config folder, not for a profile's. Neither is about one chat.
+- The launch record and the wiring cache under `.charter/` are **as writable by a chat as
+  `charter.local.toml` is** — no path guard covers that directory. That is why a launch
+  never trusts the cache and always probes: the cache exists to draw the selector's rows.
+
 ## `charter statusline --watch`
 
 The one worth knowing. It repaints the plane state in place in any spare terminal — no

--- a/docs/harnesses.md
+++ b/docs/harnesses.md
@@ -226,12 +226,19 @@ plugins where they are; `$CLAUDE_CONFIG_DIR` and `$CODEX_HOME` move both.
 | kind | what charter asks | what "wired" means |
 |---|---|---|
 | Claude Code | `<command> plugin list --json`, run in the chat's own directory with the profile's `env` | an install record of `charter@charter` covering that directory or the plane, whose `enabled` is true |
-| Codex | reads `$CODEX_HOME/config.toml` — no subprocess | all three: `plugins."charter@charter".enabled`, `shell_environment_policy.set.CHARTER_HARNESS = "codex"`, and at least one trusted hook of charter's |
+| Codex | reads `$CODEX_HOME/config.toml` — no subprocess | all three: `plugins."charter@charter".enabled`, `shell_environment_policy.set.CHARTER_HARNESS = "codex"`, and at least one trusted **guard** hook of charter's (`pre_tool_use`) |
 | opencode | `<command> debug config` with the profile's `env` | all three: a `plugin` entry naming charter's shim, the shim byte-identical to what charter writes, and no other file in `plugin/` |
 
 Measured costs, five runs each: `claude plugin list --json` 137 ms against an empty folder
 and 178 ms against a full one; `opencode debug config` 631 ms and 718 ms; Codex parses one
 file. A launch pays it twice — once before tmux and once in the pane — and always freshly.
+The `+`, a workspace tab, `charter reopen` and a handoff ask before they open anything, so
+their refusal has somewhere to be said, and the pane asks again; nothing in between does.
+
+**Nothing is asked of a profile charter may not run.** A probe runs the profile's own
+command, so it waits for the same two things a launch does: git would not commit
+`charter.local.toml`, and you have approved that command (`run this? [y/N]`). Until then
+`charter doctor` says which of the two it is waiting for, and probes nothing.
 
 Three details that decide answers, all measured on 2026-09-12:
 
@@ -246,8 +253,16 @@ Three details that decide answers, all measured on 2026-09-12:
 - **Codex records hook trust lazily**, one entry per hook as each first fires — a machine
   that has been running charter under Codex for weeks held 12 of the plugin's 18 keys — and
   a `trusted_hash` cannot be recomputed from the plugin's `hooks/hooks.json`. So charter
-  asks whether charter's hooks were approved in that home *at all*, and an old entry
-  survives a change to a hook's command.
+  asks whether one of charter's **guard** hooks — a `pre_tool_use` entry — was approved in
+  that home at all. An approved SessionStart hook is not enough: Codex asks about each hook
+  on its own, and that one guards nothing. An old entry survives a change to a hook's
+  command.
+- **A disabled plugin's fix is `claude plugin enable charter@charter --scope local`, run in
+  the chat's own directory**, and charter prints it with that `cd` in front. Measured on
+  claude 2.1.270 (2026-09-13): it undid a disable in that directory's `settings.local.json`,
+  in its `settings.json`, and in a git plane root's `settings.local.json`, which reaches a
+  session below it. `--scope project` and `--scope user` each exited 1 over a local disable
+  and changed nothing.
 
 **Charter cannot tell** — a probe that times out, exits non-zero or answers something
 unparseable — is also a refusal, with the probe to run by hand printed beside it. An unknown
@@ -261,8 +276,10 @@ is not a pass.
   profile's own config home, and for a Claude Code profile it reports the gap and names
   `charter harness install <name>`.
 - `charter harness install <name>` resolves a profile first and a registry name second, so
-  `charter harness install codex` still means what it always did. It wires that profile's
-  own folder and then asks the harness whether that worked — and exits non-zero when it did
+  `charter harness install codex` still means what it always did. A profile you have not
+  approved is shown and asked about first, as a launch would ask, and refused where there is
+  no terminal to ask on. It wires that profile's own folder and then asks the harness
+  whether that worked — and exits non-zero when it did
   not, which is the ordinary outcome for Codex, whose plugin install and hook approval are
   Codex's own commands. Charter prints them with `CODEX_HOME=` in front.
 - `charter doctor` shows a row per profile and probes them concurrently.
@@ -281,6 +298,12 @@ is not a pass.
 - The launch record and the wiring cache under `.charter/` are **as writable by a chat as
   `charter.local.toml` is** — no path guard covers that directory. That is why a launch
   never trusts the cache and always probes: the cache exists to draw the selector's rows.
+  An entry is stamped with the config folder's two files and every `.claude/settings.json`
+  and `settings.local.json` from the chat's directory up to the plane root, and an entry
+  that is a day old or dated ahead is not used.
+- A config file a chat left in a shape the harness never writes — a `plugins."charter@charter"
+  = true`, a trust entry that is a string, a NUL byte in a profile's path — is **charter
+  could not tell**, and refuses like any other unknown.
 
 ## `charter statusline --watch`
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -108,7 +108,10 @@ every profile you declared, plus a built-in for each harness whose program is in
 answering whether charter's guard actually runs in the config folder that profile names.
 A yellow row names `charter harness install <name>`, which is the same command a refused
 launch prints. They are probed concurrently, each with its own timeout, and a probe that
-raises costs that row and nothing else.
+raises costs that row and nothing else. A profile you have not approved yet is not probed —
+its row says so and names `charter <name>`, which shows the command and asks — and neither
+is any profile while git would commit `charter.local.toml`. A row too long for the table
+says how much it left out (`… +12 not shown`) rather than stopping mid-word.
 
 **The SessionStart hook runs `charter doctor --preflight`**, which is the same preflight
 with two things left out: it probes no profile and makes no git call for one. A probe is a

--- a/docs/install.md
+++ b/docs/install.md
@@ -101,6 +101,22 @@ plugin loads nothing until it is enabled. charter will not enable it for you —
 plugin enable charter@charter --scope project` is yours to run, since turning a plugin off
 is a choice and charter does not revert a deliberate edit.
 
+**`harness profiles` and `profile <name>`.** The first row reads this machine's
+`charter.local.toml` and says how many profiles charter found, or why one was refused, or
+that git would commit the file. After it comes one row per profile charter would offer —
+every profile you declared, plus a built-in for each harness whose program is installed —
+answering whether charter's guard actually runs in the config folder that profile names.
+A yellow row names `charter harness install <name>`, which is the same command a refused
+launch prints. They are probed concurrently, each with its own timeout, and a probe that
+raises costs that row and nothing else.
+
+**The SessionStart hook runs `charter doctor --preflight`**, which is the same preflight
+with two things left out: it probes no profile and makes no git call for one. A probe is a
+subprocess that writes into somebody's account folder, and the hook's whole budget is 20
+seconds. So the `profile <name>` rows appear only when you run `charter doctor` yourself.
+(Codex trusts hooks by their hash, so Codex users approve that hook once more after this
+release — its command changed.)
+
 **Which Claude Code config folder these rows answer for.** `$CLAUDE_CONFIG_DIR` points Claude
 Code at another folder — the usual way to run a second account — and Claude Code then keeps
 that folder's own plugins, settings and `.claude.json`. Run `charter doctor` from the shell you

--- a/docs/news/unreleased-harness-profiles.md
+++ b/docs/news/unreleased-harness-profiles.md
@@ -76,10 +76,12 @@ doctor` now shows a row per profile.
 chat that looks guarded and is not is the same failure whichever profile started it, and no
 flag starts one unguarded.
 
-`charter init` installs for each Claude Code and opencode profile you declared; `charter
-reinit` installs nothing, writing only the opencode shim and naming the install command for
-anything else; Codex stays opt-in through `charter harness install`, which prints the
-plugin and hook-approval steps Codex only accepts from you, with `CODEX_HOME=` in front.
+Nothing is asked of a profile before you have approved its command, because asking runs
+it. Once you have, `charter init` installs for each Claude Code and opencode profile you
+declared; `charter reinit` installs nothing, writing only the opencode shim and naming the
+install command for anything else; Codex stays opt-in through `charter harness install`,
+which asks first like a launch does and prints the plugin and hook-approval steps Codex
+only accepts from you, with `CODEX_HOME=` in front.
 
 **Codex users: approve charter's SessionStart hook once more.** Its command gained
 `--preflight`, and Codex trusts a hook by the hash of its command. The flag is what keeps

--- a/docs/news/unreleased-harness-profiles.md
+++ b/docs/news/unreleased-harness-profiles.md
@@ -62,3 +62,26 @@ before tmux; the `+` and a workspace tab ask in the new chat's own pane, because
 behind them has no terminal and the pane has one. The record lives under `.charter/`, which
 a chat can write as easily as it can write `charter.local.toml` — so this catches a command
 you did not change yourself unless whatever changed it also forged the record.
+
+**A profile is wired, or it refuses to start.** Charter's guard lives in the harness's own
+config folder, and a profile names another one — so charter asks the harness, under that
+profile's own command and environment, whether its plugin or shim is actually there. A
+profile whose folder does not carry it refuses to launch, says what is missing and prints
+`charter harness install <profile>`, which wires that folder. A probe that cannot answer
+refuses too, and names the command to run by hand: an unknown is not a pass. `charter
+doctor` now shows a row per profile.
+
+**This includes the built-ins.** `charter codex` on a plane where nobody wired Codex, and
+`charter opencode` where `init` never wrote its shim, now refuse where they used to start. A
+chat that looks guarded and is not is the same failure whichever profile started it, and no
+flag starts one unguarded.
+
+`charter init` installs for each Claude Code and opencode profile you declared; `charter
+reinit` installs nothing, writing only the opencode shim and naming the install command for
+anything else; Codex stays opt-in through `charter harness install`, which prints the
+plugin and hook-approval steps Codex only accepts from you, with `CODEX_HOME=` in front.
+
+**Codex users: approve charter's SessionStart hook once more.** Its command gained
+`--preflight`, and Codex trusts a hook by the hash of its command. The flag is what keeps
+the probes off the hook path: `charter doctor --preflight` runs every other check and asks
+no harness anything.

--- a/docs/news/unreleased-harness-profiles.md
+++ b/docs/news/unreleased-harness-profiles.md
@@ -86,4 +86,8 @@ only accepts from you, with `CODEX_HOME=` in front.
 **Codex users: approve charter's SessionStart hook once more.** Its command gained
 `--preflight`, and Codex trusts a hook by the hash of its command. The flag is what keeps
 the probes off the hook path: `charter doctor --preflight` runs every other check and asks
-no harness anything.
+no harness anything. The CLI and the plugin release together, and until the CLI is updated
+too, a session start with the new plugin runs **no preflight check at all**: the older CLI
+rejects the flag, the hook still exits 0, and the session opens with `charter preflight
+failed - fix before working:` over `charter: error: unrecognized arguments: --preflight`.
+`charter update` moves the CLI, and the line goes away.

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -19,7 +19,7 @@
           },
           {
             "type": "command",
-            "command": "out=\"$(charter doctor 2>&1)\" || printf 'charter preflight failed - fix before working:\\n%s\\n' \"$out\"",
+            "command": "out=\"$(charter doctor --preflight 2>&1)\" || printf 'charter preflight failed - fix before working:\\n%s\\n' \"$out\"",
             "timeout": 20,
             "statusMessage": "charter preflight (charter doctor)"
           },

--- a/tests/_claudeguard.py
+++ b/tests/_claudeguard.py
@@ -58,6 +58,34 @@ sys.exit(0)
 '''
 
 
+#: A fake `opencode`, for the same reason and one release later.
+#:
+#: `doctor`'s per-profile wiring rows probe every LISTED profile, and a built-in is listed
+#: when its program is on `PATH` — so on a laptop with opencode installed, every module that
+#: reaches `doctor.run_all()` would spawn the real binary (measured: 631-718 ms a call).
+#: `[]` means *opencode is here and charter's shim is not*, which is the answer CI gives and
+#: the one every assertion in the suite was written against.
+_FAKE_OPENCODE = '''#!/usr/bin/env python3
+"""The test suite's `opencode`. See tests/_claudeguard.py — nothing here is real."""
+import json, os, sys
+from pathlib import Path
+
+if sys.argv[1:3] == ["debug", "config"]:
+    # The one thing the real binary does that any test could care about: it lists every
+    # plugin in `<XDG_CONFIG_HOME>/opencode/plugin/` as a `file://` URI, with the
+    # un-resolved spelling (measured against 1.18.23). Listing `[]` unconditionally would
+    # make `charter harness install opencode` report a shim it had just written as absent.
+    xdg = os.environ.get("XDG_CONFIG_HOME") or os.path.join(os.path.expanduser("~"), ".config")
+    d = Path(xdg) / "opencode" / "plugin"
+    try:
+        here = sorted(p for p in d.iterdir() if p.suffix in (".ts", ".js"))
+    except OSError:
+        here = []
+    print(json.dumps({"plugin": [f"file://{p}" for p in here]}))
+sys.exit(0)
+'''
+
+
 def install() -> None:
     """Arm both halves. Idempotent, and called once from `tests/__init__.py`."""
     from charter import plugincache
@@ -66,13 +94,17 @@ def install() -> None:
     # every binary the suite looks up — `git`, `gh`, `tmux` — and this is a statement about
     # one of them. It is also the exact seam every existing opt-in already patches, so a
     # test that wants the other answer needs to know one name and not two.
-    plugincache.available = lambda: False
+    # `*a, **k`, not a zero-argument lambda: `available` takes the COMMAND to look up now,
+    # because a profile names its own (`["/opt/claude-wrap"]`), and the first call passing
+    # one would otherwise be a `TypeError` out of the guard rather than an answer.
+    plugincache.available = lambda *a, **k: False
 
     d = Path(tempfile.mkdtemp(prefix="charter-suite-claude-")) / "bin"
     d.mkdir(parents=True, exist_ok=True)
-    fake = d / "claude"
-    fake.write_text(_FAKE)
-    fake.chmod(fake.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+    for name, body in (("claude", _FAKE), ("opencode", _FAKE_OPENCODE)):
+        fake = d / name
+        fake.write_text(body)
+        fake.chmod(fake.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
     # PREPENDED, not appended: the operator's real `claude` is further down this same PATH
     # and appending would leave it winning. A child that spawns a grandchild inherits this
     # too, which is the point.

--- a/tests/_claudeguard.py
+++ b/tests/_claudeguard.py
@@ -86,6 +86,12 @@ sys.exit(0)
 '''
 
 
+#: `plugincache.available` as charter wrote it, kept before :func:`install` stands in for it
+#: — for the one kind of case that is ABOUT how a program is looked up (which `PATH`), and
+#: stubs `util.run` underneath so nothing it finds is ever spawned.
+REAL_AVAILABLE = None
+
+
 def install() -> None:
     """Arm both halves. Idempotent, and called once from `tests/__init__.py`."""
     from charter import plugincache
@@ -97,6 +103,9 @@ def install() -> None:
     # `*a, **k`, not a zero-argument lambda: `available` takes the COMMAND to look up now,
     # because a profile names its own (`["/opt/claude-wrap"]`), and the first call passing
     # one would otherwise be a `TypeError` out of the guard rather than an answer.
+    global REAL_AVAILABLE
+    if REAL_AVAILABLE is None:
+        REAL_AVAILABLE = plugincache.available
     plugincache.available = lambda *a, **k: False
 
     d = Path(tempfile.mkdtemp(prefix="charter-suite-claude-")) / "bin"

--- a/tests/_isolation.py
+++ b/tests/_isolation.py
@@ -436,8 +436,12 @@ class ATerminal(io.StringIO):
         return True
 
 
-def approve_profile(case, name: str = "claude-work"):
+def approve_profile(case, name="claude-work"):
     """Seed *name*'s launch record, the way an operator who already said yes once has.
+
+    *name* may also be a `profiles.Profile` built by hand, for a case whose subject is what
+    happens to a profile once it is approved and which never declares it in a file — the
+    record is keyed by the profile's name and holds what it runs, whichever way it was made.
 
     **A real-tmux test that launches a declared profile has to call this** (Global
     Constraint, N6). `_launch` passes `--attended` for an open somebody is in front of,
@@ -452,9 +456,9 @@ def approve_profile(case, name: str = "claude-work"):
     """
     from charter import profiles, profiletrust
 
-    p = profiles.current().profiles[name]
+    p = name if isinstance(name, profiles.Profile) else profiles.current().profiles[name]
     why = profiletrust.record_launched(p)
-    case.assertEqual(why, "", f"the launch record for '{name}' could not be written")
+    case.assertEqual(why, "", f"the launch record for '{p.name}' could not be written")
     return p
 
 

--- a/tests/_isolation.py
+++ b/tests/_isolation.py
@@ -488,6 +488,34 @@ def assert_approved(name: str = "claude-work") -> None:
             f"no launch record for '{name}' — its pane would wait at run this? [y/N]")
 
 
+def wired_as_today(case=None):
+    """Let every profile launch, for a case whose subject is not wiring (ruling 10).
+
+    Task 4 refuses a profile whose config folder does not carry charter's guard, and that
+    applies to built-ins: a launch test would otherwise refuse where it used to start.
+    In-process the suite's own guard makes `plugincache.available` answer False, so
+    detection reads UNKNOWN and refuses; in a CHILD process its fake `claude` answers `[]`,
+    which reads as unwired. Either way the answer is "not wired", and a test about `+`,
+    tabs or reopen is not about that.
+
+    `wiring.refusal` and not `wiring.detect`, so the probe seam stays available to the
+    module that IS about wiring. **A real-tmux test cannot use this** — a pane is a child
+    process no patch reaches — so those declare a profile whose `command` is their own
+    recorder, and the recorder answers `plugin list --json` with a covering, enabled entry.
+
+    Given no *case* it returns the patcher instead of entering it, for a module where NO
+    test is about wiring — `setUpModule` starts it and `tearDownModule` stops it, which is
+    one fixture rather than one per class in a file with thirty of them.
+    """
+    from charter import wiring
+
+    patcher = mock.patch.object(wiring, "refusal", lambda p, *, cwd: "")
+    if case is None:
+        return patcher
+    case.enterContext(patcher)
+    return None
+
+
 def isolate_state_dir(case) -> Path:
     """Point ``config.STATE_DIR`` at a throwaway dir for one test case, restoring after.
 

--- a/tests/test_a_background_chat_really_starts_on_its_brief.py
+++ b/tests/test_a_background_chat_really_starts_on_its_brief.py
@@ -54,7 +54,26 @@ from charter.frame import layout, state, tmuxctl
 _REPO_ROOT = Path(__file__).resolve().parents[1]
 
 from tests import _tmuxreap, _tmuxsocket
-from tests._isolation import PersonaIso, make_plane, no_update_check_in
+from tests._isolation import PersonaIso, make_plane, no_update_check_in, wired_as_today
+
+
+#: Ruling 10: a profile whose config folder does not carry charter's guard refuses to
+#: launch, and that applies to the built-ins every launch test here starts. In-process the
+#: suite's `claude` guard makes detection read UNKNOWN, so every one of them would refuse
+#: over a fact none of them is about. One fixture for the module, because no test in it is
+#: about wiring; `tests/test_a_profile_is_wired_or_refuses.py` is where that is the subject.
+_WIRED = None
+
+
+def setUpModule():
+    global _WIRED
+    _WIRED = wired_as_today()
+    _WIRED.start()
+
+
+def tearDownModule():
+    if _WIRED is not None:
+        _WIRED.stop()
 
 _HAS_TMUX = shutil.which("tmux") is not None
 
@@ -119,6 +138,15 @@ class _TwoChatsOnARealServer(PersonaIso):
         self.recorder.write_text(
             f"#!{sys.executable}\n"
             "import json, os, sys, time\n"
+            # **The wiring probe is answered first** (ruling 10): a pane's first process is
+            # charter's launcher, and it asks this very binary `plugin list --json` before
+            # it execs it. Falling through to the recording below would answer the probe
+            # with an argv dump, and the launch would refuse. One covering, ENABLED entry —
+            # `user` scope covers every directory (`plugincache.covers`).
+            "if sys.argv[1:3] == ['plugin', 'list']:\n"
+            "    json.dump([{'id': 'charter@charter', 'scope': 'user', 'enabled': True,\n"
+            "                'installedAt': '2026-09-12T00:00:00Z'}], sys.stdout)\n"
+            "    sys.exit(0)\n"
             "p = os.path.join(os.environ['RECORD_DIR'],\n"
             "                 os.environ['TMUX_PANE'].lstrip('%') + '.json')\n"
             "with open(p + '.tmp', 'w') as f:\n"

--- a/tests/test_a_chat_carries_its_profile.py
+++ b/tests/test_a_chat_carries_its_profile.py
@@ -29,7 +29,26 @@ from charter.frame import chats, choose, leave, reopen as reopen_state, state
 from tests import _gitguard
 from tests._isolation import (APipe as _APipe, PersonaIso,
                               approve_every_profile, approve_profile,
-                              declare_profiles, make_plane)
+                              declare_profiles, make_plane, wired_as_today)
+
+
+#: Ruling 10: a profile whose config folder does not carry charter's guard refuses to
+#: launch, and that applies to the built-ins every launch test here starts. In-process the
+#: suite's `claude` guard makes detection read UNKNOWN, so every one of them would refuse
+#: over a fact none of them is about. One fixture for the module, because no test in it is
+#: about wiring; `tests/test_a_profile_is_wired_or_refuses.py` is where that is the subject.
+_WIRED = None
+
+
+def setUpModule():
+    global _WIRED
+    _WIRED = wired_as_today()
+    _WIRED.start()
+
+
+def tearDownModule():
+    if _WIRED is not None:
+        _WIRED.stop()
 
 
 #: The real `subprocess.run`, captured before any fixture below patches the module

--- a/tests/test_a_chat_is_locked_to_the_workspace_it_was_launched_for.py
+++ b/tests/test_a_chat_is_locked_to_the_workspace_it_was_launched_for.py
@@ -51,8 +51,27 @@ from unittest import mock
 from charter import commands_frame, commands_workspace, config, hooks, todos, workspace
 from charter.frame import state
 
-from tests._isolation import PersonaIso, PlaneIso, no_background_refresh, run_hook
+from tests._isolation import PersonaIso, PlaneIso, no_background_refresh, run_hook, wired_as_today
 from tests.test_a_chat_records_where_it_was_started import _DrivesTheLauncher
+
+
+#: Ruling 10: a profile whose config folder does not carry charter's guard refuses to
+#: launch, and that applies to the built-ins every launch test here starts. In-process the
+#: suite's `claude` guard makes detection read UNKNOWN, so every one of them would refuse
+#: over a fact none of them is about. One fixture for the module, because no test in it is
+#: about wiring; `tests/test_a_profile_is_wired_or_refuses.py` is where that is the subject.
+_WIRED = None
+
+
+def setUpModule():
+    global _WIRED
+    _WIRED = wired_as_today()
+    _WIRED.start()
+
+
+def tearDownModule():
+    if _WIRED is not None:
+        _WIRED.stop()
 
 #: The chat, as the launcher names it, and what `$CHARTER_SESSION_ID` holds inside it.
 CHAT = "north.1"

--- a/tests/test_a_chat_opens_in_the_background_with_its_first_message.py
+++ b/tests/test_a_chat_opens_in_the_background_with_its_first_message.py
@@ -32,7 +32,26 @@ from charter.frame import state
 from charter.harness import claude_code
 
 from tests import _tmuxsocket
-from tests._isolation import PersonaIso
+from tests._isolation import PersonaIso, wired_as_today
+
+
+#: Ruling 10: a profile whose config folder does not carry charter's guard refuses to
+#: launch, and that applies to the built-ins every launch test here starts. In-process the
+#: suite's `claude` guard makes detection read UNKNOWN, so every one of them would refuse
+#: over a fact none of them is about. One fixture for the module, because no test in it is
+#: about wiring; `tests/test_a_profile_is_wired_or_refuses.py` is where that is the subject.
+_WIRED = None
+
+
+def setUpModule():
+    global _WIRED
+    _WIRED = wired_as_today()
+    _WIRED.start()
+
+
+def tearDownModule():
+    if _WIRED is not None:
+        _WIRED.stop()
 
 
 def _completed(cmd, rc=0, out=""):

--- a/tests/test_a_chat_pane_starts_as_charter_and_becomes_the_harness.py
+++ b/tests/test_a_chat_pane_starts_as_charter_and_becomes_the_harness.py
@@ -40,7 +40,27 @@ from charter.frame import launcher, state, tmuxctl
 from tests import _gitguard, _tmuxreap, _tmuxsocket, _ttyguard
 from tests._isolation import (PersonaIso, approve_profile, assert_approved,
                               declare_profiles, make_plane, no_background_refresh,
-                              no_update_check_in)
+                              no_update_check_in, wired_as_today)
+
+
+#: Ruling 10: a profile whose config folder does not carry charter's guard refuses to
+#: launch, and that applies to the built-ins every launch test here starts. In-process the
+#: suite's `claude` guard makes detection read UNKNOWN, so every one of them would refuse
+#: over a fact none of them is about. One fixture for the module, because no test in it is
+#: about wiring; `tests/test_a_profile_is_wired_or_refuses.py` is where that is the subject.
+_WIRED = None
+
+
+def setUpModule():
+    global _WIRED
+    _WIRED = wired_as_today()
+    _WIRED.start()
+
+
+def tearDownModule():
+    if _WIRED is not None:
+        _WIRED.stop()
+
 
 _HAS_TMUX = shutil.which("tmux") is not None
 
@@ -129,6 +149,14 @@ class _ARealChatOnARealServer(PersonaIso):
         (bindir / "claude").write_text(
             f"#!{sys.executable}\n"
             "import json, os, sys, time\n"
+            # **The wiring probe is answered first** (ruling 10). The launcher asks this
+            # binary `plugin list --json` before it execs it, and a recorder that recorded
+            # THAT call would both overwrite the measurement and leave the launch refusing.
+            # `user` scope covers every directory (`plugincache.covers`).
+            "if sys.argv[1:3] == ['plugin', 'list']:\n"
+            "    json.dump([{'id': 'charter@charter', 'scope': 'user', 'enabled': True,\n"
+            "                'installedAt': '2026-09-12T00:00:00Z'}], sys.stdout)\n"
+            "    sys.exit(0)\n"
             "out = os.path.join(os.environ['RECORD_DIR'], 'harness.json')\n"
             "with open(out + '.tmp', 'w') as f:\n"
             "    json.dump({'argv': sys.argv[1:], 'env': dict(os.environ),\n"

--- a/tests/test_a_chat_pane_starts_as_charter_and_becomes_the_harness.py
+++ b/tests/test_a_chat_pane_starts_as_charter_and_becomes_the_harness.py
@@ -162,7 +162,15 @@ class _ARealChatOnARealServer(PersonaIso):
             "    json.dump({'argv': sys.argv[1:], 'env': dict(os.environ),\n"
             "               'pid': os.getpid()}, f)\n"
             "os.replace(out + '.tmp', out)\n"
-            f"{'sys.exit(' + str(self.EXIT_WITH) + ')' if self.EXIT_WITH is not None else 'time.sleep(300)'}\n")
+            # A beat before the exit, and it is not decoration. `_launch` reports an EARLY
+            # DEATH — the harness's own code, rather than 0 — for a pane that dies while it
+            # is still setting the frame up, and a harness that exits the instant it is
+            # exec'd races that window. Measured on CI (3.12, 2026-09-12): the launch
+            # answered 7 instead of 0 on a loaded runner, having answered 0 on four
+            # interpreters an hour earlier. What this class is about is that the code
+            # TRAVELS, which the assertions below read off the chat's own state; whether it
+            # also arrives through the early-death path is a different test's subject.
+            f"{'time.sleep(1); sys.exit(' + str(self.EXIT_WITH) + ')' if self.EXIT_WITH is not None else 'time.sleep(300)'}\n")
         (bindir / "claude").chmod(0o755)
         self.enterContext(mock.patch.dict(os.environ, {
             # First on the client's `PATH`, ahead of `tests/_claudeguard`'s own fake: the

--- a/tests/test_a_chat_records_where_it_was_started.py
+++ b/tests/test_a_chat_records_where_it_was_started.py
@@ -27,7 +27,26 @@ from unittest import mock
 from charter import commands_frame, config
 from charter.frame import reopen, state
 
-from tests._isolation import PersonaIso
+from tests._isolation import PersonaIso, wired_as_today
+
+
+#: Ruling 10: a profile whose config folder does not carry charter's guard refuses to
+#: launch, and that applies to the built-ins every launch test here starts. In-process the
+#: suite's `claude` guard makes detection read UNKNOWN, so every one of them would refuse
+#: over a fact none of them is about. One fixture for the module, because no test in it is
+#: about wiring; `tests/test_a_profile_is_wired_or_refuses.py` is where that is the subject.
+_WIRED = None
+
+
+def setUpModule():
+    global _WIRED
+    _WIRED = wired_as_today()
+    _WIRED.start()
+
+
+def tearDownModule():
+    if _WIRED is not None:
+        _WIRED.stop()
 
 
 class TheDirectoryIsRecordedAndReadBack(PersonaIso, unittest.TestCase):

--- a/tests/test_a_filesystem_that_refuses_costs_what_it_says.py
+++ b/tests/test_a_filesystem_that_refuses_costs_what_it_says.py
@@ -49,13 +49,32 @@ from charter import commands_frame, config, inflight, persona, util
 from charter import workspace as ws_mod
 from charter.frame import leave, reopen, state
 
-from tests._isolation import PersonaIso
+from tests._isolation import PersonaIso, wired_as_today
 
 
 def _refuse(*_a, **_kw):
     """What a filesystem that will not do the thing raises. `EACCES` rather than a bare
     `OSError()`, because a guard narrowed to a SUBCLASS would still catch a bare one."""
     raise PermissionError(13, "refused")
+
+
+#: Ruling 10: a reopen asks whether each chat's profile is wired before it starts it
+#: (`commands_frame._reopen_one`), and in-process the suite's `claude` guard makes that read
+#: as "could not tell" — a refusal no case here is about. One fixture for the module;
+#: `tests/test_a_profile_is_wired_or_refuses.py` is where a reopen of an unwired profile is
+#: the subject.
+_WIRED = None
+
+
+def setUpModule():
+    global _WIRED
+    _WIRED = wired_as_today()
+    _WIRED.start()
+
+
+def tearDownModule():
+    if _WIRED is not None:
+        _WIRED.stop()
 
 
 class _FrameRoot(PersonaIso):

--- a/tests/test_a_frame_sends_one_invocation_per_batch.py
+++ b/tests/test_a_frame_sends_one_invocation_per_batch.py
@@ -59,7 +59,7 @@ from charter import commands_frame, config
 from charter.frame import state, tmuxctl
 
 from tests import _tmuxchain, _tmuxreap
-from tests._isolation import PersonaIso
+from tests._isolation import PersonaIso, wired_as_today
 # At module scope, and that is load-bearing rather than tidy: `test_frame_launcher`
 # captures the developer's real `config.STATE_DIR` at IMPORT time and refuses to run a
 # real `cmd_launch` against it. Imported from inside a test method — after `PersonaIso`
@@ -67,6 +67,25 @@ from tests._isolation import PersonaIso
 # one" and refuse every launch here for a plane nobody owns.
 from tests.test_frame_chat_switch import _FakeServer, _plant
 from tests.test_frame_launcher import _FakeTmux, _launch
+
+
+#: Ruling 10: a profile whose config folder does not carry charter's guard refuses to
+#: launch, and that applies to the built-ins every launch test here starts. In-process the
+#: suite's `claude` guard makes detection read UNKNOWN, so every one of them would refuse
+#: over a fact none of them is about. One fixture for the module, because no test in it is
+#: about wiring; `tests/test_a_profile_is_wired_or_refuses.py` is where that is the subject.
+_WIRED = None
+
+
+def setUpModule():
+    global _WIRED
+    _WIRED = wired_as_today()
+    _WIRED.start()
+
+
+def tearDownModule():
+    if _WIRED is not None:
+        _WIRED.stop()
 
 _HAS_TMUX = shutil.which("tmux") is not None
 

--- a/tests/test_a_green_doctor_row_keeps_nothing_back.py
+++ b/tests/test_a_green_doctor_row_keeps_nothing_back.py
@@ -102,7 +102,7 @@ class TheFrameRowStillReachesTheReader(unittest.TestCase):
         self.assertIn("charter frame-resize", r.render())
 
 
-class TheSweepCanActuallyFail(unittest.TestCase):
+class TheSweepCanActuallyFail(PersonaIso):
     """The sweep below has no real violator to find, so this proves it would find one.
 
     Without this, `test_no_check_hides_a_sentence_in_a_hint_it_will_never_print` passes on
@@ -121,7 +121,10 @@ class TheSweepCanActuallyFail(unittest.TestCase):
 
     def test_the_real_check_set_is_not_empty(self):
         """`run_all` returning nothing would satisfy the sweep vacuously, and it is the
-        one input the sweep does not choose for itself."""
+        one input the sweep does not choose for itself.
+
+        `PersonaIso` because `check_names` lists a row per harness profile now, read off
+        `charter.local.toml` — a file `tests/_planeguard` refuses for the real plane."""
         self.assertTrue(doctor.check_names())
 
 

--- a/tests/test_a_handoff_lands_at_the_front_of_the_strip.py
+++ b/tests/test_a_handoff_lands_at_the_front_of_the_strip.py
@@ -41,11 +41,30 @@ from charter import (commands_frame, commands_handoff, config, statusline, tui,
 from charter.frame import (builtin_actions, builtins, choose, chrome, picker,
                            notify, slots, state, switch)
 
-from tests._isolation import PersonaIso
+from tests._isolation import PersonaIso, wired_as_today
 from tests.test_a_chat_opens_in_the_background_with_its_first_message import (
     TheLaunchOpensWithoutMovingAnyone)
 from tests.test_a_handoff_refuses_before_it_changes_anything import _AHandoffFromAlpha
 from tests.test_a_workspace_tab_opens_what_it_names import _a_chat, _OpensBeta, _Server
+
+
+#: Ruling 10, and the reason is inherited with the fixture: `ALaunchThatAttachesClearsTheMark`
+#: re-runs `TheLaunchOpensWithoutMovingAnyone`'s real `_launch`, whose own module stands in
+#: `wiring.refusal` — but a module fixture belongs to the module that runs it, so here the
+#: suite's `claude` guard read every one of those launches as "could not tell" and refused
+#: it. No test in this module is about wiring.
+_WIRED = None
+
+
+def setUpModule():
+    global _WIRED
+    _WIRED = wired_as_today()
+    _WIRED.start()
+
+
+def tearDownModule():
+    if _WIRED is not None:
+        _WIRED.stop()
 
 #: The glyph the strip draws in the mark cell for a workspace a handoff landed in, spelled
 #: by hand rather than read off `slots._ARRIVED_MARK`. A test that took the constant from

--- a/tests/test_a_launch_too_long_for_tmux_says_so.py
+++ b/tests/test_a_launch_too_long_for_tmux_says_so.py
@@ -30,9 +30,29 @@ from unittest import mock
 from charter.frame import launcher, layout, tmuxctl
 
 from tests import _tmuxreap, _tmuxsocket
-from tests._isolation import PersonaIso
+from tests._isolation import PersonaIso, wired_as_today
 from tests.test_frame_launcher import (_FakeOperatorTmux, _FakeTmux, _launch,
                                        _launch_inside)
+
+
+#: Ruling 10: a profile whose config folder does not carry charter's guard refuses to
+#: launch, and that applies to the built-ins every launch test here starts. In-process the
+#: suite's `claude` guard makes detection read UNKNOWN, so every one of them would refuse
+#: over a fact none of them is about. One fixture for the module, because no test in it is
+#: about wiring; `tests/test_a_profile_is_wired_or_refuses.py` is where that is the subject.
+_WIRED = None
+
+
+def setUpModule():
+    global _WIRED
+    _WIRED = wired_as_today()
+    _WIRED.start()
+
+
+def tearDownModule():
+    if _WIRED is not None:
+        _WIRED.stop()
+
 
 _HAS_TMUX = shutil.which("tmux") is not None
 

--- a/tests/test_a_new_or_changed_profile_asks_once.py
+++ b/tests/test_a_new_or_changed_profile_asks_once.py
@@ -38,8 +38,27 @@ from charter.frame import launcher, reopen as reopen_state, state
 from tests import _gitguard
 from tests._isolation import (APipe as _APipe, ATerminal as _ATerminal, PersonaIso,
                               Typed as _Typed, approve_profile, assert_approved,
-                              declare_profiles, make_plane)
+                              declare_profiles, make_plane, wired_as_today)
 from tests.test_a_profile_launch_is_refused_before_tmux import _ALaunchNamesAProfile
+
+
+#: Ruling 10: a profile whose config folder does not carry charter's guard refuses to
+#: launch, and every launch here is an approved or built-in profile the suite's `claude`
+#: guard would otherwise read as unwired. This module is about the ASK; whether the ask's
+#: yes still meets the wiring refusal behind it is
+#: `tests/test_a_profile_is_wired_or_refuses.py`'s subject, where nothing stands in for it.
+_WIRED = None
+
+
+def setUpModule():
+    global _WIRED
+    _WIRED = wired_as_today()
+    _WIRED.start()
+
+
+def tearDownModule():
+    if _WIRED is not None:
+        _WIRED.stop()
 
 
 class _ADeclaringPlane(PersonaIso):
@@ -284,6 +303,17 @@ class TheAsk(_ADeclaringPlane, unittest.TestCase):
         self.assertNotIn("\x1b", said)
         # `contain.readable`'s own spelling for a byte that is not printable ASCII.
         self.assertIn("\\u000d", said)
+
+    def test_a_name_that_never_passed_the_name_rule_is_still_escaped_in_the_prompt(self):
+        """`_prompt` contains the NAME too, and every name that reaches it today passed
+        `profiles.NAME_RE` — so a sweep cannot tell that containment from its absence. It is
+        kept for ruling 35's reason (the prompt is the one line that must never be redrawn)
+        and pinned here with a `Profile` built by hand, past the rule that would refuse it."""
+        p = profiles.Profile(name="evil\x1b[2Kname", kind="claude", harness="claude-code",
+                             command=("claude",), env=(), source=profiles.LOCAL_FILE)
+        said = profiletrust._prompt(p, profiletrust.NEW, {})
+        self.assertNotIn("\x1b", said)
+        self.assertIn("evil\\u001b[2Kname", said)
 
     def test_a_control_byte_in_an_env_value_is_shown_escaped_too(self):
         """The `env` is on the prompt beside the command, and it comes out of the same

--- a/tests/test_a_profile_is_wired_or_refuses.py
+++ b/tests/test_a_profile_is_wired_or_refuses.py
@@ -304,6 +304,35 @@ class ClaudeCodeIsAskedUnderTheProfilesEnvironment(PersonaIso, unittest.TestCase
                           "claude", "plugin", "enable", plugincache.PLUGIN_ID,
                           "--scope", "local"])
 
+    def test_install_looks_the_command_up_on_the_profiles_own_path_too(self):
+        """A2, second pass: `charter harness install` and `init` reach `plugincache.install`,
+        which asked the process `PATH` and answered `unavailable` for a program that lives
+        only on the profile's own."""
+        bin_dir = self.tmp / "install-bin"
+        bin_dir.mkdir()
+        program = bin_dir / "claude-install-only-here"
+        program.write_text("#!/bin/sh\nexit 0\n")
+        program.chmod(0o755)
+        p = approve_profile(self, make_profile("claude-ipath",
+                                               command=["claude-install-only-here"],
+                                               env=[("PATH", str(bin_dir))]))
+        ran = []
+        real = util.run
+
+        def run(cmd, *a, **kw):
+            if list(cmd)[:1] == ["git"]:
+                return real(cmd, *a, **kw)
+            ran.append(list(cmd))
+            out = listing() if "list" in cmd else ""
+            return SimpleNamespace(returncode=0, stdout=out, stderr="")
+
+        with mock.patch.object(plugincache, "available", _claudeguard.REAL_AVAILABLE), \
+                mock.patch.object(util, "run", run):
+            got = wiring.install(p, self.here)
+        self.assertEqual([s for s, _l in got], ["installed"], got)
+        self.assertIn(["claude-install-only-here", "plugin", "install", plugincache.PLUGIN_ID,
+                       "--scope", plugincache.INSTALL_SCOPE, "-y"], ran)
+
     def test_a_fix_for_a_directory_with_a_space_can_still_be_pasted(self):
         """A11: every path and word is shell-quoted, so the line survives the paste."""
         here = self.tmp / "a dir; with parts"
@@ -474,6 +503,25 @@ TRUST_KEY = f"{plugincache.PLUGIN_ID}:hooks/hooks.json:pre_tool_use:0:0"
 NOT_A_GUARD_KEY = f"{plugincache.PLUGIN_ID}:hooks/hooks.json:session_start:0:0"
 
 
+#: A trust entry for charter's DISPATCH hook — `pretooluse-dispatch`, the `Task|Agent` group,
+#: which is a `pre_tool_use` hook and not the guard that refuses a shell command.
+DISPATCH_KEY = f"{plugincache.PLUGIN_ID}:hooks/hooks.json:pre_tool_use:2:0"
+
+
+def plugin_in_codex_cache(home: Path, hooks_doc: dict | None = None,
+                          version: str = "0.60.0") -> Path:
+    """The charter plugin as Codex installs it under *home*: its `hooks/hooks.json` at
+    `plugins/cache/<marketplace>/<plugin>/<version>/` (D4). The trust ledger's
+    `<event>:<group>:<hook>` positions are positions in THIS file, so it is where charter
+    reads which one is its guard. Given no *hooks_doc*, the repository's own."""
+    d = home / "plugins" / "cache" / "charter" / "charter" / version / "hooks"
+    d.mkdir(parents=True, exist_ok=True)
+    doc = hooks_doc if hooks_doc is not None else json.loads(
+        (REPO / "hooks" / "hooks.json").read_text())
+    (d / "hooks.json").write_text(json.dumps(doc))
+    return d / "hooks.json"
+
+
 def codex_config(*, plugin=True, policy=True, trust=True) -> str:
     doc = []
     if plugin:
@@ -497,6 +545,7 @@ class CodexIsReadAtTheProfilesHome(PersonaIso, unittest.TestCase):
         super().setUp()
         self.home = self.tmp / "codex-home"
         self.home.mkdir()
+        plugin_in_codex_cache(self.home)
         self.p = approve_profile(self, make_profile("codex-alt", kind="codex",
                                                     env=[("CODEX_HOME", str(self.home))]))
 
@@ -566,6 +615,67 @@ class CodexIsReadAtTheProfilesHome(PersonaIso, unittest.TestCase):
         self.assertEqual(w.state, wiring.UNWIRED)
         self.assertIn("no guard hook of charter's is trusted", w.detail)
 
+    def test_a_trusted_dispatch_hook_alone_is_not_wired(self):
+        """A5, second pass: charter's `Task|Agent` dispatch hook is ALSO a `pre_tool_use`
+        hook. Trusted alone, it reads like a guard to a rule keyed on the event, while the
+        Bash guard that actually refuses commands is untrusted."""
+        self.write(codex_config(trust=False)
+                   + f'\n[hooks.state."{DISPATCH_KEY}"]\ntrusted_hash = "sha256:abc"\n')
+        w = wiring.detect(self.p, cwd=self.tmp)
+        self.assertEqual(w.state, wiring.UNWIRED)
+        self.assertIn("no guard hook of charter's is trusted", w.detail)
+
+    def test_the_guard_is_found_where_the_installed_plugin_puts_it(self):
+        """The position comes from the installed plugin's own `hooks.json`, not a
+        hard-coded index: move the Bash guard to group 1 and group 1's entry is the guard,
+        group 0's is not."""
+        doc = json.loads((REPO / "hooks" / "hooks.json").read_text())
+        pre = doc["hooks"]["PreToolUse"]
+        pre[0], pre[1] = pre[1], pre[0]
+        plugin_in_codex_cache(self.home, doc)
+        moved = TRUST_KEY.replace(":0:0", ":1:0")
+        self.write(codex_config(trust=False)
+                   + f'\n[hooks.state."{moved}"]\ntrusted_hash = "sha256:abc"\n')
+        self.assertEqual(wiring.detect(self.p, cwd=self.tmp).state, wiring.WIRED)
+        self.write(codex_config())
+        self.assertEqual(wiring.detect(self.p, cwd=self.tmp).state, wiring.UNWIRED)
+
+    def test_a_home_with_no_plugin_in_its_cache_has_no_guard_to_trust(self):
+        shutil.rmtree(self.home / "plugins")
+        self.write(codex_config())
+        w = wiring.detect(self.p, cwd=self.tmp)
+        self.assertEqual(w.state, wiring.UNWIRED)
+        self.assertIn("plugins/cache", w.detail)
+
+    def test_two_installed_versions_must_agree_on_where_the_guard_is(self):
+        """Codex may keep an older version's cache beside the current one. A position is the
+        guard only if EVERY cached copy says so — the rule that fails closed."""
+        doc = json.loads((REPO / "hooks" / "hooks.json").read_text())
+        pre = doc["hooks"]["PreToolUse"]
+        pre[0], pre[2] = pre[2], pre[0]
+        plugin_in_codex_cache(self.home, doc, version="0.59.0")
+        self.write(codex_config())
+        self.assertEqual(wiring.detect(self.p, cwd=self.tmp).state, wiring.UNWIRED)
+
+    def test_an_unreadable_plugin_hooks_file_is_unknown(self):
+        (self.home / "plugins" / "cache" / "charter" / "charter" / "0.60.0" / "hooks"
+         / "hooks.json").write_text("{nope")
+        self.write(codex_config())
+        self.assertEqual(wiring.detect(self.p, cwd=self.tmp).state, wiring.UNKNOWN_STATE)
+
+    def test_the_guard_handler_is_the_one_charters_own_hooks_file_puts_on_bash(self):
+        """The constant the detection keys on, pinned to the source that ships it: the
+        repository's `hooks/hooks.json` runs exactly this handler for `Bash`, and it is a
+        handler the CLI dispatches."""
+        from charter import hooks
+
+        doc = json.loads((REPO / "hooks" / "hooks.json").read_text())
+        bash = [g for g in doc["hooks"]["PreToolUse"] if g.get("matcher") == "Bash"]
+        self.assertEqual(len(bash), 1)
+        self.assertEqual(hooks._HOOK_CMD_RE.findall(bash[0]["hooks"][0]["command"]),
+                         [wiring.CODEX_GUARD_HANDLER])
+        self.assertIn(wiring.CODEX_GUARD_HANDLER, hooks._HANDLERS)
+
     def test_a_config_in_a_shape_codex_never_writes_is_unknown_and_never_a_traceback(self):
         """A1. Each of these parses as TOML, and each is a line a chat can write: read
         without checking the shape first, every one of them was an `AttributeError` out of a
@@ -630,6 +740,7 @@ class CodexIsReadAtTheProfilesHome(PersonaIso, unittest.TestCase):
         home = self.tmp / "fakehome"
         (home / ".codex").mkdir(parents=True)
         (home / ".codex" / "config.toml").write_text(codex_config())
+        plugin_in_codex_cache(home / ".codex")
         p = make_profile("codex", kind="codex", source=profiles.BUILTIN)
         with mock.patch.dict(os.environ, {"HOME": str(home), "PATH": os.environ["PATH"]},
                              clear=True):
@@ -1174,7 +1285,7 @@ class TheLaunchRefusesAnUnwiredProfile(PersonaIso, unittest.TestCase):
         seen = []
         with mock.patch.object(
                 commands_frame, "_profile_refusal",
-                side_effect=lambda p, *, attended, cwd=None: seen.append(cwd)):
+                side_effect=lambda p, *, attended, cwd=None, probe=True: seen.append(cwd)):
             commands_frame._launch_refusal(profiles.current().profiles["claude"],
                                            attended=False,
                                            cwd=commands_frame._chat_dir_of("beta"))
@@ -1230,6 +1341,59 @@ class AStartPaysTheProbeTwice(_ALaunchNamesAProfile, unittest.TestCase):
         opening = commands_frame.Opening("hello there")
         self.assertEqual(self._launch(profile="claude-work", attach=False, opening=opening,
                                       rest=["hello there"], stdin=_APipe()), 0)
+        self.assertEqual(self.probed, [])
+
+    def test_a_handoff_end_to_end_probes_once_before_tmux_and_once_in_the_pane(self):
+        """A3, second pass: `charter handoff` asks `background_refusal`, then
+        `open_in_background` asks the same chain again, then `_launch` and the pane — and
+        the first two each probed. The handoff's refusal is said by the first; the pane's
+        probe covers what moved since. Two in all."""
+        from charter.frame import state
+        from tests.test_a_chat_carries_its_profile import _a_chat
+
+        _a_chat("alpha.1", ws="alpha", profile="claude-work")
+        said = "fix the widget please"
+        stood_in = [mock.patch.object(commands_frame, "_plane_session",
+                                      return_value=("$1", "beta.1")),
+                    mock.patch.object(commands_frame, "_window_size", return_value=(120, 40))]
+        for patch in stood_in:
+            self.enterContext(patch)
+        with mock.patch.object(commands_frame, "_live_sessions", return_value=set()):
+            self.assertEqual(commands_frame.background_refusal(
+                "beta", caller="alpha.1", first_message=said), "")
+        self.assertEqual(len(self.probed), 1, self.probed)
+        launched = []
+
+        def through_the_real_launch(args):
+            launched.append(args)
+            return self._launch(stdin=_APipe(), **vars(args))
+
+        with mock.patch.object(commands_frame, "cmd_launch",
+                               side_effect=through_the_real_launch):
+            commands_frame.open_in_background("beta", caller="alpha.1", first_message=said)
+        self.assertEqual(len(launched), 1)
+        self.assertEqual(len(self.probed), 1, "the open probed again before tmux")
+        self.assertEqual(launcher.start(self._profile(), launched[0].rest, fid=None,
+                                        attended=False), 0)
+        self.assertEqual(len(self.probed), 2, self.probed)
+        self.assertIsNotNone(state)
+
+    def test_the_open_after_a_handoffs_refusal_still_refuses_for_everything_else(self):
+        """Only the wiring link is left to the pane: an unapproved profile is still refused
+        by `open_in_background` itself, before anything is started."""
+        from tests.test_a_chat_carries_its_profile import _a_chat
+
+        _a_chat("alpha.1", ws="alpha", profile="claude-work")
+        (config.STATE_DIR / profiletrust.RECORD).write_text("{}")
+        with mock.patch.object(commands_frame, "_plane_session", return_value=("$1", "beta.1")), \
+                mock.patch.object(commands_frame, "_window_size", return_value=(120, 40)), \
+                mock.patch.object(commands_frame, "_live_sessions", return_value=set()), \
+                mock.patch.object(commands_frame, "cmd_launch",
+                                  side_effect=AssertionError("launched")):
+            opened = commands_frame.open_in_background("beta", caller="alpha.1",
+                                                       first_message="fix the widget please")
+        self.assertFalse(opened.ok)
+        self.assertIn("nobody is at this open", opened.message)
         self.assertEqual(self.probed, [])
 
     def test_skipping_it_skips_the_probe_and_nothing_else(self):

--- a/tests/test_a_profile_is_wired_or_refuses.py
+++ b/tests/test_a_profile_is_wired_or_refuses.py
@@ -407,6 +407,18 @@ class CodexIsReadAtTheProfilesHome(PersonaIso, unittest.TestCase):
         self.assertEqual(w.state, wiring.UNKNOWN_STATE)
         self.assertIn("could not ask", wiring.refusal(self.p, cwd=self.tmp))
 
+    def test_the_fix_once_charter_has_written_its_line_is_codexs_own_commands(self):
+        """Review 7's objection, one mark further on. Once `shell_environment_policy` names
+        the harness, `charter harness install` has done everything charter can do — the
+        plugin install and the hook approval are Codex's, and pointing back at charter's
+        command would print a fix that changes nothing."""
+        self.write(codex_config(plugin=False, trust=False))
+        w = wiring.detect(self.p, cwd=self.tmp)
+        self.assertEqual(w.state, wiring.UNWIRED)
+        self.assertIn(f"CODEX_HOME={self.home}", w.fix)
+        self.assertIn("codex plugin add", w.fix)
+        self.assertNotIn("charter harness install", w.fix)
+
     def test_the_fix_for_a_foreign_policy_table_is_the_line_not_the_command(self):
         """Review 7: `codex.install()` answers `present` for ANY `[shell_environment_policy]`,
         so naming `charter harness install` here would print a fix that changes nothing."""

--- a/tests/test_a_profile_is_wired_or_refuses.py
+++ b/tests/test_a_profile_is_wired_or_refuses.py
@@ -223,6 +223,14 @@ class ClaudeCodeIsAskedUnderTheProfilesEnvironment(PersonaIso, unittest.TestCase
         self.assertEqual(w.state, wiring.UNWIRED)
         self.assertIn("local", w.detail)
 
+    def test_a_scope_charter_does_not_recognise_sorts_last_rather_than_raising(self):
+        """`_SCOPE_ORDER` is charter's reading of three scopes the CLI documents. A fourth
+        one — a newer Claude Code, a row charter has never seen — must not take the row down,
+        and must not outrank a scope charter does understand."""
+        with spawns([], listing(entry(scope="cowork", project=self.here, enabled=False),
+                                entry(scope="user", enabled=True))):
+            self.assertEqual(wiring.detect(self.p, cwd=self.here).state, wiring.WIRED)
+
     def test_a_project_enable_over_a_user_disable_is_wired(self):
         """The same pair in the other order, so the order of the list decides nothing."""
         with spawns([], listing(entry(scope="project", project=self.here, enabled=True),
@@ -363,6 +371,15 @@ class CodexIsReadAtTheProfilesHome(PersonaIso, unittest.TestCase):
         w = wiring.detect(self.p, cwd=self.tmp)
         self.assertEqual(w.state, wiring.UNWIRED)
         self.assertIn("shell_environment_policy", w.detail)
+        # No table at all: charter writes the whole thing, so its own command IS the fix.
+        self.assertEqual(w.fix, "charter harness install codex-alt")
+
+    def test_a_policy_that_names_some_other_variable_is_not_charters(self):
+        self.write(codex_config(policy=False)
+                   + '\n[shell_environment_policy]\nset = { SOMETHING_ELSE = "codex" }\n')
+        w = wiring.detect(self.p, cwd=self.tmp)
+        self.assertEqual(w.state, wiring.UNWIRED)
+        self.assertIn("CHARTER_HARNESS", w.detail)
 
     def test_untrusted_hooks_are_unwired(self):
         """Codex trusts hooks by hash, so a plugin nobody approved is installed and inert —
@@ -478,8 +495,41 @@ class OpencodeIsAskedUnderTheProfilesConfigHome(PersonaIso, unittest.TestCase):
         self.assertEqual(calls[0].argv, ["opencode", "debug", "config"])
         self.assertEqual(calls[0].env["XDG_CONFIG_HOME"], str(self.xdg))
 
-    def test_no_shim_is_unwired(self):
+    def test_an_answer_that_names_no_plugin_is_unwired(self):
+        """The shim is on disk and is charter's, and nothing else is in the realm — so the
+        only mark that can speak is the one about what opencode actually LOADS. A shim
+        opencode does not load is a guard that does not run."""
+        self.shim()
         with spawns([], self.answer()):
+            w = wiring.detect(self.p, cwd=self.tmp)
+        self.assertEqual(w.state, wiring.UNWIRED)
+        self.assertIn("loads no plugin", w.detail)
+
+    def test_a_bare_string_is_a_plugin_list_of_one(self):
+        """opencode takes a bare string here as well as a list (`_configured_plugins` says
+        so about the other door into the same realm)."""
+        self.shim()
+        with spawns([], json.dumps({"plugin": self.named()})):
+            self.assertEqual(wiring.detect(self.p, cwd=self.tmp).state, wiring.WIRED)
+
+    def test_an_entry_that_is_not_a_file_uri_is_read_as_a_path(self):
+        self.shim()
+        with spawns([], self.answer(str(self.home / opencode.SHIM_PATH))):
+            self.assertEqual(wiring.detect(self.p, cwd=self.tmp).state, wiring.WIRED)
+
+    def test_an_entry_that_is_not_a_string_is_skipped_rather_than_raised_on(self):
+        self.shim()
+        with spawns([], self.answer(17, self.named())):
+            self.assertEqual(wiring.detect(self.p, cwd=self.tmp).state, wiring.WIRED)
+
+    def test_an_answer_that_is_not_an_object_is_unwired_rather_than_a_crash(self):
+        self.shim()
+        with spawns([], json.dumps(["not", "a", "config"])):
+            self.assertEqual(wiring.detect(self.p, cwd=self.tmp).state, wiring.UNWIRED)
+
+    def test_an_answer_with_no_plugin_key_is_unwired(self):
+        self.shim()
+        with spawns([], json.dumps({"plugin": None})):
             self.assertEqual(wiring.detect(self.p, cwd=self.tmp).state, wiring.UNWIRED)
 
     def test_a_plugin_entry_naming_a_missing_shim_is_unwired(self):
@@ -488,6 +538,7 @@ class OpencodeIsAskedUnderTheProfilesConfigHome(PersonaIso, unittest.TestCase):
         with spawns([], self.answer(self.named())):
             w = wiring.detect(self.p, cwd=self.tmp)
         self.assertEqual(w.state, wiring.UNWIRED)
+        self.assertIn("cannot vouch", w.detail)
 
     def test_a_byte_perfect_shim_beside_a_foreign_plugin_is_not_wired(self):
         """The documented bypass, reproduced (ruling 26; `opencode.foreign_plugins`, ADR 0015).
@@ -509,6 +560,7 @@ class OpencodeIsAskedUnderTheProfilesConfigHome(PersonaIso, unittest.TestCase):
         with spawns([], self.answer(self.named())):
             w = wiring.detect(self.p, cwd=self.tmp)
         self.assertEqual(w.state, wiring.UNWIRED)
+        self.assertIn("cannot vouch", w.detail)
 
     def test_an_opencode_probe_that_times_out_refuses(self):
         self.shim()
@@ -518,9 +570,12 @@ class OpencodeIsAskedUnderTheProfilesConfigHome(PersonaIso, unittest.TestCase):
         self.assertEqual(w.state, wiring.UNKNOWN_STATE)
         self.assertIn("could not ask", said)
 
-    def test_a_non_zero_probe_is_unknown(self):
+    def test_a_non_zero_probe_is_unknown_even_when_it_printed_an_answer(self):
+        """The exit code is the answer about whether there IS an answer. A `debug config`
+        that printed a wired-looking document and then failed has told charter nothing, and
+        reading the document anyway is how an unknown becomes a pass."""
         self.shim()
-        with spawns([], "", rc=2):
+        with spawns([], self.answer(self.named()), rc=2):
             self.assertEqual(wiring.detect(self.p, cwd=self.tmp).state,
                              wiring.UNKNOWN_STATE)
 
@@ -949,6 +1004,15 @@ env = {{ CODEX_HOME = "{self.codex_home}" }}
         self.assertIn('set = { CHARTER_HARNESS = "codex" }', out)
         self.assertNotIn("charter harness install", out)
 
+    def test_a_shim_charter_cannot_vouch_for_is_a_warning_and_not_an_item(self):
+        """`Harness.wire` answers `unvouched` with a SENTENCE, not a path — #433's shape,
+        where a shim with every guard cut out of it was listed under "already present"."""
+        with mock.patch.object(wiring, "install",
+                               return_value=[("unvouched", "somebody else's plugin")]), \
+                spawns([], json.dumps({"plugin": []})):
+            out = self.said(lambda: self.run_install("oc-alt"))
+        self.assertRegex(out, r"!\s+somebody else's plugin")
+
     def test_a_registry_name_still_works_as_today(self):
         """`charter harness install codex` is what `docs/harnesses.md` tells people to run,
         and a profile-first lookup must not have taken it away (ruling 8). It writes the same
@@ -1174,6 +1238,261 @@ class DoctorHasARowPerProfile(PersonaIso, unittest.TestCase):
         self.assertIs(cli.build_parser().parse_args(["doctor", "--preflight"]).preflight,
                       True)
         self.assertIs(cli.build_parser().parse_args(["doctor"]).preflight, False)
+
+
+class EveryProfileDerivedTextIsShownEscaped(PersonaIso, unittest.TestCase):
+    """Ruling 35, surface by surface: nothing a chat can write into `charter.local.toml`
+    reaches a terminal as a control byte.
+
+    The values a profile carries into these sentences are its NAME, its KIND, its COMMAND,
+    its `env` values and — through those — the folder each probe asks about. Each is
+    interpolated in its own place, so each is asked its own question here: a `contain` that
+    went missing anywhere lets a `\r` redraw the line above it, which is how a refusal
+    becomes a sentence the operator never sees.
+    """
+
+    NASTY = "x\ry\x1b[2K"
+
+    def setUp(self):
+        super().setUp()
+        make_plane(self)
+        self.enterContext(approved())
+
+    def clean(self, *texts):
+        for t in texts:
+            self.assertNotIn("\r", t)
+            self.assertNotIn("\x1b", t)
+
+    def dirty_dir(self, name: str) -> Path:
+        d = self.tmp / f"d{self.NASTY}{name}"
+        d.mkdir(parents=True, exist_ok=True)
+        return d
+
+    def test_a_kind_charter_has_no_check_for_is_named_escaped(self):
+        """Unreachable through `profiles.current()`, which refuses a kind the registry does
+        not know — and reached the day a kind joins the registry without a wiring check,
+        which is exactly when nobody is looking."""
+        p = profiles.Profile(name=self.NASTY, kind=self.NASTY, harness=self.NASTY,
+                             command=(self.NASTY,), env=(), source=profiles.BUILTIN)
+        w = wiring.detect(p, cwd=self.tmp)
+        self.assertEqual(w.state, wiring.UNKNOWN_STATE)
+        self.clean(w.detail, w.fix, wiring.refusal(p, cwd=self.tmp))
+
+    def test_an_unapproved_profile_is_named_escaped(self):
+        p = make_profile(self.NASTY)
+        with mock.patch.object(wiring, "approval_needed", lambda q: "not approved yet"):
+            answer = wiring.detect(p, cwd=self.tmp)
+        self.clean(answer.detail, answer.fix)
+
+    def test_the_claude_detail_names_its_folder_and_scope_escaped(self):
+        here = self.dirty_dir("cwd")
+        p = make_profile(self.NASTY, env=[("CLAUDE_CONFIG_DIR", str(self.dirty_dir("cc")))])
+        with spawns([], listing(entry(scope=self.NASTY, project=here, enabled=False))):
+            w = wiring.detect(p, cwd=here)
+        self.assertEqual(w.state, wiring.UNWIRED)
+        self.clean(w.detail, w.fix, wiring.refusal(p, cwd=here))
+
+    def test_the_codex_detail_names_its_home_escaped(self):
+        home = self.dirty_dir("cx")
+        (home / "config.toml").write_text("[x")
+        p = make_profile(self.NASTY, kind="codex", env=[("CODEX_HOME", str(home))])
+        w = wiring.detect(p, cwd=self.tmp)
+        self.assertEqual(w.state, wiring.UNKNOWN_STATE)
+        self.clean(w.detail, w.fix, wiring.refusal(p, cwd=self.tmp), wiring.by_hand(p))
+
+    def test_the_opencode_detail_names_its_probe_home_and_neighbours_escaped(self):
+        xdg = self.dirty_dir("xdg")
+        home = xdg / "opencode"
+        (home / "plugin").mkdir(parents=True)
+        opencode.refresh_shim(home)
+        (home / "plugin" / f"a{self.NASTY}.ts").write_text("Object.hasOwn = () => false;\n")
+        p = make_profile(self.NASTY, kind="opencode", command=[f"oc{self.NASTY}"],
+                         env=[("XDG_CONFIG_HOME", str(xdg))])
+        answer = json.dumps({"plugin": [f"file://{home / opencode.SHIM_PATH}"]})
+        with spawns([], answer):
+            w = wiring.detect(p, cwd=self.tmp)
+        self.assertEqual(w.state, wiring.UNWIRED)
+        self.clean(w.detail, w.fix)
+        with spawns([], raises=util.ProcTimeout(["oc"], 5.0)):
+            self.clean(wiring.refusal(p, cwd=self.tmp))
+
+    def test_the_install_and_the_wiring_report_name_it_escaped(self):
+        import io
+        from contextlib import redirect_stderr, redirect_stdout
+
+        p = make_profile(self.NASTY, kind="codex",
+                         env=[("CODEX_HOME", str(self.dirty_dir("cx2")))])
+        buf = io.StringIO()
+        with redirect_stderr(buf), redirect_stdout(buf), \
+                mock.patch.object(commands_harness, "_resolve", return_value=(p, "")), \
+                mock.patch.object(profiles, "ignored_refusal", return_value=""):
+            commands_harness.cmd_harness_install(SimpleNamespace(name=self.NASTY))
+        self.clean(buf.getvalue())
+
+    def test_the_init_report_names_a_skipped_profile_escaped(self):
+        import io
+        from contextlib import redirect_stderr
+
+        p = make_profile(self.NASTY)
+        read = profiles.ProfileSet(profiles={self.NASTY: p}, refused=(), default=None,
+                                  default_from=None, default_refused=None)
+        buf = io.StringIO()
+        with mock.patch.object(wiring, "approval_needed",
+                               return_value=wiring.NOT_APPROVED_YET), \
+                mock.patch.object(profiles, "current", return_value=read), \
+                redirect_stderr(buf):
+            commands._say_profile_wiring(commands._wire_profiles(config.ROOT, install=True))
+        self.clean(buf.getvalue())
+
+
+class TheSeamsTheSweepAsksAbout(PersonaIso, unittest.TestCase):
+    """One class for the lines a deletion sweep could not tell from their own absence.
+
+    Each of these is a guard, a fallback or a threaded argument that the behaviour tests
+    above reach only through a sibling that would have caught the same case. A sweep names
+    them; this is where each gets a test that goes red on its own.
+    """
+
+    def setUp(self):
+        super().setUp()
+        make_plane(self)
+        declare_profiles(self)
+        self.here = self.tmp / "here"
+        self.here.mkdir()
+
+    def test_a_codex_profiles_cache_is_stamped_with_its_own_config_file(self):
+        """`_stamp_paths` answers per kind, and a kind that fell through to `[]` would have
+        an empty stamp — which matches forever, so the selector would draw a row about a
+        Codex home somebody has since wired or unwired."""
+        home = self.tmp / "cx"
+        home.mkdir()
+        (home / "config.toml").write_text(codex_config())
+        p = make_profile("codex-alt", kind="codex", env=[("CODEX_HOME", str(home))])
+        w = wiring.Wiring(wiring.WIRED, "asked", "")
+        wiring.remember(p, cwd=self.here, w=w)
+        self.assertEqual(wiring.cached(p, cwd=self.here), w)
+        (home / "config.toml").write_text(codex_config(trust=False))
+        self.assertIsNone(wiring.cached(p, cwd=self.here))
+
+    def test_the_cache_file_is_the_one_the_docs_and_the_selector_name(self):
+        """A path a chat can write is a path the docs state at full volume (ruling 13), so
+        the spelling is a fact about this release rather than an internal detail."""
+        self.assertEqual(wiring.CACHE, "cache/harness-wiring.json")
+        p = profiles.current().profiles["claude"]
+        wiring.remember(p, cwd=self.here, w=wiring.Wiring(wiring.WIRED, "x", ""))
+        self.assertTrue((Path(config.STATE_DIR) / "cache" / "harness-wiring.json").is_file())
+
+    def test_a_cache_entry_missing_a_field_is_a_miss_rather_than_a_crash(self):
+        p = profiles.current().profiles["claude"]
+        wiring.remember(p, cwd=self.here, w=wiring.Wiring(wiring.WIRED, "x", ""))
+        path = Path(config.STATE_DIR) / wiring.CACHE
+        doc = json.loads(path.read_text())
+        for entry in doc.values():
+            entry.pop("fix", None)
+        path.write_text(json.dumps(doc))
+        self.assertIsNone(wiring.cached(p, cwd=self.here))
+
+    def test_cmd_doctor_passes_the_preflight_flag_through(self):
+        """The flag is the only thing that tells the SessionStart hook apart from a person
+        typing the same words, so a `cmd_doctor` that dropped it would put the probes back on
+        the hook path with nothing saying so."""
+        import io
+        from contextlib import redirect_stdout
+
+        buf = io.StringIO()
+        with mock.patch.object(wiring, "detect",
+                               side_effect=AssertionError("probed on a hook path")), \
+                redirect_stdout(buf):
+            commands.cmd_doctor(SimpleNamespace(json=True, preflight=True))
+        names = [r["name"] for r in json.loads(buf.getvalue())]
+        self.assertNotIn("profile claude", names)
+        self.assertIn("harness profiles", names)
+
+    def test_a_doctor_row_shows_a_profile_name_escaped(self):
+        """Ruling 35 reaches the row NAMES too — and the name column is sized from them, so
+        a control byte there would move every other row as well as redraw the line."""
+        nasty = make_profile("cl\raude\x1b[2K", source=profiles.BUILTIN)
+        with mock.patch.object(wiring, "listed", return_value=[nasty]), \
+                mock.patch.object(wiring, "detect",
+                                  return_value=wiring.Wiring(wiring.WIRED, "ok", "")):
+            names = doctor.profile_row_names()
+            rows = doctor.check_profile_wiring()
+        for text in [*names, *(r.name for r in rows)]:
+            self.assertNotIn("\r", text)
+            self.assertNotIn("\x1b", text)
+
+    def test_the_launcher_asks_about_the_directory_it_was_given(self):
+        """`_launch` and the pane are already standing in the chat's directory; a `+`, a tab
+        and a handoff are not, and the answer is about THEIR directory."""
+        calls = []
+        with approved(), spawns(calls, listing()):
+            launcher.refusal(profiles.current().profiles["claude"], root=config.ROOT,
+                             attended=False, env=dict(os.environ), cwd=self.here)
+        self.assertEqual(str(calls[0].cwd), str(self.here))
+
+    def test_a_codex_probe_charter_cannot_read_names_the_file_to_open(self):
+        """Codex has no probe argv — its three marks are a file — so `{probe}` names the
+        file. A fall-through to an empty command would print `check by hand:` and stop."""
+        home = self.tmp / "cx2"
+        home.mkdir()
+        (home / "config.toml").write_text("[x")
+        p = make_profile("codex-alt", kind="codex", env=[("CODEX_HOME", str(home))])
+        said = wiring.refusal(p, cwd=self.tmp)
+        self.assertIn(str(home / "config.toml"), said)
+
+    def test_the_listing_is_built_ins_in_registry_order_then_the_rest_by_name(self):
+        """`charter harness list`'s order, so a doctor row lands where the operator already
+        reads that profile."""
+        names = [p.name for p in wiring.listed()]
+        built_in = [n for n in profiles.builtins() if n in names]
+        self.assertEqual(names[:len(built_in)], built_in)
+        self.assertEqual(names[len(built_in):], sorted(names[len(built_in):]))
+
+    def test_no_probe_is_spawned_for_a_command_that_is_not_on_path(self):
+        """`shutil.which` and the exec are two moments, and the read charter would make in
+        between is a spawn of something that is not there."""
+        asked = []
+
+        def available(command=("claude",)):
+            asked.append(tuple(command))
+            return False
+
+        with mock.patch.object(plugincache, "available", available), \
+                mock.patch.object(util, "run",
+                                  side_effect=AssertionError("spawned anyway")):
+            self.assertIsNone(plugincache._claude_json(["list"],
+                                                       command=["/nowhere/claude"]))
+        self.assertEqual(asked, [("/nowhere/claude",)])
+
+    def test_a_registry_name_resolves_to_the_built_in_of_that_kind(self):
+        """`charter harness install claude-code` — the NAME `$CHARTER_HARNESS` carries, which
+        is not the word typed after `charter`."""
+        p, why = commands_harness._resolve("claude-code")
+        self.assertIsNotNone(p, why)
+        self.assertEqual(p.name, "claude")
+
+    def test_a_gap_is_warned_about_and_a_write_is_only_noted(self):
+        """`init` and `reinit` do not fail over a profile's own account folder, so the only
+        thing separating "charter wrote this" from "you have something to do" is which
+        stream-level this line goes out at."""
+        import io
+        from contextlib import redirect_stderr
+
+        buf = io.StringIO()
+        with redirect_stderr(buf):
+            commands._say_profile_wiring([("skipped", "a"), ("created", "b"),
+                                          ("missing", "c"), ("opt-in", "d")])
+        lines = [l for l in buf.getvalue().splitlines() if l.strip()]
+        self.assertEqual([l[0] for l in lines], ["!", "•", "!", "!"])
+
+    def test_nothing_is_wired_while_git_would_carry_the_local_file(self):
+        """Every profile in it is refused, and `charter harness list` and doctor's
+        `harness profiles` row already say so with the fix. Wiring one anyway would act on a
+        declaration charter has just refused."""
+        (config.ROOT / ".gitignore").write_text("# nothing ignored\n")
+        with approved(), mock.patch.object(wiring, "install") as inst:
+            self.assertEqual(commands._wire_profiles(config.ROOT, install=True), [])
+        inst.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/tests/test_a_profile_is_wired_or_refuses.py
+++ b/tests/test_a_profile_is_wired_or_refuses.py
@@ -21,20 +21,27 @@ No test here runs a real harness. The probe seams are `charter.util.run` — whi
 
 from __future__ import annotations
 
+import io
 import json
 import os
+import shlex
+import shutil
 import time
 import unittest
-from contextlib import contextmanager
+from contextlib import contextmanager, redirect_stderr, redirect_stdout
 from pathlib import Path
 from types import SimpleNamespace
 from unittest import mock
 
-from charter import commands, commands_harness, config, contain, doctor, plugincache
-from charter import profiles, util, wiring
-from charter.frame import launcher
+from charter import commands, commands_frame, commands_harness, config, contain, doctor
+from charter import plugincache, profiles, profiletrust, util, wiring
+from charter.frame import launcher, reopen as reopen_state
 from charter.harness import claude_code, codex, opencode
-from tests._isolation import PersonaIso, declare_profiles, make_plane
+from tests import _claudeguard
+from tests._isolation import (APipe as _APipe, ATerminal as _ATerminal, PersonaIso,
+                              Typed as _Typed, approve_every_profile, approve_profile,
+                              declare_profiles, make_plane)
+from tests.test_a_profile_launch_is_refused_before_tmux import _ALaunchNamesAProfile
 
 REPO = Path(__file__).resolve().parents[1]
 
@@ -90,6 +97,20 @@ def spawns(calls, answer=None, *, rc=0, raises=None):
         yield
 
 
+class _TempDir:
+    """A directory outside every plane, removed afterwards — for `enterContext`."""
+
+    def __enter__(self):
+        import tempfile
+
+        self.path = tempfile.mkdtemp(prefix="charter-outside-")
+        return self.path
+
+    def __exit__(self, *exc):
+        shutil.rmtree(self.path, ignore_errors=True)
+        return False
+
+
 def listing(*entries) -> str:
     """`claude plugin list --json`'s answer for *entries*, each already a dict."""
     return json.dumps(list(entries))
@@ -105,19 +126,38 @@ def entry(scope="project", enabled=True, project=None, pid=plugincache.PLUGIN_ID
     return row
 
 
-@contextmanager
-def approved():
-    """Stand in for Task 3's launch record: every profile's command may be run.
+#: Two declared profiles whose names sort the other way round from the order they are
+#: declared in, so the listing's order is shown to be its own and not the file's.
+DECLARED_WITH_A_NAME_AFTER_ITS_SIBLING = """
+[harness.claude-work]
+kind = "claude"
+command = ["claude"]
 
-    Task 4 lands before Task 3's approval record is on `main`, so today
-    `wiring.approval_needed` refuses every DECLARED profile — nothing yet stands for the
-    operator's approval of a command a chat could have written. The cases whose subject is
-    what happens AFTER the approval say so here; the cases whose subject IS the gate
-    (`NothingUnapprovedIsRun`) do not patch it. When Task 3 is on `main` this becomes
-    `tests._isolation.approve_profile`, and the body of `approval_needed` becomes
-    `profiletrust.approval_needed` — the seam is the same one either way.
-    """
-    with mock.patch.object(wiring, "approval_needed", lambda p: ""):
+[harness.aaa-codex]
+kind = "codex"
+command = ["codex"]
+"""
+
+#: The harness programs a listing depends on. `wiring.listed` shows a built-in only when its
+#: program is on `PATH`, and `tests/_claudeguard` fakes `claude` and `opencode` but not
+#: `codex` — so a case that counts rows says which of the three this machine "has" rather
+#: than inheriting whatever the machine running it has (B5; `CONTRIBUTING.md`, *your machine
+#: is not the runner*).
+HARNESS_PROGRAMS = ("claude", "codex", "opencode")
+
+
+@contextmanager
+def on_path(*present: str):
+    """`shutil.which` answering for the three harness programs as *present* says, and for
+    every other program — `git`, `tmux` — as the machine does."""
+    real = shutil.which
+
+    def which(cmd, *a, **k):
+        if cmd in HARNESS_PROGRAMS:
+            return f"/usr/bin/{cmd}" if cmd in present else None
+        return real(cmd, *a, **k)
+
+    with mock.patch.object(wiring.shutil, "which", which):
         yield
 
 
@@ -140,13 +180,15 @@ class ClaudeCodeIsAskedUnderTheProfilesEnvironment(PersonaIso, unittest.TestCase
         super().setUp()
         self.here = self.tmp / "here"
         self.here.mkdir()
+        # `$HOME` pinned, so where `~/.claude-alt` expands to is a LITERAL below rather than
+        # the same `expanduser` the code runs agreeing with itself (B4).
+        self.home = self.tmp / "home"
+        self.enterContext(mock.patch.dict(os.environ, {"HOME": str(self.home)}))
         self.p = make_profile("claude-alt", env=[("CLAUDE_CONFIG_DIR", "~/.claude-alt")])
         # These cases are about what the probe answers, which is the question AFTER the
-        # gate: `detect` refuses to run a declared profile's command until something stands
-        # for the operator's approval of it, and `NothingUnapprovedIsRun` is where that is
-        # the subject.
-        self.enterContext(approved())
-
+        # gate: a profile the operator has not approved is never probed, and
+        # `NothingUnapprovedIsRun` is where that is the subject.
+        approve_profile(self, self.p)
 
     def test_the_probe_runs_the_profiles_command_with_its_env(self):
         """Never `claude` and never charter's own environment: a profile exists to name
@@ -156,9 +198,38 @@ class ClaudeCodeIsAskedUnderTheProfilesEnvironment(PersonaIso, unittest.TestCase
         with spawns(calls, listing(entry(project=self.here))):
             wiring.detect(self.p, cwd=self.here)
         self.assertEqual(calls[0].argv, ["claude", "plugin", "list", "--json"])
-        self.assertEqual(calls[0].env["CLAUDE_CONFIG_DIR"],
-                         os.path.expanduser("~/.claude-alt"))
+        self.assertEqual(calls[0].env["CLAUDE_CONFIG_DIR"], str(self.home / ".claude-alt"))
         self.assertEqual(str(calls[0].cwd), str(self.here))
+
+    def test_the_probe_looks_the_command_up_on_the_profiles_own_path(self):
+        """A2: the launcher finds a profile's command on the `PATH` its `env` sets
+        (`launcher.refusal`), so the probe has to look there too. Looked up on this
+        process's `PATH` instead, a profile whose program lives only on its own would read
+        "could not be asked" and refuse a launch that would have found the program."""
+        bin_dir = self.tmp / "profile-bin"
+        bin_dir.mkdir()
+        program = bin_dir / "claude-only-here"
+        program.write_text("#!/bin/sh\nexit 0\n")
+        program.chmod(0o755)
+        p = make_profile("claude-path", command=["claude-only-here"],
+                         env=[("PATH", str(bin_dir))])
+        approve_profile(self, p)
+        self.assertIsNone(shutil.which("claude-only-here"))
+        calls = []
+        real = util.run
+
+        def run(cmd, *a, **kw):
+            if list(cmd)[:1] == ["git"]:
+                return real(cmd, *a, **kw)
+            calls.append(list(cmd))
+            return SimpleNamespace(returncode=0, stdout=listing(entry(project=self.here)),
+                                   stderr="")
+
+        with mock.patch.object(plugincache, "available", _claudeguard.REAL_AVAILABLE), \
+                mock.patch.object(util, "run", run):
+            w = wiring.detect(p, cwd=self.here)
+        self.assertEqual(calls, [["claude-only-here", "plugin", "list", "--json"]])
+        self.assertEqual(w.state, wiring.WIRED)
 
     def test_an_enabled_install_covering_the_directory_is_wired(self):
         calls = []
@@ -189,6 +260,18 @@ class ClaudeCodeIsAskedUnderTheProfilesEnvironment(PersonaIso, unittest.TestCase
             w = wiring.detect(self.p, cwd=self.here)
         self.assertEqual(w.state, wiring.UNWIRED)
 
+    def test_a_long_names_fix_is_whole_and_its_sentence_is_bounded(self):
+        """A `Wiring` is escaped and never clipped (a `doctor` row counts what it hides, and
+        could not count a cut made before it); the SENTENCE bounds the name it quotes."""
+        long_name = "l" * 161
+        p = approve_profile(self, make_profile(long_name))
+        for answer, rc in ((listing(), 0), ("", 1)):
+            with self.subTest(rc=rc), spawns([], answer, rc=rc):
+                w = wiring.detect(p, cwd=self.here)
+                said = wiring.refusal(p, cwd=self.here)
+            self.assertEqual(w.fix, f"charter harness install {long_name}")
+            self.assertIn(f"profile '{'l' * 160}...'", said)
+
     def test_no_entry_is_unwired(self):
         with spawns([], listing()):
             w = wiring.detect(self.p, cwd=self.here)
@@ -205,6 +288,48 @@ class ClaudeCodeIsAskedUnderTheProfilesEnvironment(PersonaIso, unittest.TestCase
         self.assertIn("disabled", w.detail)
         self.assertIn("plugin enable", w.fix)
         self.assertNotIn("charter harness install", w.fix)
+
+    def test_the_enable_names_its_scope_and_the_directory_it_must_run_in(self):
+        """A8, measured on claude 2.1.270 in throwaway folders (2026-09-13): `plugin enable
+        --scope local` run FROM the chat's directory undid a disable in that directory's
+        `settings.local.json`, in its `settings.json`, and in a git plane root's
+        `settings.local.json`; `--scope project` and `--scope user` each exited 1 over a
+        local disable and changed nothing — review 7's loop. So the fix says the scope, and
+        says where to stand, as one line that can be pasted."""
+        with spawns([], listing(entry(project=self.here, enabled=False))):
+            w = wiring.detect(self.p, cwd=self.here)
+        self.assertEqual(shlex.split(w.fix),
+                         ["cd", str(self.here), "&&",
+                          f"CLAUDE_CONFIG_DIR={self.home / '.claude-alt'}",
+                          "claude", "plugin", "enable", plugincache.PLUGIN_ID,
+                          "--scope", "local"])
+
+    def test_a_fix_for_a_directory_with_a_space_can_still_be_pasted(self):
+        """A11: every path and word is shell-quoted, so the line survives the paste."""
+        here = self.tmp / "a dir; with parts"
+        here.mkdir()
+        p = make_profile("claude-sp", env=[("CLAUDE_CONFIG_DIR", str(self.tmp / "c c"))])
+        approve_profile(self, p)
+        with spawns([], listing(entry(project=here, enabled=False))):
+            w = wiring.detect(p, cwd=here)
+        words = shlex.split(w.fix)
+        self.assertEqual(words[:3], ["cd", str(here), "&&"])
+        self.assertEqual(words[3], f"CLAUDE_CONFIG_DIR={self.tmp / 'c c'}")
+
+    def test_a_plane_install_the_chats_directory_disables_is_not_wired(self):
+        """A7, and the reason the plane-root coverage rule is safe to keep: the record that
+        covers the plane carries the `enabled` the binary resolved AT THE CHAT'S DIRECTORY,
+        so a plane install that directory disables reads as disabled — counted as covering,
+        and still refused."""
+        make_plane(self)
+        ws = config.ROOT / "workspaces" / "w"
+        ws.mkdir(parents=True)
+        record = entry(project=config.ROOT, enabled=False)
+        self.assertFalse(plugincache.covers(record, ws))
+        with spawns([], listing(record)):
+            w = wiring.detect(self.p, cwd=ws)
+        self.assertEqual(w.state, wiring.UNWIRED)
+        self.assertIn("disabled", w.detail)
 
     def test_a_disabled_user_entry_listed_first_does_not_hide_an_enabled_project_entry(self):
         """Review 6: `installed_for` returns the FIRST covering entry, and this machine lists
@@ -284,7 +409,7 @@ class ClaudeCodeIsAskedUnderTheProfilesEnvironment(PersonaIso, unittest.TestCase
         self.assertIn("could not ask", said)
 
     def test_a_wrapper_scripts_answer_is_the_one_used(self):
-        p = make_profile("wrapped", command=["/opt/claude-wrap"])
+        p = approve_profile(self, make_profile("wrapped", command=["/opt/claude-wrap"]))
         calls = []
         with spawns(calls, listing()):
             wiring.detect(p, cwd=self.here)
@@ -296,7 +421,20 @@ class ClaudeCodeIsAskedUnderTheProfilesEnvironment(PersonaIso, unittest.TestCase
         a session reads."""
         with spawns([], listing(entry(project=self.here))):
             w = wiring.detect(self.p, cwd=self.here)
-        self.assertIn(os.path.expanduser("~/.claude-alt"), w.detail)
+        self.assertIn(str(self.home / ".claude-alt"), w.detail)
+
+    def test_a_nul_byte_in_the_environment_is_unknown_and_never_a_traceback(self):
+        """A1: `exec` refuses a NUL in an environment value with `ValueError`, before
+        anything runs — and a profile's `env` is a file a chat can write. The real
+        `util.run`, so it is the refusal and not a stand-in that is caught."""
+        p = approve_profile(self, make_profile(
+            "claude-nul", env=[("CLAUDE_CONFIG_DIR", "/tmp/a\x00b")]))
+        with mock.patch.object(plugincache, "available", lambda *a, **k: True):
+            w = wiring.detect(p, cwd=self.here)
+            said = wiring.refusal(p, cwd=self.here)
+        self.assertEqual(w.state, wiring.UNKNOWN_STATE)
+        self.assertIn("could not ask", said)
+        self.assertNotIn("\x00", said)
 
 
 class TheResolverGainsAnEnvironmentRatherThanATwin(unittest.TestCase):
@@ -330,7 +468,10 @@ class TheResolverGainsAnEnvironmentRatherThanATwin(unittest.TestCase):
 # --------------------------------------------------------------------------- #
 
 
-TRUST_KEY = f"{plugincache.PLUGIN_ID}:hooks/hooks.json:session_start:0:0"
+#: A trust entry for one of charter's GUARD hooks — the Bash guard, as Codex keys it.
+TRUST_KEY = f"{plugincache.PLUGIN_ID}:hooks/hooks.json:pre_tool_use:0:0"
+#: A trust entry for one of charter's hooks that is not a guard (SessionStart's reconcile).
+NOT_A_GUARD_KEY = f"{plugincache.PLUGIN_ID}:hooks/hooks.json:session_start:0:0"
 
 
 def codex_config(*, plugin=True, policy=True, trust=True) -> str:
@@ -356,14 +497,8 @@ class CodexIsReadAtTheProfilesHome(PersonaIso, unittest.TestCase):
         super().setUp()
         self.home = self.tmp / "codex-home"
         self.home.mkdir()
-        self.p = make_profile("codex-alt", kind="codex",
-                              env=[("CODEX_HOME", str(self.home))])
-        # These cases are about what the probe answers, which is the question AFTER the
-        # gate: `detect` refuses to run a declared profile's command until something stands
-        # for the operator's approval of it, and `NothingUnapprovedIsRun` is where that is
-        # the subject.
-        self.enterContext(approved())
-
+        self.p = approve_profile(self, make_profile("codex-alt", kind="codex",
+                                                    env=[("CODEX_HOME", str(self.home))]))
 
     def write(self, body: str):
         (self.home / "config.toml").write_text(body)
@@ -412,6 +547,77 @@ class CodexIsReadAtTheProfilesHome(PersonaIso, unittest.TestCase):
         self.write(codex_config())
         self.assertEqual(wiring.detect(self.p, cwd=self.tmp).state, wiring.WIRED)
 
+    def test_a_disabled_plugin_is_unwired_whatever_else_is_there(self):
+        """A4: the plan's first mark, `plugins."charter@charter".enabled is True`, on its
+        own — the policy line and a trusted guard both present, and the plugin switched off."""
+        self.write(codex_config().replace("enabled = true", "enabled = false"))
+        w = wiring.detect(self.p, cwd=self.tmp)
+        self.assertEqual(w.state, wiring.UNWIRED)
+        self.assertIn("not an enabled plugin", w.detail)
+
+    def test_a_trusted_hook_that_is_not_a_guard_does_not_make_it_wired(self):
+        """A5, ruling 7: "wired" is charter's GUARD actually running. Codex trusts hooks one
+        at a time, so an approved SessionStart reconcile beside an untrusted Bash guard is a
+        home where nothing stops a shell command."""
+        self.write(codex_config(trust=False)
+                   + f'\n[hooks.state."{NOT_A_GUARD_KEY}"]\ntrusted_hash = "sha256:abc"\n'
+                   + f'\n[hooks.state."{TRUST_KEY}"]\nenabled = false\n')
+        w = wiring.detect(self.p, cwd=self.tmp)
+        self.assertEqual(w.state, wiring.UNWIRED)
+        self.assertIn("no guard hook of charter's is trusted", w.detail)
+
+    def test_a_config_in_a_shape_codex_never_writes_is_unknown_and_never_a_traceback(self):
+        """A1. Each of these parses as TOML, and each is a line a chat can write: read
+        without checking the shape first, every one of them was an `AttributeError` out of a
+        launch. They read as "could not tell", with the key named."""
+        hostile = {
+            f'plugins."{plugincache.PLUGIN_ID}" = true\n': f'plugins."{plugincache.PLUGIN_ID}"',
+            "plugins = 3\n": "plugins",
+            f'[hooks.state]\n"{TRUST_KEY}" = "trusted"\n': "hooks.state",
+            'hooks = "all of them"\n': "hooks",
+            "[hooks]\nstate = 1\n": "hooks.state",
+            "shell_environment_policy = 1\n": "shell_environment_policy",
+            '[shell_environment_policy]\nset = "CHARTER_HARNESS=codex"\n':
+                "shell_environment_policy.set",
+        }
+        for body, key in hostile.items():
+            with self.subTest(body=body):
+                self.write(body)
+                w = wiring.detect(self.p, cwd=self.tmp)
+                self.assertEqual(w.state, wiring.UNKNOWN_STATE)
+                self.assertIn(key, w.detail)
+                self.assertIn("could not ask", wiring.refusal(self.p, cwd=self.tmp))
+
+    def test_a_trust_entry_of_the_wrong_shape_is_named_rather_than_skipped(self):
+        """The ledger entry itself: `trusted_hash` read off a string is the traceback, and a
+        chat that wanted a home to read as wired would write exactly that."""
+        self.write(codex_config(trust=False) + f'\n[hooks.state]\n"{TRUST_KEY}" = "yes"\n')
+        w = wiring.detect(self.p, cwd=self.tmp)
+        self.assertEqual(w.state, wiring.UNKNOWN_STATE)
+        self.assertIn("pre_tool_use", w.detail)
+
+    def test_a_trusted_hash_that_is_not_a_string_is_not_trust(self):
+        self.write(codex_config(trust=False)
+                   + f'\n[hooks.state."{TRUST_KEY}"]\ntrusted_hash = 1\n')
+        self.assertEqual(wiring.detect(self.p, cwd=self.tmp).state, wiring.UNWIRED)
+
+    def test_a_nul_byte_in_the_home_is_unknown_and_never_a_traceback(self):
+        """A1: `open` refuses a NUL in a path with `ValueError`."""
+        p = approve_profile(self, make_profile("codex-nul", kind="codex",
+                                               env=[("CODEX_HOME", "/tmp/a\x00b")]))
+        self.assertEqual(wiring.detect(p, cwd=self.tmp).state, wiring.UNKNOWN_STATE)
+        self.assertIn("could not ask", wiring.refusal(p, cwd=self.tmp))
+
+    def test_the_codex_steps_are_a_list_each_pasteable_whatever_the_home_is_called(self):
+        """A11: a home holding `; ` split a joined sentence in the wrong place, and a home
+        with a space printed a `CODEX_HOME=` a shell would cut in two."""
+        home = self.tmp / "my home; really"
+        steps = wiring.codex_steps(home)
+        self.assertEqual(len(steps), len(wiring.CODEX_COMMANDS) + 1)
+        for step, argv in zip(steps, wiring.CODEX_COMMANDS):
+            self.assertEqual(shlex.split(step), [f"CODEX_HOME={home}", *argv])
+        self.assertEqual(steps[-1], wiring.CODEX_APPROVE)
+
     def test_another_plugins_trust_entry_is_not_charters(self):
         self.write(codex_config(trust=False)
                    + '\n[hooks.state."other@other:hooks/hooks.json:stop:0:0"]\n'
@@ -443,8 +649,9 @@ class CodexIsReadAtTheProfilesHome(PersonaIso, unittest.TestCase):
         self.write(codex_config(plugin=False, trust=False))
         w = wiring.detect(self.p, cwd=self.tmp)
         self.assertEqual(w.state, wiring.UNWIRED)
-        self.assertIn(f"CODEX_HOME={self.home}", w.fix)
+        self.assertIn(f"CODEX_HOME={shlex.quote(str(self.home))}", w.fix)
         self.assertIn("codex plugin add", w.fix)
+        self.assertIn(wiring.CODEX_APPROVE, w.fix)
         self.assertNotIn("charter harness install", w.fix)
 
     def test_the_fix_for_a_foreign_policy_table_is_the_line_not_the_command(self):
@@ -480,14 +687,8 @@ class OpencodeIsAskedUnderTheProfilesConfigHome(PersonaIso, unittest.TestCase):
         self.xdg = self.tmp / "xdg"
         self.home = self.xdg / "opencode"
         (self.home / "plugin").mkdir(parents=True)
-        self.p = make_profile("oc-alt", kind="opencode",
-                              env=[("XDG_CONFIG_HOME", str(self.xdg))])
-        # These cases are about what the probe answers, which is the question AFTER the
-        # gate: `detect` refuses to run a declared profile's command until something stands
-        # for the operator's approval of it, and `NothingUnapprovedIsRun` is where that is
-        # the subject.
-        self.enterContext(approved())
-
+        self.p = approve_profile(self, make_profile("oc-alt", kind="opencode",
+                                                    env=[("XDG_CONFIG_HOME", str(self.xdg))]))
 
     def shim(self):
         opencode.refresh_shim(self.home)
@@ -592,6 +793,34 @@ class OpencodeIsAskedUnderTheProfilesConfigHome(PersonaIso, unittest.TestCase):
             self.assertEqual(wiring.detect(self.p, cwd=self.tmp).state,
                              wiring.UNKNOWN_STATE)
 
+    def test_a_nul_byte_in_the_config_home_is_unknown_and_never_a_traceback(self):
+        """A1: the real `util.run`, which refuses a NUL in an environment value before it
+        spawns anything — so nothing here reaches a binary."""
+        p = approve_profile(self, make_profile("oc-nul", kind="opencode",
+                                               env=[("XDG_CONFIG_HOME", "/tmp/x\x00y")]))
+        self.assertEqual(wiring.detect(p, cwd=self.tmp).state, wiring.UNKNOWN_STATE)
+        self.assertIn("could not ask", wiring.refusal(p, cwd=self.tmp))
+
+    def test_an_entry_holding_a_nul_byte_is_skipped_rather_than_raised_on(self):
+        """`Path.resolve` refuses a NUL with `ValueError`; an answer is text the harness
+        printed, and a plugin entry charter cannot resolve is not charter's shim."""
+        self.shim()
+        with spawns([], self.answer("file:///tmp/a\x00b.ts")):
+            self.assertEqual(wiring.detect(self.p, cwd=self.tmp).state, wiring.UNWIRED)
+
+    def test_what_the_probe_is_named_as_is_contained_on_every_unknown(self):
+        """`wiring.py`'s exit and not-JSON details name the probe, which is the profile's own
+        command — text a chat wrote."""
+        nasty = "oc\r\x1b[2K"
+        p = approve_profile(self, make_profile("oc-nasty", kind="opencode", command=[nasty],
+                                               env=[("XDG_CONFIG_HOME", str(self.xdg))]))
+        for answer, rc in (("{}", 2), ("not json", 0)):
+            with self.subTest(rc=rc), spawns([], answer, rc=rc):
+                w = wiring.detect(p, cwd=self.tmp)
+            self.assertEqual(w.state, wiring.UNKNOWN_STATE)
+            self.assertIn("oc\\u000d", w.detail)
+            self.assertNotIn("\r", w.detail)
+
     def test_bad_json_is_unknown(self):
         self.shim()
         with spawns([], "not json"):
@@ -617,9 +846,9 @@ class NothingUnapprovedIsRun(PersonaIso, unittest.TestCase):
 
     Ruling 1, and the Global Constraint it comes from: `charter.local.toml` is a file a chat
     can write with no diff to show for it, and a probe is a launch of that command by another
-    name. Until Task 3's approval record is on `main`, nothing stands for the operator's
-    approval of a declared command — so `approval_needed` refuses every declared profile and
-    the surfaces say so instead of asking the harness.
+    name. So a probe passes the two checks a launch passes first — git would not carry the
+    file, and Task 3's launch record says the operator approved this command — and a surface
+    that cannot ask says so instead of asking the harness.
     """
 
     def setUp(self):
@@ -628,31 +857,64 @@ class NothingUnapprovedIsRun(PersonaIso, unittest.TestCase):
         declare_profiles(self)
         self.p = profiles.current().profiles["claude-work"]
 
-    def test_a_built_in_is_charters_own_command_and_needs_no_approval(self):
-        built_in = profiles.current().profiles["claude"]
-        self.assertEqual(wiring.approval_needed(built_in), "")
-
-    def test_a_declared_profile_is_not_approved_yet(self):
-        self.assertNotEqual(wiring.approval_needed(self.p), "")
+    def said(self, fn) -> tuple[object, str]:
+        buf = io.StringIO()
+        with redirect_stderr(buf):
+            got = fn()
+        return got, buf.getvalue()
 
     def test_the_launcher_and_the_gate_agree_about_every_profile(self):
-        """One rule, asked in two places, pinned together so they cannot drift apart. Task
-        3's merge moves both bodies to `profiletrust` at once; this is what fails if only
-        one of them moves."""
+        """One rule, asked in two places, pinned together so they cannot drift apart: the
+        launcher's chain refuses a profile for approval or for the file exactly when
+        `wiring.detect` declines to ask its harness anything. Branched on the KIND
+        (ruling 27), never on the sentence."""
+        approve_profile(self, "codex-pinned")
         for p in profiles.current().profiles.values():
-            refused = launcher.refusal(p, root=config.ROOT, attended=False,
-                                       env=dict(os.environ))
-            gated = bool(wiring.approval_needed(p))
-            self.assertEqual(gated, refused is not None and refused.kind ==
-                             launcher.KIND_NOT_YET, p.name)
+            asked = []
+            with mock.patch.object(wiring, "_asked", side_effect=lambda q, *, cwd: (
+                    asked.append(q.name) or wiring.Wiring(wiring.WIRED, "", ""))), \
+                    mock.patch.object(launcher.shutil, "which", return_value="/usr/bin/x"):
+                refused = launcher.refusal(p, root=config.ROOT, attended=False,
+                                           env=dict(os.environ), probe=False)
+                wiring.detect(p, cwd=config.ROOT)
+            gated = p.name not in asked
+            self.assertEqual(gated, refused is not None and refused.kind in (
+                launcher.KIND_UNATTENDED, launcher.KIND_IGNORED), p.name)
 
     def test_an_unapproved_profile_is_never_probed(self):
         calls = []
         with spawns(calls, raises=AssertionError("a declared command was run")):
-            self.assertEqual(wiring.detect(self.p, cwd=config.ROOT).state,
-                             wiring.UNKNOWN_STATE)
-            self.assertNotEqual(wiring.refusal(self.p, cwd=config.ROOT), "")
+            w = wiring.detect(self.p, cwd=config.ROOT)
+            said = wiring.refusal(self.p, cwd=config.ROOT)
         self.assertEqual(calls, [])
+        self.assertEqual(w.state, wiring.UNKNOWN_STATE)
+        # Task 3's own sentence, and not a paraphrase of it: the state word is the record's.
+        self.assertEqual(said, profiletrust.UNATTENDED.format(name="claude-work",
+                                                              state=profiletrust.NEW))
+        self.assertEqual(w.fix, "charter claude-work")
+
+    def test_an_approved_profile_in_a_file_git_would_commit_is_never_probed(self):
+        """D: the ignore check moved in with the approval. A record saying the operator once
+        approved a command says nothing about the file that command now sits in, and a
+        declaration in a committable file is one charter has refused."""
+        approve_profile(self)
+        (config.ROOT / ".gitignore").write_text("# nothing ignored\n")
+        calls = []
+        with spawns(calls, raises=AssertionError("a declared command was run")):
+            w = wiring.detect(self.p, cwd=config.ROOT)
+            said = wiring.refusal(self.p, cwd=config.ROOT)
+            installed = wiring.install(self.p, config.ROOT)
+            rows = {r.name: r for r in doctor.check_profile_wiring()}
+        # The built-ins are probed in the same doctor run — the file decides nothing about
+        # a command out of charter's own registry — so this is about the declared one.
+        self.assertEqual([c for c in calls if c.env.get("CHARTER_HARNESS_PROFILE") ==
+                          "claude-work"], [])
+        self.assertEqual(w.state, wiring.UNKNOWN_STATE)
+        self.assertEqual(w.fix, profiles.FIX_NOT_IGNORED)
+        self.assertIn("is refused", said)
+        self.assertEqual([s for s, _l in installed], ["refused"])
+        self.assertEqual(rows["profile claude-work"].hint, profiles.FIX_NOT_IGNORED)
+        self.assertIn("not probed", rows["profile claude-work"].detail)
 
     def test_doctor_does_not_probe_an_unapproved_profile(self):
         calls = []
@@ -661,19 +923,143 @@ class NothingUnapprovedIsRun(PersonaIso, unittest.TestCase):
         row = rows["profile claude-work"]
         self.assertEqual(row.status, doctor.WARN)
         self.assertEqual(row.hint, "charter claude-work")
+        self.assertIn("not approved yet", row.detail)
+        self.assertIn(profiletrust.NEW, row.detail)
         # The BUILT-IN `claude` is probed in the same run — it is charter's own command and
         # needs no approval — so the assertion is about this profile's folder, not about
         # whether anything was spawned at all.
         self.assertEqual([c for c in calls if "CLAUDE_CONFIG_DIR" in c.env], [])
 
-    def test_install_refuses_an_unapproved_profile_before_it_runs_anything(self):
+    def test_install_asks_first(self):
+        """Installing runs the profile's own command (`claude plugin install`), so it asks
+        exactly as a launch does. A no is the workspace picker's cancel code, and nothing ran."""
         calls = []
         with spawns(calls, raises=AssertionError("a declared command was run")), \
-                mock.patch.object(plugincache, "install") as inst:
-            rc = commands_harness.cmd_harness_install(
-                SimpleNamespace(name="claude-work"))
-        self.assertEqual(rc, 1)
+                mock.patch.object(plugincache, "install") as inst, \
+                mock.patch("sys.stdin", (typed := _Typed("n\n"))), \
+                mock.patch("sys.stdout", (screen := _ATerminal())):
+            rc = commands_harness.cmd_harness_install(SimpleNamespace(name="claude-work"))
+        self.assertEqual(rc, profiletrust.DECLINED_EXIT)
+        self.assertEqual(typed.reads, 1)
+        self.assertIn("run this? [y/N]", screen.getvalue())
         inst.assert_not_called()
+        self.assertEqual(calls, [])
+        self.assertEqual(profiletrust.approval_needed(self.p), profiletrust.NEW)
+
+    def test_install_after_a_yes_records_it_and_installs(self):
+        seen = []
+        with spawns([], listing(entry(project=config.ROOT))), \
+                mock.patch.object(plugincache, "install",
+                                  side_effect=lambda *a, **k: seen.append(k) or
+                                  ("installed", "ok")), \
+                mock.patch("sys.stdin", _Typed("y\n")), \
+                mock.patch("sys.stdout", _ATerminal()):
+            rc, _out = self.said(lambda: commands_harness.cmd_harness_install(
+                SimpleNamespace(name="claude-work")))
+        self.assertEqual(rc, 0)
+        self.assertEqual(len(seen), 1)
+        self.assertEqual(profiletrust.approval_needed(self.p), "")
+
+    def test_install_with_no_terminal_refuses_as_an_open_nobody_is_at(self):
+        """No terminal on both ends, so no question: `UNATTENDED`, and rc 1."""
+        with spawns([], raises=AssertionError("a declared command was run")), \
+                mock.patch.object(plugincache, "install") as inst, \
+                mock.patch("sys.stdin", _APipe()):
+            rc, out = self.said(lambda: commands_harness.cmd_harness_install(
+                SimpleNamespace(name="claude-work")))
+        self.assertEqual(rc, 1)
+        self.assertIn(profiletrust.UNATTENDED.format(name="claude-work",
+                                                     state=profiletrust.NEW), out)
+        inst.assert_not_called()
+
+    def test_install_refuses_a_yes_it_could_not_record(self):
+        """N2b's nit, on this surface too (`KIND_RECORD`): a yes charter cannot write down
+        would only be asked again, so it refuses — and installs nothing."""
+        with spawns([], raises=AssertionError("a declared command was run")), \
+                mock.patch.object(plugincache, "install") as inst, \
+                mock.patch.object(profiletrust, "record_launched", return_value="read-only"), \
+                mock.patch("sys.stdin", _Typed("y\n")), \
+                mock.patch("sys.stdout", _ATerminal()):
+            rc, out = self.said(lambda: commands_harness.cmd_harness_install(
+                SimpleNamespace(name="claude-work")))
+        self.assertEqual(rc, 1)
+        self.assertIn("could not record", out)
+        inst.assert_not_called()
+
+
+class AYesNeverWalksPastAWiringRefusal(_ALaunchNamesAProfile, unittest.TestCase):
+    """Ruling 27, with the wiring link in the chain: after a yes the WHOLE chain runs again
+    before the `exec`, so a profile the operator approved a moment ago and whose folder does
+    not carry charter's guard is still refused — on every path (re-review N2)."""
+
+    def unwired(self):
+        return mock.patch.object(wiring, "_asked", return_value=wiring.Wiring(
+            wiring.UNWIRED, "charter@charter is not installed", "charter harness install x"))
+
+    def test_a_yes_on_an_unwired_profile_still_refuses_with_no_frame(self):
+        said = io.StringIO()
+        with self.unwired(), redirect_stderr(said), \
+                mock.patch("sys.stdin", _Typed("y\n")), \
+                mock.patch("sys.stdout", _ATerminal()), \
+                mock.patch.object(launcher.shutil, "which", return_value="/nowhere/claude"):
+            rc = launcher.start(self._profile(), [], fid=None, attended=True)
+        self.assertEqual(profiletrust.approval_needed(self._profile()), "", "no record")
+        self.assertEqual(self.execs, [])
+        self.assertEqual(rc, launcher.REFUSED_EXIT)
+        self.assertIn("not wired", said.getvalue())
+
+    def test_a_yes_on_an_unwired_profile_still_refuses_in_the_pane(self):
+        from charter.frame import state
+
+        state.frame_dir("beta.1", create=True)
+        said = io.StringIO()
+        with self.unwired(), redirect_stderr(said), \
+                mock.patch("sys.stdin", _Typed("y\n")), \
+                mock.patch("sys.stdout", _ATerminal()), \
+                mock.patch.object(launcher.shutil, "which", return_value="/nowhere/claude"), \
+                mock.patch.object(launcher, "framed_chat", return_value="beta.1"), \
+                mock.patch.object(launcher, "_wait_for_the_operator"):
+            rc = launcher.cmd_frame_launch(SimpleNamespace(
+                profile="claude-work", attended=True, rest=[]))
+        self.assertEqual(self.execs, [])
+        self.assertEqual(rc, launcher.REFUSED_EXIT)
+        self.assertIn("not wired", said.getvalue())
+
+    def test_a_yes_before_tmux_still_refuses_an_unwired_profile_before_tmux(self):
+        """The same, where `charter <profile>` asks: `_asked_here`'s re-run is the whole
+        chain, so nothing is allocated for a profile that will not start."""
+        with self.unwired():
+            rc, said = self._said(profile="claude-work", stdin=_Typed("y\n"),
+                                  stdout=_ATerminal())
+        self.assertEqual(rc, launcher.REFUSED_EXIT)
+        self.assertIn("not wired", said)
+        self.assertFalse(self._started())
+
+    def test_callers_branch_on_the_kind_not_the_text(self):
+        """Every sentence reworded — `NEEDS_ASKING` and both of the wiring refusal's — and
+        the pane still asks, and still refuses the unwired profile after the yes: which
+        refusal it is was never read off the words."""
+        from charter.frame import state
+
+        state.frame_dir("beta.1", create=True)
+        stdin, said = _Typed("y\n"), io.StringIO()
+        with self.unwired(), redirect_stderr(said), \
+                mock.patch.object(profiletrust, "NEEDS_ASKING", "reworded {name} {state}"), \
+                mock.patch.object(wiring, "NOT_WIRED", "reworded {name} {detail} {fix}"), \
+                mock.patch.object(wiring, "CANNOT_TELL",
+                                  "reworded {kind} {name} {detail} {probe}"), \
+                mock.patch("sys.stdin", stdin), \
+                mock.patch("sys.stdout", (screen := _ATerminal())), \
+                mock.patch.object(launcher.shutil, "which", return_value="/nowhere/claude"), \
+                mock.patch.object(launcher, "framed_chat", return_value="beta.1"), \
+                mock.patch.object(launcher, "_wait_for_the_operator"):
+            rc = launcher.cmd_frame_launch(SimpleNamespace(
+                profile="claude-work", attended=True, rest=[]))
+        self.assertEqual(stdin.reads, 1)
+        self.assertIn("run this? [y/N]", screen.getvalue())
+        self.assertEqual(rc, launcher.REFUSED_EXIT)
+        self.assertEqual(self.execs, [])
+        self.assertIn("reworded claude-work", said.getvalue())
 
 
 # --------------------------------------------------------------------------- #
@@ -718,7 +1104,7 @@ class TheLaunchRefusesAnUnwiredProfile(PersonaIso, unittest.TestCase):
         self.assertEqual(r.kind, wiring.KIND_WIRING)
 
     def test_a_wired_built_in_reaches_the_end_of_the_chain(self):
-        with approved(), spawns([], listing(entry(project=Path.cwd()))):
+        with spawns([], listing(entry(project=Path.cwd()))):
             self.assertIsNone(self.refuse(profiles.current().profiles["claude"]))
 
     def test_a_cached_wired_answer_never_starts_a_chat(self):
@@ -727,7 +1113,7 @@ class TheLaunchRefusesAnUnwiredProfile(PersonaIso, unittest.TestCase):
         here = Path.cwd()
         wiring.remember(p, cwd=here, w=wiring.Wiring(wiring.WIRED, "remembered", ""))
         self.assertIsNotNone(wiring.cached(p, cwd=here))
-        with approved(), spawns([], listing()):
+        with spawns([], listing()):
             r = self.refuse(p)
         self.assertIsNotNone(r)
         self.assertEqual(r.kind, wiring.KIND_WIRING)
@@ -735,10 +1121,45 @@ class TheLaunchRefusesAnUnwiredProfile(PersonaIso, unittest.TestCase):
     def test_every_launch_probes_fresh(self):
         p = profiles.current().profiles["claude"]
         calls = []
-        with approved(), spawns(calls, listing(entry(project=Path.cwd()))):
+        with spawns(calls, listing(entry(project=Path.cwd()))):
             self.refuse(p)
             self.refuse(p)
         self.assertEqual(len(calls), 2)
+
+    def test_a_reopen_skips_an_unwired_profile_by_name(self):
+        """Ruling 10 at a reopen, which has nobody to ask and no pane anybody is reading: it
+        says which chat, why, and the fix, rather than starting a chat whose launcher refuses
+        where nobody sees it. The chat stays in the manifest for the next `charter reopen`."""
+        (config.WORKSPACES_DIR / "alpha").mkdir(parents=True, exist_ok=True)
+        chat = reopen_state.Chat(chat="alpha.1", workspace="alpha", persona="",
+                                 harness="claude-code", cwd="", resume="", transcript="",
+                                 active=True, profile="claude")
+        warned, launched = [], []
+        with spawns([], listing()), \
+                mock.patch.object(commands_frame.util, "warn", side_effect=warned.append), \
+                mock.patch.object(commands_frame, "cmd_launch",
+                                  side_effect=lambda args: launched.append(args) or 0):
+            got = commands_frame._reopen_one(chat)
+        self.assertIsNone(got)
+        self.assertEqual(launched, [])
+        said = "\n".join(warned)
+        self.assertIn("alpha.1", said)
+        self.assertIn("not wired", said)
+        self.assertIn("charter harness install claude", said)
+
+    def test_a_reopen_asks_about_the_directory_the_chat_comes_back_in(self):
+        (config.WORKSPACES_DIR / "alpha").mkdir(parents=True, exist_ok=True)
+        chat = reopen_state.Chat(chat="alpha.1", workspace="alpha", persona="",
+                                 harness="claude-code", cwd="", resume="", transcript="",
+                                 active=True, profile="claude")
+        asked = []
+        with mock.patch.object(wiring, "refusal",
+                               side_effect=lambda p, *, cwd: asked.append(cwd) or "no"), \
+                mock.patch.object(commands_frame.util, "warn"), \
+                mock.patch.object(commands_frame, "cmd_launch", return_value=0):
+            commands_frame._reopen_one(chat)
+        self.assertEqual([Path(a).resolve() for a in asked],
+                         [(config.WORKSPACES_DIR / "alpha").resolve()])
 
     def test_a_handoff_asks_about_the_workspace_the_chat_would_stand_in(self):
         """Re-review N8: a handoff probes before it writes anything, and it probes the
@@ -751,7 +1172,7 @@ class TheLaunchRefusesAnUnwiredProfile(PersonaIso, unittest.TestCase):
         ws = config.WORKSPACES_DIR / "beta"
         ws.mkdir(parents=True)
         seen = []
-        with approved(), mock.patch.object(
+        with mock.patch.object(
                 commands_frame, "_profile_refusal",
                 side_effect=lambda p, *, attended, cwd=None: seen.append(cwd)):
             commands_frame._launch_refusal(profiles.current().profiles["claude"],
@@ -770,12 +1191,54 @@ class TheLaunchRefusesAnUnwiredProfile(PersonaIso, unittest.TestCase):
     def test_wiring_is_the_last_check_so_a_refusal_behind_it_is_never_probed(self):
         """The order is the order the checks cost in, and a probe is the expensive one: a
         command that is not on `PATH` is answered without asking the harness anything."""
-        p = make_profile("gone", command=["/nowhere/claude"])
+        p = approve_profile(self, make_profile("gone", command=["/nowhere/claude"]))
         calls = []
-        with approved(), spawns(calls, raises=AssertionError("probed anyway")):
+        with spawns(calls, raises=AssertionError("probed anyway")):
             r = self.refuse(p)
         self.assertEqual(r.kind, launcher.KIND_PATH)
         self.assertEqual(calls, [])
+
+
+class AStartPaysTheProbeTwice(_ALaunchNamesAProfile, unittest.TestCase):
+    """A3: "a start pays the probe twice" — once before tmux, once in the pane — and an
+    open whose caller asked the chain for itself does not pay a third time in between."""
+
+    def setUp(self):
+        super().setUp()
+        self._no_approval_needed()
+        self.probed: list = []
+        self.enterContext(mock.patch.object(
+            wiring, "refusal", side_effect=lambda p, *, cwd: self.probed.append(cwd) or ""))
+
+    def test_a_terminal_launch_probes_before_tmux(self):
+        self.assertEqual(self._launch(profile="claude-work", stdin=_APipe()), 0)
+        self.assertEqual(len(self.probed), 1)
+
+    def test_a_plus_or_a_tab_probes_once_before_the_pane_and_not_again_in_launch(self):
+        """`cmd_new_chat` and `_open_workspace` ask `_launch_refusal` so the refusal has a
+        surface, then call `cmd_launch` with `attach=False` — which must not probe again."""
+        p = self._profile()
+        self.assertEqual(commands_frame._launch_refusal(
+            p, attended=True, cwd=commands_frame._chat_dir_of("beta")), "")
+        self.assertEqual(self._launch(profile="claude-work", attach=False, stdin=_APipe()), 0)
+        self.assertEqual(len(self.probed), 1, self.probed)
+        # …and the pane's own chain, before its `exec`, is the second.
+        self.assertEqual(launcher.start(p, [], fid=None, attended=False), 0)
+        self.assertEqual(len(self.probed), 2, self.probed)
+
+    def test_a_handoffs_opening_does_not_probe_in_launch_either(self):
+        opening = commands_frame.Opening("hello there")
+        self.assertEqual(self._launch(profile="claude-work", attach=False, opening=opening,
+                                      rest=["hello there"], stdin=_APipe()), 0)
+        self.assertEqual(self.probed, [])
+
+    def test_skipping_it_skips_the_probe_and_nothing_else(self):
+        """The skip is the WIRING link alone: a `PATH` refusal for the same open still
+        happens before tmux."""
+        rc, said = self._said(profile="claude-work", attach=False, which=None, stdin=_APipe())
+        self.assertEqual(rc, launcher.MISSING_EXIT)
+        self.assertIn("not on PATH", said)
+        self.assertFalse(self._started())
 
 
 class ARefusalThatQuotesACommandShowsItEscaped(PersonaIso, unittest.TestCase):
@@ -791,16 +1254,10 @@ class ARefusalThatQuotesACommandShowsItEscaped(PersonaIso, unittest.TestCase):
         super().setUp()
         make_plane(self)
         self.nasty = "cl\raude\x1b[2K"
-        # These cases are about what the probe answers, which is the question AFTER the
-        # gate: `detect` refuses to run a declared profile's command until something stands
-        # for the operator's approval of it, and `NothingUnapprovedIsRun` is where that is
-        # the subject.
-        self.enterContext(approved())
-
 
     def test_cannot_tell_escapes_the_command_it_names(self):
-        p = make_profile(self.nasty, command=[self.nasty],
-                         env=[("CLAUDE_CONFIG_DIR", self.nasty)])
+        p = approve_profile(self, make_profile(self.nasty, command=[self.nasty],
+                                               env=[("CLAUDE_CONFIG_DIR", self.nasty)]))
         with spawns([], "", rc=1):
             said = wiring.refusal(p, cwd=self.tmp)
         self.assertNotIn("\r", said)
@@ -808,7 +1265,7 @@ class ARefusalThatQuotesACommandShowsItEscaped(PersonaIso, unittest.TestCase):
         self.assertIn(contain.readable(self.nasty), said)
 
     def test_not_wired_escapes_the_name_and_the_fix(self):
-        p = make_profile(self.nasty)
+        p = approve_profile(self, make_profile(self.nasty))
         with spawns([], listing()):
             said = wiring.refusal(p, cwd=self.tmp)
         self.assertNotIn("\r", said)
@@ -921,6 +1378,70 @@ class TheCache(PersonaIso, unittest.TestCase):
         self.path().write_text("{nope")
         self.assertIsNone(wiring.cached(self.p, cwd=self.here))
 
+    def test_a_disable_written_at_the_plane_root_is_a_miss(self):
+        """A6, measured on claude 2.1.270: in a git plane the ROOT's `settings.local.json`
+        reaches a session in `workspaces/<ws>/` below it. A stamp of the chat's own
+        directory alone would keep drawing `wired` after the root disabled charter."""
+        ws = config.ROOT / "workspaces" / "w"
+        ws.mkdir(parents=True)
+        wiring.remember(self.p, cwd=ws, w=self.w)
+        self.assertEqual(wiring.cached(self.p, cwd=ws), self.w)
+        (config.ROOT / ".claude").mkdir(exist_ok=True)
+        (config.ROOT / ".claude" / "settings.local.json").write_text(
+            json.dumps({"enabledPlugins": {plugincache.PLUGIN_ID: False}}))
+        self.assertIsNone(wiring.cached(self.p, cwd=ws))
+
+    def test_the_directories_between_the_chat_and_the_root_are_stamped_too(self):
+        ws = config.ROOT / "workspaces" / "w"
+        ws.mkdir(parents=True)
+        wiring.remember(self.p, cwd=ws, w=self.w)
+        (config.ROOT / "workspaces" / ".claude").mkdir()
+        (config.ROOT / "workspaces" / ".claude" / "settings.json").write_text("{}")
+        self.assertIsNone(wiring.cached(self.p, cwd=ws))
+
+    def test_the_walk_stops_at_the_plane_root(self):
+        """Above the plane is somebody else's directory: a file there is no stamp of this
+        plane's, and walking to `/` would make every entry a miss on a machine whose home
+        directory has a `.claude/` at all."""
+        stamped = wiring._stamp(self.p, config.ROOT / "workspaces")
+        above = str(Path(os.path.realpath(config.ROOT)).parent / ".claude")
+        self.assertFalse(any(k.startswith(above + os.sep) for k in stamped), stamped)
+        self.assertTrue(any(k.startswith(str(Path(os.path.realpath(config.ROOT)) / ".claude"))
+                            for k in stamped), stamped)
+
+    def test_a_directory_outside_the_plane_stamps_only_itself(self):
+        outside = Path(self.enterContext(_TempDir()))
+        stamped = wiring._stamp(self.p, outside)
+        dirs = {str(Path(k).parent.parent) for k in stamped if "/.claude/" in k}
+        self.assertEqual(dirs, {os.path.realpath(outside)})
+
+    def test_a_cache_entry_of_the_wrong_shape_is_a_miss_and_never_a_traceback(self):
+        """A1: every field of an entry is a value a chat can write, and each of these was a
+        `TypeError` or a `Wiring` of the wrong type out of a selector draw."""
+        hostile = [{"checked_at": "x"}, {"checked_at": None}, {"checked_at": True},
+                   {"checked_at": [1]}, {"state": "wired-ish"}, {"detail": 3},
+                   {"fix": None}]
+        for change in hostile:
+            with self.subTest(change=change):
+                wiring.remember(self.p, cwd=self.here, w=self.w)
+                doc = json.loads(self.path().read_text())
+                for e in doc.values():
+                    e.update(change)
+                self.path().write_text(json.dumps(doc))
+                self.assertIsNone(wiring.cached(self.p, cwd=self.here))
+
+    def test_both_age_bounds_are_where_the_rule_says(self):
+        """B3: `0 <= age < MAX_AGE`, a stated security rule, pinned at each edge. An entry
+        answered this instant is a hit; one exactly `MAX_AGE` old is a miss; one a second in
+        the future is stale."""
+        now = 1_800_000_000.0
+        with mock.patch.object(wiring.time, "time", return_value=now):
+            wiring.remember(self.p, cwd=self.here, w=self.w)
+        for at, hit in ((now, True), (now + wiring.MAX_AGE - 1, True),
+                        (now + wiring.MAX_AGE, False), (now - 1, False)):
+            with self.subTest(at=at), mock.patch.object(wiring.time, "time", return_value=at):
+                self.assertEqual(wiring.cached(self.p, cwd=self.here) is not None, hit)
+
     def test_remembering_never_raises_over_a_cache_it_cannot_write(self):
         """A display cache is not worth a row, a selector or a launch."""
         with mock.patch.object(config, "write_for", side_effect=OSError("read-only")):
@@ -956,7 +1477,7 @@ kind = "codex"
 command = ["codex"]
 env = {{ CODEX_HOME = "{self.codex_home}" }}
 """)
-        self.enterContext(approved())
+        approve_every_profile(self)
 
     def run_install(self, name) -> int:
         return commands_harness.cmd_harness_install(SimpleNamespace(name=name))
@@ -1013,8 +1534,10 @@ env = {{ CODEX_HOME = "{self.codex_home}" }}
         installing a plugin and approving hooks are Codex's own commands, and a hook nobody
         approved is inert whatever charter did (ruling 7)."""
         out = self.said(lambda: self.run_install("codex-alt"))
-        self.assertIn(f"CODEX_HOME={self.codex_home}", out)
-        self.assertIn("codex plugin add", out)
+        self.assertIn(f"CODEX_HOME={shlex.quote(str(self.codex_home))}", out)
+        # Once: the refusal the install ends on names the steps, and a second list printed
+        # above it was the same three lines again (C).
+        self.assertEqual(out.count("codex plugin add"), 1, out)
 
     def test_an_existing_policy_table_without_charters_line_is_refused(self):
         self.codex_home.mkdir(parents=True, exist_ok=True)
@@ -1034,6 +1557,47 @@ env = {{ CODEX_HOME = "{self.codex_home}" }}
                 spawns([], json.dumps({"plugin": []})):
             out = self.said(lambda: self.run_install("oc-alt"))
         self.assertRegex(out, r"!\s+somebody else's plugin")
+
+    def test_a_doubled_codex_config_refuses(self):
+        """Pinned (C): without its branch a doubled install printed the detail as a note and
+        exited 0 over a Codex that runs charter twice per turn."""
+        with mock.patch.object(wiring, "install",
+                               return_value=[("doubled", "cx declares hooks")]), \
+                mock.patch.object(wiring, "detect", side_effect=AssertionError("asked")):
+            out = self.said(lambda: self.assertEqual(self.run_install("codex-alt"), 1))
+        self.assertIn("charter fires twice", out)
+
+    def test_a_malformed_codex_config_refuses_and_is_left_alone(self):
+        with mock.patch.object(wiring, "install", return_value=[("malformed", "cx/config")]), \
+                mock.patch.object(wiring, "detect", side_effect=AssertionError("asked")):
+            out = self.said(lambda: self.assertEqual(self.run_install("codex-alt"), 1))
+        self.assertIn("is not valid TOML", out)
+
+    def test_a_refused_name_says_its_own_reason(self):
+        """`:150`: a name the file declares and charter refused is not "no such profile" —
+        the operator wrote it, and the reason is what they need."""
+        declare_profiles(self, '[harness.bad-one]\nkind = "nope"\ncommand = ["x"]\n')
+        out = self.said(lambda: self.assertEqual(self.run_install("bad-one"), 2))
+        self.assertIn("profile 'bad-one' is refused", out)
+        self.assertNotIn("no harness or profile named", out)
+
+    def test_a_long_name_is_bounded_where_install_repeats_it_back(self):
+        """`commands_harness.py`'s `shown`: a refusal sentence bounds the name with contain's
+        fixed marker (ruling 45), and a 161-character name is one past that bound."""
+        long_name = "i" * 161
+        declare_profiles(self, f'[harness.{long_name}]\nkind = "claude"\ncommand = ["claude"]\n')
+        with mock.patch("sys.stdin", _APipe()):
+            out = self.said(lambda: self.assertEqual(self.run_install(long_name), 1))
+        self.assertIn("i" * 160 + "...", out)
+        self.assertNotIn(long_name, out)
+
+    def test_a_name_is_repeated_back_escaped_once(self):
+        """A12: `readable` then `!r` escaped every backslash `readable` had written, so an ESC
+        read as `\\\\u001b` — two escapes for one byte, and neither the one a reader
+        could type back."""
+        out = self.said(lambda: self.assertEqual(self.run_install("x\x1bx"), 2))
+        self.assertIn("'x\\u001bx'", out)
+        self.assertNotIn("\\\\u001b", out)
 
     def test_a_registry_name_still_works_as_today(self):
         """`charter harness install codex` is what `docs/harnesses.md` tells people to run,
@@ -1099,14 +1663,16 @@ env = {{ CODEX_HOME = "{self.tmp / 'cx'}" }}
             return commands._wire_profiles(config.ROOT, install=install)
 
     def test_init_installs_for_an_approved_claude_profile(self):
-        with approved(), mock.patch.object(wiring, "install",
+        approve_every_profile(self)
+        with mock.patch.object(wiring, "install",
                                            return_value=[("installed", "x")]) as inst:
             with spawns([], listing()):
                 commands._wire_profiles(config.ROOT, install=True)
         self.assertIn("claude-alt", {c.args[0].name for c in inst.call_args_list})
 
     def test_init_leaves_a_codex_profile_opt_in(self):
-        with approved(), mock.patch.object(wiring, "install",
+        approve_every_profile(self)
+        with mock.patch.object(wiring, "install",
                                            return_value=[("installed", "x")]) as inst:
             with spawns([], listing()):
                 out = commands._wire_profiles(config.ROOT, install=True)
@@ -1114,15 +1680,16 @@ env = {{ CODEX_HOME = "{self.tmp / 'cx'}" }}
         self.assertIn("charter harness install codex-alt", " ".join(l for _s, l in out))
 
     def test_reinit_installs_nothing_and_names_what_is_missing(self):
-        with approved(), mock.patch.object(plugincache, "install") as inst:
+        approve_every_profile(self)
+        with mock.patch.object(plugincache, "install") as inst:
             out = self.wired(install=False)
         inst.assert_not_called()
         self.assertIn("not wired", " ".join(l for _s, l in out))
 
     def test_reinit_wires_an_opencode_profiles_shim(self):
-        with approved():
-            with spawns([], json.dumps({"plugin": []})):
-                commands._wire_profiles(config.ROOT, install=False)
+        approve_every_profile(self)
+        with spawns([], json.dumps({"plugin": []})):
+            commands._wire_profiles(config.ROOT, install=False)
         self.assertTrue(opencode.shim_is_charters(self.oc / "opencode"))
 
     def test_neither_touches_an_unapproved_profile(self):
@@ -1130,6 +1697,29 @@ env = {{ CODEX_HOME = "{self.tmp / 'cx'}" }}
             out = self.wired(install=True)
         inst.assert_not_called()
         self.assertIn("not approved yet", " ".join(l for _s, l in out))
+        self.assertIn("run charter claude-alt once", " ".join(l for _s, l in out))
+
+    def test_a_long_name_is_bounded_in_the_opt_in_line(self):
+        """`commands.py`'s opt-in line repeats the name back with contain's fixed bound
+        (ruling 45) — a report line, not a row anybody picks from."""
+        long_name = "c" * 161
+        declare_profiles(self, f'[harness.{long_name}]\nkind = "codex"\ncommand = ["codex"]\n')
+        approve_every_profile(self)
+        out = " ".join(l for _s, l in self.wired(install=True))
+        self.assertIn("c" * 160 + "...", out)
+        self.assertNotIn(long_name, out)
+
+    def test_an_install_label_reaches_the_report_contained_once(self):
+        """`wiring.install` contains every label it hands back, so `_wire_profiles` prints it
+        as it is — contained twice, a path's backslashes would double."""
+        approve_every_profile(self)
+        with mock.patch.object(plugincache, "install",
+                               return_value=("installed", "at c:\\x\x1b")), \
+                spawns([], listing()):
+            out = commands._wire_profiles(config.ROOT, install=True)
+        line = next(l for _s, l in out if "claude-alt" in l)
+        self.assertIn("c:\\\\x\\u001b", line)
+        self.assertNotIn("\\\\\\\\", line)
 
 
 # --------------------------------------------------------------------------- #
@@ -1144,31 +1734,49 @@ class DoctorHasARowPerProfile(PersonaIso, unittest.TestCase):
         super().setUp()
         make_plane(self)
         declare_profiles(self)
+        approve_every_profile(self)
+        # Which harnesses this machine "has", stated (B5): the listing depends on it.
+        self.enterContext(on_path("claude", "opencode"))
 
     def test_every_listed_profile_has_a_row_in_order(self):
-        with spawns([], listing()), approved():
+        with spawns([], listing()):
             names = doctor.check_names()
             produced = [r.name for r in doctor.run_all()]
         self.assertEqual(names, produced)
         at = names.index("harness profiles")
-        self.assertTrue(names[at + 1].startswith("profile "))
+        self.assertEqual(names[at + 1:at + 5], ["profile claude", "profile opencode",
+                                                "profile claude-work",
+                                                "profile codex-pinned"])
+
+    def test_a_built_in_whose_program_is_not_installed_has_no_row(self):
+        with on_path("claude", "codex", "opencode"):
+            with_codex = doctor.profile_row_names()
+        self.assertIn("profile codex", with_codex)
+        self.assertNotIn("profile codex", doctor.profile_row_names())
+
+    def test_a_declared_profile_whose_program_is_not_installed_still_has_a_row(self):
+        """`wiring.py`'s listing (C): a declaration is somebody's, and doctor is where they
+        find out it cannot run — so only a BUILT-IN is dropped for a missing program."""
+        with on_path():
+            names = doctor.profile_row_names()
+        self.assertEqual(names, ["profile claude-work", "profile codex-pinned"])
 
     def test_a_wired_row_is_ok_with_no_hint(self):
-        with approved(), spawns([], listing(entry(project=config.ROOT))):
+        with spawns([], listing(entry(project=config.ROOT))):
             rows = {r.name: r for r in doctor.check_profile_wiring()}
         row = rows["profile claude-work"]
         self.assertEqual(row.status, doctor.OK)
         self.assertEqual(row.hint, "")
 
     def test_an_unwired_row_names_the_install(self):
-        with approved(), spawns([], listing()):
+        with spawns([], listing()):
             rows = {r.name: r for r in doctor.check_profile_wiring()}
         row = rows["profile claude-work"]
         self.assertEqual(row.status, doctor.WARN)
         self.assertEqual(row.hint, "charter harness install claude-work")
 
     def test_an_unknown_row_says_the_check_could_not_run(self):
-        with approved(), spawns([], "", rc=1):
+        with spawns([], "", rc=1):
             rows = {r.name: r for r in doctor.check_profile_wiring()}
         self.assertEqual(rows["profile claude-work"].hint, doctor._NOT_CHECKED_HINT)
 
@@ -1180,18 +1788,55 @@ class DoctorHasARowPerProfile(PersonaIso, unittest.TestCase):
                 raise RuntimeError("this one row")
             return real(p, cwd=cwd)
 
-        with approved(), spawns([], listing()), \
+        with spawns([], listing()), \
                 mock.patch.object(wiring, "detect", boom):
             rows = {r.name: r for r in doctor.check_profile_wiring()}
         self.assertEqual(rows["profile claude-work"].status, doctor.WARN)
         self.assertIn("profile codex-pinned", rows)
+
+    def test_a_probe_that_raises_is_said_contained(self):
+        """B2, ruling 35: an exception's text is whatever raised it put there, and here that
+        is a path or an argv out of the profile."""
+        def boom(p, *, cwd):
+            raise RuntimeError("bad \x1b[2K path")
+
+        with mock.patch.object(wiring, "detect", boom):
+            rows = doctor.check_profile_wiring()
+        for r in rows:
+            self.assertNotIn("\x1b", r.detail)
+        self.assertIn("RuntimeError: bad \\u001b[2K path",
+                      {r.name: r for r in rows}["profile claude-work"].detail)
+
+    def test_a_row_says_how_much_of_a_long_detail_it_did_not_show(self):
+        """B1, ruling 45: a row the operator acts on counts what it hid. A clipped fix that
+        does not say so reads as the whole fix."""
+        long = "d" * 400
+        with mock.patch.object(wiring, "detect",
+                               return_value=wiring.Wiring(wiring.UNWIRED, long, "f" * 170)):
+            row = {r.name: r for r in doctor.check_profile_wiring()}["profile claude"]
+        self.assertEqual(row.detail, "d" * contain.DISPLAY_LIMIT + "… +240 not shown")
+        self.assertEqual(row.hint, "f" * contain.DISPLAY_LIMIT + "… +10 not shown")
+        self.assertNotIn("...", row.detail)
+
+    def test_a_long_profile_name_is_counted_in_its_row_and_its_hint(self):
+        """A 161-character name — one past the display bound — on the row name, which sizes
+        the column, and on the `charter <name>` hint an unapproved row gives."""
+        long_name = "n" * 161
+        declare_profiles(self, f'[harness.{long_name}]\nkind = "claude"\ncommand = ["claude"]\n')
+        with on_path():
+            names = doctor.profile_row_names()
+            rows = doctor.check_profile_wiring()
+        self.assertEqual(names, [f"profile {'n' * 160}… +1 not shown"])
+        self.assertEqual([r.name for r in rows], names)
+        hint = f"charter {long_name}"
+        self.assertEqual(rows[0].hint, f"{hint[:contain.DISPLAY_LIMIT]}… +9 not shown")
 
     def test_rows_are_probed_concurrently(self):
         def slow(p, *, cwd):
             time.sleep(0.3)
             return wiring.Wiring(wiring.WIRED, "slept", "")
 
-        with approved(), mock.patch.object(wiring, "detect", slow):
+        with mock.patch.object(wiring, "detect", slow):
             began = time.monotonic()
             rows = doctor.check_profile_wiring()
         self.assertGreaterEqual(len(rows), 2)
@@ -1236,10 +1881,38 @@ class DoctorHasARowPerProfile(PersonaIso, unittest.TestCase):
             asked.append(p.name)
             return wiring.Wiring(wiring.UNWIRED, "no", "fix it")
 
+        profiletrust.record_launched(profiles.current().profiles["codex-pinned"])
+        (config.STATE_DIR / profiletrust.RECORD).write_text("{}")
         with mock.patch.object(wiring, "detect", seen):
             doctor.check_profile_wiring()
-        self.assertNotIn("claude-work", asked)
-        self.assertIn("claude", asked)
+        self.assertEqual(asked, ["claude", "opencode"])
+        approve_profile(self)
+        asked.clear()
+        with mock.patch.object(wiring, "detect", seen):
+            doctor.check_profile_wiring()
+        self.assertEqual(sorted(asked), ["claude", "claude-work", "opencode"])
+
+    def test_one_git_call_however_many_profiles_are_declared(self):
+        """The file's ignore check is asked once for the table, not once per row: it is the
+        same answer for every profile in the file."""
+        real = profiles.ignore_check
+        checks = []
+        with mock.patch.object(profiles, "ignore_check",
+                               side_effect=lambda root: checks.append(root) or real(root)), \
+                mock.patch.object(wiring, "_asked",
+                                  return_value=wiring.Wiring(wiring.WIRED, "ok", "")):
+            doctor.check_profile_wiring()
+        # One for the rows; each probed DECLARED profile's own `detect` gate asks again.
+        self.assertEqual(len(checks), 1 + 2, checks)
+
+    def test_a_plane_that_declares_nothing_makes_no_git_call_for_its_rows(self):
+        (config.ROOT / profiles.LOCAL_FILE).unlink()
+        with mock.patch.object(profiles, "ignore_check",
+                               side_effect=AssertionError("git for no declared profile")), \
+                mock.patch.object(wiring, "_asked",
+                                  return_value=wiring.Wiring(wiring.WIRED, "ok", "")):
+            rows = doctor.check_profile_wiring()
+        self.assertEqual([r.name for r in rows], ["profile claude", "profile opencode"])
 
     def test_the_session_start_hook_runs_the_preflight(self):
         """The hook runs the same words a person types, so nothing in the process could tell
@@ -1278,7 +1951,6 @@ class EveryProfileDerivedTextIsShownEscaped(PersonaIso, unittest.TestCase):
     def setUp(self):
         super().setUp()
         make_plane(self)
-        self.enterContext(approved())
 
     def clean(self, *texts):
         for t in texts:
@@ -1302,16 +1974,18 @@ class EveryProfileDerivedTextIsShownEscaped(PersonaIso, unittest.TestCase):
         self.clean(*(text for _status, text in wiring.install(p, self.tmp)))
 
     def test_a_reason_charter_may_not_run_it_yet_is_shown_escaped(self):
-        """Today the reason is a constant. Task 3's record makes it a sentence about a
-        `command` the operator has not approved — which is the text a profile can write."""
+        """Task 3's sentence about a profile the operator has not approved quotes its NAME,
+        which is text the file chose."""
         p = make_profile(self.NASTY)
-        with mock.patch.object(wiring, "approval_needed", lambda q: f"no: {self.NASTY}"):
-            answer = wiring.detect(p, cwd=self.tmp)
-        self.clean(answer.detail, answer.fix)
+        answer = wiring.detect(p, cwd=self.tmp)
+        self.assertEqual(answer.state, wiring.UNKNOWN_STATE)
+        self.clean(answer.detail, answer.fix, wiring.refusal(p, cwd=self.tmp),
+                   *(label for _s, label in wiring.install(p, self.tmp)))
 
     def test_the_claude_detail_names_its_folder_and_scope_escaped(self):
         here = self.dirty_dir("cwd")
-        p = make_profile(self.NASTY, env=[("CLAUDE_CONFIG_DIR", str(self.dirty_dir("cc")))])
+        p = approve_profile(self, make_profile(
+            self.NASTY, env=[("CLAUDE_CONFIG_DIR", str(self.dirty_dir("cc")))]))
         with spawns([], listing(entry(scope=self.NASTY, project=here, enabled=False))):
             w = wiring.detect(p, cwd=here)
         self.assertEqual(w.state, wiring.UNWIRED)
@@ -1320,7 +1994,8 @@ class EveryProfileDerivedTextIsShownEscaped(PersonaIso, unittest.TestCase):
     def test_the_codex_detail_names_its_home_escaped(self):
         home = self.dirty_dir("cx")
         (home / "config.toml").write_text("[x")
-        p = make_profile(self.NASTY, kind="codex", env=[("CODEX_HOME", str(home))])
+        p = approve_profile(self, make_profile(self.NASTY, kind="codex",
+                                               env=[("CODEX_HOME", str(home))]))
         w = wiring.detect(p, cwd=self.tmp)
         self.assertEqual(w.state, wiring.UNKNOWN_STATE)
         self.clean(w.detail, w.fix, wiring.refusal(p, cwd=self.tmp), wiring.by_hand(p))
@@ -1331,8 +2006,9 @@ class EveryProfileDerivedTextIsShownEscaped(PersonaIso, unittest.TestCase):
         (home / "plugin").mkdir(parents=True)
         opencode.refresh_shim(home)
         (home / "plugin" / f"a{self.NASTY}.ts").write_text("Object.hasOwn = () => false;\n")
-        p = make_profile(self.NASTY, kind="opencode", command=[f"oc{self.NASTY}"],
-                         env=[("XDG_CONFIG_HOME", str(xdg))])
+        p = approve_profile(self, make_profile(self.NASTY, kind="opencode",
+                                               command=[f"oc{self.NASTY}"],
+                                               env=[("XDG_CONFIG_HOME", str(xdg))]))
         answer = json.dumps({"plugin": [f"file://{home / opencode.SHIM_PATH}"]})
         with spawns([], answer):
             w = wiring.detect(p, cwd=self.tmp)
@@ -1345,8 +2021,8 @@ class EveryProfileDerivedTextIsShownEscaped(PersonaIso, unittest.TestCase):
         import io
         from contextlib import redirect_stderr, redirect_stdout
 
-        p = make_profile(self.NASTY, kind="codex",
-                         env=[("CODEX_HOME", str(self.dirty_dir("cx2")))])
+        p = approve_profile(self, make_profile(
+            self.NASTY, kind="codex", env=[("CODEX_HOME", str(self.dirty_dir("cx2")))]))
         buf = io.StringIO()
         with redirect_stderr(buf), redirect_stdout(buf), \
                 mock.patch.object(commands_harness, "_resolve", return_value=(p, "")), \
@@ -1362,12 +2038,39 @@ class EveryProfileDerivedTextIsShownEscaped(PersonaIso, unittest.TestCase):
         read = profiles.ProfileSet(profiles={self.NASTY: p}, refused=(), default=None,
                                   default_from=None, default_refused=None)
         buf = io.StringIO()
-        with mock.patch.object(wiring, "approval_needed",
-                               return_value=wiring.NOT_APPROVED_YET), \
-                mock.patch.object(profiles, "current", return_value=read), \
+        with mock.patch.object(profiles, "current", return_value=read), \
                 redirect_stderr(buf):
             commands._say_profile_wiring(commands._wire_profiles(config.ROOT, install=True))
+        self.assertIn("not approved yet", buf.getvalue())
         self.clean(buf.getvalue())
+
+    def test_a_hostile_install_label_reaches_init_escaped(self):
+        """`commands.py`'s install line, pinned with a label carrying the bytes a path out of
+        the profile's `env` can carry."""
+        p = approve_profile(self, make_profile(self.NASTY))
+        read = profiles.ProfileSet(profiles={self.NASTY: p}, refused=(), default=None,
+                                  default_from=None, default_refused=None)
+        buf = io.StringIO()
+        with mock.patch.object(profiles, "current", return_value=read), \
+                mock.patch.object(plugincache, "install",
+                                  return_value=("failed", f"at {self.NASTY}")), \
+                redirect_stderr(buf):
+            commands._say_profile_wiring(commands._wire_profiles(config.ROOT, install=True))
+        self.assertIn("at x", buf.getvalue())
+        self.clean(buf.getvalue())
+
+    def test_a_hostile_scope_and_command_reach_the_enable_fix_escaped(self):
+        """`wiring.py`'s disabled answer puts the listed `scope` in its detail and the
+        profile's own `env` and command in its fix — three values neither charter nor the
+        operator wrote."""
+        here = self.dirty_dir("cwd2")
+        p = approve_profile(self, make_profile(self.NASTY, command=[f"cl{self.NASTY}"],
+                                               env=[("CLAUDE_CONFIG_DIR", self.NASTY)]))
+        with spawns([], listing(entry(scope="local", project=here, enabled=False))):
+            w = wiring.detect(p, cwd=here)
+        self.assertEqual(w.state, wiring.UNWIRED)
+        self.assertIn("clx\\u000dy", w.fix)
+        self.clean(w.detail, w.fix)
 
 
 class TheSeamsTheSweepAsksAbout(PersonaIso, unittest.TestCase):
@@ -1450,7 +2153,7 @@ class TheSeamsTheSweepAsksAbout(PersonaIso, unittest.TestCase):
         """`_launch` and the pane are already standing in the chat's directory; a `+`, a tab
         and a handoff are not, and the answer is about THEIR directory."""
         calls = []
-        with approved(), spawns(calls, listing()):
+        with spawns(calls, listing()):
             launcher.refusal(profiles.current().profiles["claude"], root=config.ROOT,
                              attended=False, env=dict(os.environ), cwd=self.here)
         self.assertEqual(str(calls[0].cwd), str(self.here))
@@ -1461,15 +2164,20 @@ class TheSeamsTheSweepAsksAbout(PersonaIso, unittest.TestCase):
         home = self.tmp / "cx2"
         home.mkdir()
         (home / "config.toml").write_text("[x")
-        p = make_profile("codex-alt", kind="codex", env=[("CODEX_HOME", str(home))])
+        p = approve_profile(self, make_profile("codex-alt", kind="codex",
+                                               env=[("CODEX_HOME", str(home))]))
         said = wiring.refusal(p, cwd=self.tmp)
         self.assertIn("check by hand: ", said)
-        self.assertIn(str(home / "config.toml"), said.split("check by hand: ", 1)[1])
+        self.assertEqual(shlex.split(said.split("check by hand: ", 1)[1]),
+                         ["cat", str(home / "config.toml")])
 
     def test_the_listing_is_built_ins_in_registry_order_then_the_rest_by_name(self):
         """`charter harness list`'s order, so a doctor row lands where the operator already
         reads that profile."""
-        names = [p.name for p in wiring.listed()]
+        declare_profiles(self, DECLARED_WITH_A_NAME_AFTER_ITS_SIBLING)
+        with on_path(*HARNESS_PROGRAMS):
+            names = [p.name for p in wiring.listed()]
+        self.assertEqual(names, ["claude", "opencode", "codex", "aaa-codex", "claude-work"])
         built_in = [n for n in profiles.builtins() if n in names]
         self.assertEqual(names[:len(built_in)], built_in)
         self.assertEqual(names[len(built_in):], sorted(names[len(built_in):]))
@@ -1479,7 +2187,7 @@ class TheSeamsTheSweepAsksAbout(PersonaIso, unittest.TestCase):
         between is a spawn of something that is not there."""
         asked = []
 
-        def available(command=("claude",)):
+        def available(command=("claude",), path=None):
             asked.append(tuple(command))
             return False
 
@@ -1490,12 +2198,46 @@ class TheSeamsTheSweepAsksAbout(PersonaIso, unittest.TestCase):
                                                        command=["/nowhere/claude"]))
         self.assertEqual(asked, [("/nowhere/claude",)])
 
+    def test_a_plugin_list_under_an_environment_exec_refuses_is_an_unknown_answer(self):
+        """`plugincache._claude_json`'s own `ValueError`: `wiring` catches it one level up
+        as well, but `plugincache.install` reaches this read with no such net, and "could not
+        read the list" is the answer that installs nothing over it."""
+        with mock.patch.object(plugincache, "available", lambda *a, **k: True):
+            self.assertIsNone(plugincache._claude_json(["list"], env={"X": "a\x00b"}))
+            self.assertEqual(plugincache.install(self.here, env={"X": "a\x00b"})[0],
+                             "unknown")
+
     def test_a_registry_name_resolves_to_the_built_in_of_that_kind(self):
         """`charter harness install claude-code` — the NAME `$CHARTER_HARNESS` carries, which
         is not the word typed after `charter`."""
         p, why = commands_harness._resolve("claude-code")
         self.assertIsNotNone(p, why)
         self.assertEqual(p.name, "claude")
+
+    def ordered(self, *names):
+        """`profiles.current()` holding the plane's own profiles in the order *names* says —
+        the order a `dict` of them happens to iterate in is exactly what `_resolve` must not
+        depend on."""
+        read = profiles.current()
+        by_name = dict(read.profiles)
+        by_name.update({"codex": make_profile("codex", kind="codex", source=profiles.BUILTIN)})
+        return mock.patch.object(profiles, "current", return_value=read._replace(
+            profiles={n: by_name[n] for n in names}))
+
+    def test_a_declared_sibling_listed_first_is_not_the_built_in(self):
+        """Both halves of `_resolve`'s test (ruling 8), each with the profile that would
+        answer instead standing FIRST: `claude-work` is Claude Code and not named after its
+        kind; `codex` is named after its kind and is not Claude Code."""
+        with self.ordered("claude-work", "codex", "claude"):
+            p, _why = commands_harness._resolve("claude-code")
+        self.assertEqual(p.name, "claude")
+
+    def test_a_refused_names_reason_is_its_own_and_not_the_first_refused(self):
+        read = profiles.current()._replace(refused=(
+            profiles.Refused("other", profiles.LOCAL_FILE, "other's reason"),
+            profiles.Refused("mine", profiles.LOCAL_FILE, "my reason")))
+        with mock.patch.object(profiles, "current", return_value=read):
+            self.assertEqual(commands_harness._resolve("mine"), (None, "my reason"))
 
     def test_a_gap_is_warned_about_and_a_write_is_only_noted(self):
         """`init` and `reinit` do not fail over a profile's own account folder, so the only
@@ -1505,18 +2247,26 @@ class TheSeamsTheSweepAsksAbout(PersonaIso, unittest.TestCase):
         from contextlib import redirect_stderr
 
         buf = io.StringIO()
+        statuses = ["skipped", "created", "missing", "opt-in", "unavailable", "unknown",
+                    "unvouched", "failed", "refused", "installed", "present", "refreshed",
+                    "current", "a-status-nobody-has-written-yet"]
         with redirect_stderr(buf):
-            commands._say_profile_wiring([("skipped", "a"), ("created", "b"),
-                                          ("missing", "c"), ("opt-in", "d")])
+            commands._say_profile_wiring([(s, s) for s in statuses])
         lines = [l for l in buf.getvalue().splitlines() if l.strip()]
-        self.assertEqual([l[0] for l in lines], ["!", "•", "!", "!"])
+        # A9: `unavailable` is a gap, not a note — and so is any status a harness adds later.
+        self.assertEqual(dict(zip(statuses, (l[0] for l in lines))), {
+            "skipped": "!", "created": "•", "missing": "!", "opt-in": "!",
+            "unavailable": "!", "unknown": "!", "unvouched": "!", "failed": "!",
+            "refused": "!", "installed": "•", "present": "•", "refreshed": "•",
+            "current": "•", "a-status-nobody-has-written-yet": "!"})
 
     def test_nothing_is_wired_while_git_would_carry_the_local_file(self):
         """Every profile in it is refused, and `charter harness list` and doctor's
         `harness profiles` row already say so with the fix. Wiring one anyway would act on a
         declaration charter has just refused."""
+        approve_every_profile(self)
         (config.ROOT / ".gitignore").write_text("# nothing ignored\n")
-        with approved(), mock.patch.object(wiring, "install") as inst:
+        with mock.patch.object(wiring, "install") as inst:
             self.assertEqual(commands._wire_profiles(config.ROOT, install=True), [])
         inst.assert_not_called()
 

--- a/tests/test_a_profile_is_wired_or_refuses.py
+++ b/tests/test_a_profile_is_wired_or_refuses.py
@@ -380,10 +380,31 @@ class ClaudeCodeIsAskedUnderTheProfilesEnvironment(PersonaIso, unittest.TestCase
     def test_a_scope_charter_does_not_recognise_sorts_last_rather_than_raising(self):
         """`_SCOPE_ORDER` is charter's reading of three scopes the CLI documents. A fourth
         one — a newer Claude Code, a row charter has never seen — must not take the row down,
-        and must not outrank a scope charter does understand."""
-        with spawns([], listing(entry(scope="cowork", project=self.here, enabled=False),
-                                entry(scope="user", enabled=True))):
+        and must not outrank a scope charter does understand.
+
+        Handed to `_claude` at `plugincache.covering_entries`, the seam it reads: today
+        `plugincache._our_entries` drops a row whose scope is not one of `_SCOPES` before
+        wiring sees it, so a listing alone never reaches this rule — and the day
+        `_SCOPES` grows, this is what still holds."""
+        rows = [entry(scope="cowork", project=self.here, enabled=False),
+                entry(scope="user", enabled=True)]
+        with mock.patch.object(plugincache, "covering_entries", return_value=rows):
             self.assertEqual(wiring.detect(self.p, cwd=self.here).state, wiring.WIRED)
+        with mock.patch.object(plugincache, "covering_entries", return_value=rows[:1]):
+            w = wiring.detect(self.p, cwd=self.here)
+        self.assertEqual(w.state, wiring.UNWIRED)
+        self.assertIn("cowork", w.detail)
+
+    def test_a_typed_fix_with_no_directory_starts_with_the_variables(self):
+        """`_typed` without a *cwd* — the probe charter prints to run by hand — has no `cd`,
+        and lists the profile's variables in NAME order whatever order the profile holds
+        them in."""
+        p = profiles.Profile(name="claude-order", kind="claude", harness="claude-code",
+                             command=("claude",), source=profiles.LOCAL_FILE,
+                             env=(("ZED", "z"), ("CLAUDE_CONFIG_DIR", "/c"), ("ALPHA", "a")))
+        self.assertEqual(shlex.split(wiring.by_hand(p)),
+                         ["ALPHA=a", "CLAUDE_CONFIG_DIR=/c", "ZED=z",
+                          "claude", "plugin", "list", "--json"])
 
     def test_a_project_enable_over_a_user_disable_is_wired(self):
         """The same pair in the other order, so the order of the list decides nothing."""
@@ -657,11 +678,99 @@ class CodexIsReadAtTheProfilesHome(PersonaIso, unittest.TestCase):
         self.write(codex_config())
         self.assertEqual(wiring.detect(self.p, cwd=self.tmp).state, wiring.UNWIRED)
 
+    def cache(self) -> Path:
+        return self.home / "plugins" / "cache" / "charter" / "charter"
+
     def test_an_unreadable_plugin_hooks_file_is_unknown(self):
-        (self.home / "plugins" / "cache" / "charter" / "charter" / "0.60.0" / "hooks"
-         / "hooks.json").write_text("{nope")
+        f = self.cache() / "0.60.0" / "hooks" / "hooks.json"
+        f.write_text("{nope")
         self.write(codex_config())
-        self.assertEqual(wiring.detect(self.p, cwd=self.tmp).state, wiring.UNKNOWN_STATE)
+        w = wiring.detect(self.p, cwd=self.tmp)
+        self.assertEqual(w.state, wiring.UNKNOWN_STATE)
+        self.assertIn(f"{f} could not be read", w.detail)
+
+    def test_a_plugin_hooks_file_that_is_not_utf8_names_the_file(self):
+        f = self.cache() / "0.60.0" / "hooks" / "hooks.json"
+        f.write_bytes(b"\xff\xfe{}")
+        self.write(codex_config())
+        w = wiring.detect(self.p, cwd=self.tmp)
+        self.assertEqual(w.state, wiring.UNKNOWN_STATE)
+        self.assertIn(f"{f} could not be read", w.detail)
+
+    @unittest.skipIf(os.geteuid() == 0, "root reads a mode-000 file")
+    def test_a_plugin_hooks_file_nobody_may_read_is_unknown_and_never_a_traceback(self):
+        f = self.cache() / "0.60.0" / "hooks" / "hooks.json"
+        f.chmod(0)
+        self.addCleanup(f.chmod, 0o600)
+        self.write(codex_config())
+        w = wiring.detect(self.p, cwd=self.tmp)
+        self.assertEqual(w.state, wiring.UNKNOWN_STATE)
+        self.assertIn(f"{f} could not be read", w.detail)
+
+    @unittest.skipIf(os.geteuid() == 0, "root lists a mode-000 directory")
+    def test_a_plugin_cache_nobody_may_list_is_unknown_and_never_a_traceback(self):
+        self.cache().chmod(0)
+        self.addCleanup(self.cache().chmod, 0o700)
+        self.write(codex_config())
+        w = wiring.detect(self.p, cwd=self.tmp)
+        self.assertEqual(w.state, wiring.UNKNOWN_STATE)
+        self.assertIn(f"{self.cache()} could not be read", w.detail)
+
+    def test_a_file_among_the_versions_is_not_a_version(self):
+        """Only a DIRECTORY under the plugin's cache is a cached copy: a stray file there
+        (`.DS_Store`, a download left half-way) has no `hooks/hooks.json` to read, and read
+        as a copy it would be an unreadable one."""
+        (self.cache() / ".DS_Store").write_text("x")
+        self.write(codex_config())
+        self.assertEqual(wiring.detect(self.p, cwd=self.tmp).state, wiring.WIRED)
+
+    def test_an_empty_plugin_cache_has_no_guard_and_never_raises(self):
+        shutil.rmtree(self.cache() / "0.60.0")
+        self.write(codex_config())
+        w = wiring.detect(self.p, cwd=self.tmp)
+        self.assertEqual(w.state, wiring.UNWIRED)
+        self.assertIn("plugins/cache", w.detail)
+
+    def test_a_cached_version_with_no_hooks_file_places_no_guard(self):
+        """A copy with no `hooks.json` declares no hook at all, so it agrees with no other
+        copy about where the guard is — read as nothing to trust, not as unreadable."""
+        (self.cache() / "0.59.0").mkdir()
+        self.write(codex_config())
+        w = wiring.detect(self.p, cwd=self.tmp)
+        self.assertEqual(w.state, wiring.UNWIRED)
+
+    def test_every_wrong_shape_of_the_plugin_hooks_file_places_no_guard(self):
+        """A1's rule for the file A5 reads: it sits in the profile's own home, which a chat
+        can write, so every shape is a hostile input. Each reads as no guard, and none
+        raises. Built so that reading past the missing check would raise, not pass."""
+        bash = {"type": "command", "command": "charter hook pretooluse --plugin-version 1"}
+        shapes = {
+            "doc is not an object": [],
+            "hooks is not an object": {"hooks": []},
+            "groups are not a list": {"hooks": {"PreToolUse": 5}},
+            "a group is not an object": {"hooks": {"PreToolUse": [["x"]]}},
+            "a group's hooks are not a list": {"hooks": {"PreToolUse": [{"hooks": 5}]}},
+            "a hook is not an object": {"hooks": {"PreToolUse": [{"hooks": ["x"]}]}},
+            "a command is not a string": {"hooks": {"PreToolUse": [{"hooks": [
+                {"type": "command", "command": 5}]}]}},
+        }
+        self.write(codex_config())
+        for label, doc in shapes.items():
+            with self.subTest(label):
+                plugin_in_codex_cache(self.home, doc)
+                w = wiring.detect(self.p, cwd=self.tmp)
+                self.assertEqual(w.state, wiring.UNWIRED, w.detail)
+                self.assertIn("no copy of", w.detail)
+        plugin_in_codex_cache(self.home, {"hooks": {"PreToolUse": [{"hooks": [bash]}]}})
+        self.assertEqual(wiring.detect(self.p, cwd=self.tmp).state, wiring.WIRED)
+
+    def test_a_malformed_trust_entry_for_a_hook_that_is_not_the_guard_is_not_read(self):
+        """Only the guard's entries are read: another hook's, even charter's own dispatch
+        hook's, in a shape Codex never writes, says nothing about the guard."""
+        self.write(codex_config(trust=False)
+                   + f'\n[hooks.state]\n"{TRUST_KEY}" = {{ trusted_hash = "sha256:abc" }}\n'
+                   + f'"{DISPATCH_KEY}" = "yes"\n')
+        self.assertEqual(wiring.detect(self.p, cwd=self.tmp).state, wiring.WIRED)
 
     def test_the_guard_handler_is_the_one_charters_own_hooks_file_puts_on_bash(self):
         """The constant the detection keys on, pinned to the source that ships it: the
@@ -718,6 +827,12 @@ class CodexIsReadAtTheProfilesHome(PersonaIso, unittest.TestCase):
         self.assertEqual(wiring.detect(p, cwd=self.tmp).state, wiring.UNKNOWN_STATE)
         self.assertIn("could not ask", wiring.refusal(p, cwd=self.tmp))
 
+    def test_the_step_no_command_can_take_is_said_in_these_words(self):
+        """Operator-facing, and the one step of the three that is a sentence: pinned here
+        so a reword is a decision rather than a drift."""
+        self.assertEqual(wiring.CODEX_APPROVE,
+                         "start codex once and approve charter's hooks when it asks")
+
     def test_the_codex_steps_are_a_list_each_pasteable_whatever_the_home_is_called(self):
         """A11: a home holding `; ` split a joined sentence in the wrong place, and a home
         with a space printed a `CODEX_HOME=` a shell would cut in two."""
@@ -750,7 +865,24 @@ class CodexIsReadAtTheProfilesHome(PersonaIso, unittest.TestCase):
         self.write("[x")
         w = wiring.detect(self.p, cwd=self.tmp)
         self.assertEqual(w.state, wiring.UNKNOWN_STATE)
+        self.assertIn(f"{self.home / 'config.toml'} could not be read", w.detail)
         self.assertIn("could not ask", wiring.refusal(self.p, cwd=self.tmp))
+
+    def test_a_config_that_is_not_utf8_names_the_file(self):
+        (self.home / "config.toml").write_bytes(b"\xff\xfe[plugins]\n")
+        w = wiring.detect(self.p, cwd=self.tmp)
+        self.assertEqual(w.state, wiring.UNKNOWN_STATE)
+        self.assertIn(f"{self.home / 'config.toml'} could not be read", w.detail)
+
+    @unittest.skipIf(os.geteuid() == 0, "root reads a mode-000 file")
+    def test_a_config_nobody_may_read_is_unknown_and_never_a_traceback(self):
+        f = self.home / "config.toml"
+        f.write_text(codex_config())
+        f.chmod(0)
+        self.addCleanup(f.chmod, 0o600)
+        w = wiring.detect(self.p, cwd=self.tmp)
+        self.assertEqual(w.state, wiring.UNKNOWN_STATE)
+        self.assertIn(f"{f} could not be read", w.detail)
 
     def test_the_fix_once_charter_has_written_its_line_is_codexs_own_commands(self):
         """Review 7's objection, one mark further on. Once `shell_environment_policy` names
@@ -1026,6 +1158,10 @@ class NothingUnapprovedIsRun(PersonaIso, unittest.TestCase):
         self.assertEqual([s for s, _l in installed], ["refused"])
         self.assertEqual(rows["profile claude-work"].hint, profiles.FIX_NOT_IGNORED)
         self.assertIn("not probed", rows["profile claude-work"].detail)
+        # And a BUILT-IN's row is still the probe's answer: the file decides nothing about a
+        # command out of charter's own registry, so its row never says "not probed".
+        self.assertNotIn("not probed", rows["profile claude"].detail)
+        self.assertNotEqual(rows["profile claude"].hint, profiles.FIX_NOT_IGNORED)
 
     def test_doctor_does_not_probe_an_unapproved_profile(self):
         calls = []
@@ -1745,6 +1881,25 @@ env = {{ CODEX_HOME = "{self.codex_home}" }}
         self.assertIn("profile 'bad-one' is refused", out)
         self.assertNotIn("no harness or profile named", out)
 
+    def test_each_install_status_is_said_at_its_own_level_with_its_own_exit(self):
+        """`cmd_harness_install` per status: `refused` ends it (rc 1, no probe); a gap —
+        `unvouched`, `unavailable`, `unknown`, `failed` — is a warning and the probe still
+        decides; anything else is a note."""
+        for status, line, rc, probed in (
+                ("refused", "✗ charter: the detail", 1, False),
+                ("unvouched", "!   the detail", 0, True),
+                ("unavailable", "!   the detail", 0, True),
+                ("unknown", "!   the detail", 0, True),
+                ("failed", "!   the detail", 0, True),
+                ("installed", "•   installed: the detail", 0, True)):
+            with self.subTest(status), \
+                    mock.patch.object(wiring, "install", return_value=[(status, "the detail")]), \
+                    mock.patch.object(wiring, "detect", return_value=wiring.Wiring(
+                        wiring.WIRED, "ok", "")) as detected:
+                out = self.said(lambda: self.assertEqual(self.run_install("oc-alt"), rc))
+                self.assertIn(line, out.splitlines())
+                self.assertEqual(detected.called, probed)
+
     def test_a_long_name_is_bounded_where_install_repeats_it_back(self):
         """`commands_harness.py`'s `shown`: a refusal sentence bounds the name with contain's
         fixed marker (ruling 45), and a 161-character name is one past that bound."""
@@ -2299,6 +2454,64 @@ class TheSeamsTheSweepAsksAbout(PersonaIso, unittest.TestCase):
         names = [r["name"] for r in json.loads(buf.getvalue())]
         self.assertNotIn("profile claude", names)
         self.assertIn("harness profiles", names)
+
+    def test_an_unapproved_rows_hint_shows_a_declared_name_escaped(self):
+        """`doctor._not_probed`'s own `charter <name>`, which only a DECLARED profile reaches
+        — built by hand, past `NAME_RE`, as Task 3's prompt pin is."""
+        nasty = make_profile("cl\raude\x1b[2K")
+        with mock.patch.object(wiring, "listed", return_value=[nasty]), \
+                mock.patch.object(wiring, "detect", side_effect=AssertionError("probed")):
+            rows = doctor.check_profile_wiring()
+        self.assertEqual(rows[0].hint, "charter cl\\u000daude\\u001b[2K")
+
+    def test_a_doctor_field_exactly_at_the_limit_is_whole(self):
+        at = "x" * contain.DISPLAY_LIMIT
+        self.assertEqual(doctor._counted(at), at)
+        self.assertEqual(doctor._counted(at + "y"), at + "… +1 not shown")
+
+    def test_a_sentence_field_exactly_at_the_limit_is_whole(self):
+        at = "x" * wiring.SAID_LIMIT
+        self.assertEqual(wiring.said(at), at)
+        self.assertEqual(wiring.said(at + "y"), at + "...")
+
+    def test_a_refused_name_is_found_by_its_contained_spelling(self):
+        """`_resolve` looks a refused name up by the spelling `profiles` records it under —
+        contained — so a name with an ESC in it is told its own reason, not "no such
+        profile"."""
+        declare_profiles(self, '[harness."bad\\u001bname"]\nkind = "claude"\n'
+                               'command = ["claude"]\n')
+        p, why = commands_harness._resolve("bad\x1bname")
+        self.assertIsNone(p)
+        self.assertIn("bad\\u001bname", why)
+
+    def test_a_cwd_charter_cannot_resolve_stamps_only_itself(self):
+        """`_up_to_the_plane`'s `ValueError`: `realpath` refuses a NUL byte, and a stamp is
+        never worth a traceback."""
+        self.assertEqual(wiring._up_to_the_plane(Path("/tmp/a\x00b")), [Path("/tmp/a\x00b")])
+
+    def test_a_cwd_outside_the_plane_stamps_only_itself_even_above_it(self):
+        """Including the plane's own PARENT: its parents hold nothing of the plane's."""
+        parent = Path(os.path.realpath(config.ROOT)).parent
+        self.assertEqual(wiring._up_to_the_plane(parent), [parent])
+
+    def test_a_stamp_for_a_kind_charter_has_no_table_for_is_empty_and_never_raises(self):
+        """`profiles.current()` refuses a kind the registry does not know, so this is a
+        hand-built profile — the same one `detect` and `install` are pinned against, for the
+        day a kind joins the registry without a row in `wiring._KINDS`."""
+        p = profiles.Profile(name="odd", kind="odd", harness="odd", command=("odd",),
+                             env=(), source=profiles.BUILTIN)
+        self.assertEqual(wiring._stamp(p, self.here), {})
+        wiring.remember(p, cwd=self.here, w=wiring.Wiring(wiring.UNKNOWN_STATE, "x", "y"))
+        self.assertEqual(wiring.cached(p, cwd=self.here),
+                         wiring.Wiring(wiring.UNKNOWN_STATE, "x", "y"))
+
+    def test_an_install_under_an_environment_exec_refuses_is_failed_not_raised(self):
+        """`wiring.install`'s `ValueError`: a NUL byte in `CODEX_HOME` reaches `mkdir`."""
+        p = approve_profile(self, make_profile("codex-nul-install", kind="codex",
+                                               env=[("CODEX_HOME", "/tmp/a\x00b")]))
+        got = wiring.install(p, self.here)
+        self.assertEqual([s for s, _l in got], ["failed"])
+        self.assertIn("could not wire", got[0][1])
 
     def test_a_doctor_row_shows_a_profile_name_escaped(self):
         """Ruling 35 reaches the row NAMES too — and the name column is sized from them, so

--- a/tests/test_a_profile_is_wired_or_refuses.py
+++ b/tests/test_a_profile_is_wired_or_refuses.py
@@ -660,6 +660,33 @@ class TheLaunchRefusesAnUnwiredProfile(PersonaIso, unittest.TestCase):
             self.refuse(p)
         self.assertEqual(len(calls), 2)
 
+    def test_a_handoff_asks_about_the_workspace_the_chat_would_stand_in(self):
+        """Re-review N8: a handoff probes before it writes anything, and it probes the
+        TARGET workspace's directory. Claude Code resolves `enabledPlugins` at the session's
+        own directory and does not walk up (measured), and charter mirrors the plane's into
+        `workspaces/<ws>/` — so asking from the caller's directory would answer about the
+        wrong chat."""
+        from charter import commands_frame
+
+        ws = config.WORKSPACES_DIR / "beta"
+        ws.mkdir(parents=True)
+        seen = []
+        with approved(), mock.patch.object(
+                commands_frame, "_profile_refusal",
+                side_effect=lambda p, *, attended, cwd=None: seen.append(cwd)):
+            commands_frame._launch_refusal(profiles.current().profiles["claude"],
+                                           attended=False,
+                                           cwd=commands_frame._chat_dir_of("beta"))
+        self.assertEqual(seen, [ws])
+
+    def test_a_workspace_with_no_directory_yet_is_asked_about_at_the_plane(self):
+        """Before `--create` makes it there is nothing to read, and `workspace.ensure` is
+        not called here: a refusal that made a directory as a side effect of deciding not to
+        open a chat is the half-done open the check exists to prevent."""
+        from charter import commands_frame
+
+        self.assertEqual(commands_frame._chat_dir_of("never-made"), Path(config.ROOT))
+
     def test_wiring_is_the_last_check_so_a_refusal_behind_it_is_never_probed(self):
         """The order is the order the checks cost in, and a probe is the expensive one: a
         command that is not on `PATH` is answered without asking the harness anything."""

--- a/tests/test_a_profile_is_wired_or_refuses.py
+++ b/tests/test_a_profile_is_wired_or_refuses.py
@@ -256,13 +256,24 @@ class ClaudeCodeIsAskedUnderTheProfilesEnvironment(PersonaIso, unittest.TestCase
         with spawns([], listing(entry(scope="user", enabled=True))):
             self.assertEqual(wiring.detect(self.p, cwd=self.here).state, wiring.WIRED)
 
+    def probe_in(self, said: str) -> str:
+        """What `CANNOT_TELL` printed after `check by hand:` — the probe, and not the detail.
+
+        Asked apart from the sentence because the detail names the same command: an
+        assertion against the whole refusal passes while `{probe}` says something else
+        entirely, which is how a sentence that ends "check by hand:" and then names the wrong
+        file gets shipped.
+        """
+        self.assertIn("check by hand: ", said)
+        return said.split("check by hand: ", 1)[1]
+
     def test_an_unreadable_list_is_unknown_and_refuses(self):
         with spawns([], "", rc=1):
             w = wiring.detect(self.p, cwd=self.here)
             self.assertEqual(w.state, wiring.UNKNOWN_STATE)
             said = wiring.refusal(self.p, cwd=self.here)
         self.assertIn("could not ask", said)
-        self.assertIn("plugin list --json", said)
+        self.assertIn("claude plugin list --json", self.probe_in(said))
 
     def test_a_probe_that_times_out_refuses(self):
         """Ruling 12 and review 10: an unknown is not a pass, and nothing raises out of it."""
@@ -569,6 +580,8 @@ class OpencodeIsAskedUnderTheProfilesConfigHome(PersonaIso, unittest.TestCase):
             said = wiring.refusal(self.p, cwd=self.tmp)
         self.assertEqual(w.state, wiring.UNKNOWN_STATE)
         self.assertIn("could not ask", said)
+        self.assertIn("check by hand: ", said)
+        self.assertIn("opencode debug config", said.split("check by hand: ", 1)[1])
 
     def test_a_non_zero_probe_is_unknown_even_when_it_printed_an_answer(self):
         """The exit code is the answer about whether there IS an answer. A `debug config`
@@ -893,6 +906,15 @@ class TheCache(PersonaIso, unittest.TestCase):
         for e in doc.values():
             e["checked_at"] = time.time() + delta
         self.path().write_text(json.dumps(doc))
+
+    def test_a_cache_that_is_not_an_object_is_a_miss(self):
+        """A file a chat can write is a file that can hold a list, and `.get` on one is an
+        `AttributeError` in whatever was asking — a selector draw, or a `remember`."""
+        self.path().parent.mkdir(parents=True, exist_ok=True)
+        self.path().write_text("[1, 2, 3]")
+        self.assertIsNone(wiring.cached(self.p, cwd=self.here))
+        wiring.remember(self.p, cwd=self.here, w=self.w)
+        self.assertEqual(wiring.cached(self.p, cwd=self.here), self.w)
 
     def test_an_unreadable_cache_is_a_miss(self):
         self.path().parent.mkdir(parents=True, exist_ok=True)
@@ -1277,10 +1299,13 @@ class EveryProfileDerivedTextIsShownEscaped(PersonaIso, unittest.TestCase):
         w = wiring.detect(p, cwd=self.tmp)
         self.assertEqual(w.state, wiring.UNKNOWN_STATE)
         self.clean(w.detail, w.fix, wiring.refusal(p, cwd=self.tmp))
+        self.clean(*(text for _status, text in wiring.install(p, self.tmp)))
 
-    def test_an_unapproved_profile_is_named_escaped(self):
+    def test_a_reason_charter_may_not_run_it_yet_is_shown_escaped(self):
+        """Today the reason is a constant. Task 3's record makes it a sentence about a
+        `command` the operator has not approved — which is the text a profile can write."""
         p = make_profile(self.NASTY)
-        with mock.patch.object(wiring, "approval_needed", lambda q: "not approved yet"):
+        with mock.patch.object(wiring, "approval_needed", lambda q: f"no: {self.NASTY}"):
             answer = wiring.detect(p, cwd=self.tmp)
         self.clean(answer.detail, answer.fix)
 
@@ -1438,7 +1463,8 @@ class TheSeamsTheSweepAsksAbout(PersonaIso, unittest.TestCase):
         (home / "config.toml").write_text("[x")
         p = make_profile("codex-alt", kind="codex", env=[("CODEX_HOME", str(home))])
         said = wiring.refusal(p, cwd=self.tmp)
-        self.assertIn(str(home / "config.toml"), said)
+        self.assertIn("check by hand: ", said)
+        self.assertIn(str(home / "config.toml"), said.split("check by hand: ", 1)[1])
 
     def test_the_listing_is_built_ins_in_registry_order_then_the_rest_by_name(self):
         """`charter harness list`'s order, so a doctor row lands where the operator already

--- a/tests/test_a_profile_is_wired_or_refuses.py
+++ b/tests/test_a_profile_is_wired_or_refuses.py
@@ -1,0 +1,1141 @@
+"""A profile is wired or it refuses — detection per kind, the fix, and where it runs.
+
+Charter's guard lives in the harness's own config folder: Claude Code's plugin, Codex's
+plugin plus its hook trust, opencode's shim. A profile names another folder, so every one
+of those can be absent for a profile while the operator's default folder is wired — and a
+chat that looks guarded and is not is the failure this whole task exists to stop. Measured
+2026-09-11 and again 2026-09-12: under an empty `CLAUDE_CONFIG_DIR` charter's plugin is not
+merely disabled, it is unknown to that folder.
+
+**Wiring is detected by ASKING the harness under the profile's own environment**, never by
+reading the profile's variable names: one account can be reached through variables that do
+or do not move the plugin (`XDG_DATA_HOME` moves opencode's login and leaves its plugins
+alone). So the probe is `claude plugin list --json` / `opencode debug config` run with the
+profile's `command` and `env`, and `$CODEX_HOME/config.toml` read at the profile's home.
+
+No test here runs a real harness. The probe seams are `charter.util.run` — which
+`plugincache._claude_json` and the opencode probe both go through — and the git call
+`profiles.ignore_check` makes, which :func:`spawns` deliberately lets through to the real
+`util.run` so a fixture's `charter.local.toml` is still checked against a real repository.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+import unittest
+from contextlib import contextmanager
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
+
+from charter import commands, commands_harness, config, contain, doctor, plugincache
+from charter import profiles, util, wiring
+from charter.frame import launcher
+from charter.harness import claude_code, codex, opencode
+from tests._isolation import PersonaIso, declare_profiles, make_plane
+
+REPO = Path(__file__).resolve().parents[1]
+
+#: kind → registry NAME, asked of the registry rather than written down twice.
+KINDS = {p.kind: p.harness for p in profiles.builtins().values()}
+
+
+def make_profile(name, kind="claude", command=None, env=(), source=profiles.LOCAL_FILE):
+    """A `Profile` built by hand, for the cases whose subject is detection alone.
+
+    The fixtures that drive `init`, `harness install` and a launch declare a real
+    `charter.local.toml` instead (`declare_profiles`): those paths read the file.
+    """
+    return profiles.Profile(name=name, kind=kind, harness=KINDS[kind],
+                            command=tuple(command or [kind]),
+                            env=tuple(sorted(env)), source=source)
+
+
+class Probe(SimpleNamespace):
+    """One recorded spawn: its argv, cwd and the environment it was given."""
+
+
+@contextmanager
+def spawns(calls, answer=None, *, rc=0, raises=None):
+    """Answer every harness probe from *answer*, recording each into *calls*.
+
+    A dispatcher rather than a blanket patch: `profiles.ignore_check` runs
+    `git --no-optional-locks status` through this very function, and a fixture whose git
+    call was swallowed would be testing the refusal instead of the profile.
+
+    *answer* is either a string (stdout for every probe) or a callable taking the argv.
+    """
+    real = util.run
+
+    def run(cmd, cwd=None, check=True, env=None, timeout=None, **kw):
+        cmd = list(cmd)
+        if cmd[:1] == ["git"]:
+            return real(cmd, cwd=cwd, check=check, env=env, timeout=timeout, **kw)
+        # Only the names a profile can set, never the whole environment: `util.run`'s
+        # ``env`` is an overlay on this process's, and an assertion message that dumped it
+        # would print the operator's own shell — tokens included — into a test report.
+        seen = {k: v for k, v in (env or {}).items()
+                if k in ("CLAUDE_CONFIG_DIR", "CODEX_HOME", "XDG_CONFIG_HOME",
+                         "CHARTER_HARNESS", "CHARTER_HARNESS_PROFILE")}
+        calls.append(Probe(argv=cmd, cwd=cwd, env=seen))
+        if raises is not None:
+            raise raises
+        out = answer(cmd) if callable(answer) else (answer or "")
+        return SimpleNamespace(returncode=rc, stdout=out, stderr="")
+
+    with mock.patch.object(util, "run", run), \
+            mock.patch.object(plugincache, "available", lambda *a, **k: True):
+        yield
+
+
+def listing(*entries) -> str:
+    """`claude plugin list --json`'s answer for *entries*, each already a dict."""
+    return json.dumps(list(entries))
+
+
+def entry(scope="project", enabled=True, project=None, pid=plugincache.PLUGIN_ID) -> dict:
+    """One `claude plugin list --json` row. `installedAt` because a covering entry is an
+    INSTALL RECORD — a settings-file disable creates none (measured 2026-09-12)."""
+    row = {"id": pid, "scope": scope, "enabled": enabled,
+           "installedAt": "2026-09-12T00:00:00Z", "version": "0.60.0"}
+    if project is not None:
+        row["projectPath"] = str(project)
+    return row
+
+
+@contextmanager
+def approved():
+    """Stand in for Task 3's launch record: every profile's command may be run.
+
+    Task 4 lands before Task 3's approval record is on `main`, so today
+    `wiring.approval_needed` refuses every DECLARED profile — nothing yet stands for the
+    operator's approval of a command a chat could have written. The cases whose subject is
+    what happens AFTER the approval say so here; the cases whose subject IS the gate
+    (`NothingUnapprovedIsRun`) do not patch it. When Task 3 is on `main` this becomes
+    `tests._isolation.approve_profile`, and the body of `approval_needed` becomes
+    `profiletrust.approval_needed` — the seam is the same one either way.
+    """
+    with mock.patch.object(wiring, "approval_needed", lambda p: ""):
+        yield
+
+
+# --------------------------------------------------------------------------- #
+# Claude Code                                                                  #
+# --------------------------------------------------------------------------- #
+
+
+class ClaudeCodeIsAskedUnderTheProfilesEnvironment(PersonaIso, unittest.TestCase):
+    """`claude plugin list --json`, run as the profile would run `claude`.
+
+    Measured 2026-09-12 on 2.1.269, and it is the fact the whole class rests on: the `enabled`
+    field is the EFFECTIVE setting for the plugin id resolved at the probe's own cwd — local
+    over project over user — and every listed entry of that id carries the same value. So the
+    probe must be given the chat's directory, and a settings-file disable reaches charter
+    without charter reading a settings file (ruling 36's "unless").
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.here = self.tmp / "here"
+        self.here.mkdir()
+        self.p = make_profile("claude-alt", env=[("CLAUDE_CONFIG_DIR", "~/.claude-alt")])
+        # These cases are about what the probe answers, which is the question AFTER the
+        # gate: `detect` refuses to run a declared profile's command until something stands
+        # for the operator's approval of it, and `NothingUnapprovedIsRun` is where that is
+        # the subject.
+        self.enterContext(approved())
+
+
+    def test_the_probe_runs_the_profiles_command_with_its_env(self):
+        """Never `claude` and never charter's own environment: a profile exists to name
+        another binary and another folder, and a probe that ignored either would answer for
+        the session the operator is NOT about to start."""
+        calls = []
+        with spawns(calls, listing(entry(project=self.here))):
+            wiring.detect(self.p, cwd=self.here)
+        self.assertEqual(calls[0].argv, ["claude", "plugin", "list", "--json"])
+        self.assertEqual(calls[0].env["CLAUDE_CONFIG_DIR"],
+                         os.path.expanduser("~/.claude-alt"))
+        self.assertEqual(str(calls[0].cwd), str(self.here))
+
+    def test_an_enabled_install_covering_the_directory_is_wired(self):
+        calls = []
+        with spawns(calls, listing(entry(project=self.here))):
+            w = wiring.detect(self.p, cwd=self.here)
+        self.assertEqual(w.state, wiring.WIRED)
+        self.assertEqual(w.fix, "")
+
+    def test_an_install_covering_the_PLANE_covers_a_chat_in_its_workspace(self):
+        """D3, measured: `charter init` installs at PROJECT scope for the plane root, and a
+        chat's directory is `workspaces/<ws>/` — a different `projectPath`, so
+        `plugincache.covers` alone answers False for it. Charter mirrors the plane's
+        `enabledPlugins` into that directory (`claude_code.WORKSPACE_KEYS`), and the probe's
+        own `enabled` is resolved there, so the install record that covers the PLANE is the
+        one that answers for the chat."""
+        make_plane(self)
+        ws = config.ROOT / "workspaces" / "w"
+        ws.mkdir(parents=True)
+        record = entry(project=config.ROOT)
+        self.assertFalse(plugincache.covers(record, ws))
+        with spawns([], listing(record)):
+            self.assertEqual(wiring.detect(self.p, cwd=ws).state, wiring.WIRED)
+
+    def test_an_install_for_somebody_elses_checkout_is_not_this_planes(self):
+        """The half of the rule above that has to keep working: `covers` is what stops
+        "already installed" being printed over a plane with no plugin at all."""
+        with spawns([], listing(entry(project=self.tmp / "elsewhere"))):
+            w = wiring.detect(self.p, cwd=self.here)
+        self.assertEqual(w.state, wiring.UNWIRED)
+
+    def test_no_entry_is_unwired(self):
+        with spawns([], listing()):
+            w = wiring.detect(self.p, cwd=self.here)
+        self.assertEqual(w.state, wiring.UNWIRED)
+        self.assertEqual(w.fix, "charter harness install claude-alt")
+
+    def test_a_disabled_install_is_unwired_and_the_fix_is_the_enable(self):
+        """NOT `charter harness install`: `plugincache.install` answers `present` for an
+        install that exists, so pointing back at it would change nothing and print a fix
+        that loops — review 7's objection, one harness over."""
+        with spawns([], listing(entry(project=self.here, enabled=False))):
+            w = wiring.detect(self.p, cwd=self.here)
+        self.assertEqual(w.state, wiring.UNWIRED)
+        self.assertIn("disabled", w.detail)
+        self.assertIn("plugin enable", w.fix)
+        self.assertNotIn("charter harness install", w.fix)
+
+    def test_a_disabled_user_entry_listed_first_does_not_hide_an_enabled_project_entry(self):
+        """Review 6: `installed_for` returns the FIRST covering entry, and this machine lists
+        user, project and local entries side by side."""
+        with spawns([], listing(entry(scope="user", enabled=False),
+                                entry(scope="project", project=self.here, enabled=True))):
+            self.assertEqual(wiring.detect(self.p, cwd=self.here).state, wiring.WIRED)
+
+    def test_a_local_disable_over_a_user_enable_is_unwired(self):
+        """Ruling 28. Today the binary resolves this itself and hands every entry the same
+        `enabled` — so this pins the rule for the day it stops doing that, and the rule
+        chosen is the one that fails closed."""
+        with spawns([], listing(entry(scope="user", enabled=True),
+                                entry(scope="local", project=self.here, enabled=False))):
+            w = wiring.detect(self.p, cwd=self.here)
+        self.assertEqual(w.state, wiring.UNWIRED)
+        self.assertIn("local", w.detail)
+
+    def test_a_project_enable_over_a_user_disable_is_wired(self):
+        """The same pair in the other order, so the order of the list decides nothing."""
+        with spawns([], listing(entry(scope="project", project=self.here, enabled=True),
+                                entry(scope="user", enabled=False))):
+            self.assertEqual(wiring.detect(self.p, cwd=self.here).state, wiring.WIRED)
+
+    def test_the_settings_disable_the_binary_already_reports_needs_no_second_reader(self):
+        """Ruling 36, settled by measurement rather than by the fallback it provided for.
+
+        2.1.269, an enabled USER-scope install and a disable written ONLY to
+        `<cwd>/.claude/settings.local.json` — and only to `<cwd>/.claude/settings.json` —
+        each flipped the listed entry's `enabled` to false. So charter reads no settings file
+        of its own: a second reader would answer for a different merge than the binary's
+        (measured: `<ancestor>/.claude/settings.json` does NOT reach a session below it,
+        while `settings.local.json` does), and a wrong UNWIRED refuses a chat that would have
+        been guarded.
+        """
+        (self.here / ".claude").mkdir()
+        (self.here / ".claude" / "settings.local.json").write_text(
+            json.dumps({"enabledPlugins": {plugincache.PLUGIN_ID: False}}))
+        with spawns([], listing(entry(scope="user", enabled=False))):
+            self.assertEqual(wiring.detect(self.p, cwd=self.here).state, wiring.UNWIRED)
+        with spawns([], listing(entry(scope="user", enabled=True))):
+            self.assertEqual(wiring.detect(self.p, cwd=self.here).state, wiring.WIRED)
+
+    def test_an_unreadable_list_is_unknown_and_refuses(self):
+        with spawns([], "", rc=1):
+            w = wiring.detect(self.p, cwd=self.here)
+            self.assertEqual(w.state, wiring.UNKNOWN_STATE)
+            said = wiring.refusal(self.p, cwd=self.here)
+        self.assertIn("could not ask", said)
+        self.assertIn("plugin list --json", said)
+
+    def test_a_probe_that_times_out_refuses(self):
+        """Ruling 12 and review 10: an unknown is not a pass, and nothing raises out of it."""
+        with spawns([], raises=util.ProcTimeout(["claude"], 5.0)):
+            w = wiring.detect(self.p, cwd=self.here)
+            said = wiring.refusal(self.p, cwd=self.here)
+        self.assertEqual(w.state, wiring.UNKNOWN_STATE)
+        self.assertIn("could not ask", said)
+
+    def test_a_wrapper_scripts_answer_is_the_one_used(self):
+        p = make_profile("wrapped", command=["/opt/claude-wrap"])
+        calls = []
+        with spawns(calls, listing()):
+            wiring.detect(p, cwd=self.here)
+        self.assertEqual(calls[0].argv[0], "/opt/claude-wrap")
+
+    def test_the_detail_names_the_folder_the_probe_asked_about(self):
+        """#970's rule, with #970's resolver: `doctor`'s `plane-root guard` row and this one
+        name ONE folder for one environment, so two rows cannot disagree about which folder
+        a session reads."""
+        with spawns([], listing(entry(project=self.here))):
+            w = wiring.detect(self.p, cwd=self.here)
+        self.assertIn(os.path.expanduser("~/.claude-alt"), w.detail)
+
+
+class TheResolverGainsAnEnvironmentRatherThanATwin(unittest.TestCase):
+    """#970's `config_home`/`global_config_file` answer for a mapping charter hands them.
+
+    A second resolver is the thing not to build: two rules for "which folder does Claude Code
+    read" drift, and the drift is invisible until a row is green about the wrong folder.
+    """
+
+    def test_config_home_reads_the_mapping_it_is_given(self):
+        self.assertEqual(claude_code.config_home({"CLAUDE_CONFIG_DIR": "/tmp/alt"}),
+                         Path("/tmp/alt"))
+
+    def test_an_empty_value_still_names_the_working_directory(self):
+        """`??`, not `||` — read off the 2.1.268 binary and pinned by #970. An empty value
+        is KEPT, and a kinder rule would answer for a different folder than the one Claude
+        Code reads."""
+        self.assertEqual(claude_code.config_home({"CLAUDE_CONFIG_DIR": ""}), Path(""))
+
+    def test_no_mapping_still_means_the_process_environment(self):
+        with mock.patch.dict(os.environ, {"CLAUDE_CONFIG_DIR": "/tmp/proc"}, clear=False):
+            self.assertEqual(claude_code.config_home(), Path("/tmp/proc"))
+
+    def test_the_global_config_file_follows_the_same_mapping(self):
+        self.assertEqual(claude_code.global_config_file({"CLAUDE_CONFIG_DIR": "/tmp/alt"}),
+                         Path("/tmp/alt/.claude.json"))
+
+
+# --------------------------------------------------------------------------- #
+# Codex                                                                        #
+# --------------------------------------------------------------------------- #
+
+
+TRUST_KEY = f"{plugincache.PLUGIN_ID}:hooks/hooks.json:session_start:0:0"
+
+
+def codex_config(*, plugin=True, policy=True, trust=True) -> str:
+    doc = []
+    if plugin:
+        doc.append(f'[plugins."{plugincache.PLUGIN_ID}"]\nenabled = true\n')
+    if policy:
+        doc.append('[shell_environment_policy]\nset = { CHARTER_HARNESS = "codex" }\n')
+    if trust:
+        doc.append(f'[hooks.state."{TRUST_KEY}"]\ntrusted_hash = "sha256:abc"\n')
+    return "\n".join(doc)
+
+
+class CodexIsReadAtTheProfilesHome(PersonaIso, unittest.TestCase):
+    """Codex needs no subprocess: the three marks are all in `$CODEX_HOME/config.toml`.
+
+    All three, because each is separately absent on a fresh home and any one of them missing
+    means charter is not running there: the plugin declares the hooks, the policy line is the
+    only thing that tells a Codex shell which harness it is, and an untrusted hook is inert.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.home = self.tmp / "codex-home"
+        self.home.mkdir()
+        self.p = make_profile("codex-alt", kind="codex",
+                              env=[("CODEX_HOME", str(self.home))])
+        # These cases are about what the probe answers, which is the question AFTER the
+        # gate: `detect` refuses to run a declared profile's command until something stands
+        # for the operator's approval of it, and `NothingUnapprovedIsRun` is where that is
+        # the subject.
+        self.enterContext(approved())
+
+
+    def write(self, body: str):
+        (self.home / "config.toml").write_text(body)
+
+    def test_all_three_marks_are_wired(self):
+        self.write(codex_config())
+        w = wiring.detect(self.p, cwd=self.tmp)
+        self.assertEqual(w.state, wiring.WIRED)
+        self.assertIn(str(self.home), w.detail)
+
+    def test_an_empty_home_is_unwired(self):
+        self.assertEqual(wiring.detect(self.p, cwd=self.tmp).state, wiring.UNWIRED)
+
+    def test_the_plugin_without_the_policy_line_is_unwired(self):
+        self.write(codex_config(policy=False))
+        w = wiring.detect(self.p, cwd=self.tmp)
+        self.assertEqual(w.state, wiring.UNWIRED)
+        self.assertIn("shell_environment_policy", w.detail)
+
+    def test_untrusted_hooks_are_unwired(self):
+        """Codex trusts hooks by hash, so a plugin nobody approved is installed and inert —
+        which reads exactly like wired to anything that stops at the plugin table."""
+        self.write(codex_config(trust=False))
+        w = wiring.detect(self.p, cwd=self.tmp)
+        self.assertEqual(w.state, wiring.UNWIRED)
+        self.assertIn("approve", w.fix.lower() + w.detail.lower())
+
+    def test_one_trust_entry_is_the_measured_rule(self):
+        """Measured 2026-09-12 on the operator's own wired `~/.codex/config.toml`: Codex
+        writes a trust entry per hook LAZILY, as each first fires — 12 of the plugin's 18
+        keys were present on a machine that has been running charter under Codex for weeks.
+        So "an entry for every hook key" — the plan's fallback — would call a wired machine
+        unwired, and the rule is "charter's hooks were approved here at least once".
+        `trusted_hash` itself cannot be recomputed: the command string, the hook object as
+        JSON in three spellings, the matcher group and the joined commands were all tried
+        against a real hash and none matched."""
+        self.write(codex_config())
+        self.assertEqual(wiring.detect(self.p, cwd=self.tmp).state, wiring.WIRED)
+
+    def test_another_plugins_trust_entry_is_not_charters(self):
+        self.write(codex_config(trust=False)
+                   + '\n[hooks.state."other@other:hooks/hooks.json:stop:0:0"]\n'
+                     'trusted_hash = "sha256:def"\n')
+        self.assertEqual(wiring.detect(self.p, cwd=self.tmp).state, wiring.UNWIRED)
+
+    def test_the_default_home_is_the_one_codex_reads_with_no_env(self):
+        """No `CODEX_HOME` on the profile and none in the process: `~/.codex` and not a
+        sandbox left over from another fixture."""
+        home = self.tmp / "fakehome"
+        (home / ".codex").mkdir(parents=True)
+        (home / ".codex" / "config.toml").write_text(codex_config())
+        p = make_profile("codex", kind="codex", source=profiles.BUILTIN)
+        with mock.patch.dict(os.environ, {"HOME": str(home), "PATH": os.environ["PATH"]},
+                             clear=True):
+            self.assertEqual(wiring.detect(p, cwd=self.tmp).state, wiring.WIRED)
+
+    def test_a_malformed_config_is_unknown(self):
+        self.write("[x")
+        w = wiring.detect(self.p, cwd=self.tmp)
+        self.assertEqual(w.state, wiring.UNKNOWN_STATE)
+        self.assertIn("could not ask", wiring.refusal(self.p, cwd=self.tmp))
+
+    def test_the_fix_for_a_foreign_policy_table_is_the_line_not_the_command(self):
+        """Review 7: `codex.install()` answers `present` for ANY `[shell_environment_policy]`,
+        so naming `charter harness install` here would print a fix that changes nothing."""
+        self.write(f'[plugins."{plugincache.PLUGIN_ID}"]\nenabled = true\n\n'
+                   '[shell_environment_policy]\ninherit = "core"\n\n'
+                   f'[hooks.state."{TRUST_KEY}"]\ntrusted_hash = "sha256:abc"\n')
+        w = wiring.detect(self.p, cwd=self.tmp)
+        self.assertEqual(w.state, wiring.UNWIRED)
+        self.assertIn('CHARTER_HARNESS = "codex"', w.fix)
+        self.assertNotIn("charter harness install", w.fix)
+
+    def test_nothing_charter_reads_writes_into_the_home(self):
+        """Detection is a READ. A probe that wrote would change the answer it is asking
+        about, and would do it in somebody else's account folder."""
+        self.write(codex_config())
+        before = sorted(p.name for p in self.home.iterdir())
+        wiring.detect(self.p, cwd=self.tmp)
+        self.assertEqual(sorted(p.name for p in self.home.iterdir()), before)
+
+
+# --------------------------------------------------------------------------- #
+# opencode                                                                     #
+# --------------------------------------------------------------------------- #
+
+
+class OpencodeIsAskedUnderTheProfilesConfigHome(PersonaIso, unittest.TestCase):
+    """All three marks (ruling 26), and the third is the one a byte check cannot reach."""
+
+    def setUp(self):
+        super().setUp()
+        self.xdg = self.tmp / "xdg"
+        self.home = self.xdg / "opencode"
+        (self.home / "plugin").mkdir(parents=True)
+        self.p = make_profile("oc-alt", kind="opencode",
+                              env=[("XDG_CONFIG_HOME", str(self.xdg))])
+        # These cases are about what the probe answers, which is the question AFTER the
+        # gate: `detect` refuses to run a declared profile's command until something stands
+        # for the operator's approval of it, and `NothingUnapprovedIsRun` is where that is
+        # the subject.
+        self.enterContext(approved())
+
+
+    def shim(self):
+        opencode.refresh_shim(self.home)
+
+    def answer(self, *entries) -> str:
+        return json.dumps({"plugin": list(entries)})
+
+    def named(self) -> str:
+        return f"file://{self.home / opencode.SHIM_PATH}"
+
+    def test_the_shim_in_the_answer_is_wired(self):
+        self.shim()
+        calls = []
+        with spawns(calls, self.answer(self.named())):
+            self.assertEqual(wiring.detect(self.p, cwd=self.tmp).state, wiring.WIRED)
+        self.assertEqual(calls[0].argv, ["opencode", "debug", "config"])
+        self.assertEqual(calls[0].env["XDG_CONFIG_HOME"], str(self.xdg))
+
+    def test_no_shim_is_unwired(self):
+        with spawns([], self.answer()):
+            self.assertEqual(wiring.detect(self.p, cwd=self.tmp).state, wiring.UNWIRED)
+
+    def test_a_plugin_entry_naming_a_missing_shim_is_unwired(self):
+        """Review 5: `unvouched()` answers `()` for a missing shim, so an entry naming a
+        deleted file would read as wired to anything that asked it."""
+        with spawns([], self.answer(self.named())):
+            w = wiring.detect(self.p, cwd=self.tmp)
+        self.assertEqual(w.state, wiring.UNWIRED)
+
+    def test_a_byte_perfect_shim_beside_a_foreign_plugin_is_not_wired(self):
+        """The documented bypass, reproduced (ruling 26; `opencode.foreign_plugins`, ADR 0015).
+
+        opencode imports the whole plugin directory into ONE realm: a byte-perfect
+        `charter.ts` beside `plugin/aaa_boot.ts` holding `Object.hasOwn = () => false` turns
+        every guard lookup into `undefined`, a vault read routes to the Bash guard and is
+        allowed — while `shim_is_charters` says True throughout. Dropping this mark reopens it.
+        """
+        self.shim()
+        (self.home / "plugin" / "aaa_boot.ts").write_text("Object.hasOwn = () => false;\n")
+        with spawns([], self.answer(self.named())):
+            w = wiring.detect(self.p, cwd=self.tmp)
+        self.assertEqual(w.state, wiring.UNWIRED)
+        self.assertIn("aaa_boot.ts", w.detail)
+
+    def test_a_shim_charter_cannot_vouch_for_is_unwired(self):
+        (self.home / opencode.SHIM_PATH).write_text("// not charter's\n")
+        with spawns([], self.answer(self.named())):
+            w = wiring.detect(self.p, cwd=self.tmp)
+        self.assertEqual(w.state, wiring.UNWIRED)
+
+    def test_an_opencode_probe_that_times_out_refuses(self):
+        self.shim()
+        with spawns([], raises=util.ProcTimeout(["opencode"], 5.0)):
+            w = wiring.detect(self.p, cwd=self.tmp)
+            said = wiring.refusal(self.p, cwd=self.tmp)
+        self.assertEqual(w.state, wiring.UNKNOWN_STATE)
+        self.assertIn("could not ask", said)
+
+    def test_a_non_zero_probe_is_unknown(self):
+        self.shim()
+        with spawns([], "", rc=2):
+            self.assertEqual(wiring.detect(self.p, cwd=self.tmp).state,
+                             wiring.UNKNOWN_STATE)
+
+    def test_bad_json_is_unknown(self):
+        self.shim()
+        with spawns([], "not json"):
+            self.assertEqual(wiring.detect(self.p, cwd=self.tmp).state,
+                             wiring.UNKNOWN_STATE)
+
+    def test_the_entry_is_compared_resolved(self):
+        """Measured: the `file://` URI keeps the un-resolved spelling (`/tmp/...`), and on
+        macOS the same directory is `/private/tmp/...` — two `Path`s that are the same
+        directory and not the same string."""
+        self.shim()
+        with spawns([], self.answer(f"file://{os.path.join('/', 'tmp', '..', str(self.home / opencode.SHIM_PATH).lstrip('/'))}")):
+            self.assertEqual(wiring.detect(self.p, cwd=self.tmp).state, wiring.WIRED)
+
+
+# --------------------------------------------------------------------------- #
+# The gate: nothing unapproved is run                                          #
+# --------------------------------------------------------------------------- #
+
+
+class NothingUnapprovedIsRun(PersonaIso, unittest.TestCase):
+    """A probe runs the profile's OWN command, so it may only run what may be run.
+
+    Ruling 1, and the Global Constraint it comes from: `charter.local.toml` is a file a chat
+    can write with no diff to show for it, and a probe is a launch of that command by another
+    name. Until Task 3's approval record is on `main`, nothing stands for the operator's
+    approval of a declared command — so `approval_needed` refuses every declared profile and
+    the surfaces say so instead of asking the harness.
+    """
+
+    def setUp(self):
+        super().setUp()
+        make_plane(self)
+        declare_profiles(self)
+        self.p = profiles.current().profiles["claude-work"]
+
+    def test_a_built_in_is_charters_own_command_and_needs_no_approval(self):
+        built_in = profiles.current().profiles["claude"]
+        self.assertEqual(wiring.approval_needed(built_in), "")
+
+    def test_a_declared_profile_is_not_approved_yet(self):
+        self.assertNotEqual(wiring.approval_needed(self.p), "")
+
+    def test_the_launcher_and_the_gate_agree_about_every_profile(self):
+        """One rule, asked in two places, pinned together so they cannot drift apart. Task
+        3's merge moves both bodies to `profiletrust` at once; this is what fails if only
+        one of them moves."""
+        for p in profiles.current().profiles.values():
+            refused = launcher.refusal(p, root=config.ROOT, attended=False,
+                                       env=dict(os.environ))
+            gated = bool(wiring.approval_needed(p))
+            self.assertEqual(gated, refused is not None and refused.kind ==
+                             launcher.KIND_NOT_YET, p.name)
+
+    def test_an_unapproved_profile_is_never_probed(self):
+        calls = []
+        with spawns(calls, raises=AssertionError("a declared command was run")):
+            self.assertEqual(wiring.detect(self.p, cwd=config.ROOT).state,
+                             wiring.UNKNOWN_STATE)
+            self.assertNotEqual(wiring.refusal(self.p, cwd=config.ROOT), "")
+        self.assertEqual(calls, [])
+
+    def test_doctor_does_not_probe_an_unapproved_profile(self):
+        calls = []
+        with spawns(calls, listing()):
+            rows = {r.name: r for r in doctor.check_profile_wiring()}
+        row = rows["profile claude-work"]
+        self.assertEqual(row.status, doctor.WARN)
+        self.assertEqual(row.hint, "charter claude-work")
+        # The BUILT-IN `claude` is probed in the same run — it is charter's own command and
+        # needs no approval — so the assertion is about this profile's folder, not about
+        # whether anything was spawned at all.
+        self.assertEqual([c for c in calls if "CLAUDE_CONFIG_DIR" in c.env], [])
+
+    def test_install_refuses_an_unapproved_profile_before_it_runs_anything(self):
+        calls = []
+        with spawns(calls, raises=AssertionError("a declared command was run")), \
+                mock.patch.object(plugincache, "install") as inst:
+            rc = commands_harness.cmd_harness_install(
+                SimpleNamespace(name="claude-work"))
+        self.assertEqual(rc, 1)
+        inst.assert_not_called()
+
+
+# --------------------------------------------------------------------------- #
+# The launch                                                                   #
+# --------------------------------------------------------------------------- #
+
+
+class TheLaunchRefusesAnUnwiredProfile(PersonaIso, unittest.TestCase):
+    """The last guard before the `exec`, and it applies to built-ins too (ruling 10).
+
+    `charter codex` on a plane where nobody wired Codex now refuses where it runs today. A
+    chat that looks guarded and is not is the same failure whichever profile started it.
+    """
+
+    def setUp(self):
+        super().setUp()
+        make_plane(self)
+        declare_profiles(self)
+
+    def refuse(self, p):
+        return launcher.refusal(p, root=config.ROOT, attended=False, env=dict(os.environ))
+
+    def test_a_built_in_that_is_not_wired_is_refused_with_the_fix(self):
+        home = self.tmp / "empty-codex"
+        home.mkdir()
+        p = make_profile("codex", kind="codex", source=profiles.BUILTIN)
+        with mock.patch.dict(os.environ, {"CODEX_HOME": str(home)}), \
+                mock.patch.object(launcher.shutil, "which", lambda *a, **k: "/bin/codex"):
+            r = self.refuse(p)
+        self.assertIsNotNone(r)
+        self.assertEqual(r.kind, wiring.KIND_WIRING)
+        self.assertIn("charter harness install codex", r.text)
+
+    def test_a_built_in_claude_under_claudeguards_empty_answer_is_refused(self):
+        """This is why `wired_as_today` exists. In-process the suite's guard makes
+        `plugincache.available` answer False, so detection reads UNKNOWN and refuses; in a
+        child process its fake `claude` answers `[]`, which reads as unwired. Either way a
+        launch test that is not about wiring would refuse without the stand-in."""
+        p = profiles.current().profiles["claude"]
+        r = self.refuse(p)
+        self.assertIsNotNone(r)
+        self.assertEqual(r.kind, wiring.KIND_WIRING)
+
+    def test_a_wired_built_in_reaches_the_end_of_the_chain(self):
+        with approved(), spawns([], listing(entry(project=Path.cwd()))):
+            self.assertIsNone(self.refuse(profiles.current().profiles["claude"]))
+
+    def test_a_cached_wired_answer_never_starts_a_chat(self):
+        """Review B2 and ruling 21: the cache is a file a chat can write, key and stamp."""
+        p = profiles.current().profiles["claude"]
+        here = Path.cwd()
+        wiring.remember(p, cwd=here, w=wiring.Wiring(wiring.WIRED, "remembered", ""))
+        self.assertIsNotNone(wiring.cached(p, cwd=here))
+        with approved(), spawns([], listing()):
+            r = self.refuse(p)
+        self.assertIsNotNone(r)
+        self.assertEqual(r.kind, wiring.KIND_WIRING)
+
+    def test_every_launch_probes_fresh(self):
+        p = profiles.current().profiles["claude"]
+        calls = []
+        with approved(), spawns(calls, listing(entry(project=Path.cwd()))):
+            self.refuse(p)
+            self.refuse(p)
+        self.assertEqual(len(calls), 2)
+
+    def test_wiring_is_the_last_check_so_a_refusal_behind_it_is_never_probed(self):
+        """The order is the order the checks cost in, and a probe is the expensive one: a
+        command that is not on `PATH` is answered without asking the harness anything."""
+        p = make_profile("gone", command=["/nowhere/claude"])
+        calls = []
+        with approved(), spawns(calls, raises=AssertionError("probed anyway")):
+            r = self.refuse(p)
+        self.assertEqual(r.kind, launcher.KIND_PATH)
+        self.assertEqual(calls, [])
+
+
+class ARefusalThatQuotesACommandShowsItEscaped(PersonaIso, unittest.TestCase):
+    """Ruling 35, for the three texts that quote one: `NOT_ON_PATH`, `EXEC_FAILED` and
+    `CANNOT_TELL`.
+
+    `charter.local.toml` is a file a chat can write. A `\\r` or an ESC in a `command` could
+    redraw the line above it — the approval prompt, or a refusal an operator is reading — so
+    every profile-derived piece goes through `contain.readable` and is shown, never run.
+    """
+
+    def setUp(self):
+        super().setUp()
+        make_plane(self)
+        self.nasty = "cl\raude\x1b[2K"
+        # These cases are about what the probe answers, which is the question AFTER the
+        # gate: `detect` refuses to run a declared profile's command until something stands
+        # for the operator's approval of it, and `NothingUnapprovedIsRun` is where that is
+        # the subject.
+        self.enterContext(approved())
+
+
+    def test_cannot_tell_escapes_the_command_it_names(self):
+        p = make_profile(self.nasty, command=[self.nasty],
+                         env=[("CLAUDE_CONFIG_DIR", self.nasty)])
+        with spawns([], "", rc=1):
+            said = wiring.refusal(p, cwd=self.tmp)
+        self.assertNotIn("\r", said)
+        self.assertNotIn("\x1b", said)
+        self.assertIn(contain.readable(self.nasty), said)
+
+    def test_not_wired_escapes_the_name_and_the_fix(self):
+        p = make_profile(self.nasty)
+        with spawns([], listing()):
+            said = wiring.refusal(p, cwd=self.tmp)
+        self.assertNotIn("\r", said)
+        self.assertNotIn("\x1b", said)
+
+    def test_not_on_path_escapes_the_command(self):
+        p = make_profile("bad", command=[f"/nowhere/{self.nasty}"], source=profiles.BUILTIN)
+        r = launcher.refusal(p, root=config.ROOT, attended=False, env=dict(os.environ))
+        self.assertEqual(r.kind, launcher.KIND_PATH)
+        self.assertNotIn("\r", r.text)
+        self.assertNotIn("\x1b", r.text)
+
+    def test_exec_failed_escapes_the_command(self):
+        p = make_profile("bad", command=["/bin/sh"], source=profiles.BUILTIN)
+        with mock.patch.object(launcher, "refusal", return_value=None), \
+                mock.patch.object(launcher.os, "execvpe",
+                                  side_effect=OSError(13, self.nasty)):
+            r = launcher.attempt(p, [], fid=None, attended=False)
+        self.assertEqual(r.kind, launcher.KIND_EXEC)
+        self.assertNotIn("\r", r.text)
+        self.assertNotIn("\x1b", r.text)
+
+
+# --------------------------------------------------------------------------- #
+# The cache                                                                    #
+# --------------------------------------------------------------------------- #
+
+
+class TheCache(PersonaIso, unittest.TestCase):
+    """Display only (Task 5), and stated as writable by a chat (ruling 13).
+
+    It sits under `.charter/`, which no guard covers, so a launch never trusts it — these
+    cases are about what the SELECTOR may draw, and the last one is why the age test needs
+    two bounds rather than one.
+    """
+
+    def setUp(self):
+        super().setUp()
+        make_plane(self)
+        self.here = self.tmp / "here"
+        self.here.mkdir()
+        self.folder = self.tmp / "cc"
+        (self.folder / "plugins").mkdir(parents=True)
+        (self.folder / "plugins" / "installed_plugins.json").write_text("{}")
+        self.p = make_profile("claude-alt", env=[("CLAUDE_CONFIG_DIR", str(self.folder))])
+        self.w = wiring.Wiring(wiring.WIRED, "asked and answered", "")
+
+    def path(self) -> Path:
+        return Path(config.STATE_DIR) / wiring.CACHE
+
+    def test_a_stamp_that_still_matches_is_answered(self):
+        wiring.remember(self.p, cwd=self.here, w=self.w)
+        self.assertEqual(wiring.cached(self.p, cwd=self.here), self.w)
+
+    def test_a_touched_stamp_file_is_a_miss(self):
+        wiring.remember(self.p, cwd=self.here, w=self.w)
+        f = self.folder / "plugins" / "installed_plugins.json"
+        os.utime(f, (0, 0))
+        self.assertIsNone(wiring.cached(self.p, cwd=self.here))
+
+    def test_the_chat_directorys_settings_file_is_stamped_too(self):
+        """The Task 4 nit carried out of the plan review: a stamp that covered only the
+        plane root would keep saying `wired` after a chat wrote
+        `<chat dir>/.claude/settings.local.json`, which is exactly the file the binary reads
+        for that chat."""
+        wiring.remember(self.p, cwd=self.here, w=self.w)
+        (self.here / ".claude").mkdir()
+        (self.here / ".claude" / "settings.local.json").write_text("{}")
+        self.assertIsNone(wiring.cached(self.p, cwd=self.here))
+
+    def test_a_changed_profile_is_a_miss(self):
+        wiring.remember(self.p, cwd=self.here, w=self.w)
+        other = make_profile("claude-alt", command=["claude", "--pinned"],
+                             env=[("CLAUDE_CONFIG_DIR", str(self.folder))])
+        self.assertIsNone(wiring.cached(other, cwd=self.here))
+
+    def test_another_directory_is_a_miss(self):
+        wiring.remember(self.p, cwd=self.here, w=self.w)
+        self.assertIsNone(wiring.cached(self.p, cwd=self.tmp))
+
+    def test_an_old_entry_is_a_miss(self):
+        wiring.remember(self.p, cwd=self.here, w=self.w)
+        self.age(-25 * 3600)
+        self.assertIsNone(wiring.cached(self.p, cwd=self.here))
+
+    def test_a_stamp_in_the_future_is_stale(self):
+        """Review B2: without the lower bound an entry dated ahead passes the age test
+        forever, and the file is one a chat can write."""
+        wiring.remember(self.p, cwd=self.here, w=self.w)
+        self.age(3600)
+        self.assertIsNone(wiring.cached(self.p, cwd=self.here))
+
+    def age(self, delta: float) -> None:
+        doc = json.loads(self.path().read_text())
+        for e in doc.values():
+            e["checked_at"] = time.time() + delta
+        self.path().write_text(json.dumps(doc))
+
+    def test_an_unreadable_cache_is_a_miss(self):
+        self.path().parent.mkdir(parents=True, exist_ok=True)
+        self.path().write_text("{nope")
+        self.assertIsNone(wiring.cached(self.p, cwd=self.here))
+
+    def test_remembering_never_raises_over_a_cache_it_cannot_write(self):
+        """A display cache is not worth a row, a selector or a launch."""
+        with mock.patch.object(config, "write_for", side_effect=OSError("read-only")):
+            wiring.remember(self.p, cwd=self.here, w=self.w)
+
+
+# --------------------------------------------------------------------------- #
+# charter harness install <profile>                                            #
+# --------------------------------------------------------------------------- #
+
+
+class HarnessInstallTakesAProfile(PersonaIso, unittest.TestCase):
+    """Ruling 8: a profile name first, a registry NAME second."""
+
+    def setUp(self):
+        super().setUp()
+        make_plane(self)
+        self.oc = self.tmp / "oc"
+        self.codex_home = self.tmp / "cx"
+        declare_profiles(self, f"""
+[harness.claude-alt]
+kind = "claude"
+command = ["claude"]
+env = {{ CLAUDE_CONFIG_DIR = "{self.tmp / 'cc'}" }}
+
+[harness.oc-alt]
+kind = "opencode"
+command = ["opencode"]
+env = {{ XDG_CONFIG_HOME = "{self.oc}" }}
+
+[harness.codex-alt]
+kind = "codex"
+command = ["codex"]
+env = {{ CODEX_HOME = "{self.codex_home}" }}
+""")
+        self.enterContext(approved())
+
+    def run_install(self, name) -> int:
+        return commands_harness.cmd_harness_install(SimpleNamespace(name=name))
+
+    def test_a_claude_profile_installs_under_its_env(self):
+        seen = {}
+
+        def fake(project, scope=plugincache.INSTALL_SCOPE, *, env=None, command=None):
+            seen.update(env=env, command=command)
+            return "installed", "ok"
+
+        with mock.patch.object(plugincache, "install", fake), \
+                spawns([], listing(entry(project=config.ROOT))):
+            rc = self.run_install("claude-alt")
+        self.assertEqual(rc, 0)
+        self.assertEqual(seen["env"]["CLAUDE_CONFIG_DIR"], str(self.tmp / "cc"))
+        self.assertEqual(seen["command"], ["claude"])
+
+    def test_an_install_that_leaves_it_unwired_exits_non_zero(self):
+        with mock.patch.object(plugincache, "install", return_value=("installed", "ok")), \
+                spawns([], listing()):
+            self.assertEqual(self.run_install("claude-alt"), 1)
+
+    def test_an_opencode_profile_wires_its_own_config_home(self):
+        """Into the folder the PROFILE names, and not into the one this process reads.
+
+        The suite's own `$XDG_CONFIG_HOME` is asserted by its `(mtime_ns, size)` rather than
+        by absence: it is shared with every other case in the run, and one of them may have
+        wired it for its own reasons. What this case is about is that THIS call did not.
+        """
+        sandbox = Path(os.environ["XDG_CONFIG_HOME"]) / "opencode" / opencode.SHIM_PATH
+        before = sandbox.stat() if sandbox.exists() else None
+        with spawns([], json.dumps(
+                {"plugin": [f"file://{self.oc / 'opencode' / opencode.SHIM_PATH}"]})):
+            rc = self.run_install("oc-alt")
+        self.assertEqual(rc, 0)
+        self.assertTrue(opencode.shim_is_charters(self.oc / "opencode"))
+        after = sandbox.stat() if sandbox.exists() else None
+        self.assertEqual(before is None, after is None)
+        if before is not None:
+            self.assertEqual((before.st_mtime_ns, before.st_size),
+                             (after.st_mtime_ns, after.st_size))
+
+    def test_a_codex_profile_writes_its_policy_line_under_its_own_home(self):
+        default = Path(os.environ["CODEX_HOME"]) / "config.toml"
+        before = default.read_text() if default.exists() else None
+        self.run_install("codex-alt")
+        doc = (self.codex_home / "config.toml").read_text()
+        self.assertIn('CHARTER_HARNESS = "codex"', doc)
+        self.assertEqual(default.read_text() if default.exists() else None, before)
+
+    def test_a_codex_profile_names_the_codex_side_steps(self):
+        """Charter writes the one line Codex's plugin cannot write, and PRINTS the rest:
+        installing a plugin and approving hooks are Codex's own commands, and a hook nobody
+        approved is inert whatever charter did (ruling 7)."""
+        out = self.said(lambda: self.run_install("codex-alt"))
+        self.assertIn(f"CODEX_HOME={self.codex_home}", out)
+        self.assertIn("codex plugin add", out)
+
+    def test_an_existing_policy_table_without_charters_line_is_refused(self):
+        self.codex_home.mkdir(parents=True, exist_ok=True)
+        f = self.codex_home / "config.toml"
+        f.write_text('[shell_environment_policy]\ninherit = "core"\n')
+        before = f.read_bytes()
+        out = self.said(lambda: self.assertEqual(self.run_install("codex-alt"), 1))
+        self.assertEqual(f.read_bytes(), before)
+        self.assertIn('set = { CHARTER_HARNESS = "codex" }', out)
+        self.assertNotIn("charter harness install", out)
+
+    def test_a_registry_name_still_works_as_today(self):
+        """`charter harness install codex` is what `docs/harnesses.md` tells people to run,
+        and a profile-first lookup must not have taken it away (ruling 8). It writes the same
+        line into the same file and points at the plugin the same way; what it no longer does
+        is exit 0 over a Codex that will still refuse to launch — charter can write the
+        policy line and nothing else, and the plugin install and the hook approval are
+        Codex's own commands."""
+        out = self.said(lambda: self.assertEqual(self.run_install("codex"), 1))
+        self.assertIn(str(codex.config_path()), out)
+        self.assertIn("plugin", out.lower())
+
+    def test_an_unknown_name_is_refused_with_the_profiles_named(self):
+        out = self.said(lambda: self.assertEqual(self.run_install("nope"), 2))
+        self.assertIn("claude-alt", out)
+
+    def test_a_committable_local_file_refuses_install(self):
+        (config.ROOT / ".gitignore").write_text("# nothing ignored\n")
+        out = self.said(lambda: self.assertEqual(self.run_install("claude-alt"), 1))
+        self.assertIn("charter reinit", out)
+
+    def said(self, fn) -> str:
+        import io
+        from contextlib import redirect_stderr, redirect_stdout
+
+        buf = io.StringIO()
+        with redirect_stderr(buf), redirect_stdout(buf):
+            fn()
+        return buf.getvalue()
+
+
+# --------------------------------------------------------------------------- #
+# init / reinit                                                                #
+# --------------------------------------------------------------------------- #
+
+
+class InitAndReinitWireEachProfile(PersonaIso, unittest.TestCase):
+    """Setup runs PER PROFILE, and `reinit` installs no software (ruling 9)."""
+
+    def setUp(self):
+        super().setUp()
+        make_plane(self)
+        self.oc = self.tmp / "oc"
+        declare_profiles(self, f"""
+[harness.claude-alt]
+kind = "claude"
+command = ["claude"]
+env = {{ CLAUDE_CONFIG_DIR = "{self.tmp / 'cc'}" }}
+
+[harness.oc-alt]
+kind = "opencode"
+command = ["opencode"]
+env = {{ XDG_CONFIG_HOME = "{self.oc}" }}
+
+[harness.codex-alt]
+kind = "codex"
+command = ["codex"]
+env = {{ CODEX_HOME = "{self.tmp / 'cx'}" }}
+""")
+
+    def wired(self, *, install: bool):
+        with spawns([], listing()):
+            return commands._wire_profiles(config.ROOT, install=install)
+
+    def test_init_installs_for_an_approved_claude_profile(self):
+        with approved(), mock.patch.object(wiring, "install",
+                                           return_value=[("installed", "x")]) as inst:
+            with spawns([], listing()):
+                commands._wire_profiles(config.ROOT, install=True)
+        self.assertIn("claude-alt", {c.args[0].name for c in inst.call_args_list})
+
+    def test_init_leaves_a_codex_profile_opt_in(self):
+        with approved(), mock.patch.object(wiring, "install",
+                                           return_value=[("installed", "x")]) as inst:
+            with spawns([], listing()):
+                out = commands._wire_profiles(config.ROOT, install=True)
+        self.assertNotIn("codex-alt", {c.args[0].name for c in inst.call_args_list})
+        self.assertIn("charter harness install codex-alt", " ".join(l for _s, l in out))
+
+    def test_reinit_installs_nothing_and_names_what_is_missing(self):
+        with approved(), mock.patch.object(plugincache, "install") as inst:
+            out = self.wired(install=False)
+        inst.assert_not_called()
+        self.assertIn("not wired", " ".join(l for _s, l in out))
+
+    def test_reinit_wires_an_opencode_profiles_shim(self):
+        with approved():
+            with spawns([], json.dumps({"plugin": []})):
+                commands._wire_profiles(config.ROOT, install=False)
+        self.assertTrue(opencode.shim_is_charters(self.oc / "opencode"))
+
+    def test_neither_touches_an_unapproved_profile(self):
+        with mock.patch.object(wiring, "install") as inst:
+            out = self.wired(install=True)
+        inst.assert_not_called()
+        self.assertIn("not approved yet", " ".join(l for _s, l in out))
+
+
+# --------------------------------------------------------------------------- #
+# doctor                                                                       #
+# --------------------------------------------------------------------------- #
+
+
+class DoctorHasARowPerProfile(PersonaIso, unittest.TestCase):
+    """One row per profile the selector would list, and none of them on a hook path."""
+
+    def setUp(self):
+        super().setUp()
+        make_plane(self)
+        declare_profiles(self)
+
+    def test_every_listed_profile_has_a_row_in_order(self):
+        with spawns([], listing()), approved():
+            names = doctor.check_names()
+            produced = [r.name for r in doctor.run_all()]
+        self.assertEqual(names, produced)
+        at = names.index("harness profiles")
+        self.assertTrue(names[at + 1].startswith("profile "))
+
+    def test_a_wired_row_is_ok_with_no_hint(self):
+        with approved(), spawns([], listing(entry(project=config.ROOT))):
+            rows = {r.name: r for r in doctor.check_profile_wiring()}
+        row = rows["profile claude-work"]
+        self.assertEqual(row.status, doctor.OK)
+        self.assertEqual(row.hint, "")
+
+    def test_an_unwired_row_names_the_install(self):
+        with approved(), spawns([], listing()):
+            rows = {r.name: r for r in doctor.check_profile_wiring()}
+        row = rows["profile claude-work"]
+        self.assertEqual(row.status, doctor.WARN)
+        self.assertEqual(row.hint, "charter harness install claude-work")
+
+    def test_an_unknown_row_says_the_check_could_not_run(self):
+        with approved(), spawns([], "", rc=1):
+            rows = {r.name: r for r in doctor.check_profile_wiring()}
+        self.assertEqual(rows["profile claude-work"].hint, doctor._NOT_CHECKED_HINT)
+
+    def test_a_probe_that_raises_costs_one_row(self):
+        real = wiring.detect
+
+        def boom(p, *, cwd):
+            if p.name == "claude-work":
+                raise RuntimeError("this one row")
+            return real(p, cwd=cwd)
+
+        with approved(), spawns([], listing()), \
+                mock.patch.object(wiring, "detect", boom):
+            rows = {r.name: r for r in doctor.check_profile_wiring()}
+        self.assertEqual(rows["profile claude-work"].status, doctor.WARN)
+        self.assertIn("profile codex-pinned", rows)
+
+    def test_rows_are_probed_concurrently(self):
+        def slow(p, *, cwd):
+            time.sleep(0.3)
+            return wiring.Wiring(wiring.WIRED, "slept", "")
+
+        with approved(), mock.patch.object(wiring, "detect", slow):
+            began = time.monotonic()
+            rows = doctor.check_profile_wiring()
+        self.assertGreaterEqual(len(rows), 2)
+        self.assertLess(time.monotonic() - began, 0.3 * len(rows))
+
+    def test_the_preflight_never_probes(self):
+        real = util.run
+
+        def run(cmd, *a, **kw):
+            if cmd[:1] in (["claude"], ["opencode"], ["codex"]):
+                raise AssertionError(f"{cmd[0]} was spawned on a hook path")
+            return real(cmd, *a, **kw)
+
+        with mock.patch.object(wiring, "detect",
+                               side_effect=AssertionError("probed on a hook path")), \
+                mock.patch.object(util, "run", run):
+            rows = doctor.run_all(preflight=True)
+        self.assertEqual([r for r in rows if r.name.startswith("profile ")], [])
+        self.assertIn("harness profiles", [r.name for r in rows])
+
+    def test_the_preflight_runs_no_git_for_profiles(self):
+        """Re-review N8: every git call on a hook path is paid at every session start."""
+        real = util.run
+        seen = []
+
+        def run(cmd, *a, **kw):
+            seen.append(list(cmd))
+            return real(cmd, *a, **kw)
+
+        with mock.patch.object(util, "run", run):
+            doctor.run_all(preflight=True)
+        self.assertEqual([c for c in seen if profiles.LOCAL_FILE in c], [])
+
+    def test_the_names_agree_with_the_preflight(self):
+        self.assertEqual(doctor.check_names(preflight=True),
+                         [r.name for r in doctor.run_all(preflight=True)])
+
+    def test_a_hand_run_doctor_probes_every_approved_profile(self):
+        asked = []
+
+        def seen(p, *, cwd):
+            asked.append(p.name)
+            return wiring.Wiring(wiring.UNWIRED, "no", "fix it")
+
+        with mock.patch.object(wiring, "detect", seen):
+            doctor.check_profile_wiring()
+        self.assertNotIn("claude-work", asked)
+        self.assertIn("claude", asked)
+
+    def test_the_session_start_hook_runs_the_preflight(self):
+        """The hook runs the same words a person types, so nothing in the process could tell
+        the two apart — and a tty test would misread `charter doctor --json` and
+        `charter doctor | less` as the hook. Codex trusts hooks by hash, so its users approve
+        this one once more; the news entry says so."""
+        doc = json.loads((REPO / "hooks" / "hooks.json").read_text())
+        commands_run = [h["command"] for group in doc["hooks"]["SessionStart"]
+                        for h in group["hooks"]]
+        preflight = [c for c in commands_run if "charter doctor" in c]
+        self.assertTrue(preflight)
+        for c in preflight:
+            self.assertIn("charter doctor --preflight", c)
+
+    def test_the_parser_takes_the_preflight_flag(self):
+        from charter import cli
+
+        self.assertIs(cli.build_parser().parse_args(["doctor", "--preflight"]).preflight,
+                      True)
+        self.assertIs(cli.build_parser().parse_args(["doctor"]).preflight, False)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_a_profile_launch_is_refused_before_tmux.py
+++ b/tests/test_a_profile_launch_is_refused_before_tmux.py
@@ -30,7 +30,27 @@ from charter.frame import launcher, layout, reopen as reopen_state, state, tmuxc
 from tests import _gitguard, _tmuxsocket
 from tests._isolation import (APipe as _APipe, ATerminal as _ATerminal, PersonaIso,
                               Typed as _Typed, approve_every_profile, declare_profiles,
-                              make_plane)
+                              make_plane, wired_as_today)
+
+
+#: Ruling 10: a profile whose config folder does not carry charter's guard refuses to
+#: launch, and that applies to the built-ins every launch test here starts. In-process the
+#: suite's `claude` guard makes detection read UNKNOWN, so every one of them would refuse
+#: over a fact none of them is about. One fixture for the module, because no test in it is
+#: about wiring; `tests/test_a_profile_is_wired_or_refuses.py` is where that is the subject.
+_WIRED = None
+
+
+def setUpModule():
+    global _WIRED
+    _WIRED = wired_as_today()
+    _WIRED.start()
+
+
+def tearDownModule():
+    if _WIRED is not None:
+        _WIRED.stop()
+
 
 #: The operator's own tmux, as `tmuxctl.operator_server` reads it out of `$TMUX`: a socket
 #: PATH, which is what `is_operator_socket` tells from charter's own `-L charter` name.

--- a/tests/test_a_reopen_says_what_it_cannot_bring_back.py
+++ b/tests/test_a_reopen_says_what_it_cannot_bring_back.py
@@ -32,9 +32,28 @@ from charter import commands_frame, config, persona
 from charter import workspace as ws_mod
 from charter.frame import leave, reopen, state
 
-from tests._isolation import PersonaIso
+from tests._isolation import PersonaIso, wired_as_today
 
 SERVER = commands_frame.SOCKET
+
+
+#: Ruling 10: a reopen asks whether each chat's profile is wired before it starts it
+#: (`commands_frame._reopen_one`), and in-process the suite's `claude` guard makes that read
+#: as "could not tell" — a refusal no case here is about. One fixture for the module;
+#: `tests/test_a_profile_is_wired_or_refuses.py` is where a reopen of an unwired profile is
+#: the subject.
+_WIRED = None
+
+
+def setUpModule():
+    global _WIRED
+    _WIRED = wired_as_today()
+    _WIRED.start()
+
+
+def tearDownModule():
+    if _WIRED is not None:
+        _WIRED.stop()
 
 
 def _doomed(**kw):

--- a/tests/test_a_reopened_empty_chat_is_shown_its_brief.py
+++ b/tests/test_a_reopened_empty_chat_is_shown_its_brief.py
@@ -33,7 +33,8 @@ from charter import commands_frame, contain, hooks, profiles
 from charter.frame import leave
 from charter.frame import reopen as reopen_state
 from charter.frame import state
-from tests._isolation import PersonaIso, PlaneIso, no_background_refresh, run_hook
+from tests._isolation import (PersonaIso, PlaneIso, no_background_refresh, run_hook,
+                              wired_as_today)
 
 
 def doomed(chat: str, workspace: str, **over) -> leave.Doomed:
@@ -49,6 +50,25 @@ def doomed(chat: str, workspace: str, **over) -> leave.Doomed:
                   cwd_outside=False, profile="")
     fields.update(over)
     return leave.Doomed(**fields)
+
+
+#: Ruling 10: a reopen asks whether each chat's profile is wired before it starts it
+#: (`commands_frame._reopen_one`), and in-process the suite's `claude` guard makes that read
+#: as "could not tell" — a refusal no case here is about. One fixture for the module;
+#: `tests/test_a_profile_is_wired_or_refuses.py` is where a reopen of an unwired profile is
+#: the subject.
+_WIRED = None
+
+
+def setUpModule():
+    global _WIRED
+    _WIRED = wired_as_today()
+    _WIRED.start()
+
+
+def tearDownModule():
+    if _WIRED is not None:
+        _WIRED.stop()
 
 
 class TheRecordCarriesTheBrief(PersonaIso):

--- a/tests/test_a_second_launch_focuses_instead_of_dragging.py
+++ b/tests/test_a_second_launch_focuses_instead_of_dragging.py
@@ -48,7 +48,26 @@ from unittest import mock
 from charter import commands_frame, config, workspace
 from charter.frame import state
 from tests import _tmuxreap
-from tests._isolation import PersonaIso
+from tests._isolation import PersonaIso, wired_as_today
+
+
+#: Ruling 10: a profile whose config folder does not carry charter's guard refuses to
+#: launch, and that applies to the built-ins every launch test here starts. In-process the
+#: suite's `claude` guard makes detection read UNKNOWN, so every one of them would refuse
+#: over a fact none of them is about. One fixture for the module, because no test in it is
+#: about wiring; `tests/test_a_profile_is_wired_or_refuses.py` is where that is the subject.
+_WIRED = None
+
+
+def setUpModule():
+    global _WIRED
+    _WIRED = wired_as_today()
+    _WIRED.start()
+
+
+def tearDownModule():
+    if _WIRED is not None:
+        _WIRED.stop()
 
 _HAS_TMUX = shutil.which("tmux") is not None
 

--- a/tests/test_a_workspace_tab_opens_what_it_names.py
+++ b/tests/test_a_workspace_tab_opens_what_it_names.py
@@ -57,7 +57,26 @@ from charter import commands_frame, config, root
 from charter.frame import state
 
 from tests import _tmuxreap, _tmuxsocket, _ttyguard
-from tests._isolation import PersonaIso, make_plane, no_background_refresh
+from tests._isolation import PersonaIso, make_plane, no_background_refresh, wired_as_today
+
+
+#: Ruling 10: a profile whose config folder does not carry charter's guard refuses to
+#: launch, and that applies to the built-ins every launch test here starts. In-process the
+#: suite's `claude` guard makes detection read UNKNOWN, so every one of them would refuse
+#: over a fact none of them is about. One fixture for the module, because no test in it is
+#: about wiring; `tests/test_a_profile_is_wired_or_refuses.py` is where that is the subject.
+_WIRED = None
+
+
+def setUpModule():
+    global _WIRED
+    _WIRED = wired_as_today()
+    _WIRED.start()
+
+
+def tearDownModule():
+    if _WIRED is not None:
+        _WIRED.stop()
 
 _HAS_TMUX = shutil.which("tmux") is not None
 

--- a/tests/test_charter_records_the_plane_as_it_changes.py
+++ b/tests/test_charter_records_the_plane_as_it_changes.py
@@ -52,7 +52,26 @@ from unittest import mock
 from charter import cli, commands_frame, config, instance
 from charter.frame import leave, record, reopen, state
 
-from tests._isolation import PersonaIso
+from tests._isolation import PersonaIso, wired_as_today
+
+
+#: Ruling 10: a profile whose config folder does not carry charter's guard refuses to
+#: launch, and that applies to the built-ins every launch test here starts. In-process the
+#: suite's `claude` guard makes detection read UNKNOWN, so every one of them would refuse
+#: over a fact none of them is about. One fixture for the module, because no test in it is
+#: about wiring; `tests/test_a_profile_is_wired_or_refuses.py` is where that is the subject.
+_WIRED = None
+
+
+def setUpModule():
+    global _WIRED
+    _WIRED = wired_as_today()
+    _WIRED.start()
+
+
+def tearDownModule():
+    if _WIRED is not None:
+        _WIRED.stop()
 
 
 def _completed(rc=0, out=""):

--- a/tests/test_cmd_harness.py
+++ b/tests/test_cmd_harness.py
@@ -40,8 +40,12 @@ class HarnessList(PersonaIso):
         self.assertRegex(text, r"[*>•→].{0,4}opencode")
 
 
-class HarnessInstall(unittest.TestCase):
+class HarnessInstall(PersonaIso):
+    """`PersonaIso` because the install resolves a PROFILE before a registry name (ruling 8),
+    and profiles are read off `charter.local.toml` — the real plane's is refused."""
+
     def setUp(self) -> None:
+        super().setUp()
         self.home = Path(tempfile.mkdtemp(prefix="charter-codexhome-"))
         self.addCleanup(lambda: __import__("shutil").rmtree(self.home, True))
         self.enterContext(mock.patch.dict(os.environ, {"CODEX_HOME": str(self.home)}))
@@ -49,20 +53,35 @@ class HarnessInstall(unittest.TestCase):
     def test_installing_codex_names_the_harness_and_points_at_the_plugin(self):
         """The hooks come from the plugin. This writes the one thing the plugin cannot —
         `$CHARTER_HARNESS` — and says where the rest comes from, so nobody adds a second
-        copy by hand."""
+        copy by hand.
+
+        **Non-zero now, and that is the point of the last step.** Charter writes the policy
+        line and then asks Codex whether the profile is wired; the plugin install and the
+        hook approval are Codex's own commands, printed here with `CODEX_HOME=` in front. A
+        0 would report success over a profile that will still refuse to launch, which is the
+        remedy-that-ends-the-investigation `opencode.unvouched` was written against."""
         rc, text = _run(commands_harness.cmd_harness_install,
                         SimpleNamespace(name="codex"))
-        self.assertEqual(rc, 0)
+        self.assertEqual(rc, 1)
         self.assertTrue((self.home / "config.toml").is_file())
         self.assertIn("plugin", text.lower())
+        self.assertIn(f"CODEX_HOME={self.home}", text)
 
-    def test_a_harness_that_needs_no_opt_in_says_so_rather_than_failing(self):
+    def test_a_harness_charter_can_finish_wiring_is_wired_rather_than_pointed_at(self):
+        """It used to answer "needs no opt-in — `charter init` writes its wiring", and that
+        stopped being the whole truth when an unwired profile began refusing to launch
+        (ruling 10): the sentence a refused `charter opencode` prints is THIS command, so
+        this command has to be the one that fixes it. It writes the shim into the config
+        home the profile names and then asks opencode whether it took."""
         rc, text = _run(commands_harness.cmd_harness_install,
                         SimpleNamespace(name="opencode"))
-        self.assertEqual(rc, 0)
-        self.assertIn("charter init", text)
+        self.assertEqual(rc, 0, text)
+        self.assertIn("wired", text)
 
     def test_an_unknown_harness_is_refused_with_the_known_ones_named(self):
+        """The names are the PROFILES now, which is a superset of the registry's: a plane
+        that pinned `codex` to an older release should be told that name, not the built-in
+        it replaced."""
         rc, text = _run(commands_harness.cmd_harness_install,
                         SimpleNamespace(name="gemini-cli"))
         self.assertEqual(rc, 2)

--- a/tests/test_frame_launcher.py
+++ b/tests/test_frame_launcher.py
@@ -39,11 +39,30 @@ from types import SimpleNamespace
 from unittest import mock
 
 from tests import _tmuxchain
-from tests._isolation import PersonaIso
+from tests._isolation import PersonaIso, wired_as_today
 from charter import commands_frame, config, instance, statusline, util
 from charter.frame import (builtin_actions, gather, layout, overlay, slots, state,
                            tmuxctl)
 from tests import _envguard, _tmuxsocket
+
+
+#: Ruling 10: a profile whose config folder does not carry charter's guard refuses to
+#: launch, and that applies to the built-ins every launch test here starts. In-process the
+#: suite's `claude` guard makes detection read UNKNOWN, so every one of them would refuse
+#: over a fact none of them is about. One fixture for the module, because no test in it is
+#: about wiring; `tests/test_a_profile_is_wired_or_refuses.py` is where that is the subject.
+_WIRED = None
+
+
+def setUpModule():
+    global _WIRED
+    _WIRED = wired_as_today()
+    _WIRED.start()
+
+
+def tearDownModule():
+    if _WIRED is not None:
+        _WIRED.stop()
 
 #: The plane this test PROCESS was started in, captured at IMPORT — before any `setUp`
 #: has had a chance to repoint `config`, so it is unavoidably the developer's REAL

--- a/tests/test_news_reentrancy.py
+++ b/tests/test_news_reentrancy.py
@@ -35,6 +35,7 @@ from types import SimpleNamespace
 from unittest import mock
 
 from charter import commands, commands_persona, config, doctor, news
+from tests._isolation import PersonaIso
 
 #: A `check:` a probe is allowed to run, standing in for whatever an entry names
 #: (#317: an entry picks from `news._PROBEABLE`, not from the whole CLI). Its
@@ -49,10 +50,17 @@ STAND_IN, STAND_IN_FN = "persona lint", "cmd_persona_lint"
 SWEEP_CAP = 6
 
 
-class NewsDir(unittest.TestCase):
-    """Entries read from a throwaway directory, so no test depends on what shipped."""
+class NewsDir(PersonaIso):
+    """Entries read from a throwaway directory, so no test depends on what shipped.
+
+    `PersonaIso` and not a bare `TestCase`: `charter doctor` builds its NAME column from
+    `doctor.check_names`, which now lists one row per harness profile — read off
+    `charter.local.toml`, which `tests/_planeguard` refuses for the real plane (ruling 43).
+    A throwaway plane is what that file is read from here.
+    """
 
     def setUp(self):
+        super().setUp()
         self.dir = Path(tempfile.mkdtemp())
         patch = mock.patch.object(news, "_PACKAGED", self.dir)
         patch.start()
@@ -77,7 +85,9 @@ class CheckDoctor(NewsDir):
         super().setUp()
         self.sweeps = 0
 
-        def sweep():
+        # `**kw` because `_checks` takes `preflight` now — what the SessionStart hook
+        # passes to leave the profile probes out.
+        def sweep(**kw):
             self.sweeps += 1
             if self.sweeps > SWEEP_CAP:
                 # Break the loop rather than recursing on. Without this an unguarded tree

--- a/tests/test_plugin_install.py
+++ b/tests/test_plugin_install.py
@@ -40,7 +40,9 @@ REPO = Path(__file__).resolve().parents[1]
 @contextmanager
 def rows(entries):
     """Answer `claude plugin list --json` with *entries*, and every other read with ``[]``."""
-    def fake(args, cwd=None, timeout=None):
+    # `**kw` because `_claude_json` takes `env` and `command` now: a profile names its own
+    # `claude`, and the probe runs under the profile's environment.
+    def fake(args, cwd=None, timeout=None, **kw):
         return entries if args[:1] == ["list"] else []
 
     with mock.patch.object(plugincache, "available", return_value=True), \

--- a/tests/test_the_branch_not_taken_is_still_a_promise.py
+++ b/tests/test_the_branch_not_taken_is_still_a_promise.py
@@ -32,7 +32,7 @@ from charter import commands_frame, config, inflight, util
 from charter import workspace as ws_mod
 from charter.frame import chats, leave, reopen, state
 
-from tests._isolation import PersonaIso
+from tests._isolation import PersonaIso, wired_as_today
 
 
 def _chat(**kw):
@@ -40,6 +40,25 @@ def _chat(**kw):
                 cwd="/tmp", resume="", transcript="", active=False)
     base.update(kw)
     return reopen.Chat(**base)
+
+
+#: Ruling 10: a reopen asks whether each chat's profile is wired before it starts it
+#: (`commands_frame._reopen_one`), and in-process the suite's `claude` guard makes that read
+#: as "could not tell" — a refusal no case here is about. One fixture for the module;
+#: `tests/test_a_profile_is_wired_or_refuses.py` is where a reopen of an unwired profile is
+#: the subject.
+_WIRED = None
+
+
+def setUpModule():
+    global _WIRED
+    _WIRED = wired_as_today()
+    _WIRED.start()
+
+
+def tearDownModule():
+    if _WIRED is not None:
+        _WIRED.stop()
 
 
 def _manifest(*frames, focus="alpha", at=1700000000):

--- a/tests/test_the_chat_bars_plus_makes_a_chat.py
+++ b/tests/test_the_chat_bars_plus_makes_a_chat.py
@@ -36,7 +36,26 @@ from unittest import mock
 from charter import commands_frame, config
 from charter.frame import state
 
-from tests._isolation import PersonaIso
+from tests._isolation import PersonaIso, wired_as_today
+
+
+#: Ruling 10: a profile whose config folder does not carry charter's guard refuses to
+#: launch, and that applies to the built-ins every launch test here starts. In-process the
+#: suite's `claude` guard makes detection read UNKNOWN, so every one of them would refuse
+#: over a fact none of them is about. One fixture for the module, because no test in it is
+#: about wiring; `tests/test_a_profile_is_wired_or_refuses.py` is where that is the subject.
+_WIRED = None
+
+
+def setUpModule():
+    global _WIRED
+    _WIRED = wired_as_today()
+    _WIRED.start()
+
+
+def tearDownModule():
+    if _WIRED is not None:
+        _WIRED.stop()
 
 
 def _completed(cmd, rc=0, out=""):

--- a/tests/test_the_launcher_becomes_the_profile.py
+++ b/tests/test_the_launcher_becomes_the_profile.py
@@ -38,7 +38,27 @@ from tests import _gitguard, _tmuxsocket
 from tests._isolation import (APipe as _APipe, ATerminal as _ATerminal,
                               PersonaIso, Typed as _Typed,
                               approve_every_profile, declare_profiles,
-                              make_plane)
+                              make_plane, wired_as_today)
+
+
+#: Ruling 10: a profile whose config folder does not carry charter's guard refuses to
+#: launch, and that applies to the built-ins every launch test here starts. In-process the
+#: suite's `claude` guard makes detection read UNKNOWN, so every one of them would refuse
+#: over a fact none of them is about. One fixture for the module, because no test in it is
+#: about wiring; `tests/test_a_profile_is_wired_or_refuses.py` is where that is the subject.
+_WIRED = None
+
+
+def setUpModule():
+    global _WIRED
+    _WIRED = wired_as_today()
+    _WIRED.start()
+
+
+def tearDownModule():
+    if _WIRED is not None:
+        _WIRED.stop()
+
 
 #: The `list-panes -a` row `tmuxctl.live_pane_by_pid` parses: pid, dead, pane, session,
 #: window, `@charter_chat`. Spelled here rather than built from the format, so a change to

--- a/tests/test_what_a_quit_says_is_spelled_where_it_is_asserted.py
+++ b/tests/test_what_a_quit_says_is_spelled_where_it_is_asserted.py
@@ -74,7 +74,7 @@ from charter import commands_frame, config, contain, util
 from charter import workspace as ws_mod
 from charter.frame import builtin_actions, component, leave, palette, reopen, state
 
-from tests._isolation import PersonaIso
+from tests._isolation import PersonaIso, wired_as_today
 
 SERVER = commands_frame.SOCKET
 
@@ -82,6 +82,25 @@ SERVER = commands_frame.SOCKET
 #: prints back. The escape is `ESC [ 2 J` — erase the whole display — because a report line
 #: that let it through would not merely look wrong, it would take the operator's screen.
 HOSTILE = "claude\x1b[2Jcode\nrm -rf /"
+
+
+#: Ruling 10: a reopen asks whether each chat's profile is wired before it starts it
+#: (`commands_frame._reopen_one`), and in-process the suite's `claude` guard makes that read
+#: as "could not tell" — a refusal no case here is about. One fixture for the module;
+#: `tests/test_a_profile_is_wired_or_refuses.py` is where a reopen of an unwired profile is
+#: the subject.
+_WIRED = None
+
+
+def setUpModule():
+    global _WIRED
+    _WIRED = wired_as_today()
+    _WIRED.start()
+
+
+def tearDownModule():
+    if _WIRED is not None:
+        _WIRED.stop()
 
 
 def _doomed(**kw):


### PR DESCRIPTION
Charter's guard lives in the harness's own config folder, and a harness profile names
another one. Measured in throwaway folders on 2026-09-12 against claude 2.1.269, codex-cli
0.147.0 and opencode 1.18.23: under an empty `$CLAUDE_CONFIG_DIR` charter's plugin is not
merely disabled, it is unknown to that folder, because the marketplace is known only to the
folder it was added in; an empty `$CODEX_HOME` has no plugin, no hook trust and no
`shell_environment_policy`; a throwaway `$XDG_CONFIG_HOME` has no shim. A chat started on
such a profile looks guarded and is not.

`charter/wiring.py` asks the harness, under the profile's own `command` and `env`, whether
charter's guard actually runs there — never inferring from the profile's variable names,
because one account can be reached through variables that do or do not move the plugin
(`$XDG_DATA_HOME` moves opencode's login and leaves its plugins alone). A profile that is
not wired refuses to launch and prints `charter harness install <name>`. **Built-ins refuse
the same way** (ruling 10): `charter codex` on a plane where nobody wired Codex, and
`charter opencode` where `init` never wrote the shim, now refuse where they used to start.
A probe that cannot answer refuses too, naming the probe to run by hand — an unknown is not
a pass (ruling 12), and no flag launches one unguarded.

`charter doctor` gains a row per profile, probed concurrently; `charter doctor --preflight`
— what the SessionStart hook runs now — probes nothing and makes no git call for a profile
(ruling 11). **Codex users approve that hook once more**: Codex trusts a hook by the hash of
its command, and its command gained `--preflight`. The news entry says so.

## Task 3's approval is the gate now (rebased onto #992, `a0a474d`)

This branch was first written before Task 3 merged, with a stand-in gate that refused every
declared profile. It is rebased onto `main` and the stand-in is gone — **not as one swapped
line**: `profiletrust.approval_needed` answers `new`/`changed`, not a sentence, and the ignore
check had to move in with it.

- `wiring.detect`, `wiring.refusal` and `wiring.install` ask nothing of a profile git would
  commit (`launcher.IGNORED`) or the operator has not approved (`profiletrust.UNATTENDED`);
  doctor's rows say which of the two and probe nothing; `init`/`reinit` report an
  unapproved profile with `charter <name>`.
- `charter harness install <profile>` asks through `launcher.answered`: a no exits 130, a yes
  charter cannot record refuses (`KIND_RECORD`), no terminal is `UNATTENDED` and exits 1.
- The launcher's chain keeps wiring LAST, and ruling 27's re-run after a yes includes it —
  `AYesNeverWalksPastAWiringRefusal` pins that with `--no-frame`, in the pane, and before
  tmux. `_asked_here`'s re-run passes `cwd`. The cache key is `profiletrust.fingerprint`.
- Tests seed approval with `tests._isolation.approve_profile` (which now also takes a
  hand-built `Profile`).

## Step 0 — the measurements, and what they changed

### D1 — cost

| probe | runs (ms) | median | the plan's baseline |
|---|---|---|---|
| `claude plugin list --json`, empty alt `CLAUDE_CONFIG_DIR` | 296, 139, 135, 137, 136 | **137** | 215 |
| `claude plugin list --json`, default config (64 entries) | 181, 181, 177, 175, 178 | **178** | 281 |
| `opencode debug config`, empty alt `XDG_CONFIG_HOME` | 754, 631, 627 | **631** | 749 |
| `opencode debug config`, default config | 713, 862, 718 | **718** | 720 |

Codex needs no subprocess: detection parses `$CODEX_HOME/config.toml`.

`charter doctor` by hand on this plane: **2.70 s before** (2.76 / 2.70 / 2.38), **4.15 s
after** (4.89 / 4.15 / 4.06) with three built-in profiles — **+1.45 s**. In-process, the
concurrent probe block itself costs 631–707 ms for three profiles and **812 ms for six**
(three declared, approved, plus the three built-ins). Ruling 11's rule is on the hand-run
figure and ≤ 2 s, so: **rows for every listed profile, probed concurrently.**

`charter doctor --preflight` builds 38 rows, **none of them a `profile …` row**, and its
`harness profiles` row is still there.

### D2 — which scope wins, and what flips it

Under an alternate `CLAUDE_CONFIG_DIR` with the plugin installed at **user** scope, cwd a
throwaway plane:

| state | `(scope, enabled, projectPath)` |
|---|---|
| no plane settings | `[(user, True, None)]` |
| disable ONLY in `<plane>/.claude/settings.local.json` | `[(user, **False**, None)]` |
| disable ONLY in `<plane>/.claude/settings.json` | `[(user, **False**, None)]` |
| both removed | `[(user, True, None)]` |

**`claude plugin list --json` already reflects a settings-file disable**, so ruling 36's
"unless" clause fires and detection reads no settings file of its own. With a project
install beside the user one, every entry of the id carried the *same* `enabled` in all five
combinations tried — `enabled` is the effective `enabledPlugins` value merged local >
project > user and resolved at the probe's own cwd, not a per-entry fact.

The files whose `(mtime_ns, size)` moved on each flip, which is what the cache stamps
(minus `.claude.json`, which the probe itself writes):

| step | files that moved |
|---|---|
| `plugin uninstall --scope project` | `<config>/plugins/installed_plugins.json`, `<cwd>/.claude/settings.json` |
| `plugin install --scope project -y` | those two plus `<config>/plugins/known_marketplaces.json` |
| `plugin disable` | `<cwd>/.claude/settings.json` |
| `plugin enable` | `<config>/.claude.json`, `<cwd>/.claude/settings.json` |
| `plugin list --json` (the probe) | nothing |

### D3 — install under a profile's environment reaches a workspace chat — **PASS**

With `CLAUDE_CONFIG_DIR`, `XDG_CONFIG_HOME` and `CODEX_HOME` all pointed at throwaway
folders, `charter init` at `/private/tmp/cp-wiring/plane2` installed `charter@charter` at
project scope; `charter workspace create w`; then `claude plugin list --json` with cwd
`<plane>/workspaces/w` answered `charter@charter`, `scope=project`,
`projectPath=<plane>`, **`enabled: true`**.

`plugincache.covers(entry, <plane>/workspaces/w)` is **False** — the record's `projectPath`
is the plane root. The documented other rule the plan allows for: an install record covering
the PLANE covers a chat in that plane's workspace, because charter mirrors the plane's
`enabledPlugins` into `workspaces/<ws>/.claude/settings.json` (`claude_code.WORKSPACE_KEYS`)
and the probe's `enabled` is resolved at its own cwd. `covering_entries(project, root=…)`
asks `covers(e, cwd) or covers(e, root)`.

### D4 — Codex

`codex plugin` has `add`, `list`, `marketplace`, `remove` — no `install`, no `update`.
`codex plugin marketplace add https://github.com/diazoxide/charter` then `codex plugin add
charter@charter` writes `[marketplaces.charter]` and `[plugins."charter@charter"] enabled =
true` into `$CODEX_HOME/config.toml`, with the plugin under
`$CODEX_HOME/plugins/cache/charter/charter/<version>`. Nothing writes
`shell_environment_policy` — that stays charter's one line.

Trust is `[hooks.state."charter@charter:hooks/hooks.json:<event>:<group>:<hook>"]` with
`trusted_hash = "sha256:…"`, and **two plan assumptions are refuted**:

- `trusted_hash` **cannot be recomputed** by charter. Tried against a real hash: the command
  string, the hook object as JSON in three spellings, the whole matcher group, the group's
  `hooks` list, and the commands joined by newline. None matched.
- "a trust entry exists for **every** hook key" would call a wired machine unwired. Codex
  writes entries **lazily**, one per hook as each first fires: this operator's own wired
  `~/.codex/config.toml` holds **12 of the plugin's 18** keys.

So the rule taken is the honest weaker one — at least one trusted charter hook in that home
— and `docs/harnesses.md` states its limit.

### D5 — opencode

`charter init` under `XDG_CONFIG_HOME=/tmp/cp-wiring/oc-alt` wrote
`…/oc-alt/opencode/plugin/charter.ts`, and `opencode debug config` under that environment
answered `plugin = ['file:///tmp/cp-wiring/oc-alt/opencode/plugin/charter.ts']` — the
un-resolved `/tmp` spelling, so both sides of the comparison are resolved. Dropping the shim
emptied the list; a `plugin/aaa_boot.ts` beside it was listed too, which is the documented
bypass this refuses (ruling 26, ADR 0015). `~/.opencode/plugin/` does not exist on this
machine, so the spec's limit there stays unmeasured — recorded, not built on.

## Departures from the plan, with reasons

1. **No settings-file fallback for Claude Code** (ruling 36's "unless"). D2 settled it:
   `plugin list --json` reflects the disable. Adding the reader anyway would have introduced
   a false UNWIRED — a stale user-scope `false` would outrank a workspace `settings.json`
   `true`, which the binary does not do (the ancestor `settings.json` walk-up asymmetry is
   measured in the table above).
2. **`enabled` is not per-entry.** The plan's model is refuted for 2.1.269. The
   most-specific-covering-scope rule is implemented and pinned anyway; it decides between
   install records that disagree, which today's binary never lists. *(Corrected in the fix
   round: this used to say it "fails closed if that ever changes", which is not true of the
   whole rule — a settings-file disable creates no install record, so if the binary stopped
   resolving `enabled` at the probe's cwd, charter would read the enabled record and call
   the chat wired. Charter's answer rests on that measured behaviour, not on the scope
   order.)*
3. **`covers` alone cannot answer for a workspace chat** (D3 above) — the documented rule is
   `covers(e, cwd) or covers(e, root)`. It is kept because the record that covers the plane
   carries the `enabled` the binary resolved at the chat's own directory:
   `test_a_plane_install_the_chats_directory_disables_is_not_wired` shows a root install that
   directory disables reads as not wired. It rests on the same measured behaviour as 2.
4. **Codex hook trust: at least one entry, not every key** (D4 above) — and, since the fix
   round, at least one entry for a GUARD hook (`pre_tool_use`), because Codex trusts each
   hook separately and an approved SessionStart hook guards nothing.
5. **A DISABLED Claude Code plugin's fix is `cd <chat dir> && <env> <command> plugin enable
   charter@charter --scope local`**, not `charter harness install`. `plugincache.install`
   answers `present` for an install that exists, so the plan's fix would have printed a
   command that changes nothing and loops — review 7's objection, one harness over. The
   scope and the directory were measured in the fix round (A8 below).
6. **`doctor` does not write the wiring cache.** The plan had a hand-run doctor remember each
   answer; writing it from `run_all()` means every suite module that reaches `doctor.run_all()`
   writes into the operator's real `.charter/`, which `tests/_planeguard` exists to stop. The
   cache is display-only anyway (ruling 21) and Task 5's selector is its only reader, so the
   write belongs on the miss it takes.
7. **`charter harness install codex` exits 1, not 0**, when the Codex side is still
   incomplete — the plan's step 5 ("rc 0 only when wired") applied to today's NAME path.
   Charter writes the policy line and prints the Codex-side steps with `CODEX_HOME=` in
   front; a 0 would report success over a profile that will still refuse to launch.
   `test_cmd_harness.HarnessInstall` is updated and says why.
8. **`charter harness install opencode` wires and then asks**, instead of answering "needs no
   opt-in — `charter init` writes its wiring". That sentence stopped being the whole truth
   when an unwired built-in began refusing to launch: the command a refused `charter opencode`
   prints is this one, so this one has to fix it.
9. **`docs/harnesses.md` gains a `### Per profile` section with its own per-kind table**
   rather than a row in the table the plan's `:33` anchor names — that anchor is a `charter
   harness list` sample, not a table.
10. **`tests/_claudeguard.py` gains a fake `opencode`.** Doctor's per-profile rows probe every
    listed profile, and a built-in is listed when its program is on `PATH` — so on a laptop
    with opencode installed, every module reaching `doctor.run_all()` would spawn the real
    binary. It lists what is in `$XDG_CONFIG_HOME/opencode/plugin/`, which is what the real
    one does.
11. **`wired_as_today` is a module fixture in the fifteen launch modules**, not a per-class
    call: no test in any of them is about wiring, and `test_frame_launcher` alone has thirty
    classes. Since the rebase it is also in Task 3's module and the five that drive
    `_reopen_one`, which now checks wiring.
12. **`_launch` skips its pre-tmux probe for every open whose caller asked the chain itself**
    — a `+`, a tab, a reopen and a handoff (`not _wants_attach(args)`) — and not only for an
    `Opening`, as the plan wrote. All four paid three probes; the plan prices a start at two.
    The pane's probe is never skipped, so this can cost a refusal nothing.
13. **Codex's "check by hand" is `cat <config.toml>`**, a pasteable command, rather than the
    word `read`.

## What the plan got wrong

- *"`charter@charter` appears at scopes `project`/`local`/`user`, both enabled and
  disabled"* — on 2.1.269 every entry of one plugin id carries the same effective `enabled`;
  what differs between entries is `scope` and `projectPath`. The plan read coexistence as
  disagreement.
- The D1 baselines were pessimistic by 30–40% for Claude Code and 16% for opencode's empty
  folder.
- Entry keys no longer include `mcpServers`: `enabled`, `id`, `installPath`, `installedAt`,
  `lastUpdated`, `projectPath`, `scope`, `version`.
- D4's hook-trust fallback, twice over (above).
- This PR's own D2 said an ancestor's `settings.local.json` reaches a session below it.
  Measured again (claude 2.1.270): it does when that ancestor is the **git root** — a plane
  root — and did not in a directory that was not a repository. The stamp walks to the plane
  root either way (A6).
- The plan's `test_a_yes_on_an_unwired_profile_still_refuses_with_no_frame` expects rc 1; the
  launcher's refusal code is `REFUSED_EXIT` (3) since Task 2, and the test asserts that.
- The plan says `_launch` skips its probe "for an `Opening`"; the `+`, a tab and a reopen
  needed the same (departure 12).

## Existing tests this changes

- `tests/_claudeguard.py`: `available` takes a command; a fake `opencode` joins the fake
  `claude`.
- `tests/_isolation.py`: `wired_as_today`.
- Fifteen launch modules gain that module fixture (ruling 10 would otherwise refuse every
  launch in them).
- `tests/test_a_chat_pane_starts_as_charter_and_becomes_the_harness.py` and
  `tests/test_a_background_chat_really_starts_on_its_brief.py`: their recorders answer
  `plugin list --json` with a covering, enabled entry — a pane is a child process no patch
  reaches.
- `tests/test_plugin_install.py`, `tests/test_news_reentrancy.py`: fake signatures follow
  `_claude_json` and `_checks`.
- `tests/test_news_reentrancy.py`, `tests/test_a_green_doctor_row_keeps_nothing_back.py`,
  `tests/test_cmd_harness.py`: `PersonaIso`, because `doctor.check_names` now lists a row per
  profile and reads `charter.local.toml`, which `_planeguard` refuses for the real plane.
- `tests/test_cmd_harness.py::HarnessInstall`: the two behaviour changes in 7 and 8 above.
- Fix round: `tests/test_a_new_or_changed_profile_asks_once.py` and the five modules that
  drive a reopen (`test_a_filesystem_that_refuses_costs_what_it_says`,
  `test_a_reopen_says_what_it_cannot_bring_back`, `test_a_reopened_empty_chat_is_shown_its_brief`,
  `test_the_branch_not_taken_is_still_a_promise`,
  `test_what_a_quit_says_is_spelled_where_it_is_asserted`) gain `wired_as_today`;
  `tests/_claudeguard.py` keeps `REAL_AVAILABLE` for the one case about which `PATH` a
  command is looked up on.

## Fix round — both reviews at `ef5cad9`, finding → outcome

| # | Finding | Outcome |
|---|---|---|
| A1 | wrong-typed TOML / cache / NUL raised | Fixed. Each level of the Codex config is checked for a table and a wrong shape is UNKNOWN naming the key; a trust entry that is not a table is UNKNOWN; a non-string `trusted_hash` is not trust; cache fields are type-checked; `ValueError` (NUL) is caught in `wiring._asked`, `plugincache._claude_json` and `wiring.install`. |
| A2 | probe searched the process PATH | Fixed: `plugincache.available(command, path=)`, fed the profile environment's `PATH` — in the probe and, after verification found it missed, in `plugincache.install` too (`harness install`/`init` said `unavailable`). Tested through `wiring.install`. |
| A3 | `+`/tab/handoff probed three times | Fixed: `launcher.refusal(probe=)`; `_launch` skips it for callers that asked (departure 12); reopen asks by name. Verification found a handoff still paid three (`background_refusal`, then `open_in_background`, then the pane): `open_in_background` now skips the wiring link and keeps the rest. Probe counted end to end through a handoff. |
| A4 | Codex `enabled` untested | Test added. |
| A5 | any trusted hook counted | Fixed. First pass required a `pre_tool_use` entry, which verification showed the `Task|Agent` dispatch hook satisfies. Now the guard is `charter hook pretooluse` by handler, and its `<event>:<group>:<hook>` key is read from the installed plugin's `hooks/hooks.json` in `$CODEX_HOME/plugins/cache/charter/charter/<version>/` — the file Codex numbers against (0.42.0 had three `PreToolUse` groups, 0.60.0 four). Versions must agree; no cached copy is nothing to trust; an unreadable one is unknown. Tests: dispatch-only trusted → not wired, guard trusted → wired, guard moved to another group, disagreeing versions. |
| A6 | stamp missed an ancestor's `settings.local.json` | Fixed: every `.claude/settings{,.local}.json` from the chat's directory up to the plane root. Measured: a git root's `settings.local.json` reaches below. |
| A7 | plane-root coverage vs "fails closed" | Kept, with the test the ruling asks for; departure 2/3 text corrected. |
| A8 | enable fix named no scope | Measured (claude 2.1.270, throwaway `CLAUDE_CONFIG_DIR` and plane): `--scope local` run from the chat's directory undid a disable in its `settings.local.json`, its `settings.json`, and a git plane root's `settings.local.json`; `--scope project`/`user` exited 1 over a local disable. The fix now says exactly that, with the `cd`. |
| A9 | `unavailable` printed as a note | Fixed: only writes are notes; every other status (and any new one) warns. Pinned. |
| A10 | `--preflight` on an older CLI | Rule found: CLI and plugin release in lockstep, `charter update` moves the CLI first, and `hooks.skew_message` tells a session with a newer plugin to upgrade the CLI. Measured against `origin/main`'s CLI (0.60.0): the new hook command exits 0 via its `\|\| printf` fallback, runs no preflight check, and prints `charter preflight failed … unrecognized arguments: --preflight` until the CLI catches up. There is **no mechanism** that keeps a newer `hooks.json` command working on an older CLI, and none was invented; the news entry now describes exactly this. |
| A11 | `"; "` join and unquoted paths | Fixed: `codex_steps` returns a list; every path and word is `shlex.quote`d; variables are shown expanded (a quoted `~` is not a home). |
| A12 | double escaping | Fixed. |
| B1 | doctor rows clipped with `...` | Fixed: `… +N not shown` on row names, details and hints. Refusal sentences keep the fixed marker. |
| B2 | exception text uncontained | Fixed. |
| B3 | `cached`/`remember` named a missing file | Docstrings say Task 5's selector will read them; both age bounds pinned. |
| B4 | tests agreed with themselves on `$HOME` | `$HOME` pinned, literals asserted. |
| B5 | listing depended on the machine | `on_path(...)` states which harness programs exist. |
| CI | `2faa650` red on 3.12: `ALaunchThatAttachesClearsTheMark` (2 cases) | That class, new on main, re-runs `TheLaunchOpensWithoutMovingAnyone`'s real `_launch` from another module, and a module-level `wired_as_today` does not travel with an inherited class; the launch refused as could-not-tell before tmux. Fixture added to that module (`ccc9f7d`). Production unchanged. |
| Sweep on `8de0982` | 39 surviving mutations, most in the new A5 code | **31 pinned, 4 deleted, 4 named equivalent** (below). |
| C | ladders, copies, dead lines, unpinned lines | One `_KINDS` table; `_typed` and `_install_fix` extracted; `_probe_one`, the constant `readable`s, the second Codex step list, `or ""` and `listed(read)` deleted; every named pin added. |
| D | Task 3's swap | Done as above, with the plan's four missing tests. |
| E | `profiletrust._prompt` name escape survivor | Kept; pinned with a hand-built `Profile` carrying an ESC. |

Every fix above was checked by hand the way the sweep would: the fixed line undone in place,
its test run, the file restored. 37 of 37 went red, and 8 of 8 for the verification's three follow-ups (one needed `-B` — a stale `.pyc` of an
equal-size mutant — and one, `_claude_json`'s own `ValueError`, gained its own test).

## The sweep's survivors on `8de0982`

- **Pinned (31):** the plugin-cache `hooks.json` reader — a stray file among the versions, an
  empty versions directory, a version with no `hooks.json`, one nobody may read, bad UTF-8,
  bad JSON (each unreadable one UNKNOWN naming the file), and every wrong shape (doc,
  `hooks`, groups, a group, a group's `hooks`, a hook, `command`) reading as no guard
  without raising; the Codex config read's exceptions and detail; `_up_to_the_plane`'s
  `ValueError`; `install`'s `ValueError`; both clip boundaries (`wiring.said`,
  `doctor._counted`) and `said`'s clip itself; `_typed` with no directory and its variable
  order; an unknown Claude scope, handed in at `covering_entries` (today `_our_entries`
  drops such a row first); `_stamp` for a kind with no table; the Codex approval sentence;
  `harness install`'s exit and level per status (`refused`, `unvouched`, `unavailable`,
  `unknown`, `failed`, and a note); a refused name found by its contained spelling; an
  unapproved doctor hint with an ESC in a hand-built declared name; a built-in's row under a
  committable local file.
- **Deleted (4 mutations, 3 lines):** `_codex_marks`' prefix test — membership in the guard
  keys implies it, and the second `key in guards` conjunct went with it; `sorted` over the
  cached versions, which are intersected; `_up_to_the_plane`'s outside-the-plane branch —
  both its `drop-if` and `drop-conjunct` mutants were equivalent, because the parent filter
  already answers `[here]` for every directory outside the plane, the plane's own parent
  included (now pinned).
- **Named equivalent (4):** `_guard_positions`' `(?=[A-Z])` → `[B-Z]` (no event Codex or
  Claude Code declares has an `A` after its first letter — kept rather than replaced by a
  name table), `KIND_WIRING`'s spelling, and `_key`'s `"name"`/`"cwd"` field names — each a
  string charter only compares with itself, as ruled for `:63` and `:452-458`.

Each survivor was replayed against the pinned tree before the push: 32 of 32 mutations went red (the 31 pins, and deleting the new guard filter), with the tree restored byte for byte.

## Verification

- **First round**, on `ef5cad9`: whole suite `Ran 13134 tests in 743.364s — OK (skipped=9)`,
  and CI's sweep `8 unpinned, 40 in masked cluster(s), 1 platform-deferred, 0 unresolved, 0
  out of time, 166 pinned`.
- **Fix round**, local, `TMUX`/`TMUX_PANE` unset and a private `TMUX_TMPDIR`; no local full
  suite and no local sweep (three agents share this machine — CI's matrix and sweep are the
  full evidence): every module that imports what changed and exercises it — 71 modules,
  `Ran 2683 tests` (reopen modules red until given `wired_as_today`, then green), plus the
  wiring, Task 3, reopen, docs and news modules `Ran 862 tests — OK (skipped=1)`, and the
  final `Ran 395 tests — OK`.
- Every refusal, clamp and fallback added here has a test that goes red when the line
  changes; the three that quote a command (`NOT_ON_PATH`, `EXEC_FAILED`, `CANNOT_TELL`) have
  the escaping test ruling 35 asks for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MBdEBogeMV7DsqN6vrsVTk
