### PR TITLE
A chat, a handoff and a brief are written down, and so is why a handoff's consent is the harness's own prompt

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -78,6 +78,29 @@ and one with nothing to adopt is one line. Staged as `unreleased-<slug>.md` unti
 stamps it, so an entry never names a version that was not true.
 _Avoid_: changelog, release notes, announcement
 
+### Chats
+
+**Chat**:
+A frame tab: one harness conversation, in one workspace, for life. Its id
+(`<workspace>.<n>`) is allocated and never parsed for meaning, and its workspace is written
+by the launch that made it — so a chat cannot be moved to another workspace, only opened in
+one.
+_Avoid_: session, spawn, sub-session
+
+**Handoff**:
+Opening a chat, here or in another workspace, whose first message is a brief the operator
+approved at the harness's own permission prompt (ADR 0021). A handed-off chat never reports
+back to the chat that opened it: a caller that needs the answer wanted a sub-agent, which
+charter neither gates nor converts.
+_Avoid_: spawn, delegation, sub-session
+
+**Brief**:
+The self-contained message a handoff carries — the only context the new chat starts with.
+It travels as one command-line argument, so any process that can list processes can read it
+while the harness starts and it never carries a secret; charter keeps it in the chat's
+private state under `.charter/` and never in a committed file.
+_Avoid_: prompt, context, instructions
+
 ### Parallel work
 
 **Plan**:

--- a/README.md
+++ b/README.md
@@ -457,8 +457,8 @@ copy wins, is compared to nothing, and drifts unwatched in both directions.
 - [docs/git-policy.md](docs/git-policy.md) — the one-credential rule, and why a denial from
   the plugin's guard is the rule working rather than a bug.
 - [docs/hooks.md](docs/hooks.md) — everything the plugin does without being asked: what
-  fires when, the five guards, what to do when one of them is wrong, what gets injected,
-  and what gets counted.
+  fires when, the ten guards that deny and what each one refuses, what to do when one of
+  them is wrong, what gets injected, and what gets counted.
 - [docs/mcp.md](docs/mcp.md) — giving an MCP server a persona's vault credentials without
   the value entering the model, and what the per-persona tool allowlist does and does not
   constrain.

--- a/charter/commands_handoff.py
+++ b/charter/commands_handoff.py
@@ -221,11 +221,12 @@ def cmd_handoff(args) -> int:
         workspace.ensure(ws)
         workspace.set_vision(ws, args.vision)
     text = handoff.todo_text(brief, source_chat=source_chat, source_workspace=source_ws)
-    # `by_title`, and it is not a tweak: every handoff todo ends in the same nine-word
-    # provenance sentence, and compared over the whole text that boilerplate reads as
-    # agreement — `Fix the widget` and `Ship the release` scored 0.750, so the second
-    # handoff into a workspace recorded nothing at all. What two todos are ABOUT is their
-    # first lines (`todos.duplicate_of`).
+    # `by_title`, and it is not a tweak: every handoff todo ends in the same 18-word
+    # provenance sentence, which `memstore.wordset` reduces to NINE comparable words once
+    # it drops everything three characters or shorter. Compared over the whole text that
+    # boilerplate reads as agreement — `Fix the widget` and `Ship the release` scored
+    # 0.750, so the second handoff into a workspace recorded nothing at all. What two todos
+    # are ABOUT is their first lines (`todos.duplicate_of`).
     dup = todos.duplicate_of(ws, text, by_title=True)
     if dup:
         # Reported and continued, not refused: a second chat on the same brief may be

--- a/charter/commands_persona.py
+++ b/charter/commands_persona.py
@@ -1400,7 +1400,7 @@ def cmd_persona_stats(args) -> int:
     advice = dispatch.advice_tally()
     if advice:
         since = dispatch.first_advice()
-        followed = dispatch.handoffs_since_first_advice()
+        followed = dispatch.routed_since_first_advice()
         # SINCE the first advice, never the lifetime total: a dispatch older than the
         # roster cannot have followed it, and pairing the two made this line claim five
         # dispatches followed one piece of advice — three of them four days its senior.

--- a/charter/dispatch.py
+++ b/charter/dispatch.py
@@ -219,9 +219,15 @@ def first_advice() -> datetime | None:
     return min(stamps) if stamps else None
 
 
-def handoffs_since_first_advice() -> int:
+def routed_since_first_advice() -> int:
     """Dispatches recorded at or after the first advice — the only count that can honestly
     sit beside :func:`advice_tally`.
+
+    **Named for routing, not for handoffs**, because the word moved: a *handoff* is now
+    opening a chat (CONTEXT.md, *Chats*), and this counts sub-agent dispatches and resumes,
+    which are a different placement of the same question. The old name survived the feature
+    that took the word and would have read as "how many chats were handed off", which is
+    the one thing this number is not.
 
     The pair is meant to read as fired-vs-followed, and a dispatch that happened before the
     roster ever appeared cannot have followed it. Pairing advice against the LIFETIME total
@@ -234,9 +240,9 @@ def handoffs_since_first_advice() -> int:
     Still not proof of causation, and the report says "since" rather than "because" for
     that reason. It is a window in which the claim is at least possible.
 
-    Boundary, stated rather than hidden: rows are stamped to the second, so a handoff in
+    Boundary, stated rather than hidden: rows are stamped to the second, so a dispatch in
     the SAME second as the first advice counts as after it. It can only over-count, by at
-    most the handoffs sharing one second with the moment advice first appeared.
+    most the dispatches sharing one second with the moment advice first appeared.
     """
     since = first_advice()
     if since is None:

--- a/charter/todos.py
+++ b/charter/todos.py
@@ -102,8 +102,10 @@ def duplicate_of(name: str, text: str, *, by_title: bool = False) -> str | None:
 
     **`by_title` compares FIRST LINES, on both sides, and it exists because a writer whose
     todos all end in the same sentence otherwise reads as agreeing with itself.**
-    `charter handoff` is that writer: its todo is the brief's first line plus a nine-word
-    provenance sentence every handoff todo carries. Measured on the whole text, `Fix the
+    `charter handoff` is that writer: its todo is the brief's first line plus an 18-word
+    provenance sentence every handoff todo carries — nine comparable words once
+    :func:`memstore.wordset` drops everything three characters or shorter, and that is the
+    nine this comparison actually sees. Measured on the whole text, `Fix the
     widget` and `Ship the release` — briefs with no word in common — scored **0.750** and
     the second was refused as a duplicate of the first; any two handoff titles of four or
     fewer distinct words collided that way, so the second handoff into a workspace recorded

--- a/docs/adr/0021-a-handoffs-consent-is-the-harness-prompt.md
+++ b/docs/adr/0021-a-handoffs-consent-is-the-harness-prompt.md
@@ -190,8 +190,9 @@ ambiguous.
   identity of the normalised first line decides.
 
 **What was measured, re-measured on this branch 2026-09-12.** Every handoff todo ends in the
-same provenance sentence — eight words the comparison can see, plus the source chat and
-workspace, which two handoffs out of one chat also share. Over whole texts,
+same 18-word provenance sentence, which `memstore.wordset` reduces to **nine** comparable
+words once it drops everything three characters or shorter — eight fixed, plus the source
+chat and workspace, which two handoffs out of one chat also share. Over whole texts,
 `Fix the widget` and `Ship the release` — briefs with no word in common — score **0.750**
 (0.769 when the source chat and workspace are different words), so the second handoff into a
 workspace recorded nothing at all, silently. Over first lines they score **0.000**. And the

--- a/docs/adr/0021-a-handoffs-consent-is-the-harness-prompt.md
+++ b/docs/adr/0021-a-handoffs-consent-is-the-harness-prompt.md
@@ -1,0 +1,254 @@
+# A handoff's consent is the harness's own prompt
+
+`charter handoff <workspace>` opens a chat and sends it a first message. A first message is
+not a suggestion: the new chat starts working on it with the operator's authority, in a
+workspace that may hold clones and credentials, and nobody reads it again before it does.
+The chat that wrote the brief is the same model that decided the work should move — so its
+own proposal, however faithfully it quotes the brief, cannot be the consent for sending it.
+
+**The gate is the host's own `ask` rule for `charter handoff`, and charter's hook refuses
+what that prompt cannot cover.** Removing the rule is the operator's choice.
+
+The mechanics — every refusal, every measurement and the exact tables — are in
+[`docs/handoff.md`](../handoff.md) and [`docs/hooks.md`](../hooks.md). What the grill settled
+is `docs/superpowers/specs/2026-09-10-chat-handoff.md`; the rulings taken on the way are that
+plan's own `## Controller rulings`. This record holds the decisions that were expensive to
+reach, what each one costs, and what was measured — the half that is gone first and cannot be
+reconstructed from the code.
+
+## The decision
+
+- **The rule.** `Bash(charter handoff *)` under `permissions.ask` in `.claude/settings.json`,
+  and `"charter handoff *": "ask"` under `permission.bash` in `opencode.json`
+  (`commands.HANDOFF_ASK_PATTERN`). Codex has no command-pattern permissions, so there is
+  nowhere to put it there.
+- **Who writes it.** `charter init`, through `commands.ensure_handoff_gate`, which is
+  `charter guard ask` with the pattern fixed — the same `_guard_apply` transaction, so `init`
+  and the operator's own command cannot come to disagree about what "present" means. It is
+  the one `permissions` entry `init` writes.
+- **Who does not.** `charter update`, and everything else that runs again. A plane `init` did
+  not make adopts the rule through the news entry's `adopt: guard handoff`. A writer that ran
+  on every update would quietly reverse a removal, and removing the rule is the operator's
+  decision; `charter doctor`'s `handoff gate` row names it missing and says so in the same
+  breath.
+- **Where it has to be.** Claude Code reads project settings from the session's own
+  directory and does not walk up, and a framed chat stands in `workspaces/<ws>/`. The plane's
+  restrictive rules therefore ride into every generated workspace and clone settings file
+  (`claude_code.RESTRICTIVE_BUCKETS = ("ask", "deny")`, #942/#948). `allow` never travels:
+  a restriction only ever adds a prompt, while a grant copied sideways puts a permission in
+  force where nobody clicked for it.
+- **What charter's hook adds.** `hooks._handoff_refusal` (A7) refuses a handoff from a
+  sub-agent, from an unattended run, in a spelling the rule was measured not to match, and
+  with a stdin the prompt cannot show.
+- **No depth limit.** A handed-off chat may hand off again, because every hop needs its own
+  yes.
+
+## Why not the alternatives
+
+- **A hook `ask` cannot be the gate.** `hooks._ask` answers `allow` when the payload says
+  `permission_mode: bypassPermissions`, because a hook `ask` floors the decision at a prompt
+  the host cannot lift and would hang an unattended run. So the one mode where a handoff most
+  needs a human is the mode where a hook `ask` is not one. opencode has no ask channel at
+  tool time at all — its `tool.execute.before` can allow or throw, which is that harness's
+  own `ask-decisions` deficit.
+- **A charter-side confirmation on stdin.** There is no terminal inside a Bash tool call, and
+  stdin is already carrying the brief.
+- **A quiz in the conversation.** It is the model's own proposal. The skill still shows the
+  brief in full, because the operator reading it before the prompt appears is what makes the
+  prompt answerable — but it is a procedure, not consent.
+- **A charter-side rule list.** [ADR 0014](0014-policy-that-fits-a-pattern-belongs-to-the-host.md):
+  policy that fits a command pattern belongs to the host, and a second engine cannot win
+  against one whose ask rule prompts even when the hook returned `allow`.
+- **`--brief-file`.** A prompt that shows a path is an approval of a path. The brief arrives
+  as one quoted heredoc so the prompt shows the exact text the new chat is sent.
+- **A depth limit.** Nothing to buy: every hop already needs a yes.
+
+## The decisions somebody would otherwise undo
+
+### The prompt is consent for one spelling, and it is not a security boundary
+
+Claude Code says of its own Bash rules that one *"isn't a security boundary around the
+program"*
+([permissions#bash-rule-limits](https://code.claude.com/docs/en/permissions#bash-rule-limits)),
+and the measurement agrees: on Claude Code 2.1.268, against a stand-in model API under a
+throwaway `HOME`, `charter 'handoff'`, `python3 -m charter handoff`, a path to charter,
+`charter $'handoff'`, `charter {handoff,}`, `charter hando?f`, and a handoff inside `eval`,
+`bash -c` or a `bash <<'EOF'` body all ran with **no prompt**, while the canonical spelling
+asked in every mode including `bypassPermissions`. The tables are in `docs/handoff.md`.
+
+So A7 refuses the spellings it can recognise that the rule was measured not to match. That
+is a rule a model can follow, not a wall: A7 reads a command's words and is not a shell, and
+it does not see a handoff run by an interpreter, through a variable, from a script file, or
+behind a shell hidden by a name charter cannot know (`r() { bash; }; r <<'EOF'`).
+
+**What it costs, stated rather than discovered.** `python3 -m charter handoff` is refused —
+and that is the spelling `CONTRIBUTING.md` gives for running a checkout. Allowing it would
+run a handoff the host never asked about. Re-measured on this branch, 2026-09-12:
+`python3 -m charter handoff beta <<'BRIEF'` and `charter 'handoff' beta <<'BRIEF'` both
+answer `handoff-spelling`.
+
+### A heredoc body is judged by its own opener and by its own pipeline
+
+A brief is a heredoc body. So is a commit message, a document, a `tee` input — and so is a
+script. Charter has to decide which bodies are commands, for two guards at once (A7 and the
+secret-leak guard share one plan), and the two fail opposite ways, so the unit had to be
+right rather than convenient.
+
+**The rule.** A body is read as commands when its opener's own program is a shell or an
+interpreter (`bash`, `python3`, one of those behind `env`/`nohup`, `ssh` where the remote
+shell runs it), when charter cannot resolve the opener to a name at all (`${RUNNER} <<'EOF'`,
+`$(which bash) <<'EOF'`), or when an executor stands downstream of it **in the same
+pipeline**. Everything else hands its body on as data.
+
+**Why the pipeline and not the line or the word.** Line-scoping refused ordinary commands —
+22 of them, and `git commit -F -` inside `( … )` refused this repo's own commit messages.
+Word-scoping let `cat <<'A' | bash` through, which is a script. The pipeline is what a shell
+actually uses: measured 2026-09-12 on GNU bash 3.2.57 and zsh 5.9, `cat <<'A' | bash` runs
+the body in both, and `cat <<'A'; …` runs the command after the `;` and never the body. Nine
+review rounds converged on it; each round's finding is recorded at its own line in
+`charter/hooks.py` rather than here.
+
+Re-measured against A7 on this branch, 2026-09-12, each with a handoff in the body:
+`cat <<'A' | bash` → `handoff-shell-string`; `cat <<'A' > notes.md` → allowed;
+`git commit -F - <<'EOF'` → allowed.
+
+**What it costs.** When the word naming the program is itself a variable or a substitution,
+charter treats the body as something that could run, so a brief-shaped body under
+`${EDITOR} <<'EOF'` is refused although the program is a pager. A fail-safe that switched off
+for a friendly-looking name would not be one. Two shapes are named limits rather than fixed:
+a `'` in a non-reader's heredoc body leaves a shell string unparseable and lets a later
+`eval '…'` through, and the scan does not honour `#` comments.
+
+### The brief's fence carries a per-render marker, and the brief keeps its lines
+
+A chat that reopens with no conversation is shown its brief as a quoted block. The brief is
+attacker-influenced by construction — it is whatever another chat was told to work on — so
+the quotation has to be one it cannot close.
+
+The first shape bought that with line structure: escape every newline, and a value that
+cannot start a line cannot write the line that ends the quotation. It works, and it costs the
+feature its purpose — a 12 KB document flattened onto one line is materially harder for the
+chat to work from, and being worked from is the only thing the brief is for.
+
+**So the fence carries a marker minted at the render** (`hooks._BRIEF_OPEN`,
+`_brief_token`): six `os.urandom` bytes, hex. `charter handoff` wrote the brief at an earlier
+moment — possibly days and a restart ago — and nothing rewrites it, so its author cannot know
+the marker. A brief may spell `⟨/brief⟩` as often as it likes and close nothing. The size is
+against a bound charter already holds: a guess costs at least a dozen bytes of a brief capped
+at 12,288, so about a thousand guesses against 2^48 markers, and no bigger brief or faster
+machine moves that.
+
+**What it costs.** The block is not reproducible byte-for-byte between renders, so nothing
+may compare two of them for equality; `os.urandom` rather than `random`, because a `fork`
+hands both sides of `random` the same stream and a predictable marker is the property gone.
+Escaping happens at the render and never on the way into storage, so what was recorded stays
+the text the operator approved: measured on this branch, `\n` survives as a line break while
+`\r`, `\x1b[` and U+2028 are escaped.
+
+### The arrivals record is a directory of empty files
+
+A handoff opens a chat nobody is looking at, so the workspaces strip marks where it landed
+until somebody looks. The mark is plane-scoped state, and a plane runs many charter processes
+at once.
+
+**One file listing the marked names made every writer a read-modify-write over the whole
+set**, and it lost marks three ways: two handoffs landing together, a handoff landing while a
+switch cleared, and a switch clearing while a handoff landed. A lost mark is exactly the
+invisibility the record exists to end — the chat is open and nothing points at it.
+
+Measured 2026-09-12 on macOS 25.2.0 (APFS), Python 3.14.4, two threads released from one
+`threading.Barrier`, 400 rounds each: a read-modify-write over one file (read the set, add
+the name, atomic replace — the shape charter's other set-files use) **lost a mark in 400 of
+400 rounds**; a directory with one empty file per mark lost **0 of 400**. The suite pins the
+directory shape at 60 rounds on each of the three interleavings
+(`tests/test_a_handoff_lands_at_the_front_of_the_strip.py`).
+
+A lock was considered and refused: a plane is shared by processes that can be killed at any
+moment, so a stale lock nothing clears is a worse failure than the one it fixes — and it
+would still be a fix by timing. One file per name makes recording and clearing independent
+operations on different paths, so there is no interleaving to get wrong.
+
+**What it costs.** A name is now joined onto a path, so `workspace.valid_name` has to be
+asked again at the join — #442 arriving through a record instead of a listing. The mark is
+the file's existence, so there is nowhere to put a timestamp, and nothing may later ask when
+a workspace was marked without changing the shape.
+
+### Duplicate detection differs by caller, because the callers prefer opposite errors
+
+A handoff records a todo in the target workspace. `charter ws todo` records one too, and both
+ask "is this already on the list" — with the same metric and the opposite answer when it is
+ambiguous.
+
+- **`charter ws todo` refuses a duplicate.** A false duplicate costs the operator a rephrase;
+  a missed one leaves two near-identical todos, and closing one leaves its twin looking
+  outstanding. It wants the catching rule: whole texts, Jaccard over words longer than three
+  characters, threshold 0.5.
+- **A handoff records nothing and opens the chat anyway.** A false duplicate silently drops a
+  real todo and the work goes invisible; a missed one is a second todo beside a second chat,
+  which may be exactly what was approved. It wants the careful rule: first lines only, and
+  where fewer than three words overlap — too thin to be evidence in either direction —
+  identity of the normalised first line decides.
+
+**What was measured, re-measured on this branch 2026-09-12.** Every handoff todo ends in the
+same provenance sentence — eight words the comparison can see, plus the source chat and
+workspace, which two handoffs out of one chat also share. Over whole texts,
+`Fix the widget` and `Ship the release` — briefs with no word in common — score **0.750**
+(0.769 when the source chat and workspace are different words), so the second handoff into a
+workspace recorded nothing at all, silently. Over first lines they score **0.000**. And the
+overlap is no better in the other direction on text this short: one shared word out of two is
+**0.5** exactly, so `Fix the widget` swallowed `Break the widget`,
+while `fix the bug` has no comparable word at all and two of them agree on nothing.
+
+**What it costs.** Moving the threshold to 0.51 answers one of those pairs and neither of the
+others, so there is no number here to tune — which is why the fallback is identity rather
+than a second threshold. Two first lines differing only past `memstore.TITLE_MAX` (72
+characters) are stored as the same title and read as one todo: stated rather than engineered
+around. And punctuation is not collapsed, so `Fix the widget!` is a second todo beside
+`Fix the widget`.
+
+## Consequences, including what they cost
+
+- **`charter init` writes a `permissions` key**, which it never did before. The note in
+  `commands.cmd_guard_ask` that said so is corrected rather than deleted, because it is still
+  the rule for every other rule: charter is the editor, the operator is the author.
+- **Every `charter guard ask` rule now reaches a workspace chat**, not only the handoff rule.
+  That is the prerequisite fix this record consumed (#942/#948), and it changes what a plane's
+  existing rules do: a rule written months ago starts prompting in chats where it silently did
+  not. Workspaces pick it up at their next launch, or at `charter workspace reinit --all`.
+- **Codex has no prompt in front of a handoff at all.** Its hook payload still carries
+  `agent_id` and `permission_mode` — measured on codex-cli 0.147.0, `codex exec` reporting
+  `bypassPermissions` under every approval setting tried except `--approve-for-me` — so a
+  sub-agent's or an unattended handoff is refused, and any other Codex handoff runs without
+  asking. Named as a `handoff-gate` deficit, so `doctor` says it rather than leaving it to be
+  found.
+- **opencode cannot refuse a sub-agent's or an unattended handoff.** The payload charter's
+  plugin builds carries neither field, so the `ask` rule in `opencode.json` is the whole gate
+  there.
+- **The gate is in force where charter writes settings and nowhere else** — the plane root, a
+  workspace directory, a checkout's own root. A chat rooted in `docs/`, in `personas/<p>/`, or
+  deep inside a checkout is not gated, and `doctor` says so rather than implying otherwise.
+- **A declined prompt is still a cleared routing mark.** `hooks.pretooluse` clears
+  `routing: require`'s pending mark for a handoff that passed A7, before the host's prompt is
+  answered — the same thing `pretooluse_dispatch` does for a declined Agent call.
+- **The tally cannot answer "who handed off what".** A handoff's row is
+  `{event, ts, placement, created}` and nothing else: no workspace name, because a LOCAL
+  workspace's name must not reach a committed file, and no persona, no brief. It carries no
+  agent, so `charter persona stats` counts no dispatch for one.
+
+## Considered and rejected
+
+- **A hook `ask` as the gate** — lifted to `allow` under `bypassPermissions`, absent on
+  opencode.
+- **A charter-side confirmation on stdin** — no terminal inside a Bash tool call.
+- **A model quiz as the consent** — the proposer cannot be the approver.
+- **`--brief-file`** — the prompt would show a path, and a path is not a text.
+- **A depth limit on handoffs** — every hop already needs a yes.
+- **`charter update` writing the rule** — it would take back the operator's removal at the
+  next update, and there is no stamped version to write it only once against until the
+  release that ships the entry.
+- **A lock around the arrivals record** — a stale lock file nobody clears is worse than the
+  race, and it is still a fix by timing.
+- **A fixed brief fence defended by escaped newlines** — unforgeable, and it destroys what
+  the brief is for.
+- **Widening the duplicate threshold to 0.51** — answers one measured pair and neither of the
+  other two.

--- a/docs/handoff.md
+++ b/docs/handoff.md
@@ -22,7 +22,11 @@ a brief you read and approved.
 3. **A new chat in another workspace**, existing or new.
 
 2 and 3 are one mechanism — a **handoff** — because a chat belongs to its workspace for life.
-The only thing that differs is the workspace.
+The only thing that differs is the workspace. A **chat**, a **handoff** and a **brief** are
+defined in [CONTEXT.md](../CONTEXT.md)'s *Chats* section, each with the words charter stops
+using for it — every one of them implies a child that reports back, and a handed-off chat is
+nobody's child: it has its own workspace, its own todos and no way to answer the chat that
+opened it.
 
 **Sub-agent or chat: who reads the result?** If this chat needs the answer to continue, it is a
 sub-agent. If you will read it and talk to it, it is a chat. There is no report-back channel
@@ -68,9 +72,11 @@ BRIEF
    be exactly what you approved.
 
    **"The same work" is asked over the first lines, and only where the words can answer it.**
-   Every handoff todo ends in the same nine-word provenance sentence, so over the whole text
-   that boilerplate reads as agreement — `Fix the widget` and `Ship the release`, which share no
-   word at all, scored 0.750 and the second was dropped. Over first lines they score 0.000. But
+   Every handoff todo ends in the same provenance sentence — eight words the comparison can
+   see, plus the source chat and workspace, which two handoffs out of one chat also share — so
+   over the whole text that boilerplate reads as agreement: `Fix the widget` and `Ship the
+   release`, which share no word at all, scored 0.750 and the second was dropped. Over first
+   lines they score 0.000. But
    an overlap can also be too thin to mean anything: word comparison keeps only words longer
    than three characters, so `fix the bug` has no comparable word at all and two of them agree
    on nothing, while one shared word out of two is 0.5 exactly and `Fix the widget` swallowed
@@ -333,6 +339,11 @@ rules that one "isn't a security boundary around the program", and 2.1.268 ran `
 'handoff'`, `python3 -m charter handoff` and a path to charter with no prompt at all. So the ask
 rule is not the boundary — it is the prompt for the exact spelling, and charter's own hook
 refuses the spellings it can recognise that the rule was measured not to match.
+
+Why the gate is the host's prompt rather than a charter-side ask, a quiz or a `--brief-file`,
+and what each of those decisions cost, is
+[ADR 0021](adr/0021-a-handoffs-consent-is-the-harness-prompt.md). This page is what happens;
+that one is why it is shaped this way and what to read before changing it.
 
 ## The prompt is the consent
 

--- a/docs/handoff.md
+++ b/docs/handoff.md
@@ -72,9 +72,10 @@ BRIEF
    be exactly what you approved.
 
    **"The same work" is asked over the first lines, and only where the words can answer it.**
-   Every handoff todo ends in the same provenance sentence — eight words the comparison can
-   see, plus the source chat and workspace, which two handoffs out of one chat also share — so
-   over the whole text that boilerplate reads as agreement: `Fix the widget` and `Ship the
+   Every handoff todo ends in the same 18-word provenance sentence, nine of them comparable
+   once words of three characters or fewer are dropped — eight fixed, plus the source chat and
+   workspace, which two handoffs out of one chat also share — so over the whole text that
+   boilerplate reads as agreement: `Fix the widget` and `Ship the
    release`, which share no word at all, scored 0.750 and the second was dropped. Over first
    lines they score 0.000. But
    an overlap can also be too thin to mean anything: word comparison keeps only words longer

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -449,6 +449,18 @@ rule while one who reads a bare refusal files an issue.
   a Bash rule "isn't a security boundary around the program"
   ([What a Bash rule doesn't match](https://code.claude.com/docs/en/permissions#bash-rule-limits)).
 
+- **A hand-written state file.** A `Write` or `Edit` whose path resolves inside charter's
+  state directory (`.charter/`, or `$CHARTER_HOME`): the vault files, the vault registry, the
+  active-persona pointer, the per-session pointers, the tool-gate's session ceiling. Three of
+  those decide what the persona tool-gate auto-approves, so a write there is a session
+  widening its own permissions — and asking the agent to approve that is no guard, which is
+  why this one denies where the routing nudge beside it only asks. Resolved with `realpath`,
+  so a symlink planted into the directory answers the same as naming it. The refusal names the
+  command that owns the file — `charter persona use`, `charter vault add`,
+  `charter secret set`. A persona's own `persona.md` is deliberately **not** covered: editing a
+  charter on request is ordinary work, and what made it dangerous was the tool-gate re-reading
+  it mid-session, which the session ceiling fixes at the reading end. Gated on a control plane.
+
 One more path is not a guard but an allowance: a program the **active persona** declares in
 `tools:` runs without a prompt while that persona is active, and only then. It approves the
 **program**, so every argument rides along — which is why seven things are not smoothed
@@ -636,7 +648,7 @@ the harness's tools — they govern what an agent does with your authority insid
 Your own shell is on the other side of that boundary and always was. Open a terminal and run
 it. Nothing is being worked around: the rule never applied to you.
 
-Five guards name a narrower move first, and it is usually the one you want:
+Six guards name a narrower move first, and it is usually the one you want:
 
 - **Forge body substitution** — `--body-file <path>`, or `--body-file -` with a quoted
   heredoc. This one is rarely wrong about the shape and often wrong about the intent: the
@@ -649,6 +661,13 @@ Five guards name a narrower move first, and it is usually the one you want:
   transport, which is what most denials of it are actually asking for.
 - **Plane-root history wipe** — `charter save`. The guard is measuring commits that exist
   nowhere else; push them and it stops firing, on that command and every other one.
+- **A handoff the prompt cannot stand in front of** — spell it `charter handoff <workspace>
+  <<'BRIEF'`, from the chat the operator is talking to, attended. Three of its four refusals
+  have that as the fix, and the fourth (a sub-agent's call) is answered by returning what the
+  sub-agent found to the parent chat, which can propose the handoff itself. Your own terminal
+  is the override here too, and it does something different: outside a frame `charter handoff`
+  prints the `charter <harness> --workspace <ws> …` line to run rather than opening a chat
+  ([handoff.md](handoff.md)).
 
 **If a guard is wrong about you *every time*, that is not an override problem.** It means
 charter is holding a policy your organisation does not — an org that mandates signed

--- a/docs/news/unreleased-charter-handoff.md
+++ b/docs/news/unreleased-charter-handoff.md
@@ -35,8 +35,9 @@ charter handoff <workspace> [--create --vision "<vision>"] [--persona <name>] <<
 BRIEF
 ```
 
-The brief becomes the new chat's first message. Your harness asks before the command runs — the
-`ask` rule the previous entry is about — and the prompt shows the exact text that will be sent.
+The brief becomes the new chat's first message. Your harness asks before the command runs —
+the `Bash(charter handoff *)` ask rule that `charter init` writes and `charter guard handoff`
+adds to a plane that already exists — and the prompt shows the exact text that will be sent.
 
 ## What one does
 
@@ -136,5 +137,18 @@ shown nothing: the brief is already the first message of its transcript.
   SessionStart hook at all. `charter doctor` names that gap.
 - **The arrived mark is per plane, not per terminal**, and there is no "wants you" mark yet
   for a chat that stopped at a prompt after you visited it. Both are the next slice.
+
+## The words, and why the consent is shaped this way
+
+Three terms are in `CONTEXT.md` now — **chat**, **handoff**, **brief** — with the words
+charter stops using for them, because "spawn" and "sub-session" both imply a child that
+reports back, and a handed-off chat is neither. The dispatch counter that used "handoff" to
+mean a sub-agent dispatch is `dispatch.routed_since_first_advice`; `charter persona stats`
+prints the same line it always did.
+
+`docs/adr/0021-a-handoffs-consent-is-the-harness-prompt.md` records why the gate is your
+harness's own prompt rather than a charter-side confirmation, a hook `ask` or a model quiz —
+and what each decision cost, including the spelling `CONTRIBUTING.md` uses being refused and
+the harnesses where nothing prompts at all.
 
 `charter docs show handoff` has the whole of it, including how the consent was measured.

--- a/docs/superpowers/specs/2026-09-10-chat-handoff.md
+++ b/docs/superpowers/specs/2026-09-10-chat-handoff.md
@@ -92,7 +92,7 @@ BRIEF
 | a brief shaped like a credential — name the kind, never the value (the brief is world-readable argv while the harness starts) | the command (_ruling_) |
 | outside a frame, or inside the operator's own tmux | the command — prints the exact command to run in a new terminal |
 | unattended (`permission_mode: bypassPermissions`) | the PreToolUse guard |
-| called from a sub-agent (the payload carries `agent_id`) — Claude Code; Codex once measured | the PreToolUse guard |
+| called from a sub-agent (the payload carries `agent_id`) — Claude Code, and Codex once measured, which Task 4 did | the PreToolUse guard |
 | any spelling other than `charter handoff …`, e.g. `python3 -m charter handoff` — the host rule would not match it | the PreToolUse guard (_ruling_) |
 | a stdin that is not one quoted heredoc in the same call — the prompt would not show the text | the PreToolUse guard (_ruling_) |
 
@@ -202,8 +202,11 @@ So:
 - No "wants you" mark for a chat that stopped at a prompt after you visited it, and no
   per-client arrived mark — both are the next §4g slice.
 - The sub-agent and unattended refusals read the harness's hook payload. Claude Code carries
-  both; Codex's `agent_id` is unmeasured; where a harness does not expose them, `doctor` names
-  the gap rather than charter pretending to enforce it.
+  both; Codex's `agent_id` was unmeasured when this was agreed and **was measured in Task 4**
+  (codex-cli 0.147.0: none in the main conversation under any approval setting tried, one on a
+  sub-agent's Bash call), so the sub-agent refusal is in force there too. Where a harness does
+  not expose them — opencode, whose plugin payload carries neither — `doctor` names the gap
+  rather than charter pretending to enforce it.
 - An opencode chat that reopens empty is not shown its brief.
 - The brief reaches the harness as a command-line argument (`claude "<brief>"`,
   `codex "<brief>"`, `opencode --prompt "<brief>"`), so any process on this machine that can

--- a/tests/test_a_denial_names_its_override.py
+++ b/tests/test_a_denial_names_its_override.py
@@ -26,9 +26,9 @@ the agent — and there is deliberately no switch charter can read. That is not 
 **Appended in `_deny`, not at the call sites**, which is the assertion with the most
 value here: the next guard added carries the override without anyone remembering to,
 and the trace tally keys — computed from the reason BEFORE it reaches `_deny` — cannot drift.
-That is not a hypothetical any more: #710 and #778 each added a guard without a row in
-`DENIALS` below, and each carried the note regardless. The rows were added afterwards, so
-the enumeration says what it claims to.
+That is not a hypothetical any more: #710, #778, the state-write guard and the chat handoff's
+own A7 each arrived without a row in `DENIALS` below, and each carried the note regardless.
+The rows were added afterwards, so the enumeration says what it claims to.
 """
 
 from __future__ import annotations
@@ -70,6 +70,19 @@ DENIALS = {
     "charter-substitution": (hooks.pretooluse,
                              {"tool_input": {"command":
                                              'charter persona remember "a `id -un` span"'}}),
+    # The handoff guard (A7), added by the chat handoff and enumerated here for the third
+    # time this docstring's story has repeated: it carried the note from `_deny` on the day
+    # it landed, and the row is what makes the enumeration say what it claims to. The
+    # spelling refusal is the cheapest of its four to reach — no `agent_id`, no mode, no
+    # stdin to arrange.
+    "handoff": (hooks.pretooluse,
+                {"tool_input": {"command": "python3 -m charter handoff beta"}}),
+    # The state-write guard, which denies on `Write`/`Edit` rather than on Bash and was
+    # missing here for the same reason the two above were: a row is remembered separately
+    # from the guard, and remembering is what fails.
+    "state-write": (hooks.pretooluse_edit,
+                    {"tool_name": "Write",
+                     "tool_input": {"file_path": ".charter/persona"}}),
 }
 
 
@@ -124,9 +137,9 @@ class DenialCase(InAControlPlane):
 
 
 class TestEveryDenialNamesTheOverride(DenialCase):
-    def test_all_eight_of_them(self):
-        """The precondition is the count: eight guards deny, and all eight must say it."""
-        self.assertEqual(8, len(DENIALS))
+    def test_all_ten_of_them(self):
+        """The precondition is the count: ten guards deny, and all ten must say it."""
+        self.assertEqual(10, len(DENIALS))
         for name in DENIALS:
             with self.subTest(guard=name):
                 self.assertIn(hooks._OVERRIDE_NOTE, self.reason(name))

--- a/tests/test_charter_handoff_opens_a_chat_that_starts_working.py
+++ b/tests/test_charter_handoff_opens_a_chat_that_starts_working.py
@@ -145,11 +145,12 @@ class AHandoffOpensAChatThatStartsWorking(_AHandoffFromAlpha):
         self.assertNotIn("\x1b[2J", err)
 
     def test_a_second_handoff_about_something_else_records_its_own_todo(self):
-        """Every handoff todo ends in the same nine-word provenance sentence. Compared over
-        the whole text, that boilerplate read as agreement: `Fix the widget` and `Ship the
-        release` — no word in common — scored 0.750, so the SECOND handoff into a workspace
-        recorded nothing at all, silently, and any two titles of four or fewer distinct words
-        collided the same way. The comparison is over first lines now."""
+        """Every handoff todo ends in the same 18-word provenance sentence, nine of them
+        comparable once `memstore.wordset` drops the words of three characters or fewer.
+        Compared over the whole text, that boilerplate read as agreement: `Fix the widget`
+        and `Ship the release` — no word in common — scored 0.750, so the SECOND handoff
+        into a workspace recorded nothing at all, silently, and any two titles of four or
+        fewer distinct words collided the same way. The comparison is over first lines now."""
         self._handoff("beta", brief="Fix the widget\nIt breaks on resize.\n")
         self._handoff("beta", brief="Ship the release\nCut 0.61.0.\n")
         rc, _out, err = self._handoff("beta", brief="Rotate the token\nIt expires Friday.\n")

--- a/tests/test_resumed_delegation_counts.py
+++ b/tests/test_resumed_delegation_counts.py
@@ -92,7 +92,7 @@ class TestTheFiredVsFollowedPairCountsIt(ResumeCase):
         dispatch.record_advice(when=_ago(hours=2))
         self.dispatched("release")
         self.resumed(AGENT_ID)
-        self.assertEqual(dispatch.handoffs_since_first_advice(), 2)
+        self.assertEqual(dispatch.routed_since_first_advice(), 2)
 
     def test_handoffs_before_the_advice_still_do_not_count(self):
         """Written with explicit times rather than back-to-back calls: the store stamps to
@@ -102,7 +102,7 @@ class TestTheFiredVsFollowedPairCountsIt(ResumeCase):
         dispatch.record("release", when=_ago(hours=3))
         dispatch.record_resume("release", when=_ago(hours=2))
         dispatch.record_advice(when=_ago(hours=1))
-        self.assertEqual(dispatch.handoffs_since_first_advice(), 0)
+        self.assertEqual(dispatch.routed_since_first_advice(), 0)
 
 
 class TestItNeverBreaksTheTurn(ResumeCase):

--- a/tests/test_stats_lines_say_what_is_true.py
+++ b/tests/test_stats_lines_say_what_is_true.py
@@ -67,16 +67,16 @@ class TestTheAdviceLineComparesLikeWithLike(StatsCase):
         the roster ever appeared cannot have followed it."""
         dispatch.record("forge", when=_ago(days=4))
         dispatch.record_advice(when=_ago(hours=1))
-        self.assertEqual(dispatch.handoffs_since_first_advice(), 0)
+        self.assertEqual(dispatch.routed_since_first_advice(), 0)
 
     def test_a_dispatch_after_the_first_advice_counts(self):
         dispatch.record_advice(when=_ago(hours=2))
         dispatch.record("forge", when=_ago(hours=1))
-        self.assertEqual(dispatch.handoffs_since_first_advice(), 1)
+        self.assertEqual(dispatch.routed_since_first_advice(), 1)
 
     def test_no_advice_means_nothing_to_compare(self):
         dispatch.record("forge")
-        self.assertEqual(dispatch.handoffs_since_first_advice(), 0)
+        self.assertEqual(dispatch.routed_since_first_advice(), 0)
 
     def test_the_report_uses_that_number_not_the_lifetime_total(self):
         self.persona("forge")

--- a/tests/test_the_handoff_words_are_written_down.py
+++ b/tests/test_the_handoff_words_are_written_down.py
@@ -1,0 +1,133 @@
+"""The handoff decisions are written down where a reader without the plan can find them.
+
+A chat handoff was settled in a grill and built over six tasks, and the reasons lived in a
+workspace file that ships with nobody. This is the tripwire for the three places that carry
+them into the repo: `CONTEXT.md` for the words, `docs/adr/0021-*` for the consent decision,
+and `docs/handoff.md` for the page `charter docs show handoff` serves.
+
+The ADR is pinned **by number**, which the harness-profile plan left free by taking 0022
+(`docs/superpowers/plans/2026-09-11-harness-profiles.md`, *Controller rulings* 2, and
+`tests/test_the_profile_words_are_written_down.py`, which pins its own by slug so the two
+could merge in either order).
+
+These read files off the tree, never through `config`: a test that resolved the plane would
+be answering about whatever plane it ran in.
+"""
+
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+from charter import dispatch
+
+ROOT = Path(__file__).resolve().parents[1]
+ADR = ROOT / "docs" / "adr"
+
+
+def _entry(text: str, term: str) -> str:
+    """The body of one `**Term**:` entry in `CONTEXT.md`, up to the next bold term.
+
+    Sliced rather than line-counted because an entry's definition runs to as many lines as
+    it needs, and `_Avoid_` is the last of them.
+    """
+    start = text.index(f"**{term}**:")
+    rest = text[start + len(term) + 5:]
+    end = rest.find("\n**")
+    return rest if end < 0 else rest[:end]
+
+
+class TestTheWordsAreDefined(unittest.TestCase):
+    def test_context_defines_chat_handoff_and_brief(self):
+        """The spec's Language section names three words and three things to stop calling
+        them. A glossary that carries the terms without the refusals leaves `spawn` and
+        `sub-session` available to the next writer, which is how they got in."""
+        text = (ROOT / "CONTEXT.md").read_text()
+        for term in ("Chat", "Handoff", "Brief"):
+            self.assertIn(f"**{term}**:", text, f"CONTEXT.md defines no {term!r}")
+            body = _entry(text, term)
+            self.assertRegex(body, r"(?m)^_Avoid_:",
+                             f"{term!r} names nothing it is not")
+
+    def test_the_glossary_refuses_the_words_the_spec_ruled_out(self):
+        """`sub-session` is the one all three share: a handed-off chat is not a child of
+        anything, and a word that implies it is a word that invites a report-back channel
+        this feature deliberately does not have."""
+        text = (ROOT / "CONTEXT.md").read_text()
+        for term, words in (("Chat", ("session", "spawn", "sub-session")),
+                            ("Handoff", ("spawn", "delegation", "sub-session")),
+                            ("Brief", ("prompt", "context", "instructions"))):
+            body = _entry(text, term).lower()
+            avoid = body[body.index("_avoid_:"):]
+            for word in words:
+                with self.subTest(term=term, word=word):
+                    self.assertIn(word, avoid, f"{term!r} still permits {word!r}")
+
+
+class TestTheDecisionsAreRecorded(unittest.TestCase):
+    def test_the_consent_adr_takes_the_next_number(self):
+        found = sorted(ADR.glob("0021-*.md"))
+        self.assertEqual(1, len(found),
+                         f"expected one ADR 0021, found {[p.name for p in found]}")
+        self.assertTrue(found[0].read_text().startswith("# "),
+                        f"{found[0].name} does not open with its claim as a title")
+
+    def _adr(self) -> str:
+        return next(ADR.glob("0021-*.md")).read_text()
+
+    def test_the_consent_adr_says_the_prompt_is_not_a_boundary(self):
+        """The load-bearing sentence of the whole gate. A reader who takes the ask rule for
+        a boundary will delete A7 as redundant, and the spellings it refuses ran with no
+        prompt at all on the version this was measured on."""
+        text = self._adr()
+        self.assertIn("security boundary", text)
+        self.assertIn("2.1.268", text, "the boundary claim names no measured version")
+
+    def test_the_consent_adr_states_what_each_decision_cost(self):
+        """A decision record without its costs is a list of what was built, which the code
+        already says. These are the four that were paid knowingly."""
+        text = self._adr()
+        for claim in ("python3 -m charter handoff",   # the spelling CONTRIBUTING uses
+                      "${EDITOR}",                    # an unnameable opener errs toward refusing
+                      "os.urandom",                   # the fence marker is not reproducible
+                      "0.750"):                       # the boilerplate scored as agreement
+            with self.subTest(claim=claim):
+                self.assertIn(claim, text, f"ADR 0021 states no cost about {claim!r}")
+
+    def test_the_consent_adr_names_the_harnesses_it_cannot_gate(self):
+        """Codex has no prompt in front of a handoff and opencode cannot refuse a sub-agent's
+        one. Both are ceilings charter reports rather than closes, so both belong in the
+        record that says what the gate is."""
+        text = self._adr()
+        for harness in ("Codex", "opencode"):
+            self.assertIn(harness, text, f"ADR 0021 says nothing about {harness}")
+
+
+class TestThePageUsesChartersWords(unittest.TestCase):
+    def test_the_handoff_page_uses_charters_words(self):
+        """`spawn` and `sub-session` are what the glossary was written to stop. The page a
+        chat is pointed at is the one most likely to teach them back."""
+        text = (ROOT / "docs" / "handoff.md").read_text().lower()
+        for word in ("spawn", "sub-session"):
+            self.assertNotIn(word, text, f"docs/handoff.md still says {word!r}")
+
+    def test_the_handoff_page_points_at_the_decision_record(self):
+        """The page says what happens; the ADR says why it cannot be undone cheaply. A page
+        that never names it is a page whose reasons decay on their own."""
+        text = (ROOT / "docs" / "handoff.md").read_text()
+        self.assertIn("adr/0021-", text,
+                      "docs/handoff.md links no consent ADR")
+
+
+class TestTheAdvicePairIsNamedForRouting(unittest.TestCase):
+    def test_the_advice_pair_is_named_for_routing(self):
+        """`handoffs_since_first_advice` counted DISPATCHES, and "handoff" now means opening
+        a chat. Both halves are asserted: a rename that leaves the old name behind leaves the
+        contradiction it was for."""
+        self.assertTrue(hasattr(dispatch, "routed_since_first_advice"))
+        self.assertFalse(hasattr(dispatch, "handoffs_since_first_advice"),
+                         "the old name is still readable, so the word still means two things")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_todos_store.py
+++ b/tests/test_todos_store.py
@@ -154,8 +154,9 @@ class TestNearDuplicates(PersonaIso):
 class TestADuplicateJudgedByTitle(PersonaIso):
     """`by_title`, for a writer whose todos all end in the same sentence.
 
-    `charter handoff` is that writer. Scored over the whole text, its fixed nine-word
-    provenance tail read as agreement on both sides: two briefs with no word in common
+    `charter handoff` is that writer. Scored over the whole text, its fixed 18-word
+    provenance tail — nine words once `memstore.wordset` drops the short ones — read as
+    agreement on both sides: two briefs with no word in common
     scored 0.750 and the second was dropped, so the second handoff into a workspace recorded
     nothing at all.
     """


### PR DESCRIPTION
Part of #956 — Task 6 of docs/superpowers/plans/2026-09-10-chat-handoff.md.

The last task of the chat-handoff plan: the words, the decision record, and a closing pass
over the sentences the earlier five tasks left behind.

## What this adds

- **`CONTEXT.md` — a `### Chats` section.** **Chat**, **Handoff**, **Brief**, in the file's
  entry shape, each with the words charter stops using for it. All three avoided words imply
  a child that reports back, and a handed-off chat is not one.
- **ADR 0021 — `docs/adr/0021-a-handoffs-consent-is-the-harness-prompt.md`.** The consent
  decision, and the four others somebody would otherwise undo, each with **what it cost** and
  **what was measured**: the prompt is consent for one spelling and is not a security
  boundary; a heredoc body is judged by its own opener and its own pipeline; the brief's
  fence carries a per-render marker so the brief keeps its lines; the arrivals record is a
  directory of empty files; duplicate detection differs by caller. Numbered 0021, which the
  harness-profile plan left free by taking 0022.
- **`dispatch.handoffs_since_first_advice` → `routed_since_first_advice`** (plan Open
  question 17). It counts dispatches, and "handoff" now means opening a chat. No behaviour
  and no output moves; the `charter persona stats` line keeps its wording. Nothing outside
  the module read it as a key, so there is no old name to keep readable.
- **`tests/test_the_handoff_words_are_written_down.py`** — the tripwire for all three.
- The news entry is **extended, not replaced**, and carries no version: a closing section
  naming the three terms and the ADR.

## Sentences that disagreed with `main`, fixed here

Ruling 4 of the dispatch, and this is the list:

- **The README called `docs/hooks.md` "the five guards".** Ten guards deny, and the page
  documented nine: the state-write guard (`hooks._state_write_reason`) was named twice in
  passing and had no entry of its own. It has one now, and the README says ten.
- **`tests/test_a_denial_names_its_override.py` enumerated eight.** A7 and the state-write
  guard were both missing — the third time that enumeration has lagged a guard, which is the
  failure its own docstring is about. Both rows added, both green: `_deny` had been carrying
  the override note for them all along.
- **The news entry pointed at "the previous entry"** for the ask rule. Security entries rank
  above the rest (`news.released`), so that is not the entry that renders before it. It names
  the rule and `charter guard handoff` instead.
- **The spec called Codex's `agent_id` unmeasured.** Task 4 measured it on codex-cli 0.147.0,
  and the sub-agent refusal is in force there; the Limits bullet and the refusal table say so.
- **"the same nine-word provenance sentence"**: the sentence is **18** words. Nine is the
  comparable wordset after `memstore.wordset` drops everything three characters or shorter —
  `alpha, brief, chat, from, full, handed, opened, private, workspace`, eight of them fixed
  plus the source chat and workspace. Corrected in all five places the phrase reached:
  `charter/commands_handoff.py`, `charter/todos.py`, the two tests that repeat it, and
  `docs/handoff.md` and ADR 0021, which now say it the same way the modules do.
- `docs/hooks.md`'s *When a guard is wrong* said five guards name a narrower move; the
  handoff guard is a sixth, and its narrower move is a real one.

## Re-measured rather than restated (2026-09-12, on this branch)

No limit was carried into the ADR on the strength of a doc that already said it:

| What | Result |
| --- | --- |
| A7's verdicts, nine spellings through `hooks._handoff_refusal` | `python3 -m charter handoff` and `charter 'handoff'` → `handoff-spelling`; `cat <<'A' \| bash` → `handoff-shell-string`; `cat <<'A' > notes.md` and `git commit -F - <<'EOF'` → allowed; `agent_id` → `handoff-subagent`; `bypassPermissions` → `handoff-unattended`; `< brief.txt` → `handoff-brief-source` |
| heredoc routing, GNU bash 3.2.57 and zsh 5.9 | `cat <<'A' \| bash` runs the body in both; `cat <<'A'; …` runs the command after the `;` and never the body |
| the arrivals race, 400 rounds, two threads on one barrier | a read-modify-write over one file lost a mark in **400 of 400**; a directory of empty files lost **0 of 400** |
| the duplicate scores | 0.750 over whole texts (0.769 with a different source chat and workspace), 0.000 over first lines, 0.5 for one shared word out of two, and `fix the bug` has no comparable word at all |
| the bounds | `FIRST_MESSAGE_MAX_BYTES` 12,288 under tmux's 16,364; `_BRIEF_TOKEN_BYTES` 6; `RESTRICTIVE_BUCKETS = ("ask", "deny")`; `memstore.TITLE_MAX` 72 |

Claude Code's own permission measurements (2.1.268, stand-in model API, throwaway `HOME`) are
Task 4's and are cited with their version and where they live, not restated as fresh.

## Plan vs main

The plan says "0020 is the last on `main`" — 0022 landed since, from the harness-profile
plan, which took that number deliberately so 0021 stayed free (its
`tests/test_the_profile_words_are_written_down.py` says so). 0021 was unclaimed, so the
deliverable is unchanged. The plan's Task 6 text already carries the correction the brief
lacked — the workspace mirror carries `ask` **and** `deny`, never `allow` — and the ADR is
written to the plan.

## Verification

- `python3 tools/sweep.py` → `0 mutations across 2 file(s)`, `2 charged file(s), and no
  operator finds a mutation in what they add. Nothing to do.` **No guard is added, so the
  sweep has nothing new to charge.**
- New test red first: `test_the_handoff_page_points_at_the_decision_record` failed before
  the link went in.
- Green here: `test_the_handoff_words_are_written_down`, `test_a_denial_names_its_override`,
  `test_the_profile_words_are_written_down`, `test_docs`, `test_docs_show`, `test_news_gate`,
  `test_hooks`, the four handoff suites, `test_toolgate`, `test_persona_stats`,
  `test_stats_lines_say_what_is_true`, `test_resumed_delegation_counts`,
  `test_the_launcher_becomes_the_profile`.
- **CI is green**: `test (3.11)`, `(3.12)`, `(3.13)`, `(3.14)`, `Size the sweep`,
  `Sweep shard 1 of 1`, `nothing to sweep`, `Add up what the shards found`, both CodeQL
  analyses. The sweep shard agrees with the local run: nothing to sweep.
- `python3 -m unittest discover -s tests` locally: **`Ran 13179 tests` → `OK (skipped=9)`**.
- The sweep was re-run on the comment-correction head and again found nothing to sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
