### PR TITLE
No test can start a tmux that reaches the operator's own server

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,7 +84,12 @@ command.
   it when this one is killed before its cleanup runs — **every** socket it starts, including
   a second one, and never by decorating a name that helper already produced (#770). The slug
   is lowercase letters, digits and single hyphens; `name()` refuses anything else rather than
-  handing back a socket the reaper cannot see. **Nor does it spend a credential.**
+  handing back a socket the reaper cannot see. **And no tmux a test starts may reach
+  yours:** `tests._planeguard.RealTmuxReach` refuses a child whose socket is charter's
+  (`-L charter`), your `default` server, or the one `$TMUX` named when the suite started —
+  judged on the child's own `env=`, because a test that cleared its environment is the one
+  whose `kill-window` closed an operator's live session (2026-09-12). **Nor does it spend a
+  credential.**
   `doctor`'s preflight asks a forge whether your token is still good, and eighteen modules
   reach that line — 28 authenticated round trips to github.com and gitlab.com per run, and
   the sweep gate spends that again per mutation. `tests/_forgeprobe.py` answers the probe

--- a/tests/_planeguard.py
+++ b/tests/_planeguard.py
@@ -729,6 +729,10 @@ class AmbientGitConfig(BaseException):
     """A test spawned a git that would read the operator's own ``~/.gitconfig``."""
 
 
+class RealTmuxReach(BaseException):
+    """A test started a tmux that would talk to the operator's own server."""
+
+
 class BackgroundCharterChild(BaseException):
     """A test forked a detached charter the test itself will never wait for."""
 
@@ -790,6 +794,80 @@ def _explain_forge(parts: list[str], name: str) -> str:
 #: ``git`` through the same program-name resolution as ``op`` and ``gh`` — a path, a
 #: symlink or a wrapper cannot walk past a basename compare here either.
 _GIT: frozenset[str] = frozenset({"git"})
+
+
+#: The program whose SERVER is the operator's: their own frame on charter's socket, their
+#: own tmux on ``default`` or on whatever ``$TMUX`` named when the suite started.
+_TMUX: frozenset[str] = frozenset({"tmux"})
+
+#: `commands_frame.SOCKET`, spelled here because this module is installed before charter's
+#: frame is safe to import; `test_no_test_reaches_the_operators_tmux` pins the two equal.
+_CHARTER_SOCKET = "charter"
+
+#: tmux's own option letters that take a value (`tmux.c`'s getopt string, ``2c:CDdf:lL:NqS:T:uUvV``).
+_TMUX_VALUED = frozenset("cfLST")
+
+#: The sockets no test may reach, resolved when the guard is installed — before any test has
+#: had the chance to move ``$TMUX_TMPDIR`` — from the environment the suite was started in.
+_OPERATOR_TMUX: frozenset[str] = frozenset()
+
+
+def _operator_tmux(env) -> frozenset[str]:
+    """The operator's three tmux sockets as paths, from *env* — the suite's own environment
+    with `_envguard`'s scrubbed ``$TMUX`` put back, because the scrub is what hides it."""
+    home = os.path.join(env.get("TMUX_TMPDIR") or "/tmp", f"tmux-{os.getuid()}")
+    found = {os.path.realpath(os.path.join(home, _CHARTER_SOCKET)),
+             os.path.realpath(os.path.join(home, "default"))}
+    if env.get("TMUX"):
+        found.add(os.path.realpath(env["TMUX"].split(",")[0]))
+    return frozenset(found)
+
+
+def _tmux_socket(argv: list[str], env) -> str | None:
+    """The socket the tmux command line *argv* connects to, or ``None`` for ``-V``.
+
+    tmux's own rule, in its order: ``-S`` wins whatever else is given; with no ``-L`` either,
+    ``$TMUX`` names the server the child is inside; otherwise the label (``default`` unless
+    ``-L`` says) under ``$TMUX_TMPDIR`` or ``/tmp``. Read from the CHILD's environment — its
+    ``env=`` when it has one — because a test that clears its environment is exactly the one
+    whose ``tmux -L charter`` lands in the operator's ``/tmp`` (2026-09-12).
+    """
+    env = os.environ if env is None else env
+    label = path = None
+    words = iter(argv[1:])
+    for word in words:
+        if not word.startswith("-"):
+            break
+        for i, letter in enumerate(word[1:], 1):
+            if letter == "V":
+                return None
+            if letter in _TMUX_VALUED:
+                value = word[i + 1:] or next(words, "")
+                if letter == "L":
+                    label = value
+                if letter == "S":
+                    path = value
+                break
+    if path is not None:
+        return os.path.realpath(path)
+    if label is None and env.get("TMUX"):
+        return os.path.realpath(env["TMUX"].split(",")[0])
+    return os.path.realpath(os.path.join(env.get("TMUX_TMPDIR") or "/tmp",
+                                         f"tmux-{os.getuid()}", label or "default"))
+
+
+def _explain_tmux(parts: list[str], socket: str) -> str:
+    return (
+        f"REFUSED: spawning `tmux` against the operator's own server\n"
+        f"{_current_test()} is about to run `{' '.join(parts)}`, which connects to "
+        f"`{socket}` — the socket the operator's live frame or their own tmux is on. That is "
+        f"not a fixture. On 2026-09-12 a test run from inside a live chat sent "
+        f"`kill-window -t ''` there and closed the operator's session: tmux 3.7c answers an "
+        f"empty target with its ACTIVE window and exit 0.\n"
+        f"  The way out is a server of the test's own: `-L charter-<something>-<pid>` as the "
+        f"real-tmux modules do, or a `$TMUX_TMPDIR` of its own in the child's `env=`. A unit "
+        f"test that only needs tmux's answer stubs the call (`tmuxctl.run`, "
+        f"`tmuxctl.live_pane_by_pid`) instead.")
 
 
 def _reads_the_operators_git_config(opts: dict) -> bool:
@@ -1713,12 +1791,14 @@ def _guard_spawns() -> None:
     a call to one of them that is not the two known non-charter uses. The day a charter
     spawn is written that way, that case turns red and this docstring is what it points at.
     """
-    global _SPAWN_GUARDED, _VAULT_CLIS, _FORGE_CLIS
+    global _SPAWN_GUARDED, _VAULT_CLIS, _FORGE_CLIS, _OPERATOR_TMUX
     if _SPAWN_GUARDED:
         return
     _SPAWN_GUARDED = True
     _VAULT_CLIS = _credential_clis()
     _FORGE_CLIS = _forge_clis()
+    from . import _envguard
+    _OPERATOR_TMUX = _operator_tmux({**os.environ, **_envguard.scrubbed()})
     original = subprocess.Popen.__init__
 
     def __init__(self, args=None, *rest, **kw):
@@ -1745,6 +1825,14 @@ def _guard_spawns() -> None:
         reached = _reaches_a_credential_cli(args, opts, _GIT)
         if reached is not None and _reads_the_operators_git_config(opts):
             raise AmbientGitConfig(_explain_git_config(*reached))
+        # And the one program that can END the operator's session rather than read their
+        # settings: a tmux addressed at their own server. Judged on the socket it would
+        # reach, not on the words, so a hand-built `env=` that drops `$TMUX_TMPDIR` counts.
+        reached = _reaches_a_credential_cli(args, opts, _TMUX)
+        if reached is not None:
+            socket = _tmux_socket(_launcher_argv(reached[0])[0], opts.get("env"))
+            if socket in _OPERATOR_TMUX:
+                raise RealTmuxReach(_explain_tmux(reached[0], socket))
         parts = _charter_argv(args, opts)
         if parts is not None:
             if _REAL_ROOT:

--- a/tests/test_no_test_reaches_the_operators_tmux.py
+++ b/tests/test_no_test_reaches_the_operators_tmux.py
@@ -1,0 +1,154 @@
+"""No test may start a tmux that talks to the operator's own server.
+
+**The incident (2026-09-12).** An unfinished edit to the profile selector's cancel path
+deleted a guard, and a test run from inside a live chat sent `kill-window -t ''` to
+charter's own server — `-L charter`, the socket the operator's frame runs on — and closed
+their session. Measured on tmux 3.7c on an isolated socket: an empty target exits 0 and
+kills the ACTIVE window. `_envguard` had scrubbed `$TMUX`, and it did not matter, because
+charter addresses its own server by name and a name resolves under `/tmp` whatever the
+environment says.
+
+So `tests._planeguard.RealTmuxReach` refuses the SPAWN, judged on the socket the child would
+connect to rather than on the words: charter's socket and `default` under the suite's own
+`$TMUX_TMPDIR`, and whatever `$TMUX` named when the suite started. Every case here drives it
+with a stand-in `tmux` that only writes a marker, so no real server is involved, and a
+marker that stays absent is the evidence that nothing ran.
+"""
+
+from __future__ import annotations
+
+import os
+import pathlib
+import shutil
+import subprocess
+import tempfile
+import unittest
+
+from charter import commands_frame
+from tests import _planeguard
+
+
+def _socket(name: str, tmpdir: str = "/tmp") -> str:
+    return os.path.realpath(os.path.join(tmpdir, f"tmux-{os.getuid()}", name))
+
+
+class TheOperatorsServerIsNeverReached(unittest.TestCase):
+
+    def setUp(self):
+        self.dir = pathlib.Path(tempfile.mkdtemp(prefix="tmuxguard-"))
+        self.addCleanup(shutil.rmtree, self.dir, True)
+        self.marker = self.dir / "the-tmux-ran"
+        self.tmux = self.dir / "tmux"
+        self.tmux.write_text(f"#!/bin/sh\necho ran >> {self.marker}\n")
+        self.tmux.chmod(0o755)
+        self.charter = _socket("charter")
+        self.default = _socket("default")
+
+    def _refused(self, *words: str, env=None) -> _planeguard.RealTmuxReach:
+        with self.assertRaises(_planeguard.RealTmuxReach) as caught:
+            subprocess.run([str(self.tmux), *words], env=env)
+        self.assertFalse(self.marker.exists(), "refused, and yet it ran")
+        return caught.exception
+
+    def _allowed(self, *words: str, env=None) -> None:
+        subprocess.run([str(self.tmux), *words], env=env, check=True)
+        self.assertTrue(self.marker.exists(), "allowed, and yet it did not run")
+
+    # --- the guard is there, and reads production -------------------------------------
+
+    def test_the_sockets_are_resolved_when_the_suite_starts(self):
+        self.assertIn(_socket("charter", os.environ.get("TMUX_TMPDIR") or "/tmp"),
+                      _planeguard._OPERATOR_TMUX)
+        self.assertIn(_socket("default", os.environ.get("TMUX_TMPDIR") or "/tmp"),
+                      _planeguard._OPERATOR_TMUX)
+
+    def test_the_charter_socket_is_the_one_the_frame_runs_on(self):
+        self.assertEqual(_planeguard._CHARTER_SOCKET, commands_frame.SOCKET)
+
+    def test_the_operators_own_tmux_is_one_of_them_when_the_suite_started_inside_it(self):
+        found = _planeguard._operator_tmux(
+            {"TMUX": "/somewhere/tmux-1/work,123,0", "TMUX_TMPDIR": "/elsewhere"})
+        self.assertEqual(found, {os.path.realpath("/somewhere/tmux-1/work"),
+                                 _socket("charter", "/elsewhere"),
+                                 _socket("default", "/elsewhere")})
+
+    def test_without_tmux_set_there_are_exactly_two(self):
+        self.assertEqual(_planeguard._operator_tmux({}), {self.charter, self.default})
+
+    def test_it_is_a_base_exception_so_a_fallback_cannot_eat_it(self):
+        """`tmuxctl.run` turns a failed call into a return code, and a tripwire something
+        catches reports a server that is not there instead of failing."""
+        self.assertTrue(issubclass(_planeguard.RealTmuxReach, BaseException))
+        self.assertFalse(issubclass(_planeguard.RealTmuxReach, Exception))
+
+    # --- what reaches it --------------------------------------------------------------
+
+    def test_charters_own_socket_by_name_is_refused_from_a_hand_built_environment(self):
+        """The incident's shape: a cleared environment, and a name that resolves under
+        `/tmp` whatever `_envguard` scrubbed."""
+        self._refused("-L", "charter", "kill-window", "-t", "", env={})
+
+    def test_the_label_attached_to_its_flag_is_refused(self):
+        self._refused("-Lcharter", "ls", env={})
+
+    def test_a_bundle_of_flags_ending_in_the_label_is_refused(self):
+        self._refused("-2uL", "charter", "ls", env={})
+
+    def test_a_bare_tmux_reaches_the_default_server_and_is_refused(self):
+        self._refused("ls", env={})
+
+    def test_a_label_with_no_value_is_the_default_server(self):
+        self._refused("-L", env={})
+
+    def test_the_default_server_by_socket_path_is_refused(self):
+        self._refused("-S", self.default, "ls", env={})
+
+    def test_the_server_tmux_names_is_refused_when_nothing_else_is_given(self):
+        self._refused("ls", env={"TMUX": f"{self.charter},4242,0", "TMUX_TMPDIR": str(self.dir)})
+
+    def test_a_socket_path_wins_over_a_label_in_either_order(self):
+        """tmux's own precedence: `-S` decides whatever `-L` says, before or after it."""
+        self._refused("-L", "charter-mine", "-S", self.charter, "ls", env={})
+        self._refused("-S", self.charter, "-L", "charter-mine", "ls", env={})
+
+    def test_the_suites_own_environment_is_read_when_the_child_is_given_none(self):
+        self._refused("-L", "charter", "ls")
+
+    def test_the_refusal_names_the_test_the_command_the_socket_and_the_ways_out(self):
+        text = str(self._refused("-L", "charter", "kill-window", "-t", "", env={}))
+        self.assertIn("test_the_refusal_names_the_test_the_command_the_socket_and_the_ways_out",
+                      text)
+        self.assertIn("kill-window", text)
+        self.assertIn(self.charter, text)
+        self.assertIn("-L charter-", text)
+        self.assertIn("$TMUX_TMPDIR", text)
+        self.assertIn("tmuxctl.live_pane_by_pid", text)
+
+    # --- what does not ----------------------------------------------------------------
+
+    def test_a_server_of_the_tests_own_is_allowed(self):
+        self._allowed("-L", f"charter-tmuxguard-{os.getpid()}", "ls", env={})
+
+    def test_charters_name_under_a_tmpdir_of_the_tests_own_is_allowed(self):
+        self._allowed("-L", "charter", "ls", env={"TMUX_TMPDIR": str(self.dir)})
+
+    def test_a_label_overrides_the_server_tmux_names(self):
+        self._allowed("-L", "charter-mine", "ls", env={"TMUX": f"{self.charter},4242,0"})
+
+    def test_asking_the_version_connects_to_nothing(self):
+        self._allowed("-V", env={})
+
+    def test_words_after_the_command_are_the_commands_not_tmuxs(self):
+        self._allowed("-L", "charter-mine", "new-session", "-S", self.charter, env={})
+
+    def test_a_flags_value_that_looks_like_a_flag_is_a_value(self):
+        """`-f` takes the next word whatever it looks like — tmux's getopt does the same."""
+        self._allowed("-f", f"-S{self.charter}", "-L", "charter-mine", "ls", env={})
+
+    def test_a_value_attached_to_its_flag_ends_the_bundle(self):
+        """`-fS…` is a config file named `S…`, not `-f` followed by `-S`."""
+        self._allowed(f"-fS{self.charter}", "-L", "charter-mine", "ls", env={})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_the_close_confirmation_names_the_chat_it_stops.py
+++ b/tests/test_the_close_confirmation_names_the_chat_it_stops.py
@@ -320,6 +320,11 @@ class AWindowOnANOTHERPlaneIsNotThisPlanesChat(PersonaIso, unittest.TestCase):
                           f"{tmuxctl.FLOOR[1]}; this machine has {v}")
         self.socket = _tmuxreap.name("twoplanes")
         self.addCleanup(lambda: self._tmux("kill-server"))
+        # `_plane_servers` always asks charter's OWN socket as well, and on a developer's
+        # machine that is their live frame: an unmarked session there holding a `default.1`
+        # is "this plane's" by the veto rule below, and `cmd_close` would kill it. So
+        # charter's socket is this test's server too (`tests._planeguard.RealTmuxReach`).
+        self.enterContext(mock.patch.object(commands_frame, "SOCKET", self.socket))
         self.plane = make_plane(self, "schema = 1\n")
         self.chat = f"{self.WS}.1"
 


### PR DESCRIPTION
## What

`tests._planeguard` refuses a `tmux` child whose socket is the operator's own: charter's frame socket (`-L charter`, pinned equal to `commands_frame.SOCKET`), the `default` server, or whatever `$TMUX` named when the suite started. It raises `RealTmuxReach`, a `BaseException`, before anything runs.

## Why

On 2026-09-12 an unfinished edit to the harness-profiles selector (#996, since fixed there in `ac159bb`) deleted an empty-target guard, and a test run from inside a live chat sent `kill-window -t ''` to charter's own server. That closed the operator's session. Measured on tmux 3.7c with an isolated socket: `kill-window -t ''` exits 0 and kills the **active** window.

`_envguard` had already scrubbed `$TMUX`, and that did not help. Charter addresses its own server by **name**, and a name resolves under `/tmp` whatever the environment says. The test in question had also cleared its environment (`mock.patch.dict(os.environ, …, clear=True)`), so no environment-based guard could have caught it.

## How

The check is judged on the **socket the child would connect to**, following tmux's own precedence:

1. `-S` wins over `-L`, in either order.
2. With no label, `$TMUX` names the server.
3. Otherwise the label (`default` unless `-L` gives one) is resolved under `$TMUX_TMPDIR` or `/tmp`.

It reads the child's own `env=` when one is given. `-V` connects to nothing and is allowed. Option parsing follows tmux's getopt string (`2c:CDdf:lL:NqS:T:uUvV`), so a flag's value is never mistaken for a flag. Program-name matching reuses `_reaches_a_credential_cli`, the same matcher `git`, `gh` and `op` go through.

Still allowed:
- a server of the test's own (`tests._tmuxreap.name(...)`);
- charter's socket name under a `$TMUX_TMPDIR` of the test's own.

## Tests

`tests/test_no_test_reaches_the_operators_tmux.py`: 22 cases, all driven with a stand-in `tmux` that only writes a marker. With the refusal line removed, 10 of them fail.

**What CI measures here:** whether any existing test on `main` already reaches the operator's server. Each such test fails by name on its spawn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MBdEBogeMV7DsqN6vrsVTk
