### PR TITLE
Bare `charter`, the `+` and a workspace tab open at the profile selector

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,8 +88,12 @@ command.
   yours:** `tests._planeguard.RealTmuxReach` refuses a child whose socket is charter's
   (`-L charter`), your `default` server, or the one `$TMUX` named when the suite started —
   judged on the child's own `env=`, because a test that cleared its environment is the one
-  whose `kill-window` closed an operator's live session (2026-09-12). **Nor does it spend a
-  credential.**
+  whose `kill-window` closed an operator's live session (2026-09-12). **Nor may a test
+  replace the process running the suite:** `tests._execguard` refuses an `os.exec*` from
+  that process that would run (`ReplacedTheRunner`), because a `commands_frame.bypass` exec
+  left un-stubbed once replaced the test runner with `charter frame-launch --select` and
+  left no verdict at all — a program that could not run still raises what the kernel
+  would, and a forked child still execs. **Nor does it spend a credential.**
   `doctor`'s preflight asks a forge whether your token is still good, and eighteen modules
   reach that line — 28 authenticated round trips to github.com and gitlab.com per run, and
   the sweep gate spends that again per mutation. `tests/_forgeprobe.py` answers the probe

--- a/README.md
+++ b/README.md
@@ -86,8 +86,9 @@ its requirements against, the frame still starts. `charter opencode` and `charte
 need their own binaries the same way, and `charter claude --probe` says whether a frame can
 run here without starting one.
 
-`init` writes no `[harness] default`, because charter does not pick a harness for you. Add
-this to `charter.toml` and the command is `charter` on its own:
+`charter` on its own opens a chat at the **profile selector** and starts nothing until you
+pick a row — charter does not pick a harness for you, it asks. `init` writes no `[harness]
+default`; add one to `charter.toml` and it is the row the cursor starts on:
 
 ```toml
 [harness]
@@ -98,7 +99,7 @@ The value names a **profile** — `claude`, `codex` and `opencode` are the built
 harness, and `charter.local.toml` is where you declare your own (a pinned version, a second
 account); see [control-plane.md](docs/control-plane.md#harness--profiles-and-the-default).
 
-Piped anywhere, bare `charter` prints its usage instead of starting an agent.
+Piped anywhere, bare `charter` prints its usage instead of opening a frame.
 
 - **`charter init`** scaffolds `charter.toml`, the baseline directories (`personas/`,
   `inventory/`, `workspaces/`), a `.gitignore` tuned for the layout, and Claude Code's
@@ -115,9 +116,8 @@ Piped anywhere, bare `charter` prints its usage instead of starting an agent.
   CLI's token over HTTPS, already carrying the one-credential git policy below.
 - **`charter claude`** opens a chat in the frame. Closing the terminal detaches and leaves
   the harness running; `F2` → `charter: quit` stops every chat on the plane and records
-  them first, and `charter reopen` — or, on a plane with `[harness] default`, bare `charter`
-  when nothing is running — puts them back, resuming the conversation wherever Claude Code
-  recorded one.
+  them first, and `charter reopen` — or bare `charter` when nothing is running — puts them
+  back on their own profiles, resuming the conversation wherever Claude Code recorded one.
 
 ## You don't need charter if
 

--- a/charter/cli.py
+++ b/charter/cli.py
@@ -914,6 +914,7 @@ def _add_frame_parsers(sub) -> None:
     # listed in :data:`_OWN_FLAGS` so `_split_frame_argv` hands it to argparse instead of
     # grafting it onto the command's verbatim argv, and argparse then refuses it by name on
     # any parser but this one.
+    #
     # **No `--start` here**, and that asymmetry with `frame-launch` is deliberate. The row
     # the cursor opens on is a fact about the press — the profile of the chat `+` was
     # pressed in — and `cmd_new_chat` and `_open_workspace` call `cmd_launch` in-process

--- a/charter/cli.py
+++ b/charter/cli.py
@@ -904,6 +904,24 @@ def _add_frame_parsers(sub) -> None:
     fr = sub.add_parser("frame",
                         help="Run any command inside charter's frame — `charter frame -- <cmd>`.")
     _wire(fr, "")
+    # **Open a chat at the profile selector** — what bare `charter` rewrites to, and the
+    # only launch that starts no harness of its own. Suppressed from the help for
+    # `--profile`'s reason: an operator types `charter`, and this is the shape that rewrite
+    # produces, so every splitter and branch below runs on one set of tokens.
+    #
+    # On `frame` alone, and never on a harness's parser: `charter claude --select` would be
+    # asking charter to open a picker for a profile the operator has just named. It is
+    # listed in :data:`_OWN_FLAGS` so `_split_frame_argv` hands it to argparse instead of
+    # grafting it onto the command's verbatim argv, and argparse then refuses it by name on
+    # any parser but this one.
+    # **No `--start` here**, and that asymmetry with `frame-launch` is deliberate. The row
+    # the cursor opens on is a fact about the press — the profile of the chat `+` was
+    # pressed in — and `cmd_new_chat` and `_open_workspace` call `cmd_launch` in-process
+    # with it on the namespace, so it never has to survive a command line. A bare `charter`
+    # has no press behind it and takes the plane's `[harness] default` instead. Adding a
+    # flag nothing types would mean teaching `_OWN_VALUE_FLAGS` about a second value flag
+    # for a spelling with no caller.
+    fr.add_argument("--select", action="store_true", help=argparse.SUPPRESS)
 
     # Internal: one pane of a running frame, spawned by `layout.panel_argvs` — never
     # typed by an operator. The argv shape here (`panel <component> --session <fid>`)
@@ -1819,7 +1837,11 @@ def _frame_command_names() -> set[str]:
 #: harness named `""`, bare `frame`) hands `["--probe"]` to `bypass`, which
 #: `os.execvp("--probe", ...)` turns into a `FileNotFoundError` — confirmed by running
 #: `charter frame --probe` with this entry left out before adding it.
-_OWN_FLAGS = ("--no-frame", "--probe", "--pick", "--fresh", "-h", "--help")
+#: `--select` joined for the same reason, and it is what bare `charter` becomes: without it
+#: `charter frame --select` never reaches argparse as a flag at all — `_split_frame_argv`
+#: grafts it onto `args.rest`, `cmd_launch` finds no harness named `""` and hands
+#: `["--select"]` to `bypass`, which is an `os.execvp("--select", …)`.
+_OWN_FLAGS = ("--no-frame", "--probe", "--pick", "--fresh", "--select", "-h", "--help")
 
 #: The launcher flags bare ``charter`` may carry — the ones that are about the LAUNCH
 #: rather than about a harness that has not been named yet (#845). `_bare_launch` rewrites
@@ -1952,12 +1974,12 @@ def _record_crash(exc: BaseException, subcommand: str) -> None:
 
 
 def _bare_launch(argv: list[str]) -> tuple[list[str], int | None]:
-    """Bare ``charter``: the plane's ``[harness] default``, or today's usage error.
+    """Bare ``charter``: the profile selector, or today's usage error off a terminal.
 
     Returns the argv to parse and, when charter is finished here, a return code. Expressed
-    as a REWRITE of argv rather than as a dispatch of its own — bare ``charter`` on a plane
-    that defaults to Claude Code becomes exactly `["claude"]`, and every splitter, flag and
-    branch below it then runs on the same tokens a typed `charter claude` produces. A
+    as a REWRITE of argv rather than as a dispatch of its own — bare ``charter`` on a
+    terminal becomes exactly `["frame", "--select"]`, and every splitter, flag and branch
+    below it then runs on the same tokens a typed `charter frame --select` produces. A
     second path into `cmd_launch` would be a second set of answers about the workspace
     picker, `$CHARTER_HARNESS`, `--probe` and the frame, all of which are already settled
     for the typed form.
@@ -1969,39 +1991,36 @@ def _bare_launch(argv: list[str]) -> tuple[list[str], int | None]:
     whole widening: an argv holding anything else, `--fresh` alongside a subcommand
     included, is a command the operator typed and is returned untouched.
 
-    **Four things stop it, and each is reachable on its own.**
+    **Three things stop it, and each is reachable on its own.**
 
     *A subcommand was typed.* Nothing here runs, `--version` included. It is a flag on the
     root parser (`_VersionAction`), so ``charter --version`` is a non-empty argv and never
     reaches this function at all — the version action still exits 0 from inside
     `parse_args`, which is what `commands_update._handoff` reads back.
 
-    *The plane declared a value charter cannot launch.* Reported here, loudly, naming the
-    value and the profiles that would work. `profiles.current()` resolves the default —
-    `charter.local.toml`'s where it names one, `charter.toml`'s otherwise — and this is the
-    reader that can say so on the command the key is *for*. Silence
-    would be the whole defect: a refused default degrades to no default, which renders as
-    argparse's usage message — byte-identical to what a plane that declared nothing gets,
-    so the operator who committed ``default = "clyde"`` would watch charter behave exactly
-    as though their key were not there. Checked BEFORE the tty rule below, because a
-    committed file being wrong is not a fact about anybody's terminal.
+    *Charter refused this plane's format version.* A plane charter cannot place declares
+    nothing charter can read, so falling through would hand the operator argparse's usage
+    message for a plane charter had in fact refused. The gate in `main` cannot cover it:
+    that reads the typed subcommand and a bare argv has none.
 
-    *The plane declared nothing.* Today's behaviour, unchanged: argparse's own usage error
-    on exit 2. Charter does not guess a harness for somebody who never named one — not
-    "whatever is installed" (a plane with two of them has no answer, and the answer would
-    change when a colleague installed a third) and not "the one last used" (a machine-local
-    memory deciding what a committed command runs).
+    **What is no longer here: the default, and its refusal.** Until the selector, this
+    function read `[harness] default` and launched it, and refused loudly when the plane
+    named a profile this machine lacks. A bare `charter` now opens the selector, which
+    lists what this machine has, marks the default where there is one and says on the row
+    why anything cannot start — so there is no value left here to refuse and nothing left
+    to guess. A plane that declared no default is no longer a usage error either.
 
     *Stdout is not a terminal.* Also today's behaviour, and this is the one that has to be
     a test rather than a comment. `commands_frame.cmd_launch` returns `bypass(argv)` when
-    stdout is not a tty — it `os.execvp`s the harness in place of charter. Today bare
-    `charter` is argparse's usage error, exit 2 with no side effect, so ``charter 2>&1 |
-    head`` is a probe that costs nothing. Rewrite argv unconditionally and, on a plane that
-    sets a default, that pipeline execs Claude Code — correct against every config anyone
-    tested, wrong the first time a script asks whether charter is installed (#687, #690).
-    Stdout, and stdout alone, because that is the exact stream `cmd_launch` branches on: a
-    second, looser condition here is how the two come to disagree about what "interactive"
-    means.
+    stdout is not a tty — it `os.execvp`s the harness in place of charter. Bare `charter`
+    off a terminal is argparse's usage error, exit 2 with no side effect, so ``charter 2>&1
+    | head`` is a probe that costs nothing. Rewrite argv unconditionally and that pipeline
+    execs a harness — correct against every config anyone tested, wrong the first time a
+    script asks whether charter is installed (#687, #690). It matters MORE with a selector
+    than it did with a default: a pane with no terminal cannot draw one and cannot be asked
+    anything, so there is nothing for the rewrite to lead to. Stdout, and stdout alone,
+    because that is the exact stream `cmd_launch` branches on: a second, looser condition
+    here is how the two come to disagree about what "interactive" means.
     """
     # `all` over an empty iterable is True, so bare `charter` falls through this without
     # an `argv and` in front of it — and the deletion sweep found that conjunct as a
@@ -2009,54 +2028,38 @@ def _bare_launch(argv: list[str]) -> tuple[list[str], int | None]:
     # already says is the shape this repository deletes.
     if not all(tok in _BARE_FLAGS for tok in argv):
         return argv, None
-    from . import config
 
-    # *The plane's format version is one charter cannot place.* Reported here for the same
-    # reason the refused-default arm below is: a plane charter has refused declares nothing
-    # charter can read, `[harness] default` included — `config.HARNESS` derives from the
-    # empty config every time — so falling through hands the operator argparse's usage
-    # message, byte-identical to what a plane that declared no default gets. Bare `charter`
-    # would then look like a plane with no harness rather than one charter refused. The
-    # gate in `main` cannot cover this: it reads the typed subcommand, and a bare argv has
-    # none. Both call the same :func:`_plane_refusal`, so there is one message and one
-    # exemption rule between them.
+    # *The plane's format version is one charter cannot place.* A plane charter has refused
+    # declares nothing charter can read, so falling through would open a selector over a
+    # plane charter had already refused — every row read out of a config it will not use.
+    # Bare `charter` would look like a plane with no profiles rather than one charter
+    # refused. The gate in `main` cannot cover this: it reads the typed subcommand, and a
+    # bare argv has none. Both call the same :func:`_plane_refusal`, so there is one
+    # message and one exemption rule between them.
     refusal = _plane_refusal(None)
     if refusal:
         util.err(refusal)
         return argv, 1
 
-    # **The profiles, and not `config.HARNESS`** (ruling 43). The default a launch means is
-    # the one `charter.local.toml` names where it names one and `charter.toml`'s where it
-    # does not, and `profiles.current()` is the only thing that resolves that: `config`
-    # reads nothing from the local file, because every hook process derives config and a
-    # profile read there is the cost ruling 43 measured. A bare launch is a launch, which is
-    # exactly where the read belongs.
-    from . import profiles
-
-    read = profiles.current()
-    # Truthiness, not `is not None`, and the same test `doctor` makes of the same answer.
-    # `contain.readable` never returns a blank string, so on anything `derive` produced the
-    # two are the same question — but a planted empty value would otherwise print a refusal
-    # naming nothing at all instead of falling through to the usage message.
-    if read.default_refused:
-        util.err("charter: " + profiles.DEFAULT_REFUSED.format(
-            value=read.default_refused, names=", ".join(read.profiles)))
-        return argv, 2
-    # Two conditions, two statements, and deliberately not one `or`. They are different
-    # facts — a plane that named nothing, and a terminal that is not one — with different
-    # reasons in the docstring above, and an arm two inputs can both satisfy is an arm
-    # neither of them ends up testing.
-    if not read.default:
-        return argv, None
-    if not sys.stdout.isatty():
-        return argv, None
+    # **It no longer reads a default, and that is the whole of what the selector changes
+    # here.** Bare `charter` used to resolve `[harness] default` and launch it — a harness
+    # session started before anybody said which one they wanted — and to refuse loudly when
+    # the plane named one this machine does not have. Both go: the launch opens the profile
+    # SELECTOR, which lists what this machine actually has, marks the default where there is
+    # one, and says why any row cannot start. A default naming nothing simply marks no row
+    # (ruling 18), and `charter doctor` is where that is reported.
+    #
+    # So a plane that declared no default is no longer a usage error either: every machine
+    # has at least the built-in profile of whichever harness is installed, and the selector
+    # is how charter asks rather than guesses.
+    #
     # The flags the operator typed ride along, after the name rather than before it:
     # `_split_frame_argv` recognises `_OWN_FLAGS` only in the run immediately following
-    # `charter <name>`, which is the same position a typed `charter claude --fresh` puts
-    # them in. :func:`_profile_launch` then turns a declared profile's name into its kind's
-    # launcher, so what comes out is indistinguishable from the typed form either way —
-    # which is this function's whole contract.
-    return [read.default, *argv], None
+    # `charter <name>`, which is the same position a typed `charter frame --fresh` puts them
+    # in.
+    if not sys.stdout.isatty():
+        return argv, None
+    return ["frame", "--select", *argv], None
 
 
 def _profile_launch(argv: list[str],

--- a/charter/commands_frame.py
+++ b/charter/commands_frame.py
@@ -3380,7 +3380,8 @@ def _say_why_the_harness_did_not_start(action: str, cmd: list[str],
 
 def _launch_in_operator_tmux(socket: str, session: str, *, ws: str,
                              argv: list[str], display: list[str], profile: str, h,
-                             v: tuple[int, int], picked: bool) -> int | None:
+                             v: tuple[int, int], picked: bool,
+                             selecting: bool = False) -> int | None:
     """Build the frame as a WINDOW in the tmux the operator is already in.
 
     The same layout as the private-server path — harness in the middle, charter's panels
@@ -3515,6 +3516,11 @@ def _launch_in_operator_tmux(socket: str, session: str, *, ws: str,
     # And which profile — the same record the private-server path writes, and for the same
     # readers: `+`, a workspace tab and a reopen all ask a chat what it runs.
     state.record_profile(fid, profile)
+    # And that it has started nothing yet, before tmux — the private-server path's own call
+    # and its own reason: `leave.plan` passes over a waiting pane, so a quit landing between
+    # here and the pick does not record a chat that is a question on a screen.
+    if selecting:
+        state.record_waiting(fid)
     state.bump(fid)
     # And the record this process keeps, if it is keeping one (#845), now knows which chat
     # this terminal is on. This path is a frame process too — it stays awake for the life of
@@ -3527,6 +3533,10 @@ def _launch_in_operator_tmux(socket: str, session: str, *, ws: str,
     _spawn_gather(fid, ws)
 
     env = _frame_env(fid, h)
+    # A selector launch records no kind, on this server too — see the private-server path's
+    # own note (review 12): `launcher._picked` writes it at the pick.
+    if selecting:
+        env["CHARTER_HARNESS"] = ""
     # The launcher is the only process that knows this frame's own charter identity —
     # see `state.record_identity` for the measurement. Written before any pane exists,
     # because a `run-shell` child fired later reads the SERVER's environment, not this
@@ -5220,6 +5230,45 @@ def _restore_the_plane(args) -> int | None:
     return None
 
 
+#: What charter names when a window that was showing the SELECTOR died early. Never the
+#: launcher's own argv, which is `python -P -m charter frame-launch --select` — true of
+#: every waiting pane and an answer to a question nobody asked
+#: (`launcher.display_command`'s rule, one launch over).
+SELECTOR_DISPLAY = "the profile selector"
+
+#: `charter frame --select --no-frame`, which is two launches asked for at once.
+NO_FRAME_TO_SELECT_IN = (
+    "charter frame --select opens a chat at the profile selector, and the selector is "
+    "drawn in that chat's own pane — so there is nothing for --no-frame to draw it in and "
+    "nothing was started. Name what to run instead: charter <profile> --no-frame.")
+
+#: `charter frame --select -- <cmd>`, which asks charter both to pick and to run.
+NOTHING_TO_SELECT_FOR = (
+    "charter frame --select opens a chat at the profile selector, so it starts whatever is "
+    "picked there and not {cmd} — nothing was started rather than one of the two silently. "
+    "Run the command with charter frame -- {cmd}, or open a chat with charter on its own.")
+
+
+def _selector_start(args) -> str | None:
+    """Which row a selector launch opens the cursor on and marks — ``None`` for no row.
+
+    Two sources and one order. A press carries its own answer: `+` and a workspace tab open
+    on the profile of the chat they were pressed in, which is the only thing the operator
+    has actually expressed (`_same_profile_as`, read by the caller and put on the
+    namespace). A bare `charter` has no press behind it, so it falls to the plane's
+    `[harness] default`.
+
+    ``None`` rather than `""` for "no row", because a `default` naming a profile this
+    machine lacks resolves to nothing at all (`ProfileSet.default` is `None`, and
+    `default_refused` holds what was named) — ruling 18: it marks no row, and the cursor
+    goes where the palette's own rule puts it. `charter doctor` is where that is reported;
+    a launch does not refuse over it.
+    """
+    from . import profiles
+
+    return getattr(args, "start", "") or profiles.current().default or None
+
+
 def _profile_name(p) -> str:
     """*p*'s name, or ``""`` for a launch that runs no profile at all.
 
@@ -5281,7 +5330,33 @@ def _launch(args) -> int:
     # Attended is somebody being in front of the pane this opens. A reopen and a background
     # open are not (review 3): they must never stop on a question nobody can see.
     attended = _reopening(args) is None and _opening(args) is None
-    if h is not None:
+    # **A selector launch names no profile at all, and that is the whole shape of it.** The
+    # window's first command is charter drawing the picker in the chat's own pane; which
+    # harness runs there is decided in that pane, minutes later, by the operator. So `p`
+    # stays `None` all the way down — nothing to resolve, no guards to run before tmux (the
+    # pane runs the whole chain for whatever is picked, fresh), and nothing to name when the
+    # command dies, because no command of the operator's has been chosen yet.
+    #
+    # **Never for an open nobody is at.** A reopen, a restored plane and a handoff all name
+    # their profile; `_selector_start` is only ever reached from bare `charter`, `+`, a
+    # workspace tab and the palette's new chat, each of which has somebody at the keyboard.
+    selecting = getattr(args, "select", False)
+    if selecting and rest:
+        # **A launcher that swallowed a command would be wrong in the one direction this
+        # module refuses everywhere else, silently** — the open-or-focus gate's own words,
+        # and the same hazard through the new flag. `charter frame -- <cmd>` is the escape
+        # hatch for a command charter has never met; a selector cannot run it and cannot
+        # ask about it, so asking for both is refused rather than resolved either way.
+        util.err("charter: " + NOTHING_TO_SELECT_FOR.format(
+            cmd=contain.readable(" ".join(rest))))
+        return 2
+    if selecting:
+        argv = launcher.argv_select(_selector_start(args))
+        # What charter SHOWS if this window dies early: the selector, not
+        # `python -P -m charter frame-launch --select`, which is an answer to a question
+        # nobody asked (`launcher.display_command`'s own rule, one launch over).
+        display = [SELECTOR_DISPLAY]
+    elif h is not None:
         name = getattr(args, "profile", None) or args.harness
         p, why = launcher.resolve(name)
         if p is None:
@@ -5317,6 +5392,14 @@ def _launch(args) -> int:
     # `/dev/null`: no frame, no session, no switch, no exit code, and no surface left to
     # report any of it on. That, and not the `attach` the old refusal named, is what
     # actually stopped a detached process opening a workspace.
+    if selecting and args.no_frame:
+        # Asked before the bypass below, because that is the branch this would fall into:
+        # `p is None` for a selector launch, so `bypass` would `os.execvp` the launcher —
+        # which would draw a whole modal surface over the operator's own terminal and then
+        # exec a harness with no frame around it. Two launches asked for at once, and the
+        # honest answer is to say so rather than to pick one of them.
+        util.err(f"charter: {NO_FRAME_TO_SELECT_IN}")
+        return 2
     if args.no_frame or (not sys.stdout.isatty() and _wants_attach(args)):
         if p is None:
             return bypass(argv)
@@ -5471,7 +5554,7 @@ def _launch(args) -> int:
     if inside is not None and tmuxctl.is_operator_socket(inside[0], own=SOCKET):
         rc = _launch_in_operator_tmux(inside[0], inside[1], ws=ws, argv=argv,
                                       display=display, profile=_profile_name(p),
-                                      h=h, v=v, picked=picked)
+                                      h=h, v=v, picked=picked, selecting=selecting)
         if rc is not None:
             return rc
 
@@ -5575,8 +5658,18 @@ def _launch(args) -> int:
     # failed: not a terminal`, and the `+` reported `the launcher returned 1` instead of
     # ever adding a chat. `_wants_attach` was unpicked from `_reopening(args) is None` for
     # exactly this reason and this site kept asking the old question.
+    #
+    # **And a SELECTOR launch attaches whether or not anybody is on it** (ruling 17). The
+    # rule above asks `_workspace_to_focus`, which answers ``None`` for a live workspace
+    # with no client attached — deliberately, because with nobody there to drag, a launch
+    # that names something SHOULD add its chat and run it. A bare `charter` names nothing:
+    # it means "put me in this plane", and the workspace already has chats running. Opening
+    # a second selector beside them would be charter adding a chat nobody asked for, which
+    # is the whole defect this feature exists to close, arriving through the door it opened.
+    # `+` is how you add one.
     if not rest and _wants_attach(args):
-        focus = _workspace_to_focus(SOCKET, ws=ws)
+        focus = (_plane_session(SOCKET, ws=ws) if selecting
+                 else _workspace_to_focus(SOCKET, ws=ws))
         if focus is not None:
             return _focus_workspace(*focus, ws=ws, picked=picked)
 
@@ -5647,6 +5740,13 @@ def _launch(args) -> int:
     # resolved in the end. The escape hatch records the empty answer rather than a name it
     # does not have.
     state.record_profile(fid, _profile_name(p))
+    # **And that this chat has started nothing yet** — before tmux, because the window is
+    # about to exist and a quit landing between the two would record a chat that is a
+    # question on a screen. Cleared in the pane at the pick (`launcher._picked`); until
+    # then `leave.plan` passes over it, so `charter: quit` does not record it and
+    # `charter reopen` never brings it back.
+    if selecting:
+        state.record_waiting(fid)
     # And WHERE — see the identical call on the operator's-tmux path, and
     # `state.record_cwd` for why this fact could not ride in `identity`. Read once here
     # and used twice: recorded, and handed to `chat_window_argv` below.
@@ -5711,6 +5811,14 @@ def _launch(args) -> int:
 
     slots = _drawable_slots(cols, rows)
     env = _frame_env(fid, h)
+    # **A selector launch puts NO kind on the window** (review 12). `_frame_env` keeps
+    # `$CHARTER_HARNESS` from this process's own environment where no harness was resolved,
+    # and the process that presses `+` is a panel of a chat that HAS one — so the launching
+    # chat's kind would ride onto the new window's `-e`, into `state.record_identity`, and
+    # from there into `chats.harness_of`, the chat strip and `_same_profile_as`. A chat that
+    # has picked nothing records nothing, and `launcher._picked` writes the kind at the pick.
+    if selecting:
+        env["CHARTER_HARNESS"] = ""
     # Same as the operator's-tmux path above, and needed harder here: charter's private
     # server is SHARED, so a `run-shell` child on it reads whichever launcher's
     # environment started the server. See `state.record_identity`.
@@ -5971,12 +6079,33 @@ def _launch(args) -> int:
     refused = ""
     if code is None and p is not None and not attended:
         code, refused = _await_the_launcher(SOCKET, fid, harness_pane)
+    # **Esc at the profile selector is not a death, and this is how the two are told
+    # apart** — asked twice below, once for the early-death sentence and once for the
+    # recorded-plane one. The MARKER decides, never the number alone: a harness that exits
+    # 130 because the operator pressed Ctrl-C at its own prompt cleared `is_waiting` when it
+    # was picked, so it reads as the death it is.
+    def cancelled_at_the_selector(c) -> bool:
+        from .frame import selector
+
+        return c == selector.CANCELLED_EXIT and state.is_waiting(fid)
+
     if code is not None:
         state.record_exit(fid, code)
         if refused:
             # The launcher's own sentence, said where the operator is: this process has a
             # terminal (or a caller reading its stderr) and the pane no longer exists.
             util.err(f"charter: {refused}")
+        elif cancelled_at_the_selector(code):
+            # **Esc at the selector, and there is nothing to report about it.** The pane
+            # exited `CANCELLED_EXIT` having started nothing, and it is still `is_waiting` —
+            # so this is not an early death, it is the operator closing a chat they had not
+            # opened yet. `early_death_message` would name "the profile selector" as a
+            # command that died, and `_say_the_plane_is_recorded` below would offer
+            # `charter reopen` for a chat the record does not hold. Both are suppressed by
+            # the same reading, which is the chat's own marker rather than the number alone:
+            # a harness that genuinely exits 130 (Ctrl-C at its prompt) has long since
+            # cleared it.
+            pass
         elif code != 0:
             # The one path on which NOTHING is ever drawn (#384): no panels, no
             # `select-pane`, no `attach` — the whole `if code is None:` block below is
@@ -6150,7 +6279,12 @@ def _launch(args) -> int:
     # live harness would be told their plane was recorded and offered `charter reopen`, one
     # line above the launcher's own "detached — the harness is still running". `live_after`
     # is the same reading that decides which of those two lines is printed below.
-    if _wants_attach(args):
+    #
+    # **And never for a chat that was still at the selector.** Nothing was started in it and
+    # nothing recorded it (`leave.plan` passes over a waiting pane), so naming `charter
+    # reopen` would offer to bring back a chat the record does not hold. See
+    # `cancelled_at_the_selector` above for why this reads the marker and not the number.
+    if _wants_attach(args) and not cancelled_at_the_selector(code):
         _say_the_plane_is_recorded(fid, over=fid not in live_after)
     if code is not None:
         return code
@@ -8231,16 +8365,12 @@ def _open_workspace(fid: str, ws: str, *, socket: str,
                             f"hand if it is yours: tmux -L {socket} attach -t "
                             f"{state.workspace_prefix(ws)}")
         return None
-    p, why = _same_profile_as(fid)
-    if p is None:
-        _say_on_screen(fid, f"cannot open '{ws}': {why}")
-        return None
-    # Attended, because this open ends with the operator's client switched onto the new
-    # window: somebody is in front of whatever it says.
-    refused = _launch_refusal(p, attended=True, cwd=_chat_dir_of(ws))
-    if refused:
-        _say_on_screen(fid, f"cannot open '{ws}': {refused}")
-        return None
+    # A tab whose workspace has no running chat opens a chat at the SELECTOR — see
+    # `cmd_new_chat`'s paragraph, which is this one word for word: the pressing chat's
+    # profile is the row the cursor opens on rather than the thing that gets launched, and
+    # a press charter cannot answer that for still opens a chat. Nothing is launched here,
+    # so there is no `_launch_refusal` to ask either.
+    p, _why = _same_profile_as(fid)
     from types import SimpleNamespace
     root = _launch_root(ws)
     # Every field `cmd_launch` and `_choose_workspace` read is named rather than left to a
@@ -8250,9 +8380,10 @@ def _open_workspace(fid: str, ws: str, *, socket: str,
     # reason and for #518's pointer, `rest` is empty so §4k's open-or-focus gate stays
     # reachable and the harness starts at its own prompt with nothing sent to it, and
     # `attach` is the seam.
-    args = SimpleNamespace(harness=p.kind, profile=p.name, rest=[], no_frame=False,
-                           workspace=ws, pick=False, attach=False,
-                           size=_window_size(socket, window))
+    args = SimpleNamespace(harness="frame", profile=None, select=True,
+                           start=p.name if p is not None else "",
+                           rest=[], no_frame=False, workspace=ws, pick=False,
+                           attach=False, size=_window_size(socket, window))
     here_dir = os.getcwd()
     try:
         os.chdir(root)
@@ -11039,14 +11170,18 @@ def cmd_new_chat(args) -> int:
     written out rather than shared because a helper taking a flag for which way to point
     would be one function claiming to answer two questions.
 
-    **Four ways this stops, each with its own sentence on the frame's own attention row**
+    **Three ways this stops, each with its own sentence on the frame's own attention row**
     (:func:`_say_on_screen`), because this runs detached with its streams on `/dev/null`
     and has no other surface: a frame inside the operator's own tmux
     (:data:`NO_CHAT_HERE`), a session this plane cannot prove is its own
-    (:data:`NO_SESSION_HERE`), a chat recording no harness charter can launch, and a
-    workspace directory charter cannot enter. A `+` that silently did nothing is the
-    complaint this whole change is answering, so a `+` that silently fails would be the
-    same complaint one release later.
+    (:data:`NO_SESSION_HERE`), and a workspace directory charter cannot enter. A `+` that
+    silently did nothing is the complaint this whole change is answering, so a `+` that
+    silently fails would be the same complaint one release later.
+
+    **The fourth is gone**: a chat recording no profile charter can launch, and a plane
+    declaring no `[harness] default`, used to refuse the press by name. The new chat opens
+    at the profile selector, which lists what this machine has and says on each row why it
+    cannot start — so there is nothing left here that a `+` can fail to answer.
 
     **Always 0**, for `cmd_palette`'s reason: this is started by a click and by a palette
     row, never by a shell that reads its status, and the one caller that could see a code
@@ -11071,21 +11206,20 @@ def cmd_new_chat(args) -> int:
     if seat is None:
         _say_on_screen(fid, NO_SESSION_HERE)
         return 0
-    # Which harness, and it is the one question a `+` cannot carry — `_open_workspace`'s
-    # paragraph, unchanged: the chat the operator pressed FROM recorded its own
-    # (`state.record_identity`), and using it makes the click mean "another chat, same
-    # tool", which is the only answer available that they have actually expressed.
-    p, why = _same_profile_as(fid)
-    if p is None:
-        _say_on_screen(fid, f"cannot open another chat: {why}")
-        return 0
-    # The launcher's own chain, asked here so its refusal reaches the frame's attention row
-    # rather than `/dev/null` — see :func:`_launch_refusal`. Attended: the new window is
-    # selected, so the operator is looking at whatever it says.
-    refused = _launch_refusal(p, attended=True, cwd=_chat_dir_of(ws))
-    if refused:
-        _say_on_screen(fid, f"cannot open another chat: {refused}")
-        return 0
+    # **Which harness is no longer a question a `+` has to answer, and that is what the
+    # selector changed here.** The press used to resolve the pressing chat's profile and
+    # refuse when it could not — a chat whose profile the plane no longer declares, a chat
+    # from before profiles whose kind is gone, a plane with no `[harness] default` — and
+    # every one of those was a `+` that did nothing with a sentence on the attention row.
+    # The new chat opens at the selector instead, which lists what this machine has and
+    # says on each row why it cannot start. So the answer is now a preference and not a
+    # requirement: the pressing chat's profile is the row the cursor OPENS on, because
+    # "another chat, same tool" is the only thing the press actually expressed, and a press
+    # charter cannot answer that for still opens a chat.
+    p, _why = _same_profile_as(fid)
+    # And no `_launch_refusal` either: nothing is being launched. The pane runs the whole
+    # chain, fresh, for whichever profile is picked minutes from now — asking here would be
+    # asking about a profile nobody has chosen.
     from types import SimpleNamespace
     root = _launch_root(ws)
     # Every field `cmd_launch` and `_choose_workspace` read is named rather than left to a
@@ -11117,8 +11251,10 @@ def cmd_new_chat(args) -> int:
     # the value to `tmuxctl.PANE_ID_RE` — this is a `-t` target coming off disk, which is
     # #475's boundary exactly.
     pane = chats.pane_of(fid) or chats.pane_of(seat[1])
-    launch = SimpleNamespace(harness=p.kind, profile=p.name, rest=[], no_frame=False,
-                             workspace=ws, pick=False, attach=False,
+    launch = SimpleNamespace(harness="frame", profile=None, select=True,
+                             start=p.name if p is not None else "",
+                             rest=[], no_frame=False, workspace=ws, pick=False,
+                             attach=False,
                              size=_window_size(socket, pane) if pane else None)
     here_dir = os.getcwd()
     try:

--- a/charter/commands_frame.py
+++ b/charter/commands_frame.py
@@ -3620,6 +3620,13 @@ def _launch_in_operator_tmux(socket: str, session: str, *, ws: str,
     # building a frame around, and switching the operator's client to it would park
     # them on a dead pane.
     status, code = _pane_state(socket, harness_pane)
+    if status != _ALIVE and state.is_waiting(fid):
+        # **A pane still at the selector is a cancel, however it ended** — the same marker
+        # `_launch`'s own `nothing_ever_ran_here` reads, and for its reason: no harness ran
+        # here, so there is no early death to report and no exit code to not know.
+        _close_window()
+        _reap_this_server(socket)
+        return _cancelled_selector(fid)
     if status != _ALIVE:
         # **Ruling 42 holds on this path too, and it is the path it holds HARDEST.** A
         # launcher that refused printed into a window this function closes a few lines
@@ -3680,6 +3687,21 @@ def _launch_in_operator_tmux(socket: str, session: str, *, ws: str,
         _drop_panels(socket, leaving)
 
     code = _wait_for_harness(socket, harness_pane)
+    # **Whether this pane was still the selector, read now** — while this launch still holds
+    # its claim, which is the only thing keeping another launch's reap off a directory whose
+    # window is gone (#685). A cancelled selector's window IS gone: its launcher closed it
+    # (`launcher._close_the_cancelled_chat`), so `_wait_for_harness` answers `None` exactly
+    # as it does for a harness whose window the operator closed — and only this marker tells
+    # the two apart. Measured by the coordinator in an exported tree: Esc at the selector
+    # here said "the frame's window is gone" and exited 1, where the plan's S2 expects 130.
+    if state.is_waiting(fid):
+        if code is not None:
+            # Still listed, dead: `remain-on-exit` kept it because the launcher could not
+            # close its own window. Taken back here, as every other ending on this path does.
+            _close_window()
+        state.clear_claim(fid)
+        _reap_this_server(socket)
+        return _cancelled_selector(fid)
     # **And the refusal a launcher recorded while this process was watching** (ruling 42).
     # This path stays awake for the whole life of the frame, so a pane that refused after
     # the checks above passed — the plane moved between them — ends up here: the window is
@@ -3723,6 +3745,24 @@ def _launch_in_operator_tmux(socket: str, session: str, *, ws: str,
     state.clear_claim(fid)
     _reap_this_server(socket)
     return code
+
+
+def _cancelled_selector(fid: str) -> int:
+    """What a launch in the operator's tmux ends on when its pane never left the selector.
+
+    **Nothing is said, and the number is the cancel's — whatever tmux read.** The operator
+    pressed Esc in a pane they were looking at; a sentence here about a harness's exit code
+    would be about a harness that never existed. And tmux's reading is not consulted even
+    where it has one (a dead pane `remain-on-exit` kept because its launcher could not close
+    the window): a pane that leaves raw mode on Linux comes back with an EMPTY
+    `#{pane_dead_status}`, read as `_UNKNOWN_DEATH_CODE` — the measurement that made
+    `_launch`'s `nothing_ever_ran_here` read the marker rather than the number. The marker
+    decides here for the same reason.
+    """
+    from .frame import selector
+
+    state.record_exit(fid, selector.CANCELLED_EXIT)
+    return selector.CANCELLED_EXIT
 
 
 def _reap_this_server(socket: str) -> None:
@@ -6259,13 +6299,16 @@ def _launch(args) -> int:
     # window the marker covers is behind it. Left in place it would refuse the one thing
     # only the CLOSING reap can do — remove this frame's own directory — by naming a
     # process that is, necessarily, still alive.
-    state.clear_claim(fid)
-    # **Read before the reap, which takes this chat's directory — the marker with it — the
-    # moment its window is gone.** A cancelled selector's window IS gone by now (Esc closes
-    # it), so asked after the reap this answered "a harness ran here" for every one of them,
-    # and the recorded-plane sentence below was held back for none. CI's sweep reported the
-    # conjunct as indistinguishable from its absence, which on the real flow it was.
+    # **Read before the claim is given up, and so before any reap — this launch's own below
+    # or another's — can take this chat's directory and the marker with it.** A cancelled
+    # selector's window IS gone by now (Esc closes it), and `state.reap` spares a directory
+    # whose window is gone only while its launch holds the claim. Asked after the reap this
+    # answered "a harness ran here" for every cancel, and the recorded-plane sentence below
+    # was held back for none; asked after the claim, a concurrent launch's reap could still
+    # win. CI's sweep reported the conjunct as indistinguishable from its absence, which on
+    # the real flow it was.
     started_nothing = nothing_ever_ran_here()
+    state.clear_claim(fid)
     after_sessions = _live_sessions(SOCKET)
     after_chats = _live_chats(SOCKET)
     live_after = after_sessions | (after_chats or set())

--- a/charter/commands_frame.py
+++ b/charter/commands_frame.py
@@ -6079,15 +6079,26 @@ def _launch(args) -> int:
     refused = ""
     if code is None and p is not None and not attended:
         code, refused = _await_the_launcher(SOCKET, fid, harness_pane)
-    # **Esc at the profile selector is not a death, and this is how the two are told
-    # apart** — asked twice below, once for the early-death sentence and once for the
-    # recorded-plane one. The MARKER decides, never the number alone: a harness that exits
-    # 130 because the operator pressed Ctrl-C at its own prompt cleared `is_waiting` when it
-    # was picked, so it reads as the death it is.
-    def cancelled_at_the_selector(c) -> bool:
-        from .frame import selector
+    def nothing_ever_ran_here() -> bool:
+        """Whether this chat's pane is still the profile selector — asked twice below, once
+        for the early-death sentence and once for the recorded-plane one.
 
-        return c == selector.CANCELLED_EXIT and state.is_waiting(fid)
+        **The marker decides and the exit code decides nothing**, which is a correction
+        taken on evidence rather than a simplification. `state.is_waiting` IS "no harness
+        has ever run in this pane": both sentences below are about a harness — one names the
+        command that died, the other offers `charter reopen` for a chat the record does not
+        hold (`leave.plan` passes over a waiting pane) — so neither can be true here
+        whatever number comes back. A harness that exits 130 because somebody pressed Ctrl-C
+        at its own prompt cleared this marker when it was picked, so it still reads as the
+        death it is.
+
+        **Reading `CANCELLED_EXIT` instead was measured wrong on Linux.** A pane that exits
+        out of raw mode there comes back with an EMPTY `#{pane_dead_status}` —
+        :data:`_UNKNOWN_DEATH_CODE`'s own measurement, and ruling 42's — so a cancelled
+        selector arrived as code 1 and got `early_death_message` naming *the profile
+        selector* as a command that died. Measured on the 3.14 runner, 2026-09-12.
+        """
+        return state.is_waiting(fid)
 
     if code is not None:
         state.record_exit(fid, code)
@@ -6095,16 +6106,12 @@ def _launch(args) -> int:
             # The launcher's own sentence, said where the operator is: this process has a
             # terminal (or a caller reading its stderr) and the pane no longer exists.
             util.err(f"charter: {refused}")
-        elif cancelled_at_the_selector(code):
-            # **Esc at the selector, and there is nothing to report about it.** The pane
-            # exited `CANCELLED_EXIT` having started nothing, and it is still `is_waiting` —
-            # so this is not an early death, it is the operator closing a chat they had not
-            # opened yet. `early_death_message` would name "the profile selector" as a
-            # command that died, and `_say_the_plane_is_recorded` below would offer
-            # `charter reopen` for a chat the record does not hold. Both are suppressed by
-            # the same reading, which is the chat's own marker rather than the number alone:
-            # a harness that genuinely exits 130 (Ctrl-C at its prompt) has long since
-            # cleared it.
+        elif nothing_ever_ran_here():
+            # **The pane was still the selector, and there is nothing to report about
+            # it.** It started nothing, so this is not an early death — it is the operator
+            # closing a chat they had not opened yet, or a launcher that showed its own
+            # refusal on screen and waited for a key (ruling 42). See
+            # `nothing_ever_ran_here` for why the number is not read.
             pass
         elif code != 0:
             # The one path on which NOTHING is ever drawn (#384): no panels, no
@@ -6283,8 +6290,8 @@ def _launch(args) -> int:
     # **And never for a chat that was still at the selector.** Nothing was started in it and
     # nothing recorded it (`leave.plan` passes over a waiting pane), so naming `charter
     # reopen` would offer to bring back a chat the record does not hold. See
-    # `cancelled_at_the_selector` above for why this reads the marker and not the number.
-    if _wants_attach(args) and not cancelled_at_the_selector(code):
+    # `nothing_ever_ran_here` above for why this reads the marker and not the number.
+    if _wants_attach(args) and not nothing_ever_ran_here():
         _say_the_plane_is_recorded(fid, over=fid not in live_after)
     if code is not None:
         return code

--- a/charter/commands_frame.py
+++ b/charter/commands_frame.py
@@ -6260,6 +6260,12 @@ def _launch(args) -> int:
     # only the CLOSING reap can do — remove this frame's own directory — by naming a
     # process that is, necessarily, still alive.
     state.clear_claim(fid)
+    # **Read before the reap, which takes this chat's directory — the marker with it — the
+    # moment its window is gone.** A cancelled selector's window IS gone by now (Esc closes
+    # it), so asked after the reap this answered "a harness ran here" for every one of them,
+    # and the recorded-plane sentence below was held back for none. CI's sweep reported the
+    # conjunct as indistinguishable from its absence, which on the real flow it was.
+    started_nothing = nothing_ever_ran_here()
     after_sessions = _live_sessions(SOCKET)
     after_chats = _live_chats(SOCKET)
     live_after = after_sessions | (after_chats or set())
@@ -6291,7 +6297,7 @@ def _launch(args) -> int:
     # nothing recorded it (`leave.plan` passes over a waiting pane), so naming `charter
     # reopen` would offer to bring back a chat the record does not hold. See
     # `nothing_ever_ran_here` above for why this reads the marker and not the number.
-    if _wants_attach(args) and not nothing_ever_ran_here():
+    if _wants_attach(args) and not started_nothing:
         _say_the_plane_is_recorded(fid, over=fid not in live_after)
     if code is not None:
         return code

--- a/charter/doctor.py
+++ b/charter/doctor.py
@@ -335,9 +335,14 @@ def check_control_plane_config() -> Result:
     # default at all (`instance.harness_of`) — and that renders as argparse's usage message,
     # which is exactly what a plane declaring nothing gets. So bare `charter` on a plane with
     # a typo behaves as though the key were absent, the same silently-ignored-setting shape
-    # the `[plane] worktrees` branch above is about. `cli.main` says so on the bare launch
-    # itself; this says so to anybody who runs `doctor` instead, and to every OTHER command,
-    # where nothing else would.
+    # the `[plane] worktrees` branch above is about.
+    #
+    # **And since the profile selector this is the ONLY reader that says so** (ruling 18).
+    # The bare launch used to refuse over the value; it now opens the selector, which lists
+    # what this machine actually has and marks no row — because taking a launch away over a
+    # name is worse than showing the list the name is missing from, and because a cursor on
+    # nothing would leave Enter with nothing to do. That moves the whole of the reporting
+    # here, to the command an operator runs when something reads as absent.
     #
     # Read from `instance.load` rather than `config.HARNESS`, the way the worktrees branch
     # reads `instance.worktrees_of`: this row is about the FILE, and `derive` already ran
@@ -356,10 +361,11 @@ def check_control_plane_config() -> Result:
             "charter.toml",
             WARN,
             detail=f'[harness] default = "{_refused}" is not a harness charter can launch',
-            hint=f"Bare `charter` prints the usage message until it names one of: "
-                 f"{', '.join(_instance.launchable_harnesses())} — which is also what a "
-                 f"plane that declares no default gets, so the key currently reads as "
-                 f"absent. `charter <harness>` is unaffected.",
+            hint=f"Bare `charter`'s profile selector marks no row for it and opens on the "
+                 f"first one that can run — which is also what a plane that declares no "
+                 f"default gets, so the key currently reads as absent. Name one of: "
+                 f"{', '.join(_instance.launchable_harnesses())}, or any profile "
+                 f"charter.local.toml declares. `charter <profile>` is unaffected.",
         )
     # A committed `[[frame.component]]` arrangement charter cannot draw is refused WHOLE
     # (`instance.component_arrangement`, #535) and degrades to the frame `[frame] slots`

--- a/docs/adr/0018-charter-may-run-the-harness-but-never-draws-it.md
+++ b/docs/adr/0018-charter-may-run-the-harness-but-never-draws-it.md
@@ -291,3 +291,77 @@ now ASKS in that pane as well as writing in it, so the question is named as the 
 it writes, its containment and the two conditions for putting it are bounded, and the read
 it makes is distinguished from the two reads of a harness's pane the 2026-09-01 amendment
 allows.*
+
+## Amendment, 2026-09-12: that pane's first screen is a surface, not a line
+
+The amendment above bounded what charter writes in a chat's pane before the `exec` at *three
+kinds of line, and charter wrote every one* — a refusal, the approval prompt, or the line an
+unproven chat prints — and said *no escape sequences of charter's own, no panel, no layout,
+and never a fourth thing later*. The profile selector is the fourth thing, and it is none of
+those lines: it is a whole `frame/overlay.Surface`, painted over the alternate screen, with the pane's
+terminal in raw mode, for as long as somebody takes to choose (`charter/frame/selector.py`,
+`charter frame-launch --select`).
+
+**The distinguishing question does not move.** *Has a harness ever run in this pane, and is
+charter's own process still the one in it?* No and yes — the same answer the refusal gives,
+and for the stronger reason: at the selector nothing has been attempted at all. There is no
+harness process, no output of its own on that screen, nothing to draw over and nothing to
+parse, and every failure this ADR was written against needs a harness on the other side of
+the pane to occur.
+
+**What changes is the bound on the WRITE, and only that.** The old bound counted lines
+because the only things charter had to say there were lines. The bound is now what the
+pane is FOR before the `exec`:
+
+* **Charter's own surfaces only, and charter's own surface means `frame/overlay.py`.** The
+  selector is `palette.Palette` over profile rows — the same modal loop, the same
+  containment, the same one key that always leaves, that `F2` and the tab menu run in a pane
+  split off a harness. Nothing else may be drawn here: not a panel, not a layout, not a
+  second surface charter wrote somewhere else to a different contract.
+* **The approval is not a second surface.** Enter on a new or changed profile hands the
+  terminal back (`palette.own_the_tty` restores its mode) and the launch asks with the
+  prompt the amendment above bounds — escaped, whole, `run this? [y/N]` — exactly as
+  `charter <profile>` does in a terminal. A one-line surface heading could not hold that
+  command whole, and a prompt a `y` answers must never be clipped.
+* **A row says how much it hid.** A selector row carries a command or a reason out of a file
+  a chat can write, so the surface cuts each column to the pane with `… +N not shown`
+  (`overlay.Surface.says_what_it_hid`) rather than a bare ellipsis — the promise a `doctor`
+  row makes, in the same helper (`contain.counted`).
+* **It ends the moment a harness exists.** `os.execvpe` replaces this process, and from
+  that instant the pane is the harness's and the rule above is unqualified again. A pane
+  whose harness later EXITS closes as it always did and never comes back to the selector
+  — going back would be charter drawing in a pane a harness has run in, which is the rule
+  and not an exception to it.
+* **No escape hatch, because the thing it escapes to is not there.** `F12` hands the
+  keyboard back to the harness; in this pane there is no harness to hand it to, so the
+  selector's footer does not offer it and `Esc` closes the chat instead.
+* **Reading is still never.** This amendment, like the last, adds a WRITE before the
+  harness exists. Charter reads this pane at the two moments the 2026-09-01 amendment
+  allows and at no others, and it never reads it to react to what a harness printed.
+
+**The cost this takes on, measured rather than stated.** `palette.own_the_tty` puts the
+pane's terminal into raw mode, which the previous amendment deliberately avoided: a
+`tcsetattr` from a launcher pane on a Linux CI runner was measured leaving the process
+killed by a signal, and that is why the refusal's wait is a line read rather than a
+keypress. The difference is what the pane is doing: the refusal's pane is one the chat
+teardown is already killing, and the selector's is a live chat window nothing is tearing
+down — the same arrangement `charter frame-palette --pane` has run in on every supported
+tmux since 0.52. Measured here, on a real server with real keystrokes and nothing patched
+inside the pane (`tests/test_a_new_chat_starts_at_the_profile_selector
+.TheSelectorOnARealServer`): the selector paints, a real Enter picks a row and the launcher
+`exec`s the harness keeping its pid, on tmux 3.7c **and on the Linux runner CI uses**. Raw
+mode in a live chat pane is settled.
+
+**What that measurement also found, and what charter does about it.** A cancelled pane —
+one that leaves raw mode and exits rather than `exec`ing — comes back on Linux dead with
+BOTH `#{pane_dead_status}` and `#{pane_dead_signal}` empty, and its window is still listed a
+minute later, with `remain-on-exit on` and both `pane-died` hooks read back present. So
+charter does not leave the cancel to that hook: **Esc closes its own window**, through
+`frame/tmuxctl.py` like every other tmux call charter makes
+(`frame/launcher._close_the_cancelled_chat`) — and only the window of the pane tmux PROVES is
+this process, `#{pane_pid}` equal to its pid, never one a record or an inherited
+`$TMUX_PANE` names. An earlier shape that trusted those closed an operator's session from a
+test run inside a live chat; `kill-window -t ''` kills the active window. That is this amendment's bound met rather than
+stretched — the pane is charter's while no harness has run in it, and closing the window it
+is drawing in is the last thing it does with it. The hook is untouched and is still the
+answer for a harness that dies.

--- a/docs/control-plane.md
+++ b/docs/control-plane.md
@@ -89,8 +89,8 @@ share = "local"                  # "local" | "commit" | "push". Default: "local"
 [workspace]
 default = "default"              # Default: "default".
 
-# What bare `charter` opens. Opt-in; absent, `charter` on its own prints the usage list.
-# `default` is the only key read here. Harness profiles — a command and an environment
+# Which row bare `charter`'s profile selector starts on. Opt-in; absent, it starts on the
+# first row that can run. `default` is the only key read here. Harness profiles — a command and an environment
 # each — live in charter.local.toml, which is never committed, and a [harness.<name>]
 # table in this file is refused. See "[harness] — profiles, and the default" below.
 [harness]
@@ -679,14 +679,16 @@ does about it, and the measured cost of each probe are in
 
 ### `default` — bare `charter`
 
-**Opt-in.** Absent, `charter` on its own prints the usage list, exactly as it always has.
+**Opt-in, and it launches nothing.** Bare `charter` opens a chat at the **profile
+selector** and starts a harness only once you pick a row; this key chooses which row the
+cursor starts on, and marks it. Absent, the selector opens on the first row that can run.
 
 ```toml
 [harness]
 default = "claude"
 ```
 
-With it, `charter` is `charter claude`. Not "like" it — charter rewrites the command into
+`charter` is `charter frame --select`. Not "like" it — charter rewrites the command into
 that one and runs it, so the workspace picker, `--no-frame`, `--probe`, `--workspace` and
 everything else the launcher does are the same behaviours, not a second set of them. Every
 subcommand keeps working untouched, `charter claude` included.
@@ -697,34 +699,36 @@ of charter's own registry rather than a list in this page — or the name of a p
 `charter.local.toml` declares. A `default` in the local file wins over the committed one,
 which is how a machine chooses its own without touching what everybody else pulls.
 
-**A declared profile is a legal value here**: bare `charter` on a plane whose default names
-one is `charter <that profile>`, question and all — the first open shows its command and
-asks (*A new or changed command asks once*). A built-in default starts exactly as it did.
+**A declared profile is a legal value here**: it is the row the selector starts on, and
+Enter on it starts that profile, question and all — the first open shows its command and asks
+(*A new or changed command asks once*).
 
-**Charter does not pick one for you.** No default and you get the usage message, not
+**Charter does not pick one for you — it asks.** No default and the selector opens on the
+first row that can run. Charter still does not guess *which* harness you meant: not
 "whatever is installed" (a machine with two of them has no answer, and the answer would
 change the day a colleague installed a third) and not "the one you ran last" (a
-machine-local memory deciding what a committed command does). Naming it is one line.
+machine-local memory deciding what a committed command does). What changed is that the
+question is now asked on screen instead of answered by a key.
 
-**A name charter cannot launch is reported, not ignored.**
+**A name this machine does not have marks no row, and `doctor` says so.**
 
 ```
-$ charter
-✗ charter: [harness] default = "clyde" names no profile this machine has — one of:
+$ charter doctor
+! charter.toml: [harness] default = "clyde" names no profile this machine has — one of:
   claude, codex, opencode.
 ```
 
-That is the whole reason this key is checked where it is read rather than where it is
-used. A refused value falls back to *no default*, and no default renders as the usage
-message — the same output a plane that declared nothing gets. Silently, you could not tell
-a typo from a key you never wrote. `charter doctor` carries the same warning on its
-`charter.toml` row, for the plane where somebody else committed the typo.
+The launch itself no longer refuses over it: the selector lists what this machine actually
+has, so a typo shows up as a list with nothing marked rather than as a command that will
+not run. `doctor` is where it is named, because that is the reader that can say it without
+taking a launch away.
 
-**`charter | head` still prints usage.** Bare `charter` starts a harness only when stdout
-is a terminal. Piped or redirected, it prints the usage message and exits 2, which is what
-it did before this key existed — so a script that runs `charter 2>&1 | head` to find out
-whether charter is installed gets an answer instead of an agent session. `charter claude`
-into a pipe is unaffected: it runs the harness bare, as it always did.
+**`charter | head` still prints usage.** Bare `charter` opens a frame only when stdout is
+a terminal. Piped or redirected, it prints the usage message and exits 2, which is what it
+did before this key existed — so a script that runs `charter 2>&1 | head` to find out
+whether charter is installed gets an answer instead of an agent session, and a pipe is no
+place to draw a selector either. `charter claude` into a pipe is unaffected: it runs the
+harness bare, as it always did.
 
 ## `[update].channel` — the dev channel
 

--- a/docs/frame.md
+++ b/docs/frame.md
@@ -15,7 +15,7 @@ plane places it*, below). The middle pane is the harness's and charter draws not
 
     charter claude               # or codex, opencode
     charter claude-work          # any profile charter.local.toml declares
-    charter                      # the same thing, on a plane with [harness] default
+    charter                      # a chat at the profile selector — pick one, it starts
     charter frame -- <cmd>       # anything charter has never met
     charter claude --no-frame    # bare, no frame at all
 
@@ -28,13 +28,18 @@ changes — charter shows what it would run and asks `run this? [y/N]` before it
 ([control-plane.md](control-plane.md#a-new-or-changed-command-asks-once)). Built-ins never
 ask.
 
-`charter` on its own opens the frame once the plane says which harness it means —
-`[harness] default = "claude"` in `charter.toml`, documented in
-[control-plane.md](control-plane.md#default--bare-charter). It is a rewrite of the
-command rather than a route of its own: `charter` becomes `charter claude` and everything
-below applies to it unchanged. A plane that names no default keeps the usage list, and so
-does `charter` with its output piped or redirected — a script asking whether charter is
-installed must not get a harness session instead of an answer.
+`charter` on its own opens the frame at the **profile selector** and starts no harness
+until you pick a row (*No harness starts until you pick a profile*, below). It is a rewrite
+of the command rather than a route of its own: `charter` becomes `charter frame --select`
+and everything below applies to it unchanged. `[harness] default = "claude"` in
+`charter.toml` chooses which row the cursor opens on and launches nothing, documented in
+[control-plane.md](control-plane.md#default--bare-charter); a plane that names none simply
+opens on the first row that can run. `charter` with its output piped or redirected still
+keeps the usage list — a script asking whether charter is installed must not get a harness
+session instead of an answer, and a pipe is no place to draw a selector either.
+
+On a workspace whose chats are already running, bare `charter` **attaches** to them rather
+than opening another (*Opening a workspace you already have open*, below).
 
 `claude`, `codex` and `opencode` are top-level commands (`charter claude`), never nested
 under `frame` (`charter frame claude`) — `charter frame` is its own, separate escape hatch
@@ -498,8 +503,15 @@ chat — and a second launch that added a chat and selected it therefore pulled 
 already there off what they were reading. So it does not. `charter -w foo` from a second
 terminal, while somebody is attached to `foo`, **attaches you to what they are looking at**;
 nothing is started and nothing moves. Where nobody is attached — you closed the terminal, or
-never had one — the same command opens a chat exactly as before. It is `code <path>`'s
-behaviour: the flag means one thing whether or not the workspace happens to be running.
+never had one — a command that NAMES something opens a chat exactly as before. It is `code
+<path>`'s behaviour: the flag means one thing whether or not the workspace happens to be
+running.
+
+**A bare `charter` attaches either way**, and that is the one case where "nobody is
+attached" no longer opens a chat. It names nothing: it means *put me in this plane*, and the
+workspace already has chats running. Opening a second selector beside them would be charter
+adding a chat nobody asked for — which is the thing the selector exists to stop. `+` is how
+you add one, and `charter <profile>` or `charter frame -- <cmd>` still runs what it names.
 
 To open a *second* chat in a workspace you are already in, press the `+` at the end of the
 chat bar, or run `charter <harness>` from inside the frame. Both do the same thing: a new
@@ -855,12 +867,13 @@ one. There is no third answer available from a hook channel that reports prompts
 calls: charter can be late to stop claiming, or early, and it is set to be early.
 
 **The chat bar ends in a `+` and a `-`, and one of them is a button and one is a door.**
-Pressing the `+` opens another chat: same workspace, same **profile** you are already in —
-two chats of one harness may be two accounts, so the answer is the one in front of you —
-its id allocated for you, which is why it takes nothing and asks nothing. It runs `charter
-frame-new-chat`, which is `charter <harness>` in this workspace with one difference: it
-builds the frame without becoming your terminal, because the process behind a click is not
-one.
+Pressing the `+` opens another chat in this workspace, at the **profile selector**, with
+the **profile you are already in** as the row the cursor starts on — two chats of one
+harness may be two accounts, so the answer it offers is the one in front of you, and you
+press Enter or pick another. Its id is allocated for you, which is why the press itself
+takes nothing. It runs `charter frame-new-chat`, which is `charter frame --select` in this
+workspace with one difference: it builds the frame without becoming your terminal, because
+the process behind a click is not one.
 
 One thing it can still put to you, and it puts it **in the new chat's own pane**: a profile
 whose command is new or has changed asks `run this? [y/N]` there. The press has no terminal
@@ -891,13 +904,12 @@ nothing else read as a tool that would let you make chats and not get rid of the
 unadvertised way to create something costs you a feature; an unadvertised way to destroy
 something costs you the belief that it is there.
 
-It stops, and says why on the attention row, in four cases: your frame is a window in a
+It stops, and says why on the attention row, in three cases: your frame is a window in a
 tmux you already had (charter makes no chats for you there — `charter <harness>` in the
 workspace still does); charter cannot prove the workspace's tmux session is this plane's
-rather than another project's; this chat records no profile charter can launch and your
-plane declares no `[harness] default`; the profile it records cannot start, and the reason
-is the one the launch would have given you; or charter cannot enter the workspace's
-directory.
+rather than another project's; or charter cannot enter the workspace's directory. It no
+longer stops over the profile: a chat that records none, a plane that declares no default
+and a profile that cannot start are all things the selector says on a row.
 
 **The workspace bar has neither, deliberately.** A new chat is nothing but a press. A new
 workspace is a directory and a *name*, which is `charter workspace create` — and a picker
@@ -2938,10 +2950,11 @@ you have been in today are running. Clicking one starts it: a chat, a harness, t
 and then your terminal moves there. It is the same thing `charter <harness> --workspace
 <name>` does, which is what this used to print for you to go and type.
 
-The harness it opens with is **the one this chat is running**, because that is the only
-answer a tab can carry — a tab names a workspace and nothing else. If charter has no record
-of it, the plane's `[harness] default` is used, and with neither the click is refused by
-name rather than starting something you did not choose.
+It opens at the **profile selector**, on the profile **this chat is running** — the only
+answer a tab can carry, because a tab names a workspace and nothing else. If charter has no
+record of it, the plane's `[harness] default` is the row it starts on, and with neither the
+list simply opens on the first row that can run. Nothing you did not choose is started
+either way.
 
 What a click costs: one harness process at its own prompt with nothing sent to it, one chat
 directory, and a set of panels. Nothing is asked first, deliberately — the frame delivers no
@@ -3122,3 +3135,69 @@ straight in. And the prompt is reached only on the interactive path: `--no-frame
 redirected stdout and a stdin that is not a terminal each return before it — `charter
 claude` from a script or another agent cannot block on it. `--workspace <name>` names one
 outright and skips the picker; `--pick` asks even when something already chose.
+
+### No harness starts until you pick a profile
+
+A chat's window opens with the **profile selector** in its harness pane, and the harness
+starts in that pane once you choose a row. Opening charter used to start whatever
+`[harness] default` named; now nothing runs until somebody says what.
+
+```
+  charter · which profile? · 4 to choose from
+
+  >   claude          claude · claude
+    * claude-work     claude · CLAUDE_CONFIG_DIR=/Users/you/.claude-work claude
+      codex           codex · codex
+      codex-pinned    not on PATH: npx
+
+    up/down move   enter start   esc close this chat
+```
+
+**Where it appears:** bare `charter` on a workspace with no running chat; the `+` on the
+chat strip; the palette's `chat: new`; a workspace tab whose workspace has no running chat.
+**Where it does not:** `charter <profile>` names the profile, and so does every open nobody
+is at — `charter reopen`, a restored plane, and a chat handed off by another chat. A
+selector is a question, and those have nobody there to answer one.
+
+It is the `F2` palette's picker, so it behaves like one: type to narrow, up/down to move,
+Enter to start. **It always shows, even where one profile can run** — one profile costs one
+Enter, and skipping it would bring back the harness nobody picked on a machine with one
+harness.
+
+**Every profile you declared is a row.** A built-in — `claude`, `codex`, `opencode` — is a
+row only where its program is installed, because a harness this machine does not have is not
+an option you were offered. A profile that **cannot** start is still listed, with the reason
+on the row: its command is not on `PATH`, git would carry `charter.local.toml`, or
+`charter.local.toml` itself refused it. **Enter on such a row shows the reason in the footer
+and leaves the selector open.** The palette does the opposite — a refused Enter closes it —
+and that is right there, where the surface is a pane over a running harness. Here the
+surface is the chat, so closing it would close the chat.
+
+**The cursor opens on the row that can run.** `[harness] default` marks its row and the
+cursor starts there; a `default` naming a profile this machine does not have marks nothing,
+and the cursor goes where the palette's own rule puts it — the first row that can run, so
+Enter always does something. (`charter doctor` warns about a default nothing declares.)
+
+**Esc closes that chat, having started nothing.** No harness ran, no identity was recorded,
+and if it was the workspace's only window the session goes with it — the frame's own rule
+for its last chat. A pane sitting at the selector has a **tab**, so you can leave it and
+come back to it, but it is not a chat: `charter: quit` does not record it and `charter
+reopen` never brings it back. There is nothing to bring back, and restoring a question is
+not restoring a chat. Its harness and its profile are written down at the pick and not
+before.
+
+**A pick charter refuses comes straight back here.** The row you chose was drawn from what
+was true when the pane painted; the launch asks again, fresh, the instant before it runs
+anything — so a `.gitignore` edited or a binary uninstalled in between is a refusal, and the
+selector reopens with that row updated and the reason in the footer. Only Esc closes the
+window.
+
+**What it costs to open.** Measured on this machine with three declared profiles beside the
+installed built-ins, the list charter reads and lays out — the profiles, and the one
+`git status` that says whether `charter.local.toml` is ignored — takes a median of 13 ms
+cold. Nothing here runs a profile's own command.
+
+Charter drawing in a chat's pane at all is [ADR
+0018](adr/0018-charter-may-run-the-harness-but-never-draws-it.md) as its later amendments
+qualify it. Charter draws there only while **no harness has ever run in that pane**; the
+instant `exec` succeeds, the pane is the harness's for good.

--- a/docs/frame.md
+++ b/docs/frame.md
@@ -3167,11 +3167,26 @@ harness.
 **Every profile you declared is a row.** A built-in — `claude`, `codex`, `opencode` — is a
 row only where its program is installed, because a harness this machine does not have is not
 an option you were offered. A profile that **cannot** start is still listed, with the reason
-on the row: its command is not on `PATH`, git would carry `charter.local.toml`, or
-`charter.local.toml` itself refused it. **Enter on such a row shows the reason in the footer
-and leaves the selector open.** The palette does the opposite — a refused Enter closes it —
+on the row: its command is not on `PATH`, git would carry `charter.local.toml`,
+`charter.local.toml` itself refused it, or it is **not wired** — its config folder does not
+carry charter's guard, said in the same sentence a launch refuses with, fix included. **Enter
+on such a row shows the reason in the footer and leaves the selector open.** The palette does the opposite — a refused Enter closes it —
 and that is right there, where the surface is a pane over a running harness. Here the
 surface is the chat, so closing it would close the chat.
+
+**A new or changed profile is not refused — it asks.** Its row says `not approved yet (new)`
+or `(changed)` and nothing about wiring, because finding out means running the command you
+have not approved. Enter on it hands the pane back to an ordinary terminal and shows the same
+question `charter <profile>` shows — the command and its environment, whole, then `run this?
+[y/N]` ([control-plane.md](control-plane.md#a-new-or-changed-command-asks-once)). A no puts
+the list back with the cursor on that row. A yes charter could not write down comes back as
+that row's reason and is never asked twice, and a yes runs every check again, wiring last,
+before anything starts.
+
+**A row says how much it could not fit.** A command or a reason too wide for the pane ends in
+`… +N not shown` rather than a bare ellipsis, the way `charter doctor`'s rows do — a
+clipped command looks exactly like a whole one otherwise. `charter harness list` prints it
+whole.
 
 **The cursor opens on the row that can run.** `[harness] default` marks its row and the
 cursor starts there; a `default` naming a profile this machine does not have marks nothing,
@@ -3198,8 +3213,17 @@ none: **a median of 145 ms on tmux 3.7c and 137 ms at the 3.2 floor**, over 12 r
 slowest was under a sixth of a second, with the count of declared profiles making no
 difference anybody could see. That is the
 whole open — the tmux session, the window, charter starting in the pane, the profiles read,
-the one `git status` that says whether `charter.local.toml` is ignored, and the paint.
-Nothing here runs a profile's own command.
+the one `git status` that says whether `charter.local.toml` is ignored, and the paint — and
+it was measured before the rows asked about wiring.
+
+**The wiring answer adds its own half, measured separately.** A row that is approved asks
+its harness whether it is wired, and that runs the profile's own command (`claude plugin
+list --json`, `opencode debug config`; Codex's is a file read). Every row's probe runs at
+once, and the answer is remembered in a cache stamped with the files that can change it. On
+macOS, with claude 2.1.270 and opencode 1.18.23 installed beside codex, four Claude profiles
+and throwaway config folders, the rows took **a median of 611 ms cold** (990 ms on the very
+first run) and **15 ms warm**, over five of each. A launch never trusts that cache — a chat can write the
+file — so picking a row asks again, fresh, in the pane.
 
 Charter drawing in a chat's pane at all is [ADR
 0018](adr/0018-charter-may-run-the-harness-but-never-draws-it.md) as its later amendments

--- a/docs/frame.md
+++ b/docs/frame.md
@@ -3192,10 +3192,11 @@ anything — so a `.gitignore` edited or a binary uninstalled in between is a re
 selector reopens with that row updated and the reason in the footer. Only Esc closes the
 window.
 
-**What it costs to open.** Measured on this machine with three declared profiles beside the
-installed built-ins, the list charter reads and lays out — the profiles, and the one
+**What it costs to open.** Measured on this machine with three declared profiles beside
+the installed built-ins: the list charter reads and lays out — the profiles, and the one
 `git status` that says whether `charter.local.toml` is ignored — takes a median of 13 ms
-cold. Nothing here runs a profile's own command.
+with nothing cached and 11 ms with the read memoised. Nothing here runs a profile's own
+command.
 
 Charter drawing in a chat's pane at all is [ADR
 0018](adr/0018-charter-may-run-the-harness-but-never-draws-it.md) as its later amendments

--- a/docs/frame.md
+++ b/docs/frame.md
@@ -3192,11 +3192,14 @@ anything — so a `.gitignore` edited or a binary uninstalled in between is a re
 selector reopens with that row updated and the reason in the footer. Only Esc closes the
 window.
 
-**What it costs to open.** Measured on this machine with three declared profiles beside
-the installed built-ins: the list charter reads and lays out — the profiles, and the one
-`git status` that says whether `charter.local.toml` is ignored — takes a median of 13 ms
-with nothing cached and 11 ms with the read memoised. Nothing here runs a profile's own
-command.
+**What it costs to open.** Measured end to end, from the launch to the first painted row,
+on a real server with three declared profiles beside the installed built-ins and again with
+none: **a median of 145 ms on tmux 3.7c and 137 ms at the 3.2 floor**, over 12 runs whose
+slowest was under a sixth of a second, with the count of declared profiles making no
+difference anybody could see. That is the
+whole open — the tmux session, the window, charter starting in the pane, the profiles read,
+the one `git status` that says whether `charter.local.toml` is ignored, and the paint.
+Nothing here runs a profile's own command.
 
 Charter drawing in a chat's pane at all is [ADR
 0018](adr/0018-charter-may-run-the-harness-but-never-draws-it.md) as its later amendments

--- a/docs/install.md
+++ b/docs/install.md
@@ -344,9 +344,10 @@ need their own binaries the same way. `charter claude --probe` says whether a fr
 here without starting one; [frame.md](frame.md) is the rest. If you ran `charter init` from
 inside a Claude Code session, restart that session first — the plugin loads at the next one.
 
-`init` writes no `[harness] default`, so bare `charter` prints its usage until the plane
-names a profile — one key in `charter.toml`, and `claude` is the built-in profile of Claude
-Code ([control-plane.md](control-plane.md#default--bare-charter)):
+Bare `charter` opens a chat at the profile selector and starts nothing until you pick a
+row. `init` writes no `[harness] default`; it is optional, and it chooses which row the
+cursor starts on — one key in `charter.toml`, and `claude` is the built-in profile of
+Claude Code ([control-plane.md](control-plane.md#default--bare-charter)):
 
 ```toml
 [harness]

--- a/docs/news/unreleased-harness-profiles.md
+++ b/docs/news/unreleased-harness-profiles.md
@@ -1,6 +1,6 @@
 ---
 version: unreleased
-headline: A chat starts on the harness profile you name — its own command and config folder, never through tmux
+headline: A new chat asks which harness profile to start — no harness runs until you pick one
 adopt: reinit
 ---
 
@@ -38,6 +38,37 @@ exit code and everything charter reads off it stay exactly what they were. The c
 the profile it runs: the `+`, a workspace tab and a chat handed off by another chat all
 open on that same profile rather than merely on the same kind of harness, because two chats
 of one harness may be two accounts.
+
+**And no harness starts until you pick a profile.** Before any harness has run in it, a
+chat's pane draws the **profile selector** — the `F2` palette's own picker, so you type to
+narrow it and press Enter to start. Every profile you declared is a row; a built-in is a row
+where its program is installed; a profile that cannot start is listed with the reason on it,
+and Enter there shows the reason and leaves the list open rather than closing the chat. A new
+or changed profile shows its command and asks in place. Esc closes that chat having started
+nothing — a pane at the selector has a tab, but it is not a chat: `charter: quit` does not
+record it and `charter reopen` never brings it back. It always shows, even where one profile
+can run: one profile costs one Enter, and skipping it would bring back the harness nobody
+picked.
+
+**Where it appears:** bare `charter` on a workspace with no running chat, the `+` on the
+chat strip, the palette's `chat: new`, and a workspace tab whose workspace has nothing
+running. **Where it does not:** `charter <profile>` names the profile, and so does every
+open nobody is at — `charter reopen`, a restored plane, and a chat handed off by another
+chat. A selector is a question, and those have nobody there to answer one.
+
+Two stops went with it. **`[harness] default` no longer launches anything** — it chooses
+which row the cursor starts on, and a value naming a profile this machine does not have
+marks no row instead of refusing the command; `charter doctor` is where that typo is now
+reported. And the `+` no longer refuses a chat whose profile the plane no longer declares,
+or a plane that declares no default: it opens the selector, which says on each row why
+anything cannot start. Bare `charter` on a plane that declares nothing opens it too, rather
+than printing the usage list.
+
+**Bare `charter` on a workspace that is already running attaches to it** whether or not
+anybody else is, instead of adding a chat. It names nothing — it means *put me in this
+plane* — and the workspace already has chats. `+` is how you add one, and `charter
+<profile>` or `charter frame -- <cmd>` still opens a chat and runs what it names. Piped
+anywhere, bare `charter` still prints its usage: a pipe is no place to draw a selector.
 
 `charter reopen` brings each chat back on its own profile, and a chat whose profile is gone
 is **skipped by name** rather than moved onto another one — another profile may be another

--- a/docs/news/unreleased-harness-profiles.md
+++ b/docs/news/unreleased-harness-profiles.md
@@ -42,9 +42,11 @@ of one harness may be two accounts.
 **And no harness starts until you pick a profile.** Before any harness has run in it, a
 chat's pane draws the **profile selector** — the `F2` palette's own picker, so you type to
 narrow it and press Enter to start. Every profile you declared is a row; a built-in is a row
-where its program is installed; a profile that cannot start is listed with the reason on it,
-and Enter there shows the reason and leaves the list open rather than closing the chat. A new
-or changed profile shows its command and asks in place. Esc closes that chat having started
+where its program is installed; a profile that cannot start — not on `PATH`, not wired,
+refused by the file — is listed with the reason on it, and Enter there shows the reason and
+leaves the list open rather than closing the chat. A new or changed profile says it is not
+approved yet, and Enter on it asks `run this? [y/N]` in that pane over its whole command. A
+row too wide for the pane says how much it could not show. Esc closes that chat having started
 nothing — a pane at the selector has a tab, but it is not a chat: `charter: quit` does not
 record it and `charter reopen` never brings it back. It always shows, even where one profile
 can run: one profile costs one Enter, and skipping it would bring back the harness nobody

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -103,6 +103,15 @@ from . import _claudeguard      # noqa: E402
 
 _claudeguard.install()
 
+# A test that reaches a REAL exec replaces the process running the suite: no summary and no
+# exit code of its own — the same no-verdict a hang is. Measured on #998's deletion sweep,
+# where one mutant sent a launch test through `commands_frame.bypass` into a real
+# `python -m charter frame-launch --select` and the mutation came back unresolved. See
+# `tests/_execguard.py`: an exec that would run now fails the test that made it, by name.
+from . import _execguard      # noqa: E402
+
+_execguard.install()
+
 # And the one thing no guard can prevent, only clean up after: a run that was KILLED.
 # Measured — a `kill -9` two seconds into `test_frame_overlay_escape_hatch` leaves a live
 # tmux server and its socket file behind, because the signal skips every `addCleanup`

--- a/tests/_execguard.py
+++ b/tests/_execguard.py
@@ -25,9 +25,11 @@ primitives every `os.exec*` spelling ends in — `os.execv` and `os.execve`, whi
   so that path is real behaviour and not a hazard: `bypass`'s own "not installed" sentence
   and exit 127 are tested exactly that way, and `os.execvp` walks `PATH` by trying each
   candidate and catching the first of those;
-* **a program that WOULD run raises :class:`ReplacedTheRunner`**, which is an
-  `AssertionError`: not an `OSError`, so no `except OSError` in charter and no candidate loop
-  in `os._execvpe` can take it for an ordinary failure to start;
+* **a program that WOULD run raises :class:`ReplacedTheRunner`**, a `BaseException` like
+  every tripwire in `tests/_planeguard.py`: not an `OSError`, so no `except OSError` in
+  charter and no candidate loop in `os._execvpe` can take it for an ordinary failure to
+  start — and not an `Exception` either, so no `except Exception` on the path between the
+  exec and the test (`cli.main` has one) can swallow it into a green;
 * **a forked child is never refused.** `pty.fork()` followed by `os.execvp("tmux", …)` is how
   a real-terminal case puts a real client on a server, and after the fork the process
   replaced is the child's own, not the suite's. Told apart by pid, recorded at install.
@@ -47,8 +49,12 @@ _RUNNER_PID: int | None = None
 _installed = False
 
 
-class ReplacedTheRunner(AssertionError):
-    """A test exec'd a real program from the process running the suite."""
+class ReplacedTheRunner(BaseException):
+    """A test exec'd a real program from the process running the suite.
+
+    `BaseException`, for `_planeguard.RealTmuxReach`'s reason: a tripwire an `except
+    Exception` can catch is a tripwire the code under test can turn into a pass.
+    """
 
 
 def _tripwire(name: str, real):

--- a/tests/_execguard.py
+++ b/tests/_execguard.py
@@ -1,0 +1,81 @@
+"""Suite-wide tripwire: no test may REPLACE the process that is running the suite.
+
+`charter` execs in two places, and both are the point of the code they are in:
+`commands_frame.bypass` (`os.execvp`, a harness with no frame) and `frame/launcher.attempt`
+(`os.execvpe`, the profile's command taking over its pane). A test reaches either with the
+exec stood in — `launcher.os.execvpe` patched, or `os.execvp` patched to raise — and every
+test that remembered to is fine.
+
+**A test that did not remember is not a failure, it is a missing verdict.** A real exec
+from the test process replaces the test runner: no summary, no exit code of its own, and
+whatever the exec'd program does next — measured 2026-09-13 on #998's deletion sweep, whose
+`if selecting:` mutant (every launch treated as a selector launch) sent
+`tests.test_a_profile_launch_is_refused_before_tmux` through `bypass` into a real
+`python -P -m charter frame-launch --select`. Locally that printed `No module named charter`
+in place of the run; on the sweep it came back neither green nor red — **unresolved**, the
+same no-verdict a hang produces. A mutation nobody can measure is a guard nobody knows is
+pinned.
+
+**So an exec from the suite's own process fails the test that made it, by name.** The two
+primitives every `os.exec*` spelling ends in — `os.execv` and `os.execve`, which
+`os._execvpe` looks up at call time — are replaced once, at import of the `tests` package:
+
+* **a program that does not exist, or cannot be executed, still raises what the kernel
+  would** (`FileNotFoundError`, `PermissionError`). Nothing is replaced when an exec fails,
+  so that path is real behaviour and not a hazard: `bypass`'s own "not installed" sentence
+  and exit 127 are tested exactly that way, and `os.execvp` walks `PATH` by trying each
+  candidate and catching the first of those;
+* **a program that WOULD run raises :class:`ReplacedTheRunner`**, which is an
+  `AssertionError`: not an `OSError`, so no `except OSError` in charter and no candidate loop
+  in `os._execvpe` can take it for an ordinary failure to start;
+* **a forked child is never refused.** `pty.fork()` followed by `os.execvp("tmux", …)` is how
+  a real-terminal case puts a real client on a server, and after the fork the process
+  replaced is the child's own, not the suite's. Told apart by pid, recorded at install.
+
+A test that patches `os.execvp`, `os.execvpe` or `launcher.os.execvpe` itself never reaches
+these primitives at all, which is the right answer: nothing is exec'd.
+"""
+
+from __future__ import annotations
+
+import errno
+import os
+
+#: The suite's own process — the one process an exec must never replace.
+_RUNNER_PID: int | None = None
+
+_installed = False
+
+
+class ReplacedTheRunner(AssertionError):
+    """A test exec'd a real program from the process running the suite."""
+
+
+def _tripwire(name: str, real):
+    def exec_(path, *rest):
+        if os.getpid() != _RUNNER_PID:
+            return real(path, *rest)
+        shown = os.fsdecode(path)
+        if not os.path.exists(path):
+            raise FileNotFoundError(errno.ENOENT, os.strerror(errno.ENOENT), shown)
+        if os.path.isdir(path) or not os.access(path, os.X_OK):
+            raise PermissionError(errno.EACCES, os.strerror(errno.EACCES), shown)
+        raise ReplacedTheRunner(
+            f"a test called os.{name}({shown!r}, …) from the process running the suite — "
+            f"that replaces the test runner and leaves no verdict at all. Stand the exec "
+            f"in (`launcher.os.execvpe`, or `os.execvp` for `commands_frame.bypass`). "
+            f"See tests/_execguard.py.")
+
+    exec_.__name__ = name
+    return exec_
+
+
+def install() -> None:
+    """Replace the two exec primitives for the suite's own process. Idempotent."""
+    global _installed, _RUNNER_PID
+    if _installed:
+        return
+    _installed = True
+    _RUNNER_PID = os.getpid()
+    os.execv = _tripwire("execv", os.execv)
+    os.execve = _tripwire("execve", os.execve)

--- a/tests/test_a_chat_carries_its_profile.py
+++ b/tests/test_a_chat_carries_its_profile.py
@@ -216,17 +216,22 @@ class APressRunsNoGuardForAProfileNobodyHasPicked(_APressInAlpha, unittest.TestC
     """The `+` used to run the launcher's whole refusal chain before it launched, so its
     reason could reach the frame's attention row rather than `/dev/null`. Nothing is being
     launched now: the pane runs that chain, fresh, for whichever profile is picked minutes
-    from now — so asking here would be asking about a profile nobody has chosen.
-
-    Review B1 is what makes this visible: every declared profile is refused until Task 3,
-    and the press opens a chat regardless.
+    from now — so asking here would be asking about a profile nobody has chosen, and a
+    refusal here would take away a list whose rows already say why.
     """
 
     def test_the_press_opens_a_chat_over_a_profile_the_launcher_would_refuse(self):
-        self._press()
+        """The pressing chat's profile is not on `PATH` and has never been approved, so the
+        launcher refuses it twice over — and the press opens the selector on it anyway,
+        says nothing, and asks the chain nothing."""
+        with mock.patch("charter.commands_frame.shutil.which", return_value=None), \
+                mock.patch.object(commands_frame, "_launch_refusal",
+                                  side_effect=AssertionError("the press asked the chain")):
+            self._press()
         self.assertEqual(len(self.launched), 1, self._sentences())
         self.assertTrue(self.launched[0].select)
-        self.assertNotIn("cannot yet ask", " ".join(self._sentences()))
+        self.assertEqual(self.launched[0].start, "claude-work")
+        self.assertEqual(self._sentences(), [], self._sentences())
 
 
 class AWorkspaceTabStartsOnTheSameProfile(_APressInAlpha, unittest.TestCase):

--- a/tests/test_a_chat_carries_its_profile.py
+++ b/tests/test_a_chat_carries_its_profile.py
@@ -148,112 +148,88 @@ class _APressInAlpha(PersonaIso):
         return [c[0][1] for c in self.said.call_args_list]
 
 
-class ANewChatTakesThePressersProfile(_APressInAlpha, unittest.TestCase):
+class ANewChatStartsOnThePressersProfile(_APressInAlpha, unittest.TestCase):
+    """**A `+` opens a chat at the selector, and the pressing chat's profile is the row it
+    opens ON.** It used to launch that profile outright and refuse the press whenever it
+    could not resolve one, which is a `+` that does nothing with a sentence on the
+    attention row. The selector answers every one of those cases, so the rungs below are
+    about which ROW the cursor lands on — and a press charter cannot answer that for still
+    opens a chat.
+
+    `_same_profile_as`'s own refusals are unchanged and still tested where they are decided
+    (`tests/test_a_chat_carries_its_profile.AHandoffTakesTheCallingChatsProfile`, and the
+    reopen cases below): a handoff still names its profile, because nobody is at that one.
+    """
+
     def setUp(self) -> None:
         super().setUp()
         self._no_approval_needed()
-        # **The profile's command is on `PATH`, said rather than inherited.** These cases
-        # name `codex` as well as `claude`, and a press now runs the launcher's own checks
-        # before it launches — so on a machine without codex installed (CI is one; the
-        # machine this was written on is not) every one of them would be refused for a
-        # reason none of them is about. `charter.commands_frame.shutil` is the `shutil`
-        # module, so this is the answer the launcher's own check gets too.
-        self.enterContext(mock.patch("charter.commands_frame.shutil.which",
-                                     return_value="/nowhere/harness"))
 
-    def test_the_plus_launches_the_profile_this_chat_records(self):
+    def test_the_plus_starts_on_the_profile_this_chat_records(self):
         self._press()
         self.assertEqual(len(self.launched), 1, self._sentences())
-        self.assertEqual(self.launched[0].harness, "claude")
-        self.assertEqual(self.launched[0].profile, "claude-work")
+        self.assertTrue(self.launched[0].select)
+        self.assertEqual(self.launched[0].start, "claude-work")
 
-    def test_a_chat_from_before_profiles_takes_the_built_in_of_its_kind(self):
+    def test_a_chat_from_before_profiles_starts_on_the_built_in_of_its_kind(self):
         _a_chat(self.FID, ws="alpha", harness="codex")
         (config.STATE_DIR / "frame" / self.FID / "profile").unlink(missing_ok=True)
         self._press()
-        self.assertEqual(self.launched[0].profile, "codex")
+        self.assertEqual(self.launched[0].start, "codex")
 
-    def test_a_declared_replacement_of_the_built_in_is_what_that_chat_gets(self):
-        """A command that really resolves, because the launcher's PATH guard runs here for
-        real: a replacement pinning a path this machine does not have is a different case
-        (`…refused_before_tmux`), and it would pass this one for the wrong reason."""
-        self.local.write_text('[harness.codex]\nkind = "codex"\n'
-                              'command = ["/bin/sh"]\n')
-        _a_chat(self.FID, ws="alpha", harness="codex")
-        (config.STATE_DIR / "frame" / self.FID / "profile").unlink(missing_ok=True)
-        self._press()
-        self.assertEqual(self.launched[0].profile, "codex")
-        from charter import profiles
-        self.assertEqual(profiles.current().profiles["codex"].command, ("/bin/sh",))
-
-    def test_a_chat_whose_profile_is_gone_is_refused_not_given_the_default(self):
-        """Ruling 15's reason, one surface over: another profile may be another account."""
+    def test_a_chat_whose_profile_is_gone_starts_on_no_row_rather_than_the_default(self):
+        """Ruling 15's reason, one surface over: another profile may be another account, so
+        a profile the plane no longer declares is never silently swapped for the default.
+        What changed is that this is no longer a refusal — the chat opens, on no row, and
+        the selector lists what this machine actually has."""
         _a_chat(self.FID, ws="alpha", profile="gone")
         self.local.write_text(self.local.read_text()
                               + '\n[harness]\ndefault = "claude"\n')
         self._press()
-        self.assertEqual(self.launched, [])
-        self.assertTrue(any("no longer declares" in s for s in self._sentences()),
-                        self._sentences())
+        self.assertEqual(len(self.launched), 1, self._sentences())
+        self.assertEqual(self.launched[0].start, "")
+        self.assertEqual(self._sentences(), [], self._sentences())
 
-    def test_the_gone_profiles_name_is_repeated_back_escaped(self):
-        """The record is a file under `.charter/`, not something charter minted this run —
-        and this sentence goes to the frame, where an ESC would repaint the line around it.
-        (A `\\r` cannot make the trip: `read_text` translates it to `\\n` on the way back,
-        which is a fact about the record and not about the containment.)"""
-        _a_chat(self.FID, ws="alpha", profile="go\x1bne")
-        self._press()
-        self.assertEqual(self.launched, [])
-        self.assertTrue(any("\\u001b" in s for s in self._sentences()),
-                        self._sentences())
-
-    def test_a_chat_from_before_profiles_says_why_its_kinds_profile_was_refused(self):
-        """Rung 2, and ruling 37 on the way down it: the built-in named after this chat's
-        kind is one the file replaced and charter refused, so the press says THAT reason
-        rather than running the command the operator replaced. Losing the reason here is
-        the silent half — a `+` that does nothing, with nothing said about why."""
+    def test_a_refused_replacement_of_a_built_in_starts_on_no_row(self):
+        """Rung 2 and ruling 37: the built-in named after this chat's kind is one the file
+        replaced and charter refused, so the press never falls back to the command the
+        operator replaced. The row it would have opened on is simply not offered — and the
+        selector lists that name refused, with the file's own reason on it."""
         self.local.write_text('[harness.codex]\nkind = "codex"\ncommand = "codex --x"\n')
         _a_chat(self.FID, ws="alpha", harness="codex")
         (config.STATE_DIR / "frame" / self.FID / "profile").unlink(missing_ok=True)
         self._press()
-        self.assertEqual(self.launched, [])
-        self.assertTrue(any("never a shell string" in s for s in self._sentences()),
-                        self._sentences())
+        self.assertEqual(self.launched[0].start, "")
 
-    def test_with_no_record_and_no_default_the_press_is_refused_by_name(self):
+    def test_with_no_record_and_no_default_the_press_still_opens_a_chat(self):
         _a_chat(self.FID, ws="alpha", harness="zzz-nothing")
         (config.STATE_DIR / "frame" / self.FID / "profile").unlink(missing_ok=True)
         self.local.write_text("")
         self._press()
-        self.assertEqual(self.launched, [])
-        self.assertTrue(any("no profile" in s for s in self._sentences()),
-                        self._sentences())
+        self.assertEqual(len(self.launched), 1, self._sentences())
+        self.assertTrue(self.launched[0].select)
+        self.assertEqual(self.launched[0].start, "")
+        self.assertEqual(self._sentences(), [], self._sentences())
 
 
-class APressThatCannotLaunchSaysWhyOnTheFrame(_APressInAlpha, unittest.TestCase):
-    """`cmd_new_chat` runs detached with its three streams on `/dev/null`, so a refusal
-    `_launch` printed is read by nobody: without this the `+` would report only "the
-    launcher returned 3" for a profile the operator could have fixed in a line."""
+class APressRunsNoGuardForAProfileNobodyHasPicked(_APressInAlpha, unittest.TestCase):
+    """The `+` used to run the launcher's whole refusal chain before it launched, so its
+    reason could reach the frame's attention row rather than `/dev/null`. Nothing is being
+    launched now: the pane runs that chain, fresh, for whichever profile is picked minutes
+    from now — so asking here would be asking about a profile nobody has chosen.
 
-    def test_the_press_says_the_launchers_own_refusal(self):
-        self._no_approval_needed()
-        with mock.patch("charter.commands_frame.shutil.which", return_value=None):
-            self._press()
-        self.assertEqual(self.launched, [])
-        self.assertTrue(any("not on PATH" in s for s in self._sentences()),
-                        self._sentences())
+    Review B1 is what makes this visible: every declared profile is refused until Task 3,
+    and the press opens a chat regardless.
+    """
 
-    def test_a_press_defers_the_one_question_the_pane_can_ask_itself(self):
-        """N2a's nit, on the surface it matters on. A profile nobody has approved is not a
-        refusal a `+` reports — the pane it opens has a terminal on both ends and asks
-        there. Reported here instead, the press would say "charter asks before it runs a
-        command it has not been shown before" and open no chat at all."""
+    def test_the_press_opens_a_chat_over_a_profile_the_launcher_would_refuse(self):
         self._press()
         self.assertEqual(len(self.launched), 1, self._sentences())
-        self.assertEqual(self.launched[0].profile, "claude-work")
+        self.assertTrue(self.launched[0].select)
+        self.assertNotIn("cannot yet ask", " ".join(self._sentences()))
 
 
-class AWorkspaceTabOpensTheSameProfile(_APressInAlpha, unittest.TestCase):
+class AWorkspaceTabStartsOnTheSameProfile(_APressInAlpha, unittest.TestCase):
     def setUp(self) -> None:
         super().setUp()
         self._no_approval_needed()
@@ -273,11 +249,11 @@ class AWorkspaceTabOpensTheSameProfile(_APressInAlpha, unittest.TestCase):
                                                   socket=commands_frame.SOCKET,
                                                   window="@1")
 
-    def test_a_workspace_tab_opens_the_profile_the_presser_is_running(self):
+    def test_a_workspace_tab_starts_on_the_profile_the_presser_is_running(self):
         self._open()
         self.assertEqual(len(self.launched), 1, self._sentences())
-        self.assertEqual(self.launched[0].profile, "claude-work")
-        self.assertEqual(self.launched[0].harness, "claude")
+        self.assertTrue(self.launched[0].select)
+        self.assertEqual(self.launched[0].start, "claude-work")
 
 
 class AHandoffTakesTheCallingChatsProfile(_APressInAlpha, unittest.TestCase):
@@ -331,6 +307,21 @@ class AHandoffTakesTheCallingChatsProfile(_APressInAlpha, unittest.TestCase):
     def test_a_handoff_from_a_chat_whose_profile_is_gone_is_refused(self):
         _a_chat(self.FID, ws="alpha", profile="gone")
         self.assertIn("no longer declares", self._refusal())
+
+    def test_the_gone_profiles_name_is_repeated_back_escaped(self):
+        """Ruling 35. The record is a file under `.charter/`, not something charter minted
+        this run, and this sentence reaches a model's tool result — where an ESC would
+        repaint the line around it. (A `\\r` cannot make the trip: `read_text` translates it
+        to `\\n` on the way back, which is a fact about the record rather than about the
+        containment.)
+
+        Asked HERE rather than at the `+`, and that is where it moved to: a press no longer
+        surfaces this sentence at all, because it opens the selector instead of refusing.
+        A handoff still names its profile — nobody is at that open to be asked."""
+        _a_chat(self.FID, ws="alpha", profile="go\x1bne")
+        said = self._refusal()
+        self.assertIn("\\u001b", said)
+        self.assertNotIn("\x1b", said)
 
 
 class TheRecordCarriesTheProfile(PersonaIso, unittest.TestCase):

--- a/tests/test_a_new_chat_starts_at_the_profile_selector.py
+++ b/tests/test_a_new_chat_starts_at_the_profile_selector.py
@@ -1517,6 +1517,28 @@ class WhereItAppears(_APlaneWithProfiles, unittest.TestCase):
         self.assertNotIn("\x1b", said[0])
         self.assertIn("\\u000d", said[0])
 
+    def test_the_operators_own_tmux_records_the_same_two_things(self):
+        """The other launch path, and it needs its own case because it writes its own
+        records: a frame built as a window in the tmux the operator already had goes
+        through `_launch_in_operator_tmux`, not through the private-server branch above.
+        Both halves — the waiting marker before tmux, and no kind on the window — are what
+        `launcher._picked` fills in at the pick, so a path that skipped either would leave
+        a chat claiming a harness it has not started."""
+        def answer(cmd, **kw):
+            if not cmd or cmd[0] != "tmux":
+                return _completed(cmd, 0)
+            return _completed(cmd, 0, "%7\n")
+
+        with mock.patch("charter.commands_frame.subprocess.run", side_effect=answer), \
+                mock.patch.object(commands_frame, "_wait_for_harness", return_value=130), \
+                mock.patch.dict(os.environ, {"CHARTER_HARNESS": "codex"}):
+            commands_frame._launch_in_operator_tmux(
+                "op", "$1", ws="beta", argv=launcher.argv_select("claude"),
+                display=[commands_frame.SELECTOR_DISPLAY], profile="", h=None,
+                v=(3, 7), picked=False, selecting=True)
+        self.assertTrue(state.is_waiting("beta.2"))
+        self.assertEqual(state.identity("beta.2").get("CHARTER_HARNESS"), "")
+
     def test_a_reopen_never_opens_the_selector(self):
         """An open nobody is at names its profile: there is no one there to pick."""
         args = commands_frame._reopen_args(

--- a/tests/test_a_new_chat_starts_at_the_profile_selector.py
+++ b/tests/test_a_new_chat_starts_at_the_profile_selector.py
@@ -1738,6 +1738,26 @@ class TheSelectorOnARealServer(PersonaIso, unittest.TestCase):
     def _text(self, pane: str) -> str:
         return "".join(self._tmux("capture-pane", "-p", "-t", pane).stdout.splitlines())
 
+    def _status(self, pane: str) -> str:
+        """`#{pane_dead}:#{pane_dead_status}` for *pane*, or what tmux said instead.
+
+        A pane tmux no longer lists at all is gone, which is the same answer as dead for
+        every claim here — the window went with it.
+        """
+        out = self._tmux("display-message", "-p", "-t", pane,
+                         "#{pane_dead}:#{pane_dead_status}")
+        return out.stdout.strip() if out.returncode == 0 else f"(gone: {out.stderr.strip()})"
+
+    def _dead(self, pane: str) -> bool:
+        """Whether *pane*'s own process has ended — an empty `#{pane_dead_status}` included.
+
+        Measured on the CI runner, 2026-09-12: a pane that exits out of raw mode on Linux
+        comes back dead with an EMPTY status where the same pane on macOS carries the
+        number (`commands_frame._UNKNOWN_DEATH_CODE`, and ruling 42). So the question is
+        whether the process ended, never what it ended with.
+        """
+        return self._status(pane).startswith(("1:", "(gone"))
+
     def test_a_cancelled_only_window_takes_the_session_with_it(self):
         """S2, and the frame's own rule for its last chat: Esc closes that chat having
         started nothing, and the workspace's session goes with its last window."""
@@ -1746,6 +1766,15 @@ class TheSelectorOnARealServer(PersonaIso, unittest.TestCase):
         self._tmux("send-keys", "-t", pane, "Escape")
         t.join(timeout=40)
         self.assertFalse(t.is_alive(), "the launch never returned")
+        # **The pane first, the session second**, so a failure says which link broke. A lone
+        # ESC is the one key `overlay.decode` cannot resolve from its own bytes — it waits
+        # for a tick with nothing behind it (`palette.TICK`) — so "the surface left" and
+        # "the window went" are two claims, and reading them as one would blame tmux for a
+        # keystroke that never arrived.
+        self.assertTrue(
+            _eventually(lambda: self._dead(pane), timeout=30.0),
+            f"the selector never left on Escape: pane {self._status(pane)}, "
+            f"screen {self._text(pane)!r}")
         # **The exit NUMBER is deliberately not asserted, and that is measured rather than
         # conceded.** A pane that exits out of raw mode on the Linux runner comes back with
         # an empty `#{pane_dead_status}` — `commands_frame._UNKNOWN_DEATH_CODE`'s own
@@ -1759,8 +1788,10 @@ class TheSelectorOnARealServer(PersonaIso, unittest.TestCase):
         # window exists (`_wants_attach`) — long before anybody presses anything.
         self.assertEqual(out, [0])
         self.assertTrue(
-            _eventually(lambda: self.WS not in self._tmux("list-sessions").stdout),
-            "the cancelled chat's session outlived its only window")
+            _eventually(lambda: self.WS not in self._tmux("list-sessions").stdout,
+                        timeout=30.0),
+            f"the cancelled chat's session outlived its only window: "
+            f"{self._tmux('list-windows', '-a', '-F', '#{session_name}:#{window_id}').stdout!r}")
         self.assertFalse((self.records / "harness.json").exists(),
                          "a cancelled selector started a harness")
         self.assertTrue(state.is_waiting("beta.1"),

--- a/tests/test_a_new_chat_starts_at_the_profile_selector.py
+++ b/tests/test_a_new_chat_starts_at_the_profile_selector.py
@@ -31,7 +31,15 @@ module drives `launcher.start`.
 
 from __future__ import annotations
 
+import inspect
+import itertools
+import json
 import os
+import shutil
+import subprocess
+import sys
+import threading
+import time
 import unittest
 from pathlib import Path
 from types import SimpleNamespace
@@ -40,11 +48,14 @@ from unittest import mock
 import re
 import threading
 
-from charter import config, contain, doctor, profiles, profiletrust, tui, util, wiring
-from charter.frame import chats, launcher, leave, overlay, palette, selector, state
-from tests import _gitguard
+from charter import (commands_frame, config, contain, doctor, profiles, profiletrust, tui,
+                     util, wiring)
+from charter.frame import (chats, launcher, leave, overlay, palette, selector, state,
+                           tmuxctl)
+from tests import _gitguard, _tmuxreap, _tmuxsocket, _ttyguard
 from tests._isolation import (APipe, ATerminal, PersonaIso, Typed, approve_every_profile,
-                              approve_profile, declare_profiles, make_plane, wired_as_today)
+                              approve_profile, declare_profiles, make_plane,
+                              no_background_refresh, no_update_check_in, wired_as_today)
 from tests.test_a_profile_is_wired_or_refuses import entry, listing, spawns
 
 #: A profile whose row can run: on `PATH`, approved and wired. The fixture's `which` says
@@ -1290,6 +1301,426 @@ class TheSurfaceDrawsTheFooterItWasGiven(unittest.TestCase):
         self.assertNotIn("\n", line)
         self.assertNotIn("\x1b[31m", line)
         self.assertIn(contain.one_line("\x1b[31m"), line)
+
+
+
+def _completed(argv, rc=0, out="", err=""):
+    return subprocess.CompletedProcess(argv, rc, stdout=out, stderr=err)
+
+
+class _AServerWithOneWorkspaceRunning:
+    """The four answers a selector launch reads off tmux, and a log of everything it asked.
+
+    Deliberately small: what every case in `WhereItAppears` is about is which question was
+    asked and what charter did with the answer, not what a real server would do next.
+    """
+
+    def __init__(self, *, clients=(), sessions=("beta",), chats=("beta.1",)):
+        self.clients = list(clients)
+        self.sessions = list(sessions)
+        self.chats = list(chats)
+        self.calls: list[list[str]] = []
+        #: Run inside the `new-window` answer, where `state.record_waiting` has happened
+        #: and tmux has not: the one moment "before tmux" can be read.
+        self.at_new_window = lambda: None
+
+    @staticmethod
+    def _lines(rows) -> str:
+        # One per line and NOTHING at all for none — a bare newline reads as one client
+        # with a blank name, which is the opposite answer.
+        return "".join(f"{r}\n" for r in rows)
+
+    def __call__(self, cmd, **kw):
+        self.calls.append(list(cmd))
+        if "list-panes" in cmd:
+            return _completed(cmd, 0, f"$3\t%0\t{config.STATE_DIR}\n")
+        if "list-clients" in cmd:
+            return _completed(cmd, 0, self._lines(self.clients))
+        if "list-sessions" in cmd:
+            return _completed(cmd, 0, self._lines(self.sessions))
+        if "list-windows" in cmd:
+            return _completed(cmd, 0, self._lines(self.chats))
+        if "new-window" in cmd or "new-session" in cmd:
+            self.at_new_window()
+            # And the server now HAS what was just created. `_launch` reaps again on its
+            # way out, against this same listing — so a fake that kept answering "nothing
+            # is running" would have charter collect the chat directory it had just
+            # written, and every case reading that chat's state would read an empty one.
+            self.sessions.append("beta")
+            self.chats.append("beta.1")
+            return _completed(cmd, 0, "%9\n")
+        if "display-message" in cmd:
+            return _completed(cmd, 0, "132:43")
+        return _completed(cmd, 0)
+
+    def asked(self, verb: str) -> int:
+        return sum(1 for c in self.calls if verb in c)
+
+    def argv_of(self, verb: str) -> list[str]:
+        return next(c for c in self.calls if verb in c)
+
+
+class WhereItAppears(_APlaneWithProfiles, unittest.TestCase):
+    """Which opens reach the selector, and which name their profile and skip it.
+
+    Bare `charter`, `+`, a workspace tab and the palette's new chat all open at it. Every
+    open nobody is at — reopen, a restored plane, a handoff — names its profile, because a
+    selector is a question and there is nobody there to answer one.
+    """
+
+    #: The id a launch allocates here. `state.reap` takes the cold `beta.1` this fixture
+    #: leaves behind before `new_chat_id` walks upward from 1, so the new chat gets that
+    #: ordinal back — spelled out rather than inferred, because a case reading the wrong
+    #: chat's state is a case that passes for the wrong reason.
+    NEW = "beta.1"
+
+    def setUp(self) -> None:
+        super().setUp()
+        (config.WORKSPACES_DIR / "beta").mkdir(parents=True, exist_ok=True)
+        state.frame_dir("beta.1", create=True)
+        state.record_workspace("beta.1", "beta")
+        state.record_server("beta.1", commands_frame.SOCKET)
+        state.record_harness_pane("beta.1", "%0")
+        self.enterContext(mock.patch.object(commands_frame, "_spawn_gather"))
+        self.enterContext(mock.patch.object(commands_frame, "_drawable_slots",
+                                            return_value=[]))
+        self.focused: list = []
+        self.enterContext(mock.patch.object(
+            commands_frame, "_focus_workspace",
+            side_effect=lambda *a, **kw: self.focused.append((a, kw)) or 0))
+
+    def _launch(self, fake, **ns) -> int:
+        args = SimpleNamespace(**{"harness": "", "rest": [], "no_frame": False,
+                                 "workspace": "beta", "pick": False, "select": True,
+                                 "start": "", "profile": None, **ns})
+        stripped = {k: v for k, v in os.environ.items()
+                    if k not in ("TMUX", "TMUX_PANE")}
+        with mock.patch.dict(os.environ, stripped, clear=True), \
+                mock.patch("charter.commands_frame.subprocess.run", side_effect=fake), \
+                mock.patch("charter.frame.tmuxctl.version", return_value=(3, 7)), \
+                mock.patch("sys.stdout.isatty", return_value=True), \
+                mock.patch("sys.stdin.isatty", return_value=False):
+            return commands_frame._launch(args)
+
+    def test_bare_charter_on_a_workspace_nobody_is_attached_to_attaches(self):
+        """Ruling 17. `_workspace_to_focus` answers `None` for a live workspace with no
+        client on it — rightly, for a launch that NAMES something: with nobody to drag, it
+        should add its chat and run it. A bare `charter` names nothing, so opening a second
+        selector beside chats that are already running would be charter adding a chat
+        nobody asked for. `+` is how you add one."""
+        fake = _AServerWithOneWorkspaceRunning(clients=[])
+        self.assertEqual(self._launch(fake), 0)
+        self.assertEqual(len(self.focused), 1)
+        self.assertEqual(fake.asked("new-window"), 0)
+        self.assertEqual(fake.asked("new-session"), 0)
+
+    def test_a_named_profile_on_that_workspace_still_opens_a_chat(self):
+        """The other half of ruling 17, and the control for the case above: `charter
+        <profile>` keeps today's open-a-chat-where-nobody-is behaviour."""
+        fake = _AServerWithOneWorkspaceRunning(clients=[])
+        self._launch(fake, harness="claude", select=False, profile="claude")
+        self.assertEqual(self.focused, [])
+        self.assertEqual(fake.asked("new-window"), 1)
+
+    def test_a_workspace_somebody_is_on_is_attached_to_either_way(self):
+        fake = _AServerWithOneWorkspaceRunning(clients=["/dev/ttys001"])
+        self._launch(fake)
+        self.assertEqual(len(self.focused), 1)
+
+    def test_a_workspace_with_nothing_running_opens_the_selector(self):
+        """The negative control: with no live session there is nothing to attach to, so
+        the launch opens a chat — at the selector."""
+        fake = _AServerWithOneWorkspaceRunning(sessions=[], chats=[])
+        self._launch(fake)
+        self.assertEqual(self.focused, [])
+        self.assertEqual(fake.asked("new-session"), 1)
+
+    def test_the_selector_launch_records_the_chat_as_waiting_before_tmux(self):
+        """Before, and not after: a quit landing between the window and the pick must not
+        record a chat that is a question on a screen."""
+        fake = _AServerWithOneWorkspaceRunning(sessions=[], chats=[])
+        seen: list[bool] = []
+        fake.at_new_window = lambda: seen.append(state.is_waiting(self.NEW))
+        self._launch(fake)
+        self.assertEqual(seen, [True])
+
+    def test_a_launch_that_names_its_profile_records_no_waiting_pane(self):
+        fake = _AServerWithOneWorkspaceRunning(sessions=[], chats=[])
+        seen: list[bool] = []
+        fake.at_new_window = lambda: seen.append(state.is_waiting(self.NEW))
+        self._launch(fake, harness="claude", select=False, profile="claude")
+        self.assertEqual(seen, [False])
+
+    def test_the_window_starts_on_the_launcher_with_no_inherited_kind(self):
+        """Review 12. `_frame_env` keeps `$CHARTER_HARNESS` from this process where no
+        harness was resolved, and the process that presses `+` is a panel of a chat that
+        HAS one — so without the clear, the pressing chat's kind rides onto the new
+        window's `-e` and into its identity record, and `chats.harness_of` then answers for
+        a chat that has picked nothing."""
+        fake = _AServerWithOneWorkspaceRunning(sessions=[], chats=[])
+        with mock.patch.dict(os.environ, {"CHARTER_HARNESS": "codex"}):
+            self._launch(fake, start="claude-work")
+        argv = fake.argv_of("new-session")
+        self.assertEqual(argv[-4:], ["--select", "--attended", "--start", "claude-work"])
+        self.assertIn("CHARTER_HARNESS=", argv)
+        self.assertEqual(state.identity(self.NEW).get("CHARTER_HARNESS"), "")
+
+    def test_no_start_puts_no_name_on_the_launchers_argv(self):
+        fake = _AServerWithOneWorkspaceRunning(sessions=[], chats=[])
+        self._launch(fake)
+        argv = fake.argv_of("new-session")
+        self.assertEqual(argv[-2:], ["--select", "--attended"])
+        self.assertNotIn("--start", argv)
+
+    def test_the_planes_default_is_the_row_a_bare_launch_opens_on(self):
+        self.local.write_text(self.local.read_text()
+                              + '\n[harness]\ndefault = "claude-work"\n')
+        fake = _AServerWithOneWorkspaceRunning(sessions=[], chats=[])
+        self._launch(fake)
+        self.assertEqual(fake.argv_of("new-session")[-2:], ["--start", "claude-work"])
+
+    def test_select_with_no_frame_is_refused_rather_than_execd(self):
+        """`--no-frame` reaches `bypass`, which `os.execvp`s the launcher — a whole modal
+        surface over the operator's own terminal and then a harness with no frame around
+        it. Two launches asked for at once."""
+        said: list[str] = []
+        fake = _AServerWithOneWorkspaceRunning()
+        with mock.patch.object(commands_frame.util, "err", side_effect=said.append):
+            rc = self._launch(fake, no_frame=True)
+        self.assertEqual(rc, 2)
+        self.assertEqual(fake.calls, [])
+        self.assertEqual(len(said), 1, said)
+        self.assertIn("--no-frame", said[0])
+
+    def test_select_with_a_command_is_refused_rather_than_swallowing_it(self):
+        """`charter frame -- <cmd>` is the escape hatch for a command charter has never
+        met. A selector cannot run it and cannot ask about it, so asking for both is
+        refused — a launcher that swallowed a command would be wrong in the one direction
+        this module refuses everywhere else, silently."""
+        said: list[str] = []
+        fake = _AServerWithOneWorkspaceRunning()
+        with mock.patch.object(commands_frame.util, "err", side_effect=said.append):
+            rc = self._launch(fake, rest=["--", "htop"])
+        self.assertEqual(rc, 2)
+        self.assertEqual(fake.calls, [])
+        self.assertEqual(len(said), 1, said)
+        self.assertIn("htop", said[0])
+
+    def test_the_command_it_refuses_is_repeated_back_escaped(self):
+        """Ruling 35's reason through another door: this is the operator's own word, and
+        it goes to a terminal."""
+        said: list[str] = []
+        fake = _AServerWithOneWorkspaceRunning()
+        with mock.patch.object(commands_frame.util, "err", side_effect=said.append):
+            self._launch(fake, rest=["--", "ht\rop\x1b[2K"])
+        self.assertNotIn("\r", said[0])
+        self.assertNotIn("\x1b", said[0])
+        self.assertIn("\\u000d", said[0])
+
+    def test_a_reopen_never_opens_the_selector(self):
+        """An open nobody is at names its profile: there is no one there to pick."""
+        args = commands_frame._reopen_args(
+            SimpleNamespace(workspace="beta", persona="", cwd="", resume="", brief=""),
+            harness_name="claude", profile="claude-work", rest=[], reopening=None)
+        self.assertFalse(getattr(args, "select", False))
+        self.assertEqual(args.profile, "claude-work")
+
+    def test_a_handoff_never_opens_the_selector(self):
+        """#956's own rule read through profiles: the chat opened in the background takes
+        the calling chat's profile, and a selector would stop it before it started —
+        nobody is at a background open to answer a question."""
+        state.record_profile("beta.1", "claude")
+        (config.WORKSPACES_DIR / "gamma").mkdir(parents=True, exist_ok=True)
+        seen: list = []
+        # The launcher's own `PATH` check runs before a background open, and `claude` is
+        # not on CI's — `charter.commands_frame.shutil` is the module, so this is the
+        # answer that check gets.
+        with mock.patch("charter.commands_frame.shutil.which", return_value="/nowhere/x"), \
+                mock.patch.object(commands_frame, "cmd_launch",
+                               side_effect=lambda a: seen.append(a) or 0), \
+                mock.patch.object(commands_frame, "_plane_session",
+                                  return_value=("$3", "beta.1")), \
+                mock.patch.object(commands_frame, "_window_size", return_value=(120, 40)), \
+                mock.patch.object(commands_frame, "_live_sessions", return_value=set()):
+            commands_frame.open_in_background(
+                "gamma", caller="beta.1",
+                first_message="pick up the review notes in gamma")
+        self.assertEqual(len(seen), 1, seen)
+        self.assertFalse(getattr(seen[0], "select", False))
+        self.assertEqual(seen[0].profile, "claude")
+
+_HAS_TMUX = shutil.which("tmux") is not None
+
+#: A fresh socket per CASE, never per class — a server told to exit is still accepting on
+#: its socket for a few milliseconds, and the next case's `new-session` draws that race.
+_SERVERS = itertools.count()
+
+#: This checkout, for the `$PYTHONPATH` the pane's own launcher needs. `python -P -m
+#: charter` keeps the child's cwd off `sys.path` (#390) and its cwd is a workspace
+#: directory, so without this the pane cannot import the charter under test.
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _eventually(predicate, timeout: float = 20.0) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(0.05)
+    return bool(predicate())
+
+
+@unittest.skipUnless(_HAS_TMUX, "no tmux on this machine")
+class TheSelectorOnARealServer(PersonaIso, unittest.TestCase):
+    """The selector in a REAL chat pane, driven by real keystrokes through a real tmux.
+
+    **Nothing here is patched inside the pane.** The keys go in with `send-keys`, which is
+    what makes this the measurement the plan asks for rather than a second unit test: the
+    pane really puts its terminal into raw mode (`palette.own_the_tty`), really paints the
+    alternate screen, and really `exec`s the profile's command on Enter. That raw-mode call
+    is the one thing ADR 0018's previous amendment deliberately avoided after a `tcsetattr`
+    from a launcher pane was measured leaving the process killed by a signal on a Linux
+    runner — so this is where that stops being an argument.
+
+    The launch runs on a WORKER, because `_launch` owns this thread until the pane is gone.
+    The recorder standing in for `claude` is first on the client's `PATH`: the launcher
+    resolves the profile in the PANE, so patching `Harness.binary` in this process would
+    reach nothing.
+    """
+
+    WS = "beta"
+
+    def setUp(self) -> None:
+        super().setUp()
+        v = tmuxctl.version()
+        if v is None or v < tmuxctl.FLOOR:
+            self.skipTest(f"the frame's floor is tmux {tmuxctl.FLOOR[0]}.{tmuxctl.FLOOR[1]}"
+                          f"; this machine has {v}")
+        make_plane(self)
+        no_background_refresh(self)
+        no_update_check_in(config.ROOT)
+        _ttyguard.no_terminal()
+        self.tmux = shutil.which("tmux")
+        self.socket = _tmuxreap.name(f"the-selector-{next(_SERVERS)}")
+        self.enterContext(mock.patch.object(commands_frame, "SOCKET", self.socket))
+        self.addCleanup(self._reap_the_server)
+        self.enterContext(mock.patch.object(commands_frame, "_spawn_gather"))
+        self.enterContext(mock.patch.object(commands_frame, "_drawable_slots",
+                                            return_value=[]))
+        (config.WORKSPACES_DIR / self.WS).mkdir(parents=True, exist_ok=True)
+        self.records = self.tmp / "records"
+        self.records.mkdir()
+        bindir = self.tmp / "bin"
+        bindir.mkdir()
+        (bindir / "claude").write_text(
+            f"#!{sys.executable}\n"
+            "import json, os, sys, time\n"
+            "out = os.path.join(os.environ['RECORD_DIR'], 'harness.json')\n"
+            "with open(out + '.tmp', 'w') as f:\n"
+            "    json.dump({'argv': sys.argv[1:], 'pid': os.getpid()}, f)\n"
+            "os.replace(out + '.tmp', out)\n"
+            "time.sleep(300)\n")
+        (bindir / "claude").chmod(0o755)
+        self.enterContext(mock.patch.dict(os.environ, {
+            "PATH": f"{bindir}{os.pathsep}{os.environ.get('PATH', '')}",
+            "RECORD_DIR": str(self.records),
+            "CHARTER_ROOT": str(config.ROOT),
+            "PYTHONPATH": os.pathsep.join(
+                [str(_REPO_ROOT), os.environ.get("PYTHONPATH", "")]).rstrip(os.pathsep),
+            **_gitguard.environment(),
+        }, clear=True))
+
+    def _reap_the_server(self) -> None:
+        subprocess.run([self.tmux, "-L", self.socket, "kill-server"],
+                       capture_output=True, timeout=20)
+        try:
+            os.unlink(_tmuxsocket.socket_path(self.socket))
+        except OSError:
+            pass
+
+    def _tmux(self, *args: str) -> subprocess.CompletedProcess:
+        return subprocess.run([self.tmux, "-L", self.socket, *args], capture_output=True,
+                              text=True, timeout=20)
+
+    def _in_the_background(self):
+        """Run the selector launch on a worker and hand back the thread and its answer.
+
+        `_launch` holds its thread until the pane is gone (`_wait_for_harness`), and the
+        keystroke that ends the selector has to come from somewhere else.
+        """
+        out: list = []
+
+        def work() -> None:
+            args = SimpleNamespace(harness="", rest=[], no_frame=False, workspace=self.WS,
+                                   pick=False, select=True, start="claude", profile=None,
+                                   attach=False, size=(120, 40))
+            try:
+                out.append(commands_frame._launch(args))
+            except BaseException as e:                    # noqa: BLE001 — reported
+                out.append(e)
+
+        t = threading.Thread(target=work, daemon=True)
+        t.start()
+        return t, out
+
+    def _pane_showing_the_selector(self) -> str:
+        """The harness pane of `beta.1`, once the selector has painted in it."""
+        self.assertTrue(_eventually(lambda: bool(state.harness_pane("beta.1"))),
+                        "the launch never recorded a harness pane")
+        pane = state.harness_pane("beta.1")
+        self.assertTrue(
+            _eventually(lambda: "which profile" in self._text(pane)),
+            f"the selector never painted: {self._text(pane)!r}")
+        return pane
+
+    def _text(self, pane: str) -> str:
+        return "".join(self._tmux("capture-pane", "-p", "-t", pane).stdout.splitlines())
+
+    def test_a_cancelled_only_window_takes_the_session_with_it(self):
+        """S2, and the frame's own rule for its last chat: Esc closes that chat having
+        started nothing, and the workspace's session goes with its last window."""
+        t, out = self._in_the_background()
+        pane = self._pane_showing_the_selector()
+        self._tmux("send-keys", "-t", pane, "Escape")
+        t.join(timeout=40)
+        self.assertFalse(t.is_alive(), "the launch never returned")
+        # **The number is read off the chat's own record, not off this launch**, and that
+        # is a fact about the fixture rather than a weaker claim. A launch that will never
+        # attach returns as soon as the window exists (`_wants_attach`), so it is long gone
+        # by the time anybody presses anything; what waits for the pane is the `pane-died`
+        # hook, which writes the code the pane exited with. Reading it here is reading what
+        # the frame itself recorded.
+        self.assertEqual(out, [0])
+        self.assertTrue(
+            _eventually(lambda: state.exit_code("beta.1") == selector.CANCELLED_EXIT),
+            f"the cancelled pane recorded {state.exit_code('beta.1')!r}, not "
+            f"{selector.CANCELLED_EXIT}")
+        self.assertTrue(
+            _eventually(lambda: self.WS not in self._tmux("list-sessions").stdout),
+            "the cancelled chat's session outlived its only window")
+        self.assertFalse((self.records / "harness.json").exists(),
+                         "a cancelled selector started a harness")
+        self.assertTrue(state.is_waiting("beta.1"),
+                        "a cancelled pane stopped being a waiting pane, so a quit would "
+                        "record a chat that never started")
+
+    def test_a_pick_leaves_the_same_pane_running_the_harness(self):
+        """L1 for the selector: the pane charter recorded is the pane the harness is in,
+        because `exec` kept the launcher's pid — and the pick is a real Enter on a real
+        raw-mode surface."""
+        t, out = self._in_the_background()
+        pane = self._pane_showing_the_selector()
+        self._tmux("send-keys", "-t", pane, "Enter")
+        record = self.records / "harness.json"
+        self.assertTrue(_eventually(record.is_file),
+                        f"the harness never started: {self._text(pane)!r}")
+        harness = json.loads(record.read_text())
+        pid = self._tmux("display-message", "-p", "-t", pane, "#{pane_pid}").stdout.strip()
+        self.assertEqual(pid, str(harness["pid"]),
+                         "the exec did not keep the launcher's pid for the harness")
+        self.assertTrue(_eventually(lambda: not state.is_waiting("beta.1")),
+                        "the pick left the pane recorded as still waiting")
+        self.assertEqual(state.profile("beta.1"), "claude")
 
 
 if __name__ == "__main__":

--- a/tests/test_a_new_chat_starts_at_the_profile_selector.py
+++ b/tests/test_a_new_chat_starts_at_the_profile_selector.py
@@ -1628,6 +1628,110 @@ class WhereItAppears(_APlaneWithProfiles, unittest.TestCase):
         self.assertTrue(state.is_waiting("beta.2"))
         self.assertEqual(state.identity("beta.2").get("CHARTER_HARNESS"), "")
 
+    def _in_the_operators_tmux(self, *states, select: bool = True) -> tuple[int, str]:
+        """`_launch_in_operator_tmux` to its end, with the pane answering *states* in turn.
+
+        `_pane_state` is what both of that path's reads of the pane go through — the eager
+        one after the start and `_wait_for_harness`'s loop — so answering it, rather than
+        `_wait_for_harness`, is what lets the case see what the path does with a pane that
+        VANISHED: which is how a cancelled selector ends there, because its launcher closes
+        its own window (`launcher._close_the_cancelled_chat`) and nothing sets
+        `remain-on-exit` on a window that is gone.
+        """
+        def answer(cmd, **kw):
+            if not cmd or cmd[0] != "tmux":
+                return _completed(cmd, 0)
+            # `new-window -P` answers the window AND the pane, and a path that could not
+            # read both would stop long before the pane is asked anything.
+            return _completed(cmd, 0, "@1 %7\n" if "new-window" in cmd else "%7\n")
+
+        queue = list(states)
+        said: list[str] = []
+        with mock.patch("charter.commands_frame.subprocess.run", side_effect=answer), \
+                mock.patch.object(commands_frame, "_pane_state",
+                                  side_effect=lambda *a: queue.pop(0) if len(queue) > 1
+                                  else queue[0]), \
+                mock.patch.object(commands_frame.util, "err", side_effect=said.append), \
+                mock.patch.object(commands_frame.util, "warn", side_effect=said.append):
+            rc = commands_frame._launch_in_operator_tmux(
+                "op", "$1", ws="beta",
+                argv=(launcher.argv_select("claude") if select
+                      else launcher.argv("claude", [], attended=True)),
+                display=([commands_frame.SELECTOR_DISPLAY] if select else ["claude"]),
+                profile="" if select else "claude", h=None, v=(3, 7), picked=False,
+                selecting=select)
+        return rc, " ".join(said)
+
+    def test_esc_at_the_selector_in_the_operators_tmux_is_a_cancel_not_a_dead_harness(self):
+        """S2 on the other server, and the plan expects 130 on BOTH. The pane was alive when
+        the frame was drawn and is simply gone afterwards — Esc closed its own window — and
+        the waiting marker is what says no harness ever ran there: nothing is printed about
+        a harness's exit code nobody can know, and the launch ends on the cancel's own
+        number. Found by the coordinator in an exported tree, where it said "the frame's
+        window is gone" and exited 1."""
+        rc, said = self._in_the_operators_tmux((commands_frame._ALIVE, None),
+                                               (commands_frame._GONE, None))
+        self.assertEqual(rc, selector.CANCELLED_EXIT)
+        self.assertEqual(said, "")
+
+    def test_a_selector_gone_before_the_frame_was_drawn_is_a_cancel_too(self):
+        """The eager read's branch: the pane vanished before anything was drawn around it.
+        Still a pane no harness ran in, so still the cancel's number and nothing said."""
+        rc, said = self._in_the_operators_tmux((commands_frame._GONE, None))
+        self.assertEqual(rc, selector.CANCELLED_EXIT)
+        self.assertEqual(said, "")
+
+    def test_a_selector_pane_tmux_kept_dead_is_closed_and_still_ends_on_the_cancel(self):
+        """The launcher could not close its window, so `remain-on-exit` kept the dead pane —
+        here with the EMPTY status a pane leaving raw mode on Linux reads as, which tmux
+        reports as `_UNKNOWN_DEATH_CODE`. Still a cancel: nothing said, the cancel's own
+        number rather than tmux's, and the window charter opened taken back rather than
+        left in the operator's session."""
+        closed: list = []
+        real = commands_frame.tmuxctl.run
+
+        def run(what, argv, **kw):
+            if "kill-window" in argv:
+                closed.append(argv)
+            return real(what, argv, **kw)
+
+        with mock.patch.object(commands_frame.tmuxctl, "run", side_effect=run):
+            rc, said = self._in_the_operators_tmux((commands_frame._ALIVE, None),
+                                                   (commands_frame._DEAD,
+                                                    commands_frame._UNKNOWN_DEATH_CODE))
+        self.assertEqual((rc, said), (selector.CANCELLED_EXIT, ""))
+        self.assertEqual(len(closed), 1, closed)
+        self.assertEqual(state.exit_code("beta.2"), selector.CANCELLED_EXIT)
+
+    def test_a_harness_whose_window_vanished_in_the_operators_tmux_still_says_so(self):
+        """The control: a pane that picked — or never waited — is a harness, and a harness
+        whose window is gone has an exit code charter cannot know, which it says."""
+        with mock.patch.object(commands_frame, "_await_the_launcher",
+                               return_value=(None, "")):
+            rc, said = self._in_the_operators_tmux((commands_frame._ALIVE, None),
+                                                   (commands_frame._GONE, None),
+                                                   select=False)
+        self.assertEqual(rc, commands_frame._UNKNOWN_DEATH_CODE)
+        self.assertIn("the frame's window is gone", said)
+
+    def test_the_waiting_marker_is_read_before_the_claim_that_protects_it_is_released(self):
+        """`state.reap` spares a chat directory only while its launch still holds the claim
+        (#685), and a cancelled selector's window is gone — so the instant `clear_claim`
+        runs, ANOTHER launch's reap may take the directory and the marker with it. Read
+        after that, the marker says "a harness ran here" and the cancel is reported as a
+        plane to reopen. Stood in as exactly that reap, at exactly that instant."""
+        real = state.clear_claim
+
+        def released_and_reaped(fid):
+            real(fid)
+            state.clear_waiting(fid)
+
+        with mock.patch.object(commands_frame.state, "clear_claim",
+                               side_effect=released_and_reaped):
+            said = self._closing_pane(waiting=True, code=selector.CANCELLED_EXIT,
+                                      recorded=True)
+        self.assertNotIn("reopen", said)
+
     def test_a_reopen_never_opens_the_selector(self):
         """An open nobody is at names its profile: there is no one there to pick."""
         args = commands_frame._reopen_args(

--- a/tests/test_a_new_chat_starts_at_the_profile_selector.py
+++ b/tests/test_a_new_chat_starts_at_the_profile_selector.py
@@ -1745,7 +1745,7 @@ class TheSelectorOnARealServer(PersonaIso, unittest.TestCase):
         every claim here — the window went with it.
         """
         out = self._tmux("display-message", "-p", "-t", pane,
-                         "#{pane_dead}:#{pane_dead_status}")
+                         "#{pane_dead}:#{pane_dead_status}:#{pane_dead_signal}")
         return out.stdout.strip() if out.returncode == 0 else f"(gone: {out.stderr.strip()})"
 
     def _dead(self, pane: str) -> bool:
@@ -1754,7 +1754,9 @@ class TheSelectorOnARealServer(PersonaIso, unittest.TestCase):
         Measured on the CI runner, 2026-09-12: a pane that exits out of raw mode on Linux
         comes back dead with an EMPTY status where the same pane on macOS carries the
         number (`commands_frame._UNKNOWN_DEATH_CODE`, and ruling 42). So the question is
-        whether the process ended, never what it ended with.
+        whether the process ended, never what it ended with — and `#{pane_dead_signal}` is
+        read into the message beside it, because an empty status is tmux's own spelling for
+        *killed by a signal* and the signal is the thing a reader would want next.
         """
         return self._status(pane).startswith(("1:", "(gone"))
 
@@ -1787,9 +1789,16 @@ class TheSelectorOnARealServer(PersonaIso, unittest.TestCase):
         # `out == [0]` because a launch that will never attach returns as soon as the
         # window exists (`_wants_attach`) — long before anybody presses anything.
         self.assertEqual(out, [0])
+        # **A minute, and the number is measured rather than chosen.** What is left here is
+        # tmux's own work: charter's `pane-died[1] kill-window` is installed before the pane
+        # can die (the message below reads it back), and the window going is that hook
+        # firing. On CI the same commit was green on one Python and red at 30 s on another,
+        # with the hooks present, `remain-on-exit on` and the pane dead — a runner busy with
+        # six sweep shards, not a rule about the platform. Doubling the margin is the honest
+        # fix for a claim about somebody else's queue.
         self.assertTrue(
             _eventually(lambda: self.WS not in self._tmux("list-sessions").stdout,
-                        timeout=30.0),
+                        timeout=60.0),
             f"the cancelled chat's session outlived its only window: "
             f"windows {self._tmux('list-windows', '-a', '-F', '#{session_name}:#{window_id}').stdout!r}, "
             f"pane {self._status(pane)!r}, "

--- a/tests/test_a_new_chat_starts_at_the_profile_selector.py
+++ b/tests/test_a_new_chat_starts_at_the_profile_selector.py
@@ -46,12 +46,12 @@ from types import SimpleNamespace
 from unittest import mock
 
 import re
-import threading
 
 from charter import (commands_frame, config, contain, doctor, profiles, profiletrust, tui,
                      util, wiring)
 from charter.frame import (chats, launcher, leave, overlay, palette, selector, state,
                            tmuxctl)
+from charter.frame import reopen as reopen_state
 from tests import _gitguard, _tmuxreap, _tmuxsocket, _ttyguard
 from tests._isolation import (APipe, ATerminal, PersonaIso, Typed, approve_every_profile,
                               approve_profile, declare_profiles, make_plane,
@@ -1353,6 +1353,12 @@ class _AServerWithOneWorkspaceRunning:
             self.sessions.append("beta")
             self.chats.append("beta.1")
             return _completed(cmd, 0, "%9\n")
+        if "kill-window" in cmd and self.dead is not None:
+            # A dead pane's window is closed by the launch, and a server that went on
+            # listing it would tell the launch the chat is still running — which is what
+            # keeps its directory from the closing reap, and reality does not.
+            self.chats = [c for c in self.chats if c != "beta.1"]
+            return _completed(cmd, 0)
         if "display-message" in cmd:
             if "pane_dead" in cmd[-1] and self.dead is not None:
                 return _completed(cmd, 0, self.dead)
@@ -1394,6 +1400,10 @@ class WhereItAppears(_APlaneWithProfiles, unittest.TestCase):
         self.enterContext(mock.patch.object(
             commands_frame, "_focus_workspace",
             side_effect=lambda *a, **kw: self.focused.append((a, kw)) or 0))
+        # The controls here name a profile, and a launch that names one probes its wiring
+        # before tmux (ruling 10): stated, as Task 4's modules state it, because no case in
+        # this class is about wiring and each would otherwise be refused "could not tell".
+        wired_as_today(self)
 
     def _launch(self, fake, **ns) -> int:
         args = SimpleNamespace(**{"harness": "", "rest": [], "no_frame": False,
@@ -1523,26 +1533,45 @@ class WhereItAppears(_APlaneWithProfiles, unittest.TestCase):
         self.assertNotIn("\x1b", said[0])
         self.assertIn("\\u000d", said[0])
 
-    def _closing_pane(self, *, waiting: bool, code: int):
+    def _closing_pane(self, *, waiting: bool, code: int, recorded: bool = False,
+                      picked: bool = False, **ns) -> str:
         """A launch whose pane is already dead with *code*, said the way tmux says it.
 
         The two sentences this is about are written after the pane has gone: charter asks
         `#{pane_dead_status}` eagerly, kills the window and then reports. So the fixture
         answers that question and lets `_launch` run to its end.
+
+        *recorded* puts the new chat in the plane's record first, which is the premise of
+        the recorded-plane sentence at all: without it that sentence says nothing whatever
+        else is true, and a case about it would pass for the wrong reason. *picked* clears
+        the waiting marker as the window opens — a selector whose pane picked a profile and
+        whose harness then died before the frame was drawn.
         """
+        if recorded:
+            reopen_state.write([reopen_state.Frame(workspace="beta", chats=(
+                reopen_state.Chat(chat=self.NEW, workspace="beta", persona="",
+                                  harness="claude-code", cwd="", resume="conv-1",
+                                  transcript="", active=True),))], focus="beta")
         said: list[str] = []
         fake = _AServerWithOneWorkspaceRunning(sessions=[], chats=[], dead=f"1:{code}")
+        if picked:
+            fake.at_new_window = lambda: state.clear_waiting(self.NEW)
         with mock.patch.object(commands_frame.util, "err", side_effect=said.append), \
                 mock.patch.object(commands_frame.util, "info", side_effect=said.append):
-            self._launch(fake, harness="" if waiting else "claude",
-                         select=waiting, profile=None if waiting else "claude")
+            # `fresh`: a plane with a record and nothing running RESTORES that record on
+            # an open (#845), and these cases are about the tail of an open, not a restore.
+            self._launch(fake, harness="" if waiting else "claude", fresh=recorded,
+                         select=waiting, profile=None if waiting else "claude", **ns)
         return " ".join(said)
 
     def test_a_cancelled_selector_says_nothing_about_a_death_or_a_recorded_plane(self):
         """The pane started nothing, so neither sentence can be true of it: one names a
         command that died and the other offers `charter reopen` for a chat the record does
-        not hold (`leave.plan` passes over a waiting pane)."""
-        said = self._closing_pane(waiting=True, code=selector.CANCELLED_EXIT)
+        not hold (`leave.plan` passes over a waiting pane).
+
+        *recorded*, so the second half is a measurement: the record DOES name this chat
+        here, and only the waiting marker keeps the sentence back."""
+        said = self._closing_pane(waiting=True, code=selector.CANCELLED_EXIT, recorded=True)
         self.assertNotIn("before the frame was drawn", said)
         self.assertNotIn(commands_frame.SELECTOR_DISPLAY, said)
         self.assertNotIn("reopen", said)
@@ -1552,10 +1581,30 @@ class WhereItAppears(_APlaneWithProfiles, unittest.TestCase):
         exit code: a harness that exits 130 because somebody pressed Ctrl-C at its own
         prompt cleared the marker when it was picked, so it reads as the death it is —
         the SAME number the case above suppresses, which is what makes this a control
-        rather than a second case about a different input."""
-        said = self._closing_pane(waiting=False, code=selector.CANCELLED_EXIT)
+        rather than a second case about a different input. And the record naming it is
+        said, which is what shows the case above was held back by the marker alone."""
+        said = self._closing_pane(waiting=False, code=selector.CANCELLED_EXIT, recorded=True)
         self.assertIn("before the frame was drawn", said)
         self.assertIn("claude", said)
+        self.assertIn("charter reopen", said)
+
+    def test_a_launch_that_is_nobodys_terminal_never_says_the_plane_is_recorded(self):
+        """`_wants_attach`, the other half of that gate: a launch that never became the
+        operator's terminal — a detached tab open, a reopen building chats — hands nobody a
+        shell to read the sentence on, and a reopen would be naming `charter reopen` while
+        `charter reopen` was putting the chat back."""
+        said = self._closing_pane(waiting=False, code=7, recorded=True, attach=False)
+        self.assertNotIn("reopen", said)
+
+    def test_a_selector_whose_pick_died_before_the_frame_names_the_selector(self):
+        """What an early death names for a pane that opened at the selector: the selector,
+        in words — never `python -P -m charter frame-launch --select`, an answer to a
+        question nobody asked, and never a profile, because which one was picked is known
+        only inside that pane."""
+        said = self._closing_pane(waiting=True, code=7, picked=True)
+        self.assertIn("before the frame was drawn", said)
+        self.assertIn("the profile selector", said)
+        self.assertNotIn("frame-launch", said)
 
     def test_the_operators_own_tmux_records_the_same_two_things(self):
         """The other launch path, and it needs its own case because it writes its own
@@ -1677,6 +1726,14 @@ class TheSelectorOnARealServer(PersonaIso, unittest.TestCase):
         (bindir / "claude").write_text(
             f"#!{sys.executable}\n"
             "import json, os, sys, time\n"
+            # **The wiring probe is answered first** (ruling 10), as Task 4's real-tmux
+            # recorders answer it: the selector's rows and the launch both ask this binary
+            # `plugin list --json`, and a recorder that recorded THAT call would take a probe
+            # for a harness starting. `user` scope covers every directory.
+            "if sys.argv[1:3] == ['plugin', 'list']:\n"
+            "    json.dump([{'id': 'charter@charter', 'scope': 'user', 'enabled': True,\n"
+            "                'installedAt': '2026-09-12T00:00:00Z'}], sys.stdout)\n"
+            "    sys.exit(0)\n"
             "out = os.path.join(os.environ['RECORD_DIR'], 'harness.json')\n"
             "with open(out + '.tmp', 'w') as f:\n"
             "    json.dump({'argv': sys.argv[1:], 'pid': os.getpid()}, f)\n"

--- a/tests/test_a_new_chat_starts_at_the_profile_selector.py
+++ b/tests/test_a_new_chat_starts_at_the_profile_selector.py
@@ -1791,7 +1791,11 @@ class TheSelectorOnARealServer(PersonaIso, unittest.TestCase):
             _eventually(lambda: self.WS not in self._tmux("list-sessions").stdout,
                         timeout=30.0),
             f"the cancelled chat's session outlived its only window: "
-            f"{self._tmux('list-windows', '-a', '-F', '#{session_name}:#{window_id}').stdout!r}")
+            f"windows {self._tmux('list-windows', '-a', '-F', '#{session_name}:#{window_id}').stdout!r}, "
+            f"pane {self._status(pane)!r}, "
+            f"remain-on-exit "
+            f"{self._tmux('show-options', '-g', 'remain-on-exit').stdout.strip()!r}, "
+            f"hooks {self._tmux('show-hooks', '-p', '-t', pane).stdout.strip()!r}")
         self.assertFalse((self.records / "harness.json").exists(),
                          "a cancelled selector started a harness")
         self.assertTrue(state.is_waiting("beta.1"),

--- a/tests/test_a_new_chat_starts_at_the_profile_selector.py
+++ b/tests/test_a_new_chat_starts_at_the_profile_selector.py
@@ -1315,7 +1315,11 @@ class _AServerWithOneWorkspaceRunning:
     asked and what charter did with the answer, not what a real server would do next.
     """
 
-    def __init__(self, *, clients=(), sessions=("beta",), chats=("beta.1",)):
+    def __init__(self, *, clients=(), sessions=("beta",), chats=("beta.1",), dead=None):
+        #: What `#{pane_dead}:#{pane_dead_status}` answers, or ``None`` for a pane that is
+        #: still running. The one tmux question whose answer decides what a launch SAYS
+        #: on its way out, which is why it is a knob rather than a constant.
+        self.dead = dead
         self.clients = list(clients)
         self.sessions = list(sessions)
         self.chats = list(chats)
@@ -1350,6 +1354,8 @@ class _AServerWithOneWorkspaceRunning:
             self.chats.append("beta.1")
             return _completed(cmd, 0, "%9\n")
         if "display-message" in cmd:
+            if "pane_dead" in cmd[-1] and self.dead is not None:
+                return _completed(cmd, 0, self.dead)
             return _completed(cmd, 0, "132:43")
         return _completed(cmd, 0)
 
@@ -1516,6 +1522,40 @@ class WhereItAppears(_APlaneWithProfiles, unittest.TestCase):
         self.assertNotIn("\r", said[0])
         self.assertNotIn("\x1b", said[0])
         self.assertIn("\\u000d", said[0])
+
+    def _closing_pane(self, *, waiting: bool, code: int):
+        """A launch whose pane is already dead with *code*, said the way tmux says it.
+
+        The two sentences this is about are written after the pane has gone: charter asks
+        `#{pane_dead_status}` eagerly, kills the window and then reports. So the fixture
+        answers that question and lets `_launch` run to its end.
+        """
+        said: list[str] = []
+        fake = _AServerWithOneWorkspaceRunning(sessions=[], chats=[], dead=f"1:{code}")
+        with mock.patch.object(commands_frame.util, "err", side_effect=said.append), \
+                mock.patch.object(commands_frame.util, "info", side_effect=said.append):
+            self._launch(fake, harness="" if waiting else "claude",
+                         select=waiting, profile=None if waiting else "claude")
+        return " ".join(said)
+
+    def test_a_cancelled_selector_says_nothing_about_a_death_or_a_recorded_plane(self):
+        """The pane started nothing, so neither sentence can be true of it: one names a
+        command that died and the other offers `charter reopen` for a chat the record does
+        not hold (`leave.plan` passes over a waiting pane)."""
+        said = self._closing_pane(waiting=True, code=selector.CANCELLED_EXIT)
+        self.assertNotIn("before the frame was drawn", said)
+        self.assertNotIn(commands_frame.SELECTOR_DISPLAY, said)
+        self.assertNotIn("reopen", said)
+
+    def test_a_pane_that_picked_and_then_died_still_says_so(self):
+        """The control, and the reason the suppression reads the marker rather than the
+        exit code: a harness that exits 130 because somebody pressed Ctrl-C at its own
+        prompt cleared the marker when it was picked, so it reads as the death it is —
+        the SAME number the case above suppresses, which is what makes this a control
+        rather than a second case about a different input."""
+        said = self._closing_pane(waiting=False, code=selector.CANCELLED_EXIT)
+        self.assertIn("before the frame was drawn", said)
+        self.assertIn("claude", said)
 
     def test_the_operators_own_tmux_records_the_same_two_things(self):
         """The other launch path, and it needs its own case because it writes its own
@@ -1706,17 +1746,18 @@ class TheSelectorOnARealServer(PersonaIso, unittest.TestCase):
         self._tmux("send-keys", "-t", pane, "Escape")
         t.join(timeout=40)
         self.assertFalse(t.is_alive(), "the launch never returned")
-        # **The number is read off the chat's own record, not off this launch**, and that
-        # is a fact about the fixture rather than a weaker claim. A launch that will never
-        # attach returns as soon as the window exists (`_wants_attach`), so it is long gone
-        # by the time anybody presses anything; what waits for the pane is the `pane-died`
-        # hook, which writes the code the pane exited with. Reading it here is reading what
-        # the frame itself recorded.
+        # **The exit NUMBER is deliberately not asserted, and that is measured rather than
+        # conceded.** A pane that exits out of raw mode on the Linux runner comes back with
+        # an empty `#{pane_dead_status}` — `commands_frame._UNKNOWN_DEATH_CODE`'s own
+        # measurement, and ruling 42's — so 130 reaches the chat's `exit` record here and
+        # not there. What S2 is about survives that on both: the window went, the session
+        # went with it, nothing was started, and the pane is still a waiting one. It is
+        # also why `_launch` suppresses its early-death sentence on the MARKER rather than
+        # on the code (`nothing_ever_ran_here`).
+        #
+        # `out == [0]` because a launch that will never attach returns as soon as the
+        # window exists (`_wants_attach`) — long before anybody presses anything.
         self.assertEqual(out, [0])
-        self.assertTrue(
-            _eventually(lambda: state.exit_code("beta.1") == selector.CANCELLED_EXIT),
-            f"the cancelled pane recorded {state.exit_code('beta.1')!r}, not "
-            f"{selector.CANCELLED_EXIT}")
         self.assertTrue(
             _eventually(lambda: self.WS not in self._tmux("list-sessions").stdout),
             "the cancelled chat's session outlived its only window")

--- a/tests/test_a_real_click_on_a_real_tab_bar_switches.py
+++ b/tests/test_a_real_click_on_a_real_tab_bar_switches.py
@@ -69,21 +69,27 @@ _SGR = re.compile(r"\x1b\[([0-9;]*)m")
 def _NOT_OPEN(ws: str) -> str:
     """What a click on a not-open workspace's tab puts on this fixture's attention row.
 
-    **This used to be a flat refusal and is now as far as an OPEN gets here.** A tab for a
-    workspace with no session opens it (`commands_frame._open_workspace`); what stops it in
-    *this* module is the next question along — which harness to open it with. The chats
-    these cases build record no `$CHARTER_HARNESS` and the isolated plane declares no
-    `[harness] default`, so the open refuses by name rather than starting something nobody
-    chose. That is deliberate and load-bearing for a test suite: **no case in this file may
-    ever start a real harness process**, and the assertion below is what would notice if
-    one became reachable.
+    **This is as far as an OPEN gets here, and the fixture arranges which stop it hits.**
+    A tab for a workspace with no session of this plane's opens it
+    (`commands_frame._open_workspace`), and letting that run to the end would build a whole
+    frame — a chat window, its panels, and a charter process in each — for every case in
+    this file. So :meth:`_ARealFrameWithBars._block_the_open` starts an UNMARKED session of
+    that workspace's name on this fixture's own server, and #793's cross-plane guard stops
+    the open there: charter cannot prove a session of that name is this plane's, so it
+    refuses rather than adding a window to what is probably another project's frame.
+
+    **It used to be the harness question that stopped it**, and that stop is gone: a chat
+    recording no profile now opens at the profile selector like any other. The promise the
+    old one carried is kept by the selector itself rather than by an accident of the
+    fixture — **no case in this file starts a harness process**, because the selector is
+    what a chat's pane runs until somebody picks one.
 
     Spelled here rather than imported, deliberately: it is the operator-visible sentence
     and this module's whole subject is that a click PRODUCES one. A constant read out of
     the module under test would follow a reworded sentence silently, and the wording is
     the thing. It carries the name, so a click that landed on the wrong tab fails here.
     """
-    return f"cannot open '{ws}': this chat records no profile"
+    return f"cannot open '{ws}': a session of that name is already running"
 
 _REPO_ROOT = Path(__file__).resolve().parents[1]
 
@@ -207,6 +213,15 @@ class _ARealFrameWithBars(PersonaIso):
                         env=self.env)
         self.assertEqual(started.returncode, 0, started.stderr)
         return started.stdout.strip()
+
+    def _block_the_open(self, ws: str) -> None:
+        """Stop a click on *ws*'s tab short of building a whole frame — see :func:`_NOT_OPEN`.
+
+        An unmarked session of that name on this fixture's own server: `_plane_session`
+        cannot prove it is this plane's, so the tab still reads as "not open" and the open
+        still runs, and #793's guard is what it lands on.
+        """
+        self.assertEqual(self._start_session(ws)[:1], "%")
 
     def _source_conf(self, fid: str) -> None:
         """charter's OWN frame config, `mouse = true`, and its own menu-button bind.
@@ -434,6 +449,7 @@ class ARealClickOnTheWorkspaceBarReachesTheSwitch(_ARealFrameWithBars,
         state.record_harness_pane(self.fid, self.harness)
         self._source_conf(self.fid)
         self.bar = self._split_bar(self.harness, "workspaces", self.fid)
+        self._block_the_open(self.THERE)
         # **The harness is put back in front, and that is the regime, not tidiness.**
         # `split-window` selects the pane it made, and a frame whose bar was the ACTIVE
         # pane would be reporting the mouse because THAT pane asked — the `mouse = false`
@@ -910,6 +926,7 @@ class ARealClickOnAWINDOWEDWorkspaceBarReachesTheSwitch(_ARealFrameWithBars,
         state.record_harness_pane(self.fid, self.harness)
         self._source_conf(self.fid)
         self.bar = self._split_bar(self.harness, "workspaces", self.fid)
+        self._block_the_open(self.THERE)
         self.assertEqual(self._tmux("select-pane", "-t", self.harness).returncode, 0)
         self.fd = self._attach(self.fid)
         self.assertTrue(
@@ -1049,40 +1066,32 @@ class ARealPressOnThePlusReachesTheCommandBehindIt(_ARealFrameWithBars,
     painted by a `charter panel chats` child, the report is decoded there, and
     `charter frame-new-chat` is started detached by that child.
 
-    **What this can and cannot say, stated rather than left to be discovered.**
-    `commands_frame.SOCKET` is a module constant — `"charter"`, the one shared server every
-    frame on this machine runs on — and `cmd_launch` uses it rather than the server the
-    frame recorded. So a case that let the launch RUN would build a session on the
-    operator's own live charter server, from a suite. That is the one thing no test in this
-    repository may do, so no test here does it: the launcher itself is asserted against a
-    stand-in by `tests/test_the_chat_bars_plus_makes_a_chat.py`, and what is real here is
-    everything up to it.
-
-    Everything is a great deal: the affordance is at the column the paint put it in, tmux
-    routes the report to a pane that is not active, the panel decodes it and tells a `+`
-    from a tab, the child resolves which frame it belongs to out of its own environment,
-    it establishes that this is charter's own server, it proves the workspace's session is
+    Every link is real: the affordance is at the column the paint put it in, tmux routes
+    the report to a pane that is not active, the panel decodes it and tells a `+` from a
+    tab, the child resolves which frame it belongs to out of its own environment, it
+    establishes that this is charter's own server, it proves the workspace's session is
     this plane's (`_plane_session` — a real `list-panes` against a real server), and it
-    reports on the frame's own attention row, which is the only surface a detached process
-    with `/dev/null` for stdout has. Every one of those is a link that was not there
-    before this change.
+    builds the chat.
 
-    **The stop this fixture reaches is the harness one, and it is reached honestly rather
-    than arranged.** The plane declares no `[harness] default` and the chats this fixture
-    plants record none, which is the migration state of every chat launched by a charter
-    that predates `state.record_identity`. So the last link — "which harness does the new
-    chat run" — has no answer, and the command says so instead of guessing. A case that
-    passed this by faking a harness would have to let the launch happen.
+    **It builds it HERE, and that is measured rather than assumed.** `commands_frame.SOCKET`
+    is a module constant — `"charter"`, the one shared server every frame on this machine
+    runs on — so a launch that took the private-server path would build a session on the
+    operator's own live charter server, from a suite, which is the one thing no test in this
+    repository may do. It does not: the detached child is started from a pane on THIS
+    fixture's server, so its `$TMUX` names this socket, `tmuxctl.is_operator_socket` answers
+    yes, and `_launch_in_operator_tmux` adds a window to the session the press came from.
+    Measured 2026-09-12 while the profile selector was wired to the `+`: the new window and
+    the new chat directory appear here, and `tmux -L charter list-sessions` is byte-identical
+    before and after.
+
+    **Until the selector, this fixture stopped one link earlier and could not say any of
+    that.** The plane declares no `[harness] default` and the chats it plants record none,
+    so "which harness does the new chat run" had no answer and the press refused by name —
+    which is exactly the stop the selector took away: a chat that records no profile opens
+    at the selector like any other.
     """
 
     WS = "alpha"
-
-    #: A word out of :data:`commands_frame.cmd_new_chat`'s harness refusal, spelled by hand
-    #: rather than imported: a constant read out of the module under test follows a
-    #: reworded sentence into a green run, which is the survivor this repository's sweep
-    #: reports. Short enough to survive a rewording that keeps the meaning, specific enough
-    #: that no other refusal on this path says it.
-    _NO_HARNESS = "records no profile this charter can launch"
 
     def setUp(self) -> None:
         super().setUp()
@@ -1137,40 +1146,44 @@ class ARealPressOnThePlusReachesTheCommandBehindIt(_ARealFrameWithBars,
         last cell of the row."""
         return self._tail_at() + len(self.TAIL) - 1
 
+    def _windows(self) -> list[str]:
+        return self._tmux("list-windows", "-t", self.WS,
+                          "-F", "#{window_id}").stdout.split()
+
     def test_a_press_on_the_plus_reaches_the_command_behind_it(self):
-        """The whole chain, end to end, with the answer coming back on the frame's own
-        row — which is where every outcome of a detached charter has to land."""
+        """The whole chain, end to end: the press really makes a chat, in this workspace,
+        on this server."""
+        before = self._windows()
         self._click(self.bar, col=self._plus())
         self.assertTrue(
-            _await(lambda: self._NO_HARNESS in state.notice(self.here)),
-            f"the press never reached the command: {state.notice(self.here)!r} — "
-            f"row {self._bar_row(self.bar)!r}")
+            _await(lambda: len(self._windows()) > len(before)),
+            f"the press never reached the command: windows {self._windows()}, "
+            f"chats {chats.of_workspace(self.WS)}, notice "
+            f"{state.notice(self.here)!r} — row {self._bar_row(self.bar)!r}")
+        self.assertEqual(chats.of_workspace(self.WS), [self.here, f"{self.WS}.2"])
 
-    def test_the_press_leaves_the_keyboard_on_the_harness(self):
+    def test_the_press_leaves_the_keyboard_on_a_harness_pane(self):
         """`docs/frame.md`'s promise, kept for the third gesture as well as the first two:
-        a click on a PANEL acts where it points and does not move the keyboard. Nothing
-        about making a chat changes that — the new chat's own window is what a successful
-        press would select, and that is tmux moving a client, not a pointer moving focus.
+        a click on a PANEL acts where it points and does not move the keyboard onto the
+        panel it was aimed at. The client does move — to the new chat's own window, which
+        is `select-window` and not a pointer moving focus — so what is asserted is the
+        panel it was clicked in, which is where a pointer-driven focus would have left it.
         """
         self._click(self.bar, col=self._plus())
-        self.assertTrue(_await(lambda: self._NO_HARNESS in state.notice(self.here)),
+        self.assertTrue(_await(lambda: len(chats.of_workspace(self.WS)) > 1),
                         "the press never arrived, so this proves nothing about focus")
-        self.assertEqual(self._active(), self.harness,
-                         "a press on the `+` took the keyboard off the harness")
+        self.assertNotEqual(self._active(), self.bar,
+                            "a press on the `+` took the keyboard onto the bar")
 
-    def test_a_press_that_could_not_finish_created_nothing(self):
-        """The negative that makes the refusal worth having: it stopped, and it stopped
-        BEFORE anything existed. One window on the server and one chat on the plane, after
-        a press that reached the command and declined."""
-        before = self._tmux("list-windows", "-t", self.WS, "-F", "#{window_id}").stdout
+    def test_the_press_makes_exactly_one_chat(self):
+        """One press, one chat — the property a press repeated by a stray release, or a
+        report decoded twice, would break. Waiting first, then reading again after a beat,
+        is what makes it a count rather than a race."""
         self._click(self.bar, col=self._plus())
-        self.assertTrue(_await(lambda: self._NO_HARNESS in state.notice(self.here)))
+        self.assertTrue(_await(lambda: len(chats.of_workspace(self.WS)) > 1))
         time.sleep(1.5)
-        self.assertEqual(
-            self._tmux("list-windows", "-t", self.WS, "-F", "#{window_id}").stdout,
-            before, "a refused press still added a window")
-        self.assertEqual(chats.of_workspace(self.WS), [self.here],
-                         "a refused press still made a chat directory")
+        self.assertEqual(chats.of_workspace(self.WS), [self.here, f"{self.WS}.2"])
+        self.assertEqual(len(self._windows()), 2, self._windows())
 
     def test_the_strip_really_draws_both_affordances(self):
         """**What #921 is about, on a real pane.** The strip advertising `+` and nothing

--- a/tests/test_a_workspace_tab_opens_what_it_names.py
+++ b/tests/test_a_workspace_tab_opens_what_it_names.py
@@ -371,23 +371,26 @@ class AnOpenNeverLandsInAnotherPlanesSession(_OpensBeta):
         self.assertEqual(len(self.launched), 1)
 
 
-class TheOpenUsesTheHarnessTheOperatorIsAlreadyIn(_OpensBeta):
-    """Which harness a tab opens with — the one question a click cannot carry.
+class TheOpenStartsOnTheProfileTheOperatorIsAlreadyIn(_OpensBeta):
+    """Which profile a tab opens ON — the one question a click cannot carry, and no longer
+    one it has to answer.
 
     A tab names a workspace and nothing else. The chat it was clicked FROM recorded its own
-    harness, and using that makes the click mean "another workspace, same tool" — the only
-    answer available that the operator actually expressed.
+    profile, and that is now the row the SELECTOR opens on: "another workspace, same tool"
+    is the only answer available that the operator actually expressed, and it is a
+    preference rather than a requirement, because the new chat asks.
     """
 
-    def test_it_is_the_harness_this_chat_records(self):
+    def test_it_starts_on_the_profile_this_chat_records(self):
         _a_chat(self.FID, ws="alpha", pane="%1", harness="codex")
         self._run()
-        self.assertEqual(self.launched[0].harness, "codex")
+        self.assertTrue(self.launched[0].select)
+        self.assertEqual(self.launched[0].start, "codex")
 
-    def test_a_chat_with_no_recorded_harness_falls_back_to_the_planes_default(self):
+    def test_a_chat_with_no_recorded_harness_starts_on_the_planes_default(self):
         """A chat launched by a charter that predates `state.record_identity`. The plane's
-        `[harness] default` is a thing somebody chose, so it is a better answer than
-        refusing.
+        `[harness] default` is a thing somebody chose, so it is a better row to open on
+        than none.
 
         Declared in the FILE, not patched onto `config.HARNESS`: the effective default is
         `profiles.current()`'s since ruling 43 — `charter.local.toml`'s where it names one
@@ -395,8 +398,8 @@ class TheOpenUsesTheHarnessTheOperatorIsAlreadyIn(_OpensBeta):
         _a_chat(self.FID, ws="alpha", pane="%1", harness="")
         (config.ROOT / "charter.local.toml").write_text('[harness]\ndefault = "codex"\n')
         self._run()
-        self.assertEqual(self.launched[0].harness, "codex")
-        self.assertEqual(self.launched[0].profile, "codex")
+        self.assertTrue(self.launched[0].select)
+        self.assertEqual(self.launched[0].start, "codex")
 
     def test_the_launch_runs_in_the_workspaces_own_directory(self):
         """Where `charter --workspace beta` typed in it would have run, and what
@@ -514,18 +517,24 @@ class TheOpenUsesTheHarnessTheOperatorIsAlreadyIn(_OpensBeta):
 
         That read is gone — the default is `profiles.current()`'s now (ruling 43) — so this
         case holds the stronger promise in its place: the click reads that setting nowhere,
-        so whatever it holds, a chat with nothing recorded is refused by name."""
+        so whatever it holds, the tab opens and says nothing about it."""
         _a_chat(self.FID, ws="alpha", pane="%1", harness="")
         with mock.patch.object(config, "HARNESS", None):
             self._run()
-        self.assertEqual(self.launched, [])
-        self.assertIn("no profile", self.said.call_args[0][1])
+        self.assertTrue(self.launched[0].select)
+        self.assertNotIn("cannot open", str(self.said.call_args_list))
 
-    def test_with_neither_it_refuses_by_name_rather_than_guessing(self):
+    def test_with_neither_it_opens_the_selector_on_no_row_rather_than_refusing(self):
+        """**The stop that is gone.** A chat recording no profile, on a plane declaring no
+        default, used to refuse the tab by name — a click that did nothing. The selector
+        answers that case: it lists what this machine has, and `palette.aim` puts the cursor
+        on the first row that can run (ruling 18), so Enter always does something."""
         _a_chat(self.FID, ws="alpha", pane="%1", harness="")
         self._run()
-        self.assertEqual(self.launched, [])
-        self.assertIn("no profile", self.said.call_args[0][1])
+        self.assertEqual(len(self.launched), 1)
+        self.assertTrue(self.launched[0].select)
+        self.assertEqual(self.launched[0].start, "")
+        self.assertNotIn("cannot open", str(self.said.call_args_list))
 
 
 class TheLauncherCanBuildAFrameWithNoTerminalOfItsOwn(PersonaIso, unittest.TestCase):

--- a/tests/test_bare_charter_opens_the_frame.py
+++ b/tests/test_bare_charter_opens_the_frame.py
@@ -20,6 +20,14 @@ is that hazard as a test.
 The refusal cases assert the REASON, not merely that the value was not honoured: a
 `default` that came back `None` proves nothing on its own, because that is also what a
 plane declaring nothing gets — which is precisely the confusion `refused` exists to end.
+
+**Since the profile selector, bare `charter` starts no harness of its own.** It rewrites to
+`charter frame --select` and the harness starts in that chat's pane once a row is picked,
+so `[harness] default` chooses which ROW the cursor opens on and launches nothing. Two
+refusals went with that: a plane declaring nothing is no longer a usage error on a terminal,
+and a `default` naming a profile this machine lacks no longer stops the launch — it marks no
+row (ruling 18) and `doctor` is the reader that names it. The tty rule is unchanged and
+matters more, not less: a pipe has no terminal for a selector to be drawn in.
 """
 
 from __future__ import annotations
@@ -285,17 +293,22 @@ class _BareLaunchCase(PersonaIso):
         return "\n".join(str(c.args[0]) for c in self.err.call_args_list)
 
 
-class TheBareCommandLaunchesTheDeclaredHarness(_BareLaunchCase):
+class TheBareCommandOpensTheSelector(_BareLaunchCase):
+    """**Bare `charter` starts no harness of its own any more.** It opens a chat at the
+    profile selector, and the harness starts in that pane once somebody picks a row — which
+    is the whole feature: opening charter used to start `[harness] default` before anybody
+    had said which harness they wanted."""
 
-    def test_bare_charter_on_a_terminal_reaches_the_launcher(self):
+    def test_bare_charter_on_a_terminal_opens_the_selector(self):
         with self._declare(default="claude"), \
              mock.patch("sys.stdout.isatty", return_value=True):
             rc = cli.main([])
         self.assertEqual(rc, 0)
         self.assertEqual(len(self.launch.calls), 1)
-        self.assertEqual(self.launch.calls[0].harness, "claude")
+        self.assertTrue(self.launch.calls[0].select)
+        self.assertEqual(self.launch.calls[0].harness, "")
 
-    def test_it_is_the_same_call_typing_the_harness_makes(self):
+    def test_it_is_the_same_call_typing_the_frame_makes(self):
         """The design in one assertion: bare `charter` is a REWRITE of argv, not a second
         route into `cmd_launch`. Anything the typed form settles — the workspace picker,
         `--probe`, `--no-frame`, `rest` — is settled identically here, because the same
@@ -303,19 +316,32 @@ class TheBareCommandLaunchesTheDeclaredHarness(_BareLaunchCase):
         with self._declare(default="claude"), \
              mock.patch("sys.stdout.isatty", return_value=True):
             cli.main([])
-            cli.main(["claude"])
+            cli.main(["frame", "--select"])
         bare, typed = self.launch.calls
         self.assertEqual(vars(bare), vars(typed))
 
-    def test_the_declared_harness_is_the_one_launched(self):
-        """Not "whatever is installed" and not "the one last used" — the plane's word."""
+    def test_it_names_no_harness_whatever_the_plane_declares(self):
+        """Not "whatever is installed", not "the one last used", and no longer "the plane's
+        word" either. The plane's `default` decides which ROW the selector opens on
+        (`commands_frame._selector_start`) and nothing else."""
         for name in ("claude", "opencode", "codex"):
             with self.subTest(name=name):
                 self.launch.calls.clear()
                 with self._declare(default=name), \
                      mock.patch("sys.stdout.isatty", return_value=True):
                     cli.main([])
-                self.assertEqual(self.launch.calls[0].harness, name)
+                self.assertTrue(self.launch.calls[0].select)
+                self.assertEqual(self.launch.calls[0].harness, "")
+
+    def test_the_flags_the_operator_typed_ride_along(self):
+        """`--fresh` is a launch flag with no harness name in front of it for it to belong
+        to, so the rewrite puts one there. `_split_frame_argv` reads charter's own flags
+        only in the run immediately after `charter <name>`, which is where they land."""
+        with self._declare(default="claude"), \
+             mock.patch("sys.stdout.isatty", return_value=True):
+            cli.main(["--fresh"])
+        self.assertTrue(self.launch.calls[0].select)
+        self.assertTrue(self.launch.calls[0].fresh)
 
 
 class TheNonTtyPathStartsNothing(_BareLaunchCase):
@@ -357,55 +383,59 @@ class TheNonTtyPathStartsNothing(_BareLaunchCase):
         self.assertEqual(len(self.launch.calls), 1)
 
 
-class APlaneThatDeclaredNothingKeepsTodaysUsage(_BareLaunchCase):
+class APlaneThatDeclaredNothingStillOpensTheSelector(_BareLaunchCase):
+    """**Charter still does not guess — it asks.** A plane with no `[harness] default` used
+    to get argparse's usage error, because charter would not pick a harness for somebody
+    who had not named one. The selector is how that question gets asked instead of
+    answered, so there is nothing left here to refuse."""
 
-    def test_bare_charter_on_a_terminal_still_prints_usage(self):
-        """The other half of the design: charter does not guess. A tty is present and a
-        harness is installed, and charter still refuses to pick one."""
+    def test_bare_charter_on_a_terminal_opens_the_selector_anyway(self):
         with self._declare(), mock.patch("sys.stdout.isatty", return_value=True):
+            rc = cli.main([])
+        self.assertEqual(rc, 0)
+        self.assertTrue(self.launch.calls[0].select)
+        self.exec.assert_not_called()
+
+
+class ARefusedDefaultNoLongerStopsBareCharter(_BareLaunchCase):
+    """A committed `default = "clyde"` used to refuse bare `charter` outright, loudly,
+    because a default that degraded to nothing rendered as argparse's usage message —
+    byte-identical to what a plane declaring nothing gets, so the typo was invisible.
+
+    **The selector makes the value visible instead of the refusal** (ruling 18). The launch
+    opens the list of what this machine actually has, marks no row for a name it does not
+    have, and the cursor goes where `palette.aim` puts it — so Enter always does something.
+    `charter doctor` is where the typo is reported (`DoctorNamesASilentlyIgnoredDefault`
+    below), which is the reader that can say it without taking a launch away.
+    """
+
+    def test_bare_charter_opens_the_selector_and_says_nothing(self):
+        with self._declare(refused="clyde"), \
+             mock.patch("sys.stdout.isatty", return_value=True):
+            rc = cli.main([])
+        self.assertEqual(rc, 0)
+        self.assertTrue(self.launch.calls[0].select)
+        self.assertEqual(self._messages(), "")
+
+    def test_it_marks_no_row(self):
+        """Ruling 18's own half of it, asked where the value is resolved: a `default` naming
+        a profile this machine lacks is no row for the cursor to open on."""
+        with self._declare(refused="clyde"):
+            self.assertIsNone(commands_frame._selector_start(
+                mock.Mock(spec=[])))
+
+    def test_a_default_this_machine_has_is_the_row_it_opens_on(self):
+        with self._declare(default="claude"):
+            self.assertEqual(commands_frame._selector_start(mock.Mock(spec=[])), "claude")
+
+    def test_it_is_not_reported_off_a_terminal_either(self):
+        """The piped path is unchanged and stays a free probe: argparse's usage error, exit
+        2, nothing started and nothing said about the plane's file."""
+        with self._declare(refused="clyde"), \
+             mock.patch("sys.stdout.isatty", return_value=False):
             with self.assertRaises(SystemExit) as caught:
                 cli.main([])
         self.assertEqual(caught.exception.code, 2)
-        self.assertEqual(self.launch.calls, [])
-        self.exec.assert_not_called()
-
-
-class ARefusedDefaultIsReportedNotSwallowed(_BareLaunchCase):
-    """The grill: a committed `default = "clyde"` must fail loudly.
-
-    It degrades to no default, and no default renders as argparse's usage message — which
-    is byte-identical to what a plane declaring nothing gets. So the operator who made the
-    typo would watch charter behave exactly as though their key were not there.
-    """
-
-    def test_the_refusal_is_printed_and_names_the_value(self):
-        with self._declare(refused="clyde"), \
-             mock.patch("sys.stdout.isatty", return_value=True):
-            rc = cli.main([])
-        self.assertEqual(rc, 2)
-        self.assertIn("clyde", self._messages())
-        self.assertEqual(self.launch.calls, [])
-        self.exec.assert_not_called()
-
-    def test_the_refusal_names_the_words_that_would_work(self):
-        """A refusal that does not say what to write instead sends somebody to the docs
-        for a list charter is already holding."""
-        with self._declare(refused="clyde"), \
-             mock.patch("sys.stdout.isatty", return_value=True):
-            cli.main([])
-        said = self._messages()
-        for name in instance.launchable_harnesses():
-            self.assertIn(name, said)
-
-    def test_it_is_reported_off_a_terminal_too(self):
-        """A committed file being wrong is not a fact about anybody's terminal, so the
-        refusal is checked before the tty rule. Still exit 2 and still nothing started,
-        which is what makes it safe to report on the piped path."""
-        with self._declare(refused="clyde"), \
-             mock.patch("sys.stdout.isatty", return_value=False):
-            rc = cli.main([])
-        self.assertEqual(rc, 2)
-        self.assertIn("clyde", self._messages())
         self.exec.assert_not_called()
 
     def test_a_typed_subcommand_is_not_blocked_by_a_broken_default(self):

--- a/tests/test_charter_names_a_profile_on_the_command_line.py
+++ b/tests/test_charter_names_a_profile_on_the_command_line.py
@@ -135,33 +135,45 @@ class TheProfileFlagIsChartersAndTheRestIsTheHarnesses(_APlaneWithProfiles,
         self.assertIn("frame-launch", cli.command_words())
 
 
-class BareCharterRunsTheDefaultProfile(_APlaneWithProfiles, unittest.TestCase):
+class BareCharterOpensTheSelector(_APlaneWithProfiles, unittest.TestCase):
+    """Bare `charter` names no profile any more: it opens a chat at the selector, and
+    `[harness] default` chooses which row the cursor starts on."""
+
     def _bare(self, text: str):
         self.local.write_text(text)
         config.use(config.ROOT)
         with mock.patch("sys.stdout.isatty", return_value=True):
             return cli._bare_launch([])
 
-    def test_bare_charter_on_a_terminal_runs_the_declared_default_profile(self):
+    def test_bare_charter_on_a_terminal_opens_the_selector(self):
         argv, rc = self._bare(_LOCAL + '\n[harness]\ndefault = "claude-work"\n')
-        self.assertEqual((argv, rc), (["claude-work"], None))
-        self.assertEqual(self._launch_argv(argv),
-                         (["claude", "--profile", "claude-work"], None))
+        self.assertEqual((argv, rc), (["frame", "--select"], None))
 
-    def test_bare_charter_names_a_refused_default_and_exits_2(self):
+    def test_the_declared_default_is_the_row_the_selector_starts_on(self):
+        """The rewrite carries no name, so this is where the default is read — by the
+        launch, for the row rather than for the command (`_selector_start`)."""
+        self.local.write_text(_LOCAL + '\n[harness]\ndefault = "claude-work"\n')
+        config.use(config.ROOT)
+        self.assertEqual(commands_frame._selector_start(mock.Mock(spec=[])),
+                         "claude-work")
+
+    def test_a_refused_default_no_longer_stops_it_and_marks_no_row(self):
+        """Ruling 18. The refusal is `doctor`'s now: a launch that refused over a name this
+        machine does not have would take the command away over a list charter is about to
+        show, with nothing marked on it."""
         err = io.StringIO()
         with redirect_stderr(err):
             argv, rc = self._bare('[harness]\ndefault = "nope"\n')
-        self.assertEqual(rc, 2)
-        self.assertIn("nope", err.getvalue())
-        self.assertIn("names no profile", err.getvalue())
+        self.assertEqual((argv, rc), (["frame", "--select"], None))
+        self.assertEqual(err.getvalue(), "")
+        self.assertIsNone(commands_frame._selector_start(mock.Mock(spec=[])))
 
-    def test_bare_charter_on_a_plane_that_declares_nothing_is_unchanged(self):
-        self.assertEqual(self._bare(""), ([], None))
+    def test_a_plane_that_declares_nothing_opens_it_too(self):
+        self.assertEqual(self._bare(""), (["frame", "--select"], None))
 
     def test_bare_charter_off_a_terminal_starts_nothing(self):
         """#687/#690: `charter 2>&1 | head` is a probe that costs nothing, and it must stay
-        one whatever the plane defaults to."""
+        one whatever the plane defaults to — a pipe is no place to draw a selector."""
         self.local.write_text(_LOCAL + '\n[harness]\ndefault = "claude-work"\n')
         config.use(config.ROOT)
         with mock.patch("sys.stdout.isatty", return_value=False):

--- a/tests/test_charter_records_the_plane_as_it_changes.py
+++ b/tests/test_charter_records_the_plane_as_it_changes.py
@@ -979,12 +979,14 @@ class FreshIsARunThatDoesNotParticipate(PersonaIso, unittest.TestCase):
             f'schema = 1\n\n[harness]\ndefault = "{harness}"\n')
         config.use(self.tmp)
 
-    def test_bare_charter_fresh_becomes_the_planes_harness_carrying_the_flag(self):
+    def test_bare_charter_fresh_becomes_the_selector_carrying_the_flag(self):
+        """The flag rides after the name the rewrite puts in front of it, which is the one
+        position `_split_frame_argv` reads charter's own flags in."""
         self._plane_defaults_to("claude")
         with mock.patch.object(cli.sys.stdout, "isatty", return_value=True):
             argv, rc = cli._bare_launch(["--fresh"])
         self.assertIsNone(rc)
-        self.assertEqual(argv, ["claude", "--fresh"])
+        self.assertEqual(argv, ["frame", "--select", "--fresh"])
 
     def test_a_word_that_is_not_charters_own_flag_is_still_a_subcommand(self):
         """The rewrite widens by exactly one token and no further: anything else in `argv`
@@ -995,14 +997,15 @@ class FreshIsARunThatDoesNotParticipate(PersonaIso, unittest.TestCase):
             self.assertEqual(cli._bare_launch(["--fresh", "doctor"]),
                              (["--fresh", "doctor"], None))
 
-    def test_a_plane_that_names_no_harness_is_still_a_usage_error(self):
-        """The rewrite is gated on a declared `[harness] default` exactly as bare `charter`
-        is: charter does not guess a harness for somebody who never named one, and adding a
-        flag does not make it start guessing."""
+    def test_a_plane_that_names_no_harness_still_opens_the_selector(self):
+        """The rewrite is gated on a terminal and on nothing else now: charter still does
+        not guess a harness for somebody who never named one — it opens the selector and
+        asks — and adding a flag changes neither half."""
         (self.tmp / "charter.toml").write_text("schema = 1\n")
         config.use(self.tmp)
         with mock.patch.object(cli.sys.stdout, "isatty", return_value=True):
-            self.assertEqual(cli._bare_launch(["--fresh"]), (["--fresh"], None))
+            self.assertEqual(cli._bare_launch(["--fresh"]),
+                             (["frame", "--select", "--fresh"], None))
 
     def test_the_flag_reaches_the_launcher_rather_than_the_harness(self):
         parser = cli.build_parser()

--- a/tests/test_no_test_replaces_the_process_running_the_suite.py
+++ b/tests/test_no_test_replaces_the_process_running_the_suite.py
@@ -29,7 +29,18 @@ class AnExecThatWouldRunFailsTheTestThatMadeIt(unittest.TestCase):
         """`os._execvpe` walks `PATH` catching `OSError` per candidate; an `OSError` here
         would be swallowed and the NEXT candidate tried — which may be the real one."""
         self.assertFalse(issubclass(_execguard.ReplacedTheRunner, OSError))
-        self.assertTrue(issubclass(_execguard.ReplacedTheRunner, AssertionError))
+
+    def test_an_except_exception_on_the_way_out_does_not_swallow_it(self):
+        """The tripwires in `tests/_planeguard.py` are `BaseException`s for this reason:
+        `cli.main` wraps every command in `except Exception`, and a refusal that clause can
+        catch is a refusal the code under test turns into a crash report and a green."""
+        caught_by_exception = False
+        with self.assertRaises(_execguard.ReplacedTheRunner):
+            try:
+                commands_frame.bypass([sys.executable, "-c", "pass"])
+            except Exception:                              # noqa: BLE001 — the point
+                caught_by_exception = True
+        self.assertFalse(caught_by_exception)
 
     def test_the_environment_spelling_is_refused_too(self):
         with self.assertRaises(_execguard.ReplacedTheRunner):

--- a/tests/test_no_test_replaces_the_process_running_the_suite.py
+++ b/tests/test_no_test_replaces_the_process_running_the_suite.py
@@ -1,0 +1,77 @@
+"""No test may replace the process that is running the suite (`tests/_execguard.py`).
+
+A real exec from the test runner is not a failure, it is a missing verdict: the runner is
+gone, and what reports next is whatever program took its place. #998's deletion sweep
+measured it — a mutant sent `tests.test_a_profile_launch_is_refused_before_tmux` through
+`commands_frame.bypass` into a real `python -m charter frame-launch --select`, and the
+mutation came back unresolved rather than red.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+from unittest import mock
+
+from charter import commands_frame
+from tests import _execguard
+
+
+class AnExecThatWouldRunFailsTheTestThatMadeIt(unittest.TestCase):
+    def test_bypass_into_a_real_program_is_refused_by_name(self):
+        with self.assertRaises(_execguard.ReplacedTheRunner) as caught:
+            commands_frame.bypass([sys.executable, "-c", "pass"])
+        self.assertIn("replaces the test runner", str(caught.exception))
+        self.assertIn(sys.executable, str(caught.exception))
+
+    def test_it_is_not_an_oserror_so_no_candidate_loop_takes_it_for_a_miss(self):
+        """`os._execvpe` walks `PATH` catching `OSError` per candidate; an `OSError` here
+        would be swallowed and the NEXT candidate tried — which may be the real one."""
+        self.assertFalse(issubclass(_execguard.ReplacedTheRunner, OSError))
+        self.assertTrue(issubclass(_execguard.ReplacedTheRunner, AssertionError))
+
+    def test_the_environment_spelling_is_refused_too(self):
+        with self.assertRaises(_execguard.ReplacedTheRunner):
+            getattr(os, "execvpe")(sys.executable, [sys.executable, "-c", "pass"],
+                                   dict(os.environ))
+
+
+class AnExecThatCannotRunStillFailsTheWayTheKernelSays(unittest.TestCase):
+    """Nothing is replaced when an exec fails, so that path is real behaviour — and it is
+    how `bypass`'s own "not installed" sentence is tested."""
+
+    def test_a_program_nobody_installed_is_still_127(self):
+        with mock.patch.object(commands_frame.util, "err"):
+            self.assertEqual(commands_frame.bypass(["no-such-harness-anywhere-xyz"]), 127)
+
+    def test_a_file_that_is_not_executable_is_still_a_permission_error(self):
+        import tempfile
+
+        with tempfile.NamedTemporaryFile() as f, \
+                mock.patch.object(commands_frame.util, "err"):
+            self.assertEqual(commands_frame.bypass([f.name]), 126)
+
+    def test_a_directory_is_not_something_to_run(self):
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as d:
+            with self.assertRaises(PermissionError):
+                getattr(os, "execv")(d, [d])
+
+
+class AForkedChildIsNeverRefused(unittest.TestCase):
+    def test_a_process_that_is_not_the_runner_execs_for_real(self):
+        """`pty.fork()` then `os.execvp("tmux", …)` is how a real-terminal case puts a real
+        client on a server; the process replaced there is the child's own."""
+        reached: list = []
+        real = mock.Mock(side_effect=lambda *a: reached.append(a))
+        exec_ = _execguard._tripwire("execv", real)
+        with mock.patch.object(_execguard.os, "getpid",
+                               return_value=(_execguard._RUNNER_PID or 0) + 1):
+            exec_(sys.executable, [sys.executable])
+        self.assertEqual(reached, [(sys.executable, [sys.executable])])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_the_chat_bars_plus_makes_a_chat.py
+++ b/tests/test_the_chat_bars_plus_makes_a_chat.py
@@ -173,13 +173,16 @@ class ThePressRunsTheLauncherForThisWorkspace(_APlusOnAFrameInAlpha):
         self.assertFalse(self.launched[0].pick)
         self.assertFalse(self.launched[0].no_frame)
 
-    def test_the_launch_uses_the_harness_this_chat_records(self):
-        """The one question a `+` cannot carry, answered the only way the operator has
-        expressed: the tool they are already in."""
+    def test_the_launch_opens_the_selector_on_the_profile_this_chat_records(self):
+        """The one question a `+` cannot carry is no longer one it has to answer: the new
+        chat opens at the selector, and the tool the operator is already in is the row the
+        cursor OPENS on — the only answer the press actually expressed."""
         self._press()
-        self.assertEqual(self.launched[0].harness, "claude")
+        self.assertTrue(self.launched[0].select)
+        self.assertEqual(self.launched[0].start, "claude")
+        self.assertEqual(self.launched[0].harness, "frame")
 
-    def test_a_chat_with_no_recorded_harness_falls_back_to_the_planes_default(self):
+    def test_a_chat_with_no_recorded_harness_opens_on_the_planes_default(self):
         """The migration case — a chat launched by a charter that predates
         `state.record_identity`, which is the one rung where nothing about the chat itself
         is left to go on.
@@ -191,8 +194,8 @@ class ThePressRunsTheLauncherForThisWorkspace(_APlusOnAFrameInAlpha):
         state.record_identity(self.FID, {"CHARTER_HARNESS": ""})
         (config.ROOT / "charter.local.toml").write_text('[harness]\ndefault = "claude"\n')
         self._press()
-        self.assertEqual(self.launched[0].harness, "claude")
-        self.assertEqual(self.launched[0].profile, "claude")
+        self.assertTrue(self.launched[0].select)
+        self.assertEqual(self.launched[0].start, "claude")
 
     def test_the_launch_is_sized_for_the_window_the_chat_is_on(self):
         """A launcher with no terminal of its own measures nothing, and `cmd_launch`'s own
@@ -359,18 +362,20 @@ class ThePressSaysWhyWhenItWillNotMakeAChat(_APlusOnAFrameInAlpha):
         self.assertEqual(said, [commands_frame.NO_SESSION_HERE],
                          "the constant and the sentence have come apart")
 
-    def test_a_chat_recording_no_launchable_harness_is_refused_by_name(self):
+    def test_a_chat_recording_no_launchable_harness_opens_the_selector_anyway(self):
+        """**The stop that is gone.** A chat recording no profile charter can launch, on a
+        plane declaring no `[harness] default`, used to refuse the press by name — a `+`
+        that did nothing, with a sentence on the attention row. The selector answers that
+        case: it lists what this machine has and says on each row why it cannot start, so
+        there is nothing left for the press to fail to answer. The cursor opens on no row
+        of its own and `palette.aim` places it (ruling 18)."""
         with mock.patch.dict(config.HARNESS, {"default": "nothing-installed"}):
             state.record_identity(self.FID, {"CHARTER_HARNESS": "also-nothing"})
             self.assertEqual(self._press(), 0)
-        self.assertEqual(self.launched, [])
-        said = self._sentences()
-        self.assertEqual(len(said), 1, said)
-        self.assertIn("records no profile this charter can launch", said[0])
-        self.assertIn("[harness] default", said[0],
-                      "the refusal does not name the key that would fix it")
-        self.assertTrue(said[0].startswith("cannot open another chat:"),
-                        f"the refusal does not name its own subject: {said[0]!r}")
+        self.assertEqual(len(self.launched), 1)
+        self.assertTrue(self.launched[0].select)
+        self.assertEqual(self.launched[0].start, "")
+        self.assertEqual(self._sentences(), [], self._sentences())
 
     def test_a_workspace_directory_charter_cannot_enter_is_refused_by_name(self):
         with mock.patch("charter.commands_frame.os.chdir", side_effect=OSError("nope")):


### PR DESCRIPTION
The second half of Task 5, stacked on **#996** (base: `task5-the-selector`). #996 built the
selector surface, its rows, the cursor, cancel and what a waiting pane is; nothing on `main`
reached it. **This wires the four doors** — bare `charter`, the `+`, the palette's new chat
and a workspace tab — and takes away the two stops that existed because charter used to have
to know which harness a press meant.

## What it does

**Bare `charter` opens the selector.** `cli._bare_launch` rewrites to `["frame", "--select"]`
on a terminal, and reads no default: `[harness] default` now chooses which ROW the cursor
opens on (`commands_frame._selector_start`) and launches nothing. The tty rule is unchanged
and matters more than it did — a pipe has no terminal for a selector to be drawn in.

**`+` and a workspace tab open at it too**, on the profile of the chat they were pressed in
(`_same_profile_as`, which still refuses where it cannot answer; the press just no longer
needs it to). Neither runs `_launch_refusal` any more: nothing is being launched, and the
pane runs the whole chain fresh for whichever profile is picked.

**Ruling 17 — attach and add nothing.** A `--select` launch asks `_plane_session` rather than
`_workspace_to_focus`, so bare `charter` on a workspace whose chats are running attaches
whether or not anybody else is attached. `_workspace_to_focus` answers `None` for a live
workspace with no client on it, which is right for a launch that NAMES something — with
nobody to drag, it should add its chat and run it — and wrong for one that names nothing.
`charter <profile>` and `charter frame -- <cmd>` keep today's rule exactly.

**Review 12 — no inherited kind.** `_frame_env(fid, None)` keeps `$CHARTER_HARNESS` from
this process, and the process that presses `+` is a panel of a chat that HAS one. A selector
launch clears it on both servers, so a chat that has picked nothing records nothing, and
`launcher._picked` (from #996) writes the kind at the pick.

**The waiting marker is written before tmux**, on both launch paths — a quit landing between
the window and the pick must not record a chat that is a question on a screen.

**A cancelled selector says nothing**, and this is the one thing CI corrected rather than
confirmed. `nothing_ever_ran_here` reads the chat's own MARKER and not the exit code:
`early_death_message` would name "the profile selector" as a command that died, and
`_say_the_plane_is_recorded` would offer `charter reopen` for a chat the record does not
hold. `state.is_waiting` IS "no harness has ever run in this pane", so neither sentence can
be true of one whatever number comes back; a harness that exits 130 at its own prompt
cleared the marker when it was picked, and that case is the control.

Written on the number first, it passed here and failed on the 3.14 runner: **a pane that
exits out of raw mode on Linux comes back with an empty `#{pane_dead_status}`** —
`_UNKNOWN_DEATH_CODE`'s own measurement, and ruling 42's — so Esc arrived as code 1 and got
the early-death sentence. The real-tmux S2 case stops asserting the number for the same
reason and keeps what S2 is about.

**Two new refusals**, both where a launch would otherwise do one of two things silently.
`charter frame --select --no-frame` is two launches asked for at once — `bypass` would
`os.execvp` the launcher, drawing a modal surface over the operator's own terminal and then
exec'ing a harness with no frame. And `charter frame --select -- <cmd>` asks charter both to
pick and to run: a selector cannot run a command charter has never met and cannot ask about
one, and *a launcher that swallowed a command would be wrong in the one direction this
module refuses everywhere else, silently* is `_launch`'s own sentence about the open-or-focus
gate. Both say so instead of picking one.

## The stops that are gone

* the `+` and a workspace tab refusing "this chat records no profile this charter can launch
  and your plane declares no `[harness] default`" — the selector answers that case, and
  `palette.aim` puts the cursor on the first row that can run so Enter always does something;
* bare `charter` refusing a `default` that names a profile this machine does not have. It
  marks no row (ruling 18) and `charter doctor` names the typo — the reader that can say it
  without taking a launch away;
* bare `charter` printing the usage list on a plane that declares no default, on a terminal.
  Charter still does not guess which harness you meant; it asks on screen instead.

Each is rewritten as a case rather than deleted: `test_the_chat_bars_plus_makes_a_chat
::test_a_chat_recording_no_launchable_harness_opens_the_selector_anyway`,
`test_a_workspace_tab_opens_what_it_names::test_with_neither_it_opens_the_selector_on_no_row
_rather_than_refusing`, and `test_bare_charter_opens_the_frame
::ARefusedDefaultNoLongerStopsBareCharter`.

`_same_profile_as`'s own refusals are untouched and still tested where they are decided — a
handoff still names its profile, because nobody is at that open. Its containment of a
recorded name (ruling 35) moved with it, to the handoff case that still surfaces the
sentence.

## Real tmux — the plan's S2, and L1 for the selector

`TheSelectorOnARealServer` drives the real thing: a real server, a real chat pane, and real
keystrokes through `send-keys`. **Nothing is patched inside the pane** — it puts its own
terminal into raw mode, paints the alternate screen and `exec`s on Enter.

* **A pick leaves the same pane running the harness.** `#{pane_pid}` after the exec equals
  the pid the harness wrote down, the chat stops being a waiting pane, and its profile is
  recorded.
* **A cancelled only window takes the session with it.** Esc, the window goes, the session
  goes with it, no harness ran, and the pane is still `is_waiting` — so a quit would not
  record it. **Green on macOS and on all four of CI's Pythons**, including 3.11 and 3.13,
  where it was red before charter stopped waiting for `pane-died`.

**The finding that came out of those reds, kept because it is the durable half.** On the
Linux runner a chat pane that exits at the selector is marked dead with BOTH
`#{pane_dead_status}` and `#{pane_dead_signal}` empty, and its window is still listed a
minute later — with `remain-on-exit on` and both hooks read back present. macOS takes the
window and the session, and a hand probe there fires `pane-died[1]` for a `SIGKILL`ed pane
and even when `pane-died[0]` fails. Two hypotheses fit — tmux declining to fire for a pane
it can name neither a code nor a signal for, and a launcher not exiting cleanly from raw
mode there (ruling 42's signature a third time) — and neither is settleable from this
machine. **`grep` says this was the only case in the suite that has ever watched a chat's
session end after its pane died on a real server**, so it may well pre-date this branch and
simply have had nobody looking. Charter no longer depends on which is true: Esc closes its
own window (#996, `launcher._close_the_cancelled_chat`), and the hook is untouched and still
the answer for a harness that dies. It is written into ADR 0018's amendment and into a
comment beside the close.

## Step 0, run here

The plan's S1 and S2 had not been run; they run in this PR because this is the PR with a
path to a real server. Driven through `commands_frame._launch`, a throwaway plane and socket
per run, each tmux version first on `$PATH`.

**S1 — launch to the first painted row.** Median **145 ms on tmux 3.7c** and **137 ms at the
3.2 floor**, twelve runs, the slowest under a sixth of a second, with three declared profiles
and with none — the count made no visible difference. The stop rule was two seconds cold and
it is not close. In `docs/frame.md`, and it is the whole open: the session, the window,
charter starting in the pane, the profiles, the one `git status`, the paint.

**S2 — Esc as the session's only window.** Twelve of twelve: the session gone, the chat still
a waiting pane, no window left on the server, and the eager `_query_pane_dead_status`
answering `None` while it waited — exactly as the plan predicted. **One correction to the
plan's line:** `_launch` returns **0**, not 130, because a launch that will never attach
returns as soon as the window exists; the 130 is the pane's, and `state.exit_code` is where
it lands when tmux can name it.

**S1's row half, measured in the final round.** The numbers above predate the rows asking
about wiring. `selector.rows` alone, on macOS with claude 2.1.270 and opencode 1.18.23
beside codex, four Claude profiles and throwaway config folders, every probe concurrent: a
median of **611 ms cold** (990 ms on the first run) and **15 ms warm**, five of each. A cold
open is therefore under a second — still well inside the two-second stop rule. In
`docs/frame.md` beside the open's own number.

**And ADR 0018's amendment is here**, with the reliance and the evidence (standards review
F2, ruling 44), along with `docs/frame.md`'s section and the news entry's paragraph, which
announce a selector only this PR gives anybody a way to open (F1).

## Final round (rebased onto #996 at `3184066`, over Tasks 3 and 4) — finding → outcome

| | finding | outcome |
|---|---|---|
| **R1** | rebase onto the new selector head, #998's own eleven commits only | done with `--onto`; conflicts resolved to both sides — `+` and tabs drop `main`'s `_launch_refusal(…, cwd=…)` because nothing is launched there, the news headline is the selector's (the plan's), `test_the_profile_words_are_written_down` keeps `main`'s term locator, ADR 0018's selector amendment now counts **three** kinds of line before it (Task 3 added the prompt) and says the approval is Task 3's prompt and not a surface. #998 no longer touches `launcher.py`, so **the session-kill fix from `ac159bb` is intact** (the old branch predated it) |
| **R2** | survivor `commands_frame.py:5228`, `SELECTOR_DISPLAY`'s literal | pinned by `test_a_selector_whose_pick_died_before_the_frame_names_the_selector`, which asserts the words `the profile selector` and not the constant |
| **R3** | survivors `:6258`, both conjuncts of `_wants_attach(args) and not nothing_ever_ran_here()` | **a real bug behind them**: the marker was read AFTER `state.reap`, which takes the chat's directory the moment its window is gone — so for a cancelled selector (whose window Esc closes) it always answered "a harness ran here" and held nothing back. Now read once before the reap (`started_nothing`). Pinned with the plane's record naming the chat and the fake server closing the dead window: a cancelled selector says no `reopen`, a picked-then-died pane does, and a launch that is nobody's terminal does not |
| **R4** | `:5344` `if selecting:` disable-branch **unresolved** | **neither known cause.** The `True` mutant makes every launch a selector launch with `p is None`, so a test launch with a non-terminal stdout reaches `bypass`, whose `os.execvp` is not stood in — and the test runner is **replaced** by `python -P -m charter frame-launch --select`. Replayed locally on `test_a_profile_launch_is_refused_before_tmux`: the run ended in `No module named charter` with no summary. Fixed suite-wide: `tests/_execguard.py`, installed with the other tripwires, refuses an exec that would run from the suite's own process (`ReplacedTheRunner`, an `AssertionError`), keeps `FileNotFoundError`/`PermissionError` for one that could not, and passes a forked child through. Replayed again: `FAILED (failures=26)` in seconds. The `False` mutant is red on the selector module (`failures=8, errors=3`) |
| **R5** | the open paths stood in for the row states anywhere? | the real-server recorder answered no wiring probe, so the rows' probe was recorded as the harness starting — it now answers `plugin list --json` first, as Task 4's recorders do; `WhereItAppears` states wiring (`wired_as_today`); `APressRunsNoGuardForAProfileNobodyHasPicked` no longer leans on "refused until Task 3" — it presses over a profile not on `PATH`, stands `_launch_refusal` in to raise, and asserts a chat opens on that row with nothing said |
| **R6** | docs move with the code | `docs/frame.md`'s section: the not-wired row, the not-approved row and Task 3's prompt in the pane, `… +N not shown`, and the rows' measured cost; the news paragraph says the same in one breath |

## Verification round (coordinator, on `d757923`; rebased onto #996 at `4c84f9b`) — finding → outcome

| | finding | outcome |
|---|---|---|
| **V5** | Esc at the selector in the operator's own tmux reported a dead harness (`the frame's window is gone …`, exit 1); S2 expects 130 on both servers, and the only case stubbed `_wait_for_harness` to 130 | **ruling applied.** Both of `_launch_in_operator_tmux`'s readings of a pane that is not alive — the eager one and the wait — ask `state.is_waiting` first, with the claim still held: a waiting pane ends on `selector.CANCELLED_EXIT`, recorded, nothing printed, its window taken back if tmux kept it dead (the cancel's number even then — Linux reads a pane leaving raw mode as an unknown death). A harness whose window vanished keeps its sentence. Cases drive `_pane_state`, not `_wait_for_harness`; the two cancel cases were red on `d757923` |
| **V5b** | read `started_nothing` before `clear_claim` | done in `_launch`: `state.reap` spares a gone window's directory only while the claim is held. Pinned by standing in a reap at the instant the claim is released — red with the old order |
| **V6** | `ReplacedTheRunner` was an `AssertionError`, catchable by `except Exception` | a `BaseException`, like `_planeguard`'s tripwires; pinned (red as an `AssertionError`). `CONTRIBUTING.md`'s guard paragraph names `tests._execguard` beside `RealTmuxReach` |

## Departures from the plan

1. **`frame` gets `--select` and not `--start`.** The row the cursor opens on is a fact about
   the press, and `cmd_new_chat`/`_open_workspace` call `cmd_launch` in-process with it on
   the namespace — it never has to survive a command line. A bare `charter` takes the plane's
   default. Adding the flag would mean teaching `_OWN_VALUE_FLAGS` about a second value flag
   with no caller. (`frame-launch --start` is real and unchanged: that one does cross tmux.)
2. **`--select` is on the `frame` parser only**, not on every harness parser. `charter claude
   --select` is asking for a picker for a profile just named; it is in `_OWN_FLAGS`, so
   argparse refuses it by name rather than grafting it onto the harness's verbatim argv.
3. **`--select` with `--no-frame`, and `--select` with a command, are refused** rather than
   left to `bypass` and to silence. The plan mentions neither combination; both are reachable
   by hand, and one would exec a modal surface over the operator's own terminal while the
   other would discard an argv they typed.
4. **The cancelled-selector suppression reads the marker, not the exit code.** The plan says
   "a waiting pane that exited 130". Spelled as a number alone it would both swallow a
   harness that exits 130 at its own prompt and, measured on the 3.14 runner, MISS a
   cancelled selector on Linux, which arrives with no number at all.
5. **`docs/frame.md`'s existing paragraphs moved rather than being appended to**: the `+`,
   the workspace tab, the open-or-focus paragraph and the top four lines each said the old
   rule, and leaving them beside the new section would be two answers in one page.

## Verification

* **CI's matrix is the full-suite evidence**; earlier rounds' local full runs are in this
  PR's history.
* Final round, locally and isolated (`TMUX`/`TMUX_PANE` unset, own `TMUX_TMPDIR`): the
  selector module with both real-tmux cases, carries-its-profile, the new tripwire module
  and `test_plane_spawn_guard` — `Ran 262 … OK`; tab opens, bare `charter`, profile on the
  command line, records the plane, the `+`, profile words, pane style, news gate, docs,
  docs claims, `frame_launcher`, refused-before-tmux, wired-or-refuses — `Ran 939 … OK`;
  and the real-tmux and real-pty modules the tripwire's fork pass-through matters to (real
  click on the tab bar, second launch focuses, one invocation per batch, the launcher pane)
  — `Ran 108 … OK`.
* Verification round, isolated: the selector module (real tmux included), carries-its-profile, the tripwire and spawn-guard modules, bare `charter`, `frame_launcher`, refused-before-tmux, profile on the command line, tab opens, records the plane, the `+`, too-long-for-tmux, the launcher pane, plane-write and background-fork guards, docs, news gate, wired-or-refuses, profile words — `Ran 1186 … OK`. Replays: both operator-path guards, the kept-dead close, the claim order and the tripwire's base each red.
* Targeted replays against one module each, files restored byte for byte: R3's old
  read-after-reap, both conjunct drops, `SELECTOR_DISPLAY`'s literal and `if selecting` →
  `False` all red on the selector module; `if selecting` → `True` red on
  refused-before-tmux once the tripwire is in.

**Merge after #996.** Do not merge anything here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MBdEBogeMV7DsqN6vrsVTk
