### PR TITLE
A profile runs through the command you launch its harness with (from #968)

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,8 +79,9 @@ session, after `init` and `--fix` alike, so restart any session that was already
 
 **The recording stops before `charter claude`**, because the frame is a full-screen tmux
 client and `capture-demo.sh` records a line transcript; the picture at the top of this page
-is what that step opens. `charter claude` needs `claude` on your `PATH`: without it no frame
-is drawn, and charter says the binary is not installed and exits 127. The frame also needs
+is what that step opens. `charter claude` needs `claude` on your `PATH` — a profile needs
+whatever its command names, a wrapper like `ccs work` included: without it no frame is
+drawn, and charter says the program is not installed and exits 127. The frame also needs
 tmux, and of tmux only its absence stops a launch — below 3.2, the version charter checks
 its requirements against, the frame still starts. `charter opencode` and `charter codex`
 need their own binaries the same way, and `charter claude --probe` says whether a frame can

--- a/docs/control-plane.md
+++ b/docs/control-plane.md
@@ -510,6 +510,12 @@ one-credential guard — would change plane policy with no trace in git.
 - The table's name is letters, digits, `_` and `-`, starting with a letter or digit. No dot:
   a dot in a name broke tmux targets once (#695).
 
+**The file stays beside `charter.toml` when `$CHARTER_HOME` moves the state directory.**
+What charter keeps about your profiles does move with it: the record of each command you
+approved (`harness-profiles-launched.json`) and the wiring cache
+(`cache/harness-wiring.json`). A plane whose state directory moved keeps its profiles and
+asks about each declared one again on its first launch there.
+
 **Every harness is also a built-in profile named after itself** — `claude` runs `claude`,
 with no extra environment — so a plane that declares nothing sees no change. A declared
 profile of the same name replaces it, which is how plain `claude` gets pinned. A built-in

--- a/docs/harnesses.md
+++ b/docs/harnesses.md
@@ -69,6 +69,30 @@ refused:
 Then `refused:`, one line per profile charter would not read and why, and a warning while
 git would commit the file.
 
+**A wrapper around a harness is a profile too.** If you reach Claude Code through something
+else — `ccs work`, which picks the account a chat is billed to, or a script that runs a
+binary kept off your `PATH` — declare the wrapper as the command:
+
+```toml
+[harness.claude-ccs]
+kind = "claude"
+command = ["ccs", "work"]
+```
+
+`charter claude-ccs` then runs `ccs work`, your arguments follow it (`charter claude-ccs -p
+hi` runs `ccs work -p hi`, and a reopen hands it `--resume <id>`), and it is still the
+Claude Code harness: the pane carries `$CHARTER_HARNESS`, the workspace layer and a session
+`charter reopen` can resume. `charter frame -- ccs work` runs the same words and forgets all
+three. The program charter looks for before it starts anything is the wrapper — a missing
+`ccs` is refused and named, and a `claude` your `PATH` cannot see is the wrapper's to find.
+
+**The wrapper has to pass its arguments on**, and not only yours: charter asks the harness
+whether its plugin is wired by running the profile's own command with the harness's probe
+after it — `plugin list --json` for Claude Code, `debug config` for opencode (see *Per
+profile — wired, or it refuses to start*, below) — so `ccs work plugin list --json` has to
+reach `claude`. A wrapper that swallows arguments reads as a profile charter could not ask,
+and it refuses to start.
+
 **There is no `charter harness add`.** A profile is added by editing `charter.local.toml`. A
 chat can run a command as easily as it can edit a file, so a command could never stand for
 your approval of what a profile runs; it would only save typing.

--- a/tests/test_a_harness_runs_through_the_command_you_name.py
+++ b/tests/test_a_harness_runs_through_the_command_you_name.py
@@ -1,0 +1,132 @@
+"""A harness profile runs through the command YOU launch it with — `ccs work`, a wrapper, a
+binary kept off `$PATH`.
+
+An operator who reaches Claude Code through a wrapper — `ccs work`, which picks the
+subscription a chat is billed to; a script that pins a binary off `$PATH` — had two doors,
+both wrong. `charter frame -- ccs work` runs the words but forgets the harness: no
+`$CHARTER_HARNESS` in the pane, no workspace layer, nothing `charter reopen` can resume. A
+shell alias is invisible to charter, which execs a program by name. A profile in
+`charter.local.toml` is the third door: the REGISTERED harness, launched through the
+operator's own words, with everything the registration carries.
+
+    [harness.claude-ccs]
+    kind = "claude"
+    command = ["ccs", "work"]
+
+**Where this came from.** PR #968 proposed exactly this door as a per-developer
+`.charter/local.toml` naming one command per harness; the harness-profiles work (ADR 0022)
+reached the same place with a per-machine file, several profiles per kind, an approval
+before a new command runs and a wiring check. What that PR specified and profiles had not
+yet pinned is here:
+
+* **the command's words come first and the operator's arguments follow them**, on a bare
+  launch and in the pane — so `--resume <id>` on a reopen reaches whatever the wrapper
+  forwards it to. Nothing failed if the launcher kept only a command's first word;
+* **the program that is checked is the program that runs** — `ccs` missing is refused
+  before tmux and named, and `claude` missing does not stop a `ccs` that is there: the
+  wrapper is what runs, so the wrapper is what has to be findable;
+* **a file that is not UTF-8 is a refusal with a sentence, never a traceback**, and the
+  built-ins still load.
+"""
+
+from __future__ import annotations
+
+import io
+import unittest
+from contextlib import redirect_stderr
+from unittest import mock
+
+from charter import config, profiles
+from charter.frame import launcher
+from tests._isolation import approve_every_profile, wired_as_today
+from tests.test_a_profile_launch_is_refused_before_tmux import _ALaunchNamesAProfile
+
+#: A wrapper, one word of its own after the program.
+WRAPPED = '[harness.claude-ccs]\nkind = "claude"\ncommand = ["ccs", "work"]\n'
+
+#: Ruling 10 refuses an unwired profile before tmux, and no case here is about wiring
+#: (`tests/test_a_profile_launch_is_refused_before_tmux.py` records the same choice).
+_WIRED = None
+
+
+def setUpModule():
+    global _WIRED
+    _WIRED = wired_as_today()
+    _WIRED.start()
+
+
+def tearDownModule():
+    if _WIRED is not None:
+        _WIRED.stop()
+
+
+def _only(missing: str):
+    """A `shutil.which` that finds every program but *missing*."""
+    return lambda name, *a, **kw: None if name == missing else f"/usr/bin/{name}"
+
+
+class _AWrappedProfile(_ALaunchNamesAProfile):
+    def setUp(self) -> None:
+        super().setUp()
+        self.local.write_text(WRAPPED)
+        approve_every_profile(self)
+
+
+class TheCommandsWordsComeFirstAndYourArgumentsFollow(_AWrappedProfile, unittest.TestCase):
+
+    def test_a_bare_launch_execs_every_word_of_the_command_then_the_operators(self):
+        self.assertEqual(self._launch(profile="claude-ccs", no_frame=True,
+                                      rest=["-p", "hi"]), 0)
+        (program, argv, _env), = self.execs
+        self.assertEqual((program, argv), ("ccs", ["ccs", "work", "-p", "hi"]))
+
+    def test_the_pane_execs_every_word_of_the_command_then_the_resume_it_was_handed(self):
+        """What a reopen hands the pane is `--resume <id>`; a wrapper that forwards its
+        arguments passes it on, and one that dropped `work` would start the wrong account."""
+        p = profiles.current().profiles["claude-ccs"]
+        with mock.patch.object(launcher.shutil, "which", side_effect=_only("")):
+            self.assertEqual(launcher.start(p, ["--resume", "abc"], fid=None,
+                                            attended=False), 0)
+        (program, argv, _env), = self.execs
+        self.assertEqual((program, argv), ("ccs", ["ccs", "work", "--resume", "abc"]))
+
+    def test_the_wrapper_is_still_the_harness_it_wraps(self):
+        """The whole point of the door: `charter frame -- ccs work` forgot which harness it
+        was, and a profile does not."""
+        self._launch(profile="claude-ccs", no_frame=True)
+        (_program, _argv, env), = self.execs
+        self.assertEqual(env["CHARTER_HARNESS"], "claude-code")
+        self.assertEqual(env["CHARTER_HARNESS_PROFILE"], "claude-ccs")
+
+
+class TheProgramCheckedIsTheProgramThatRuns(_AWrappedProfile, unittest.TestCase):
+
+    def test_a_missing_wrapper_is_refused_before_tmux_and_named(self):
+        err = io.StringIO()
+        with redirect_stderr(err):
+            rc = self._launch(profile="claude-ccs", which=_only("ccs"))
+        self.assertEqual(rc, launcher.MISSING_EXIT)
+        self.assertIn("ccs", err.getvalue())
+        self.assertFalse(self._started(), "refused AFTER tmux — nothing was drawn")
+        self.assertEqual(self.execs, [])
+
+    def test_a_missing_harness_binary_does_not_stop_a_wrapper_that_is_there(self):
+        self.assertEqual(self._launch(profile="claude-ccs", which=_only("claude")), 0)
+        self.assertTrue(self._started(), self.argvs)
+
+
+class AFileThatIsNotUtf8IsRefusedWithASentence(_ALaunchNamesAProfile, unittest.TestCase):
+
+    def test_the_file_is_refused_and_the_built_ins_still_load(self):
+        (config.ROOT / profiles.LOCAL_FILE).write_bytes(
+            b'[harness.claude-ccs]\nkind = "claude"\ncommand = ["c\xffcs"]\n')
+        read = profiles.current()
+        self.assertNotIn("claude-ccs", read.profiles)
+        self.assertIn("claude", read.profiles)
+        why = [r for r in read.refused if r.source == profiles.LOCAL_FILE and not r.name]
+        self.assertEqual(len(why), 1, read.refused)
+        self.assertIn("could not be read", why[0].reason)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_a_profile_launch_is_refused_before_tmux.py
+++ b/tests/test_a_profile_launch_is_refused_before_tmux.py
@@ -104,7 +104,7 @@ class _ALaunchNamesAProfile(PersonaIso):
             out = "@1 %9\n"
         return subprocess.CompletedProcess(argv, 0, out, "")
 
-    def _launch(self, *, which: str | None = "/nowhere/claude", dead_status=None,
+    def _launch(self, *, which="/nowhere/claude", dead_status=None,
                 verdict: tuple = (None, ""), operator=None, stdin=None, stdout=None,
                 **ns) -> int:
         """The real `_launch` with tmux stood in — and every answer a case might care about
@@ -130,8 +130,12 @@ class _ALaunchNamesAProfile(PersonaIso):
                    else mock.patch("sys.stdout.isatty", return_value=True)]
         for s in streams:
             self.enterContext(s)
-        with mock.patch("charter.commands_frame.shutil.which", return_value=which), \
-                mock.patch.object(launcher.shutil, "which", return_value=which), \
+        # *which* is one answer for every program, or a function of the program's name for
+        # a case where the answer depends on WHICH program is asked (a wrapper and the
+        # harness it wraps, `tests/test_a_harness_runs_through_the_command_you_name.py`).
+        answer = {"side_effect": which} if callable(which) else {"return_value": which}
+        with mock.patch("charter.commands_frame.shutil.which", **answer), \
+                mock.patch.object(launcher.shutil, "which", **answer), \
                 mock.patch.object(tmuxctl, "version", return_value=(3, 7)), \
                 mock.patch.object(tmuxctl, "operator_server", return_value=operator), \
                 mock.patch.object(commands_frame, "_live_sessions", return_value={"beta"}), \


### PR DESCRIPTION
Carries what #968 (@Biacode) specified onto harness profiles, and keeps his authorship on the commit that does it.

## Background

#968 proposed a per-developer `.charter/local.toml` naming the command each harness is launched with. The use case: an operator who reaches Claude Code through a wrapper, such as `ccs work` (which picks the account a chat is billed to) or a binary kept off `$PATH`. Such an operator had two doors, and both were wrong:

- `charter frame -- ccs work` runs the words but forgets the harness.
- A shell alias is invisible to an exec.

Harness profiles (ADR 0022, tasks 1–6, now on main) reached the same place with `charter.local.toml`, adding several profiles per kind, approval before a new command runs, a wiring check and a selector. That supersedes #968's mechanism: `instance.harness_local_of`, `launch_argv(command=)`, and the `local.toml` doctor row are not carried.

## What is carried

**`8c88455`** (author: Artur): #968's launch test module, re-pointed at profiles. Each case below is a behaviour nothing on main pinned before.

- **The command's words come first and the operator's arguments follow**, on a bare launch and in the pane, so `--resume <id>` on a reopen reaches what the wrapper forwards.
  - Replayed: with the launcher keeping only the first word, 2 cases fail.
- **The program checked before tmux is the program that runs.** A missing `ccs` is refused and named; a missing `claude` does not stop a `ccs` that is there.
  - Replayed: checking the kind's binary instead, 2 cases fail.
- **A `charter.local.toml` that is not UTF-8** is a refusal with a sentence, and the built-ins still load.
  - Replayed: with the decode error uncaught, the case errors.
- The launch fixture's `which` may now answer per program name.

**`8c4e3fd`**: #968's docs use case.
- `docs/harnesses.md` shows a wrapper as a profile, and that a wrapper has to forward arguments, because the wiring probe runs `<command> plugin list --json`.
- `docs/control-plane.md` says `charter.local.toml` stays put under `$CHARTER_HOME` while the approval record and wiring cache move.
- The README's `PATH` sentence names a profile's command.

## Verification

All runs used an unset `TMUX`/`TMUX_PANE`.
- **The new module plus its fixture's module:** 48 tests, OK.
- **Every module that reads `README.md`, `docs/harnesses.md` or `docs/control-plane.md`:** 1,795 tests. The only failures were 13 in `test_frame_tmux_integration` under an isolated `TMUX_TMPDIR` that module does not support (its socket paths are built under `/tmp`). That module alone, run the default way: 106 tests, OK.

Merge with **rebase**, not squash, so `8c88455` lands with its author.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MBdEBogeMV7DsqN6vrsVTk
