### PR TITLE
An empty Codex trust hash is pinned as no trust

### DIFF
--- a/tests/test_a_profile_is_wired_or_refuses.py
+++ b/tests/test_a_profile_is_wired_or_refuses.py
@@ -820,6 +820,15 @@ class CodexIsReadAtTheProfilesHome(PersonaIso, unittest.TestCase):
                    + f'\n[hooks.state."{TRUST_KEY}"]\ntrusted_hash = 1\n')
         self.assertEqual(wiring.detect(self.p, cwd=self.tmp).state, wiring.UNWIRED)
 
+    def test_an_empty_trusted_hash_is_not_trust(self):
+        """The other half of the same test: a string, and nothing in it. Codex approves a hook
+        by recording the hash it approved, so an empty one records no approval — and a chat
+        that wanted this home to read as guarded only has to write the key with `""`. The
+        sweep on `791c1e7` (#995) found the `and entry["trusted_hash"]` half unpinned."""
+        self.write(codex_config(trust=False)
+                   + f'\n[hooks.state."{TRUST_KEY}"]\ntrusted_hash = ""\n')
+        self.assertEqual(wiring.detect(self.p, cwd=self.tmp).state, wiring.UNWIRED)
+
     def test_a_nul_byte_in_the_home_is_unknown_and_never_a_traceback(self):
         """A1: `open` refuses a NUL in a path with `ValueError`."""
         p = approve_profile(self, make_profile("codex-nul", kind="codex",


### PR DESCRIPTION
The deletion sweep on #995's final head (`791c1e7`) left five survivors. Four were named equivalent in that PR: `KIND_WIRING`'s spelling, `_key`'s two field names, and a `[A-Z]`→`[B-Z]` event-name regex mutation no declared event can tell apart. The fifth is real:

`charter/wiring.py` `_codex_marks`: `isinstance(entry.get("trusted_hash"), str) and entry["trusted_hash"]`. With the second half dropped, nothing failed. That half is what stops `trusted_hash = ""` from reading as an approved guard hook. An empty string is the line a chat would write to make a Codex home look guarded.

The code was already right; this adds the test. `test_an_empty_trusted_hash_is_not_trust` passes as-is (`tests.test_a_profile_is_wired_or_refuses`: 203 tests, OK) and fails with the half removed (failures=1). It was run with `TMUX`/`TMUX_PANE` unset and an isolated `TMUX_TMPDIR`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MBdEBogeMV7DsqN6vrsVTk
